### PR TITLE
Implement `stack bench --benchmark-arguments`

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -123,7 +123,7 @@ printPlan finalAction plan = do
     let mfinalLabel =
             case finalAction of
                 DoNothing -> Nothing
-                DoBenchmarks -> Just "benchmark"
+                DoBenchmarks _ -> Just "benchmark"
                 DoTests _ -> Just "test"
     case mfinalLabel of
         Nothing -> return ()
@@ -405,8 +405,8 @@ toActions runInBase ee (mbuild, mfinal) =
     mfunc =
         case boptsFinalAction $ eeBuildOpts ee of
             DoNothing -> Nothing
-            DoTests rerunTests -> Just (singleTest rerunTests, checkTest)
-            DoBenchmarks -> Just (singleBench, checkBench)
+            DoTests topts -> Just (singleTest (toRerunSuccessful topts), checkTest)
+            DoBenchmarks _ -> Just (singleBench, checkBench)
 
     checkTest task =
         case taskType task of

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -701,7 +701,8 @@ singleTest topts ac ee task =
                     TTLocal lp -> lpDirtyFiles lp
                     _ -> assert False True) ||
                 not testBuilt
-            needHpc = boptsCoverage (eeBuildOpts ee)
+
+            needHpc = toCoverage topts
 
             componentsRaw =
                 case taskType task of
@@ -721,19 +722,19 @@ singleTest topts ac ee task =
             setTestBuilt pkgDir
 
         toRun <-
-            if (boptsNoTests (eeBuildOpts ee))
-                then do
-                    announce "Test running disabled by --no-run-tests flag."
-                    return False
-                else if toRerunTests topts
-                    then return True
-                    else do
-                        success <- checkTestSuccess pkgDir
-                        if success
-                            then do
-                                unless (null testsToRun) $ announce "skipping already passed test"
-                                return False
-                            else return True
+            if toDisableRun topts
+              then do
+                  announce "Test running disabled by --no-run-tests flag."
+                  return False
+              else if toRerunTests topts
+                  then return True
+                  else do
+                      success <- checkTestSuccess pkgDir
+                      if success
+                          then do
+                              unless (null testsToRun) $ announce "skipping already passed test"
+                              return False
+                          else return True
 
         when toRun $ do
             bconfig <- asks getBuildConfig

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -766,7 +766,7 @@ singleTest rerunTests ac ee task =
                                 $logWarn ("Removing HPC file " <> T.pack (toFilePath nameTix))
                             removeFileIfExists nameTix
 
-                        let args = boptsTestArgs (eeBuildOpts ee)
+                        let args = boptsAdditionalArgs (eeBuildOpts ee)
                             argsDisplay =
                                 case args of
                                   [] -> ""
@@ -897,8 +897,9 @@ singleBench ac ee task =
             cabal (console && configHideTHLoading config) ["build"]
             setBenchBuilt pkgDir
 
+        let args = boptsAdditionalArgs (eeBuildOpts ee)
         announce "benchmarks"
-        cabal False ["bench"]
+        cabal False ["bench","--benchmark-options=" <> unwords args]
 
 -- | Grab all output from the given @Handle@ and print it to stdout, stripping
 -- Template Haskell "Loading package" lines. Does work in a separate thread.

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -405,8 +405,8 @@ toActions runInBase ee (mbuild, mfinal) =
     mfunc =
         case boptsFinalAction $ eeBuildOpts ee of
             DoNothing -> Nothing
-            DoTests topts -> Just (singleTest (toRerunSuccessful topts), checkTest)
-            DoBenchmarks _ -> Just (singleBench, checkBench)
+            DoTests topts -> Just (singleTest topts, checkTest)
+            DoBenchmarks beopts -> Just (singleBench beopts, checkBench)
 
     checkTest task =
         case taskType task of
@@ -684,12 +684,12 @@ singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} =
             Set.empty
 
 singleTest :: M env m
-           => Bool -- ^ rerun tests?
+           => TestOpts
            -> ActionContext
            -> ExecuteEnv
            -> Task
            -> m ()
-singleTest rerunTests ac ee task =
+singleTest topts ac ee task =
     withSingleContext ac ee task $ \package cabalfp pkgDir cabal announce console mlogFile -> do
         (_cache, neededConfig) <- ensureConfig pkgDir ee task (announce "configure (test)") cabal cabalfp ["--enable-tests"]
         config <- asks getConfig
@@ -725,7 +725,7 @@ singleTest rerunTests ac ee task =
                 then do
                     announce "Test running disabled by --no-run-tests flag."
                     return False
-                else if rerunTests
+                else if toRerunTests topts
                     then return True
                     else do
                         success <- checkTestSuccess pkgDir
@@ -766,11 +766,10 @@ singleTest rerunTests ac ee task =
                                 $logWarn ("Removing HPC file " <> T.pack (toFilePath nameTix))
                             removeFileIfExists nameTix
 
-                        let args = boptsAdditionalArgs (eeBuildOpts ee)
-                            argsDisplay =
-                                case args of
-                                  [] -> ""
-                                  _ -> ", args: " <> T.intercalate " " (map showProcessArgDebug args)
+                        let args = toAdditionalArgs topts
+                            argsDisplay = case args of
+                                            [] -> ""
+                                            _ -> ", args: " <> T.intercalate " " (map showProcessArgDebug args)
                         announce $ "test (suite: " <> testName <> argsDisplay <> ")"
                         let cp = (proc (toFilePath exeName) args)
                                 { cwd = Just $ toFilePath pkgDir
@@ -872,11 +871,12 @@ generateHpcReport pkgDir hpcDir dotHpcDir tixes = do
             , ["--reset-hpcdirs"]]
 
 singleBench :: M env m
-            => ActionContext
+            => BenchmarkOpts
+            -> ActionContext
             -> ExecuteEnv
             -> Task
             -> m ()
-singleBench ac ee task =
+singleBench beopts ac ee task =
     withSingleContext ac ee task $ \_package cabalfp pkgDir cabal announce console _mlogFile -> do
         (_cache, neededConfig) <- ensureConfig pkgDir ee task (announce "configure (benchmarks)") cabal cabalfp ["--enable-benchmarks"]
 
@@ -896,10 +896,11 @@ singleBench ac ee task =
             config <- asks getConfig
             cabal (console && configHideTHLoading config) ["build"]
             setBenchBuilt pkgDir
-
-        let args = boptsAdditionalArgs (eeBuildOpts ee)
+        let args = maybe []
+                         ((:[]) . ("--benchmark-options=" <>))
+                         (beoAdditionalArgs beopts)
         announce "benchmarks"
-        cabal False ["bench","--benchmark-options=" <> unwords args]
+        cabal False ("bench" : args)
 
 -- | Grab all output from the given @Handle@ and print it to stdout, stripping
 -- Template Haskell "Loading package" lines. Does work in a separate thread.

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -206,7 +206,9 @@ loadLocals bopts latestVersion = do
                     case boptsFinalAction bopts of
                         DoTests _ -> wanted
                         _ -> False
-                , packageConfigEnableBenchmarks = wanted && boptsFinalAction bopts == DoBenchmarks
+                , packageConfigEnableBenchmarks = wanted && case boptsFinalAction bopts of
+                                                              (DoBenchmarks _) -> True
+                                                              _ -> False
                 }
         pkg <- readPackage config cabalfp
         pkgFinal <- readPackage configFinal cabalfp

--- a/src/Stack/Build/Types.hs
+++ b/src/Stack/Build/Types.hs
@@ -20,6 +20,8 @@ module Stack.Build.Types
     ,LocalPackage(..)
     ,BaseConfigOpts(..)
     ,Plan(..)
+    ,TestOpts(..)
+    ,BenchmarkOpts(..)
     ,FinalAction(..)
     ,BuildOpts(..)
     ,defaultBuildOpts
@@ -328,11 +330,21 @@ defaultBuildOpts = BuildOpts
     , boptsNoTests = False
     }
 
+-- | Options for the 'FinalAction' 'DoTests'
+data TestOpts =
+  TestOpts {toRerunTests :: !Bool -- ^ Whether successful tests will be run gain
+           ,toAdditionalArgs :: ![String] -- ^ Arguments passed to the test program
+           } deriving (Eq,Show)
+
+-- | Options for the 'FinalAction' 'DoBenchmarks'
+data BenchmarkOpts =
+  BenchmarkOpts {beoAdditionalArgs :: !(Maybe String) -- ^ Arguments passed to the benchmark program
+                } deriving (Eq,Show)
+
 -- | Run a Setup.hs action after building a package, before installing.
 data FinalAction
-  = DoTests
-      Bool -- rerun tests which already passed?
-  | DoBenchmarks
+  = DoTests TestOpts
+  | DoBenchmarks BenchmarkOpts
   | DoNothing
   deriving (Eq,Show)
 

--- a/src/Stack/Build/Types.hs
+++ b/src/Stack/Build/Types.hs
@@ -289,8 +289,8 @@ data BuildOpts =
             -- ^ Install executables to user path after building?
             ,boptsPreFetch :: !Bool
             -- ^ Fetch all packages immediately
-            ,boptsTestArgs :: ![String]
-            -- ^ Arguments to pass to the test suites if we're running them.
+            ,boptsAdditionalArgs :: ![String]
+            -- ^ Arguments to pass to the test/benchmark suites if we're running them.
             ,boptsOnlySnapshot :: !Bool
             -- ^ Only install packages in the snapshot database, skipping
             -- packages intended for the local database.
@@ -320,7 +320,7 @@ defaultBuildOpts = BuildOpts
     , boptsFlags = Map.empty
     , boptsInstallExes = False
     , boptsPreFetch = False
-    , boptsTestArgs = []
+    , boptsAdditionalArgs = []
     , boptsOnlySnapshot = False
     , boptsCoverage = False
     , boptsFileWatch = False

--- a/src/Stack/Build/Types.hs
+++ b/src/Stack/Build/Types.hs
@@ -294,15 +294,10 @@ data BuildOpts =
             ,boptsOnlySnapshot :: !Bool
             -- ^ Only install packages in the snapshot database, skipping
             -- packages intended for the local database.
-            ,boptsCoverage :: !Bool
-            -- ^ Enable code coverage report generation for test
-            -- suites.
             ,boptsFileWatch :: !Bool
             -- ^ Watch files for changes and automatically rebuild
             ,boptsKeepGoing :: !(Maybe Bool)
             -- ^ Keep building/running after failure
-            ,boptsNoTests :: !Bool
-            -- ^ If set, don't run the tests
             }
   deriving (Show)
 
@@ -321,16 +316,16 @@ defaultBuildOpts = BuildOpts
     , boptsInstallExes = False
     , boptsPreFetch = False
     , boptsOnlySnapshot = False
-    , boptsCoverage = False
     , boptsFileWatch = False
     , boptsKeepGoing = Nothing
-    , boptsNoTests = False
     }
 
 -- | Options for the 'FinalAction' 'DoTests'
 data TestOpts =
   TestOpts {toRerunTests :: !Bool -- ^ Whether successful tests will be run gain
            ,toAdditionalArgs :: ![String] -- ^ Arguments passed to the test program
+           ,toCoverage :: !Bool -- ^ Generate a code coverage report
+           ,toDisableRun :: !Bool -- ^ Disable running of tests
            } deriving (Eq,Show)
 
 -- | Options for the 'FinalAction' 'DoBenchmarks'

--- a/src/Stack/Build/Types.hs
+++ b/src/Stack/Build/Types.hs
@@ -291,8 +291,6 @@ data BuildOpts =
             -- ^ Install executables to user path after building?
             ,boptsPreFetch :: !Bool
             -- ^ Fetch all packages immediately
-            ,boptsAdditionalArgs :: ![String]
-            -- ^ Arguments to pass to the test/benchmark suites if we're running them.
             ,boptsOnlySnapshot :: !Bool
             -- ^ Only install packages in the snapshot database, skipping
             -- packages intended for the local database.
@@ -322,7 +320,6 @@ defaultBuildOpts = BuildOpts
     , boptsFlags = Map.empty
     , boptsInstallExes = False
     , boptsPreFetch = False
-    , boptsAdditionalArgs = []
     , boptsOnlySnapshot = False
     , boptsCoverage = False
     , boptsFileWatch = False

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -684,7 +684,7 @@ buildOpts :: Command -> Parser BuildOpts
 buildOpts cmd = fmap process $
             BuildOpts <$> target <*> libProfiling <*> exeProfiling <*>
             optimize <*> haddock <*> haddockDeps <*> finalAction <*> dryRun <*> ghcOpts <*>
-            flags <*> installExes <*> preFetch <*> additionalArgs <*> onlySnapshot <*> coverage <*>
+            flags <*> installExes <*> preFetch <*> onlySnapshot <*> coverage <*>
             fileWatch' <*> keepGoing <*> noTests
   where process bopts =
             if boptsCoverage bopts
@@ -746,21 +746,6 @@ buildOpts cmd = fmap process $
         preFetch = flag False True
             (long "prefetch" <>
              help "Fetch packages necessary for the build immediately, useful with --dry-run")
-        additionalArgs =
-             fmap (fromMaybe [])
-                  (case cmd of
-                     Test -> optional
-                                 (argsOption
-                                      (long "test-arguments" <> metavar "TEST_ARGS" <>
-                                       help "Arguments passed in to the test suite program"))
-                     Bench -> fmap (fmap (:[]))
-                                   (optional
-                                      (strOption
-                                      (long "benchmark-arguments" <>
-                                      metavar "BENCH_ARGS" <>
-                                      help ("Forward BENCH_ARGS to the benchmark suite." <>
-                                            "Supports templates from `cabal bench`"))))
-                     _ -> pure Nothing)
         onlySnapshot = flag False True
             (long "only-snapshot" <>
              help "Only build packages for the snapshot database, not the local database")


### PR DESCRIPTION
Implements #496.

I renamed the `boptsTestArgs` to `boptsAdditionalArgs` and use that field for both testing and benchmarking.  I also chose to use `--benchmark-arguments` instead of `--benchmark-options` because for tests it is `--test-arguments`.

With this `stack bench --benchmark-arguments='-o $benchmark.html --csv $benchmark.csv'` works as expected.