### PR TITLE
Add a symlink to the last install directory #391

### DIFF
--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -644,6 +644,16 @@ installationRootLocal = do
     platform <- platformRelDir
     return $ configProjectWorkDir bc </> $(mkRelDir "install") </> platform </> name </> ghc
 
+-- | Location of symlink which points to the last local installation
+-- root.  This path points to a file, since operations like symlink
+-- removal use file operations.  This also discourages any stack code
+-- from using paths into this directory - instead
+-- 'installationRootLocal' should be used.
+lastInstallSymlink :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs File)
+lastInstallSymlink = do
+   bc <- asks getBuildConfig
+   return $ configProjectWorkDir bc </> $(mkRelFile "install/last")
+
 -- | Package database for installing dependencies into
 packageDatabaseDeps :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs Dir)
 packageDatabaseDeps = do

--- a/stack.cabal
+++ b/stack.cabal
@@ -146,6 +146,7 @@ library
                    , time >= 1.4.2
                    , transformers >= 0.3.0.0
                    , transformers-base >= 0.4.4
+                   , unix-compat
                    , unordered-containers >= 0.2.5.1
                    , vector >= 0.10.12.3
                    , vector-binary-instances


### PR DESCRIPTION
This implements the feature discussed in #391.

It creates a symlink from `.stack-work/install/last` at the beginning of executing the build plan.  I found `last` to be a more sensible name for this directory than the name choice of `latest` from the issue.

Since `.stack-work/dist/<platform>/<cabal>/` also exists, I added a `.stack-work/dist/last` directory as well, for consistency, though it seems less useful than the install directory symlink.