### PR TITLE
Implement clever stack ghci (aka cabal repl)

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,4 +1,0 @@
-:set -package optparse-applicative -package optparse-simple -package binary
-:set -isrc/main -isrc
-:set -i.stack-work/dist/x86_64-linux/Cabal-1.18.1.5/build/autogen/
-:set -optP-include -optP.stack-work/dist/x86_64-linux/Cabal-1.18.1.5/build/autogen/cabal_macros.h

--- a/src/Stack/Exec.hs
+++ b/src/Stack/Exec.hs
@@ -1,31 +1,39 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | Execute commands within the properly configured Stack
 -- environment.
 
 module Stack.Exec where
 
 import           Control.Monad.Reader
+import           Control.Monad.Logger
+import           Control.Monad.Catch
+
+
 import           Path
 import           Stack.Types
 import           System.Exit
 import qualified System.Process as P
 import           System.Process.Read
 
+
 -- | Execute a process within the Stack configured environment.
-exec :: (HasConfig r, MonadReader r m, MonadIO m)
+exec :: (HasConfig r, MonadReader r m, MonadIO m, MonadLogger m, MonadThrow m)
         => String -> [String] -> m b
 exec cmd args = do
     config <- asks getConfig
-    liftIO $ do
-        menv <- configEnvOverride config
-                        EnvSettings
-                            { esIncludeLocals = True
-                            , esIncludeGhcPackagePath = True
-                            }
-        cmd' <- join $ System.Process.Read.findExecutable menv cmd
-        let cp = (P.proc (toFilePath cmd') args)
-                { P.env = envHelper menv
-                , P.delegate_ctlc = True
-                }
-        (Nothing, Nothing, Nothing, ph) <- P.createProcess cp
-        ec <- P.waitForProcess ph
-        exitWith ec
+    menv <- liftIO (configEnvOverride config
+                            EnvSettings
+                                { esIncludeLocals = True
+                                , esIncludeGhcPackagePath = True
+                                })
+    cmd' <- join $ System.Process.Read.findExecutable menv cmd
+    let cp = (P.proc (toFilePath cmd') args)
+            { P.env = envHelper menv
+            , P.delegate_ctlc = True
+            }
+    $logProcessRun (toFilePath cmd') args
+    (Nothing, Nothing, Nothing, ph) <- liftIO (P.createProcess cp)
+    ec <- liftIO (P.waitForProcess ph)
+    liftIO (exitWith ec)

--- a/src/Stack/Repl.hs
+++ b/src/Stack/Repl.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+
+-- | Run a REPL configured with the user's project(s).
+
+module Stack.Repl where
+
+import           Control.Monad.Catch
+import           Control.Monad.IO.Class
+import           Control.Monad.Logger
+import           Control.Monad.Reader
+import           Data.List
+import qualified Data.Map.Strict as M
+import           Data.Maybe
+import           Data.Monoid
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Path
+import           Path.IO
+import           Stack.Build.Source
+import           Stack.Exec
+import           Stack.Package
+import           Stack.Types
+
+-- | Launch a GHCi REPL for the given local project targets with the
+-- given options and configure it with the load paths and extensions
+-- of those targets.
+repl :: (HasConfig r, HasBuildConfig r, HasEnvConfig r, MonadReader r m, MonadIO m, MonadThrow m, MonadLogger m, MonadCatch m)
+     => [Text] -- ^ Targets.
+     -> [String] -- ^ GHC options.
+     -> m ()
+repl targets opts = do
+    bconfig <- asks getBuildConfig
+    pwd <- getWorkingDir
+    pkgOpts <-
+        liftM catMaybes $
+        forM (M.toList (bcPackages bconfig)) $
+        \(dir,validWanted) ->
+             do cabalfp <- getCabalFileName dir
+                name <- parsePackageNameFromFilePath cabalfp
+                let config =
+                        PackageConfig
+                        { packageConfigEnableTests = True
+                        , packageConfigEnableBenchmarks = True
+                        , packageConfigFlags = localFlags mempty bconfig name
+                        , packageConfigGhcVersion = bcGhcVersion bconfig
+                        , packageConfigPlatform = configPlatform
+                              (getConfig bconfig)
+                        }
+                pkg <- readPackage config cabalfp
+                if validWanted &&
+                   wanted pwd cabalfp pkg
+                    then do
+                        pkgOpts <-
+                            getPackageOpts
+                                (packageOpts pkg)
+                                cabalfp
+                        return (Just (packageName pkg, pkgOpts))
+                    else return Nothing
+    $logInfo
+        ("Configuring GHCi with the following projects: " <>
+         T.intercalate
+             ", "
+             (map packageNameText (map fst pkgOpts)))
+    exec
+        "ghc"
+        ("--interactive" :
+         filter (not . badForGhci) (concat (map snd pkgOpts)) <>
+         opts)
+  where
+    wanted pwd cabalfp pkg =
+        isInWantedList || targetsEmptyAndInDir
+      where
+        isInWantedList =
+            elem
+                (packageNameText
+                     (packageName pkg))
+                targets
+        targetsEmptyAndInDir =
+            null targets ||
+            isParentOf
+                (parent cabalfp)
+                pwd
+    badForGhci = isPrefixOf "-O"

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -21,6 +21,7 @@ import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe
 import           Data.Monoid
+import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import           Network.HTTP.Client
@@ -42,6 +43,7 @@ import           Stack.Fetch
 import           Stack.GhcPkg (getCabalPkgVer)
 import qualified Stack.PackageIndex
 import           Stack.Path
+import           Stack.Repl
 import           Stack.Setup
 import           Stack.Types
 import           Stack.Types.StackT
@@ -123,11 +125,16 @@ main =
                             <$> pure "ghc"
                             <*> many (strArgument (metavar "-- ARGS (e.g. stack ghc -- X.hs -o x)")))
              addCommand "ghci"
-                        "Run ghci"
-                        execCmd
-                        ((,)
-                            <$> pure "ghci"
-                            <*> many (strArgument (metavar "-- ARGS (e.g. stack ghci -- -i<dir>)")))
+                        "Run ghci in the context of project(s)"
+                        replCmd
+                        ((,) <$>
+                         fmap (map T.pack)
+                              (many (strArgument
+                                       (metavar "TARGET" <>
+                                        help "If none specified, use all packages defined in current directory"))) <*>
+                         many (strOption (long "ghc-options" <>
+                                          metavar "OPTION" <>
+                                          help "Additional options passed to GHCi")))
              addCommand "runghc"
                         "Run runghc"
                         execCmd
@@ -375,6 +382,10 @@ execCmd (cmd,args) go@GlobalOpts{..} =
     withBuildConfig go ExecStrategy $
     exec cmd args
 
+-- | Run the REPL in the context of a project, with
+replCmd :: ([Text], [String]) -> GlobalOpts -> IO ()
+replCmd (targets,args) go@GlobalOpts{..} = withBuildConfig go CreateConfig $ do
+      repl targets args
 
 -- | Pull the current Docker image.
 dockerPullCmd :: () -> GlobalOpts -> IO ()

--- a/stack.cabal
+++ b/stack.cabal
@@ -39,6 +39,7 @@ library
                      Stack.PackageDump
                      Stack.PackageIndex
                      Stack.Path
+                     Stack.Repl
                      Stack.Setup
                      Stack.Types
                      Stack.Types.Internal


### PR DESCRIPTION
This is for #130.

Here is demonstration output: http://lpaste.net/raw/277892153647038464

This configures with 

* All source directories, cabal macros and autogen directories.
* Extensions.

From every target in the cabal project, and every package in your stack.yaml.

You can call 

    $ stack ghci  

or 

    $ stack ghci projectname

Like in `stack build`.

There're a number of other options in [`BuildInfo`](http://hackage.haskell.org/package/Cabal-1.22.3.0/docs/Distribution-PackageDescription.html#t:BuildInfo):  `ldOptions`, `ccOptions`, `includes` etc.  I'm not sure which of them are actually necessary. Needs to be figured out.

Meanwhile, I'd like to float this by the interested parties: @feuerbach @hesselink @acfoltzer @ndmitchell @snoyberg 

Other points:

* I think some might want a `--load-all` flag which will run `:load X Y Z` on all modules in all packages on start-up. Is that needed for your ghcid @ndmitchell?
* I probably want a `--with-ghc` arg so that I can run `ghci-ng`.