### PR TITLE
make the resolver error show a hopefully more clear description for nightlies

### DIFF
--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -335,7 +335,8 @@ instance Show ConfigException where
     show (ParseResolverException t) = concat
         [ "Invalid resolver value: "
         , T.unpack t
-        , ". Possible valid values include lts-2.12, nightly-YYYY-MM-DD, and ghc-7.10."
+        , ". Possible valid values include lts-2.12, nightly-YYYY-MM-DD, and ghc-7.10. "
+        , "See https://www.stackage.org/snapshots for a complete list."
         ]
     show (NoProjectConfigFound dir) = concat
         [ "Unable to find a stack.yaml file in the current directory ("

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -335,7 +335,7 @@ instance Show ConfigException where
     show (ParseResolverException t) = concat
         [ "Invalid resolver value: "
         , T.unpack t
-        , ". Possible valid values include lts-2.12, nightly-2015-01-01, and ghc-7.10."
+        , ". Possible valid values include lts-2.12, nightly-YYYY-MM-DD, and ghc-7.10."
         ]
     show (NoProjectConfigFound dir) = concat
         [ "Unable to find a stack.yaml file in the current directory ("


### PR DESCRIPTION
This is a quick fix for #241. More could be done -- perhaps show a URL to a definitive list of possible values?