### PR TITLE
Build haddocks for dependencies (#143)

### DIFF
--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -26,6 +26,7 @@ import           Control.Monad.Trans.Resource
 import           Data.Function
 import           Data.Map.Strict (Map)
 import qualified Data.Map as Map
+import           Data.Maybe (fromMaybe)
 import           Network.HTTP.Client.Conduit (HasHttpManager)
 import           Path.IO
 import           Prelude hiding (FilePath, writeFile)
@@ -55,7 +56,12 @@ build bopts = do
     menv <- getMinimalEnvOverride
 
     (mbp, locals, extraToBuild, sourceMap) <- loadSourceMap bopts
-    (installedMap, locallyRegistered) <- getInstalled menv profiling sourceMap
+    (installedMap, locallyRegistered) <-
+        getInstalled menv
+                     GetInstalledOpts
+                         { getInstalledProfiling = profiling
+                         , getInstalledHaddock   = fromMaybe (boptsHaddock bopts) (boptsDepsHaddock bopts) }
+                     sourceMap
 
     baseConfigOpts <- mkBaseConfigOpts bopts
     plan <- withLoadPackage menv $ \loadPackage ->

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -89,6 +89,7 @@ data Ctx = Ctx
     , callStack      :: ![PackageName]
     , extraToBuild   :: !(Set PackageName)
     , latestVersions :: !(Map PackageName Version)
+    , wanted         :: !(Set PackageName)
     }
 
 instance HasStackRoot Ctx
@@ -161,6 +162,7 @@ constructPlan mbp0 baseConfigOpts0 locals extraToBuild0 locallyRegistered loadPa
         , callStack = []
         , extraToBuild = extraToBuild0
         , latestVersions = latest
+        , wanted = wantedLocalPackages locals
         }
     toolMap = getToolMap mbp0
 
@@ -197,7 +199,7 @@ addFinal lp = do
                             allDeps
                             True -- wanted
                             Local
-                            (packageFlags package)
+                            package
                 , taskPresent = present
                 , taskType = TTLocal lp
                 }
@@ -239,7 +241,7 @@ addDep'' name = do
             installPackage name ps
         Just (PIBoth ps installed) -> do
             tellExecutables name ps
-            needInstall <- checkNeedInstall name ps installed
+            needInstall <- checkNeedInstall name ps installed (wanted ctx)
             if needInstall
                 then installPackage name ps
                 else return $ Right $ ADRFound (piiLocation ps) (piiVersion ps) installed
@@ -290,7 +292,7 @@ installPackage name ps = do
                             -- An assertion to check for a recurrence of
                             -- https://github.com/commercialhaskell/stack/issues/345
                             (assert (destLoc == piiLocation ps) destLoc)
-                            (packageFlags package)
+                            package
                 , taskPresent = present
                 , taskType =
                     case ps of
@@ -298,14 +300,14 @@ installPackage name ps = do
                         PSUpstream _ loc _ -> TTUpstream package $ loc <> minLoc
                 }
 
-checkNeedInstall :: PackageName -> PackageSource -> Installed -> M Bool
-checkNeedInstall name ps installed = assert (piiLocation ps == Local) $ do
+checkNeedInstall :: PackageName -> PackageSource -> Installed -> Set PackageName -> M Bool
+checkNeedInstall name ps installed wanted = assert (piiLocation ps == Local) $ do
     package <- psPackage name ps
     depsRes <- addPackageDeps package
     case depsRes of
         Left _e -> return True -- installPackage will find the error again
         Right (missing, present, _loc)
-            | Set.null missing -> checkDirtiness ps installed package present
+            | Set.null missing -> checkDirtiness ps installed package present wanted
             | otherwise -> return True
 
 addPackageDeps :: Package -> M (Either ConstructPlanException (Set PackageIdentifier, Set GhcPkgId, Location))
@@ -345,28 +347,35 @@ checkDirtiness :: PackageSource
                -> Installed
                -> Package
                -> Set GhcPkgId
+               -> Set PackageName
                -> M Bool
-checkDirtiness ps installed package present = do
+checkDirtiness ps installed package present wanted = do
     ctx <- ask
+    moldOpts <- tryGetFlagCache installed
     let configOpts = configureOpts
             (getEnvConfig ctx)
             (baseConfigOpts ctx)
             present
             (psWanted ps)
             (piiLocation ps) -- should be Local always
-            (packageFlags package)
-        configCache = ConfigCache
+            package
+        buildOpts = bcoBuildOpts (baseConfigOpts ctx)
+        wantConfigCache = ConfigCache
             { configCacheOpts = map encodeUtf8 configOpts
             , configCacheDeps = present
             , configCacheComponents =
                 case ps of
                     PSLocal lp -> Set.map encodeUtf8 $ lpComponents lp
                     PSUpstream _ _ _ -> Set.empty
+            , configCacheHaddock =
+                shouldBuildHaddock buildOpts wanted (packageName package) ||
+                -- Disabling haddocks when old config had haddocks doesn't make dirty.
+                maybe False configCacheHaddock moldOpts
             }
-    moldOpts <- tryGetFlagCache installed
     case moldOpts of
         Nothing -> return True
-        Just oldOpts -> return $ oldOpts /= configCache || psDirty ps
+        Just oldOpts -> return $ oldOpts /= wantConfigCache ||
+                                 psDirty ps
 
 psDirty :: PackageSource -> Bool
 psDirty (PSLocal lp) = lpDirtyFiles lp

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -6,6 +6,7 @@
 module Stack.Build.Installed
     ( InstalledMap
     , Installed (..)
+    , GetInstalledOpts (..)
     , getInstalled
     ) where
 
@@ -49,33 +50,41 @@ data LoadHelper = LoadHelper
 
 type InstalledMap = Map PackageName (Version, Location, Installed) -- TODO Version is now redundant and can be gleaned from Installed
 
+-- | Options for 'getInstalled'.
+data GetInstalledOpts = GetInstalledOpts
+    { getInstalledProfiling :: !Bool
+      -- ^ Require profiling libraries?
+    , getInstalledHaddock   :: !Bool
+      -- ^ Require haddocks?
+    }
+
 -- | Returns the new InstalledMap and all of the locally registered packages.
 getInstalled :: (M env m, PackageInstallInfo pii)
              => EnvOverride
-             -> Bool -- ^ profiling?
+             -> GetInstalledOpts
              -> Map PackageName pii -- ^ does not contain any installed information
              -> m (InstalledMap, Set GhcPkgId)
-getInstalled menv profiling sourceMap = do
+getInstalled menv opts sourceMap = do
     snapDBPath <- packageDatabaseDeps
     localDBPath <- packageDatabaseLocal
 
     bconfig <- asks getBuildConfig
 
-    mpcache <-
-        if profiling
-            then liftM Just $ loadProfilingCache $ configProfilingCache bconfig
+    mcache <-
+        if getInstalledProfiling opts || getInstalledHaddock opts
+            then liftM Just $ loadInstalledCache $ configInstalledCache bconfig
             else return Nothing
 
-    let loadDatabase' = loadDatabase menv mpcache sourceMap
+    let loadDatabase' = loadDatabase menv opts mcache sourceMap
     (installedLibs', localInstalled) <-
         loadDatabase' Nothing [] >>=
         loadDatabase' (Just (Snap, snapDBPath)) . fst >>=
         loadDatabase' (Just (Local, localDBPath)) . fst
     let installedLibs = M.fromList $ map lhPair installedLibs'
 
-    case mpcache of
+    case mcache of
         Nothing -> return ()
-        Just pcache -> saveProfilingCache (configProfilingCache bconfig) pcache
+        Just pcache -> saveInstalledCache (configInstalledCache bconfig) pcache
 
     -- Add in the executables that are installed, making sure to only trust a
     -- listed installation under the right circumstances (see below)
@@ -108,12 +117,13 @@ getInstalled menv profiling sourceMap = do
 -- location needed by the SourceMap
 loadDatabase :: (M env m, PackageInstallInfo pii)
              => EnvOverride
-             -> Maybe ProfilingCache -- ^ if Just, profiling is required
+             -> GetInstalledOpts
+             -> Maybe InstalledCache -- ^ if Just, profiling or haddock is required
              -> Map PackageName pii -- ^ to determine which installed things we should include
              -> Maybe (Location, Path Abs Dir) -- ^ package database, Nothing for global
              -> [LoadHelper] -- ^ from parent databases
              -> m ([LoadHelper], Set GhcPkgId)
-loadDatabase menv mpcache sourceMap mdb lhs0 = do
+loadDatabase menv opts mcache sourceMap mdb lhs0 = do
     (lhs1, gids) <- ghcPkgDump menv (fmap snd mdb)
                   $ conduitDumpPackage =$ sink
     let lhs = pruneDeps
@@ -124,14 +134,21 @@ loadDatabase menv mpcache sourceMap mdb lhs0 = do
             (lhs0 ++ lhs1)
     return (map (\lh -> lh { lhDeps = [] }) $ Map.elems lhs, Set.fromList gids)
   where
-    conduitCache =
-        case mpcache of
-            Just pcache -> addProfiling pcache
+    conduitProfilingCache =
+        case mcache of
+            Just cache | getInstalledProfiling opts -> addProfiling cache
             -- Just an optimization to avoid calculating the profiling
             -- values when they aren't necessary
-            Nothing -> CL.map (\dp -> dp { dpProfiling = False })
-    sinkDP = conduitCache
-          =$ CL.mapMaybe (isAllowed mpcache sourceMap (fmap fst mdb))
+            _ -> CL.map (\dp -> dp { dpProfiling = False })
+    conduitHaddockCache =
+        case mcache of
+            Just cache | getInstalledHaddock opts -> addHaddock cache
+            -- Just an optimization to avoid calculating the haddock
+            -- values when they aren't necessary
+            _ -> CL.map (\dp -> dp { dpHaddock = False })
+    sinkDP = conduitProfilingCache
+          =$ conduitHaddockCache
+          =$ CL.mapMaybe (isAllowed opts mcache sourceMap (fmap fst mdb))
           =$ CL.consume
     sinkGIDs = CL.map dpGhcPkgId =$ CL.consume
     sink = getZipSink $ (,)
@@ -142,14 +159,17 @@ loadDatabase menv mpcache sourceMap mdb lhs0 = do
 -- on the package selections made by the user. This does not perform any
 -- dirtiness or flag change checks.
 isAllowed :: PackageInstallInfo pii
-          => Maybe ProfilingCache
+          => GetInstalledOpts
+          -> Maybe InstalledCache
           -> Map PackageName pii
           -> Maybe Location
-          -> DumpPackage Bool
+          -> DumpPackage Bool Bool
           -> Maybe LoadHelper
-isAllowed mpcache sourceMap mloc dp
+isAllowed opts mcache sourceMap mloc dp
     -- Check that it can do profiling if necessary
-    | isJust mpcache && not (dpProfiling dp) = Nothing
+    | getInstalledProfiling opts && isJust mcache && not (dpProfiling dp) = Nothing
+    -- Check that it has haddocks if necessary
+    | getInstalledHaddock opts && isJust mcache && not (dpHaddock dp) = Nothing
     | toInclude = Just LoadHelper
         { lhId = gid
         , lhDeps =

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -120,7 +120,8 @@ data Package =
           ,packageTests :: !(Set Text)                    -- ^ names of test suites
           ,packageBenchmarks :: !(Set Text)               -- ^ names of benchmarks
           ,packageExes :: !(Set Text)                     -- ^ names of executables
-          ,packageOpts :: !GetPackageOpts              -- ^ Args to pass to GHC.
+          ,packageOpts :: !GetPackageOpts                 -- ^ Args to pass to GHC.
+          ,packageHasExposedModules :: !Bool              -- ^ Does the package have exposed modules?
           }
  deriving (Show,Typeable)
 
@@ -243,6 +244,7 @@ resolvePackage packageConfig gpkg = Package
     , packageExes = S.fromList $ [ T.pack (exeName b) | b <- executables pkg, buildable (buildInfo b)]
     , packageOpts = GetPackageOpts $ \cabalfp ->
         generatePkgDescOpts cabalfp pkg
+    , packageHasExposedModules = maybe False (not . null . exposedModules) (library pkg)
     }
 
   where

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -559,9 +559,9 @@ configProjectWorkDir = do
     bc <- asks getBuildConfig
     return (bcRoot bc </> workDirRel)
 
--- | File containing the profiling cache, see "Stack.PackageDump"
-configProfilingCache :: (HasBuildConfig env, MonadReader env m) => m (Path Abs File)
-configProfilingCache = liftM (</> $(mkRelFile "profiling-cache.bin")) configProjectWorkDir
+-- | File containing the installed cache, see "Stack.PackageDump"
+configInstalledCache :: (HasBuildConfig env, MonadReader env m) => m (Path Abs File)
+configInstalledCache = liftM (</> $(mkRelFile "installed-cache.bin")) configProjectWorkDir
 
 -- | Relative directory for the platform identifier
 platformRelDir :: (MonadReader env m, HasPlatform env, MonadThrow m) => m (Path Rel Dir)

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -76,23 +76,23 @@ main =
          (do addCommand "build"
                         "Build the project(s) in this directory/configuration"
                         (buildCmd DoNothing)
-                        buildOpts
+                        (buildOpts False)
              addCommand "install"
                         "Build executables and install to a user path"
                         installCmd
-                        buildOpts
+                        (buildOpts False)
              addCommand "test"
                         "Build and test the project(s) in this directory/configuration"
                         (buildCmd DoTests)
-                        buildOpts
+                        (buildOpts False)
              addCommand "bench"
                         "Build and benchmark the project(s) in this directory/configuration"
                         (buildCmd DoBenchmarks)
-                        buildOpts
+                        (buildOpts False)
              addCommand "haddock"
                         "Generate haddocks for the project(s) in this directory/configuration"
-                        (buildCmd DoHaddock)
-                        buildOpts
+                        (buildCmd DoNothing)
+                        (buildOpts True)
              addCommand "new"
                         "Create a brand new project"
                         newCmd
@@ -424,10 +424,10 @@ dockerExecCmd (cmd,args) go@GlobalOpts{..} = do
                                              (return (cmd,args,lcConfig lc))
 
 -- | Parser for build arguments.
-buildOpts :: Parser BuildOpts
-buildOpts =
+buildOpts :: Bool -> Parser BuildOpts
+buildOpts defaultHaddock =
             BuildOpts <$> target <*> libProfiling <*> exeProfiling <*>
-            optimize <*> finalAction <*> dryRun <*> ghcOpts <*> flags <*>
+            optimize <*> localHaddock <*> depsHaddock <*> finalAction <*> dryRun <*> ghcOpts <*> flags <*>
             installExes <*> preFetch <*> testArgs <*> onlySnapshot
   where optimize =
           maybeBoolFlags "optimizations" "optimizations for TARGETs and all its dependencies" idm
@@ -445,6 +445,16 @@ buildOpts =
           boolFlags False
                     "executable-profiling"
                     "library profiling for TARGETs and all its dependencies"
+                    idm
+        localHaddock =
+          boolFlags defaultHaddock
+                    "haddock"
+                    "building Haddocks"
+                    idm
+        depsHaddock =
+          maybeBoolFlags
+                    "deps-haddock"
+                    "building Haddocks for dependencies"
                     idm
         finalAction = pure DoNothing
         installExes = pure False

--- a/src/test/Stack/PackageDumpSpec.hs
+++ b/src/test/Stack/PackageDumpSpec.hs
@@ -76,7 +76,9 @@ spec = do
                 , dpLibDirs = ["/opt/ghc/7.8.4/lib/ghc-7.8.4/haskell2010-1.1.2.0"]
                 , dpDepends = depends
                 , dpLibraries = ["HShaskell2010-1.1.2.0"]
+                , dpHaddockInterfaces = ["/opt/ghc/7.8.4/share/doc/ghc/html/libraries/haskell2010-1.1.2.0/haskell2010.haddock"]
                 , dpProfiling = ()
+                , dpHaddock = ()
                 }
 
         it "ghc 7.10" $ do
@@ -104,28 +106,32 @@ spec = do
             haskell2010 `shouldBe` DumpPackage
                 { dpGhcPkgId = ghcPkgId
                 , dpLibDirs = ["/opt/ghc/7.10.1/lib/ghc-7.10.1/ghc_EMlWrQ42XY0BNVbSrKixqY"]
+                , dpHaddockInterfaces = ["/opt/ghc/7.10.1/share/doc/ghc/html/libraries/ghc-7.10.1/ghc.haddock"]
                 , dpDepends = depends
                 , dpLibraries = ["HSghc-7.10.1-EMlWrQ42XY0BNVbSrKixqY"]
                 , dpProfiling = ()
+                , dpHaddock = ()
                 }
 
-    it "ghcPkgDump + addProfiling" $ (id :: IO () -> IO ()) $ runNoLoggingT $ do
+    it "ghcPkgDump + addProfiling + addHaddock" $ (id :: IO () -> IO ()) $ runNoLoggingT $ do
         menv' <- getEnvOverride buildPlatform
         menv <- mkEnvOverride buildPlatform $ Map.delete "GHC_PACKAGE_PATH" $ unEnvOverride menv'
-        pcache <- newProfilingCache
+        icache <- newInstalledCache
         ghcPkgDump menv Nothing
             $  conduitDumpPackage
-            =$ addProfiling pcache
+            =$ addProfiling icache
+            =$ addHaddock icache
             =$ CL.sinkNull
 
     it "sinkMatching" $ do
         menv' <- getEnvOverride buildPlatform
         menv <- mkEnvOverride buildPlatform $ Map.delete "GHC_PACKAGE_PATH" $ unEnvOverride menv'
-        pcache <- newProfilingCache
+        icache <- newInstalledCache
         m <- runNoLoggingT $ ghcPkgDump menv Nothing
             $  conduitDumpPackage
-            =$ addProfiling pcache
-            =$ sinkMatching False (Map.singleton $(mkPackageName "transformers") $(mkVersion "0.0.0.0.0.0.1"))
+            =$ addProfiling icache
+            =$ addHaddock icache
+            =$ sinkMatching False False (Map.singleton $(mkPackageName "transformers") $(mkVersion "0.0.0.0.0.0.1"))
         case Map.lookup $(mkPackageName "base") m of
             Nothing -> error "base not present"
             Just _ -> return ()


### PR DESCRIPTION
This doesn't yet generate the index or do relative links, and it requires rebuilding the package in order to generate haddocks, but does work well in my testing and think it's worth merging with the current feature set (especially as this touches enough code that conflicts are frequent).  

As for building haddocks without rebuilding the packages: this should be doable by adding some extra logic to singleBuild that lets it skip `runhaskell Setup.hs build` when building only haddocks (along with some adjustments to ConfigCache and maybe getInstalled), but interested in opinion about whether that's the right approach or if this would be better done at the Plan level (i.e. split the plan into _build_, _haddock_, and _install_ steps).  Note that haddocks need to be built before installing the package (that way, install takes care of putting them where they belong).

For #143.