### PR TITLE
Add --ignore-subdirs flag to init command

### DIFF
--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -275,7 +275,7 @@ loadBuildConfig menv mproject config stackRoot mresolver noConfigStrat = do
       Nothing -> case noConfigStrat of
         ThrowException -> do
             currDir <- getWorkingDir
-            cabalFiles <- findCabalFiles currDir
+            cabalFiles <- findCabalFiles True currDir
             throwM $ NoProjectConfigFound currDir
                 $ Just $ if null cabalFiles then "new" else "init"
         ExecStrategy -> do


### PR DESCRIPTION
Currently `stack init` takes into account *all* .cabal files in the cwd as well as non-ignored sub directories.  If I run it on the `stack` project it will for example also pick up the `new-template.cabal`
and refuse all of the available build plans due to unresolved packages like `acme-dont` that are used in some of the integration tests.

With the new flag `stack init --ignore-subdirs` it will only consider `stack.cabal` and not recurse into sub directories. 

To allow this I added a boolean flag to `findCabalFiles` which I don't like that much but I avoided to define a data type for the argument (e.g  `data FindCabalRecurse = DoRecurse | Don'tRecurse`) for simplicity. 