### PR TITLE
Cache package ids

### DIFF
--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -63,7 +63,7 @@ build bopts = do
 
     if boptsDryrun bopts
         then printPlan plan
-        else executePlan menv bopts baseConfigOpts locals plan
+        else executePlan menv bopts baseConfigOpts locals plan installedMap
   where
     profiling = boptsLibProfile bopts || boptsExeProfile bopts
 


### PR DESCRIPTION
If the install step doesn't run for a package in `singleBuild` it just uses the package id it already has from the map. Not a necessary optimization but shaves off some time:

```
chris@retina:~/Packages$ time stack build

real	0m1.246s
user	0m4.484s
sys	0m1.760s
```
→
```
chris@retina:~/Packages$ time stack build

real	0m0.911s
user	0m2.532s
sys	0m1.376s
```

If this isn't semantically correct don't bother merging it. 