### PR TITLE
Test arguments

### DIFF
--- a/src/Stack/Build/Types.hs
+++ b/src/Stack/Build/Types.hs
@@ -57,6 +57,7 @@ data BuildOpts =
             ,boptsFinalAction :: !FinalAction
             ,boptsDryrun :: !Bool
             ,boptsGhcOptions :: ![Text]
+            ,boptsTestArgs :: ![Text]
             }
   deriving (Show)
 

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -232,6 +232,7 @@ depsCmd (names, dryRun) GlobalOpts{..} = do
             , boptsFinalAction = DoNothing
             , boptsDryrun = dryRun
             , boptsGhcOptions = []
+            , boptsTestArgs = []
             }
 
 -- | Parser for package names
@@ -421,7 +422,7 @@ dockerExecCmd cmdArgs GlobalOpts{..} = do
 -- | Parser for build arguments.
 buildOpts :: Parser BuildOpts
 buildOpts = BuildOpts <$> target <*> libProfiling <*> exeProfiling <*>
-            optimize <*> finalAction <*> dryRun <*> ghcOpts
+            optimize <*> finalAction <*> dryRun <*> ghcOpts <*> testArgs
   where optimize =
           maybeBoolFlags "optimizations" "optimizations for TARGETs and all its dependencies"
         target =
@@ -445,6 +446,12 @@ buildOpts = BuildOpts <$> target <*> libProfiling <*> exeProfiling <*>
                      (strOption (long "ghc-options" <>
                                  metavar "OPTION" <>
                                  help "Additional options passed to GHC")))
+
+        testArgs =
+          many (fmap T.pack
+                     (strOption (long "test-args" <>
+                                 metavar "ARGUMENT" <>
+                                 help "Command line arguments to pass to the test suites")))
 
 -- | Parser for docker cleanup arguments.
 dockerCleanupOpts :: Parser Docker.CleanupOpts


### PR DESCRIPTION
I'm unsure of this one for two reasons:
1. I don't think this should be part of `BuildOpts`, but rather part of a new `TestOpts` data type which contains a field for a `BuildOpts`. But I wanted to touch base on that first.
2. In order to use this right now, you have to do silly things like `stack test --test-args=-m --test-args PackageDump`. I'd rather modify it to work with `stack test --test-args="-m PackageDump"`
