### PR TITLE
Skip unreachable directories during init

### DIFF
--- a/test/integration/tests/skip-unreachable-dirs/Main.hs
+++ b/test/integration/tests/skip-unreachable-dirs/Main.hs
@@ -1,0 +1,8 @@
+import StackTest
+import System.Directory (setPermissions, emptyPermissions, createDirectory)
+
+main :: IO ()
+main = do
+    createDirectory "unreachabledir"
+    setPermissions  "unreachabledir" $ emptyPermissions
+    stack ["init"]

--- a/test/integration/tests/skip-unreachable-dirs/files/foo.cabal
+++ b/test/integration/tests/skip-unreachable-dirs/files/foo.cabal
@@ -1,0 +1,10 @@
+name:                foo
+version:             0.0.0
+synopsis:            foo
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  exposed-modules:   Foo
+  build-depends:     base
+  default-language:  Haskell2010


### PR DESCRIPTION
Catch permission denied exception in findFiles function and ignore such
directories.

In my project I have directory with content of linux container. After running `stack init` command I got an error "Permission denied" on this directory.

Fixed such behavior and added test for this usecase.