### PR TITLE
Add --prune to `stack dot`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
-* Add --ignore-subdirs flag to init command [#435](https://github.com/commercialhaskell/stack/pull/435)
+* Add `--prune` flag to `stack dot` [#487](https://github.com/commercialhaskell/stack/issues/487)
+* Add `--[no-]external`,`--[no-]include-base` flags to `stack dot` [#437](https://github.com/commercialhaskell/stack/issues/437)
+* Add `--ignore-subdirs` flag to init command [#435](https://github.com/commercialhaskell/stack/pull/435)
 * Handle attempt to use non-existing resolver [#436](https://github.com/commercialhaskell/stack/pull/436)
 * Add `--force` flag to `init` command
 * exec style commands accept the `--package` option (see [Reddit discussion](http://www.reddit.com/r/haskell/comments/3bd66h/stack_runghc_turtle_as_haskell_script_solution/))

--- a/stack.cabal
+++ b/stack.cabal
@@ -205,6 +205,7 @@ test-suite stack-test
                 , Stack.BuildPlanSpec
                 , Stack.Build.ExecuteSpec
                 , Stack.ConfigSpec
+                , Stack.DotSpec
                 , Stack.PackageDumpSpec
                 , Stack.ArgsSpec
                 , Network.HTTP.Download.VerifiedSpec
@@ -229,6 +230,7 @@ test-suite stack-test
                 , text
                 , optparse-applicative
                 , bytestring
+                , QuickCheck
   default-language:    Haskell2010
 
 test-suite stack-integration-test

--- a/stack.cabal
+++ b/stack.cabal
@@ -141,6 +141,7 @@ library
                    , process >= 1.2.0.0
                    , resourcet >= 1.1.4.1
                    , safe >= 0.3
+                   , split
                    , stm >= 2.4.4
                    , streaming-commons >= 0.1.10.0
                    , tar >= 0.4.1.0


### PR DESCRIPTION
TL;DR: Add `--prune p1,p2,p3` to `stack dot` to remove nodes from the dependency graph


### The Motivation

Playing around with some haskell projects and their `stack dot` graphs, it becomes apparent that it it a little hard to look at them because they get quite huge.  As an example, take the graph for `wreq` generated by `stack dot --external --no-include-base`:
![wreq](https://cloud.githubusercontent.com/assets/591567/8476380/0d8755f2-20c1-11e5-8790-b359de33660d.png)

okay that is a LOT.  Looking a bit more we see that `wreq-examples` is also there which depends on a bunch of the dependencies.

The new feature is that `--prune` takes a comma separated list of package names that will be pruned.

So here is `wreq` without dependencies of `wreq-examples` and `lens`:
![wreq_pruned_lens](https://cloud.githubusercontent.com/assets/591567/8476761/935ca544-20c4-11e5-8e0b-6373aacc2024.png)
Still a lot but more manageable.

Of course we can have a dependency graph that is a little more focused by pruning more (randomly chosen) dependencies from the graph:

`stack dot --external --no-include-base --prune lens,wreq-examples,http-client,aeson,tls,http-client-tls`
![wreq_pruned](https://cloud.githubusercontent.com/assets/591567/8476413/6169a6d4-20c1-11e5-8258-c9b1bd6f9d64.png)

### The implementation
- new flag `--prune PACKAGE1,PACKAGE2,...`
- add pruning functionality to `Stack.Dot`
- properties in `DotSpec` for pruning
- new dependency for stack library: `split` *without* version bound, **do we need one**?
- new dependency in stack tests: QuickCheck, should not be questionable

### Help text for `stack dot`
```
Usage: stack dot ([--external] | [--no-external]) ([--include-base] |
                 [--no-include-base]) [--depth DEPTH] [--prune PACKAGES]
  Visualize your project's dependency graph using Graphviz dot

Available options:
  --external               Enable inclusion of external dependencies
  --no-external            Disable inclusion of external dependencies
  --include-base           Enable inclusion of dependencies on base
  --no-include-base        Disable inclusion of dependencies on base
  --depth DEPTH            Limit the depth of dependency resolution (Default: No
                           limit)
  --prune PACKAGES         Prune each package name from the comma separated list
                           of package names PACKAGES

```

PS: I also took the liberty to add the changes to CHANGELOG, or is this not wanted / do you prefer to do it yourself in the future?

