### PR TITLE
Remove usage of `ByteString.breakByte`

### DIFF
--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -378,7 +378,7 @@ eachPair inner =
     start' bs1 =
         toConsumer (valSrc =$= inner key) >>= yield >> start
       where
-        (key, bs2) = S.breakByte _colon bs1
+        (key, bs2) = S.break (== _colon) bs1
         (spaces, bs3) = S.span (== _space) $ S.drop 1 bs2
         indent = S.length key + 1 + S.length spaces
 


### PR DESCRIPTION
Warning and solution printed during compilation:
```
Deprecated: "It is an internal function and should never have been
exported. Use 'break (== x)' instead. (There are rewrite rules that
handle this special case of 'break'.)"
```