### PR TITLE
Bypass decodeUtf8 in printBuildOutput

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -47,6 +47,7 @@ import qualified Data.Text.Encoding             as T
 import           Data.Text.Encoding             (encodeUtf8)
 import           Distribution.System            (OS (Windows),
                                                  Platform (Platform))
+import           Language.Haskell.TH            (Loc(..))
 import           Network.HTTP.Client.Conduit    (HasHttpManager)
 import           Path
 import           Path.IO
@@ -860,7 +861,7 @@ printBuildOutput excludeTHLoading level outH = void $ fork $
          CB.sourceHandle outH
     $$ CB.lines
     =$ CL.filter (not . isTHLoading)
-    =$ CL.mapM_ (logOtherN level . T.decodeUtf8)
+    =$ CL.mapM_ (monadLoggerLog (Loc "<unknown>" "<unknown>" "<unknown>" (0,0) (0,0)) "" level)
   where
     -- | Is this line a Template Haskell "Loading package" line
     -- ByteString


### PR DESCRIPTION
`printBuildOutput` (https://github.com/commercialhaskell/stack/blob/706736a6a46810533281eb7cc38714f31a6a5412/src/Stack/Build/Execute.hs) re-prints the output from `ghc`.  However, in my environment (GHC 7.10.1, Windows 8.1), it suffers from indigestion due to `decodeUtf8`:

```
stack: Cannot decode byte '\x81': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream
```

This patch fixes this so that stack correctly prints compile errors.