### PR TITLE
Build progress

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -260,6 +260,9 @@ executePlan' plan ee = do
     -- stack always using transformer stacks that are safe for this use case.
     runInBase <- liftBaseWith $ \run -> return (void . run)
 
+    let size = Map.size (planTasks plan)
+    when (size > 1)
+         ($logSticky ("Progress: 0/" <> T.pack (show size)))
     let actions = concatMap (toActions runInBase ee) $ Map.elems $ planTasks plan
     threads <- liftIO getNumCapabilities -- TODO make a build opt to override this
     errs <- liftIO $ runActions threads actions

--- a/src/Stack/Types/Internal.hs
+++ b/src/Stack/Types/Internal.hs
@@ -14,7 +14,7 @@ data Env config =
   Env {envConfig :: !config
       ,envLogLevel :: !LogLevel
       ,envManager :: !Manager
-      ,envSticky :: !(MVar Sticky)}
+      ,envSticky :: !Sticky}
 
 instance HasStackRoot config => HasStackRoot (Env config) where
     getStackRoot = getStackRoot . envConfig
@@ -37,14 +37,16 @@ instance HasLogLevel (Env config) where
 instance HasLogLevel LogLevel where
   getLogLevel = id
 
-data Sticky = Sticky
+newtype Sticky = Sticky { unSticky :: Maybe (MVar StickyState)}
+
+data StickyState = StickyState
     { stickyCurrentLine :: !(Maybe ByteString)
     , stickyMaxColumns :: !Int
     , stickyLastWasSticky :: !Bool
     }
 
 class HasSticky r where
-    getSticky :: r -> MVar Sticky
+    getSticky :: r -> Sticky
 
 instance HasSticky (Env config) where
   getSticky = envSticky

--- a/src/Stack/Types/StackT.hs
+++ b/src/Stack/Types/StackT.hs
@@ -135,12 +135,13 @@ stickyLoggerFunc :: (HasSticky r, HasLogLevel r, ToLogStr msg, MonadReader r (t 
 stickyLoggerFunc loc src level msg = do
     ref <- asks getSticky
     sticky <- liftIO (takeMVar ref) -- TODO: make exception-safe.
-    let clear =
+    let backSpaceChar = '\8'
+        clear =
             liftIO
                 (S8.putStr
                      (S8.replicate
                           (stickyMaxColumns sticky)
-                          '\8'))
+                          backSpaceChar))
     case level of
         LevelOther "sticky-done" -> do
             liftIO

--- a/src/Stack/Types/StackT.hs
+++ b/src/Stack/Types/StackT.hs
@@ -138,11 +138,9 @@ stickyLoggerFunc loc src level msg = do
     let clear =
             liftIO
                 (S8.putStr
-                     ("\r" <>
-                      S8.replicate
+                     (S8.replicate
                           (stickyMaxColumns sticky)
-                          ' ' <>
-                      "\r"))
+                          '\8'))
     case level of
         LevelOther "sticky-done" -> do
             liftIO

--- a/src/Stack/Types/StackT.hs
+++ b/src/Stack/Types/StackT.hs
@@ -33,7 +33,7 @@ import           Control.Monad.Reader
 import           Control.Monad.Trans.Control
 import qualified Data.ByteString.Char8 as S8
 import           Data.Char
-import           Data.Monoid
+
 import           Data.Text (Text)
 import           Data.Time
 import           Language.Haskell.TH


### PR DESCRIPTION
Handle runhaskell output with logInfo
    
@snoyberg I think b1b88f5 is slightly subtle of a change so I'd like you to
    take a look. The summary is:
    
1. All output goes into the printBuildOutput function now, unless a log
    file is specified.
2. printBuildOutput can probably do other filtering in the future. But
    its purpose is now two-fold; the filtering, and ensuring no stray stdout
    makes it into the world without going through monad-logger first.
    
Now sticky output can work properly even with build output dumped live. Pinging @DanBurton as this serves as a decent example of display progress output with the new `logSticky` and `logStickyDone`.