### PR TITLE
Add --no-tests parameter to stack test, which disables the running of tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.swp
 *.tag
 *~
+*_flymake.hs
 .hsenv
 .stack-work/
 /.cabal-sandbox/

--- a/src/Stack/Build/Types.hs
+++ b/src/Stack/Build/Types.hs
@@ -291,6 +291,8 @@ data BuildOpts =
             ,boptsCoverage :: !Bool
             -- ^ Enable code coverage report generation for test
             -- suites.
+            ,boptsNoTests :: !Bool
+            -- ^ If set, don't run the tests
             }
   deriving (Show)
 

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -43,6 +43,7 @@ dot = do
             , boptsTestArgs = []
             , boptsOnlySnapshot = False
             , boptsCoverage = False
+            , boptsNoTests = False
             }
         Map.empty
     let localNames = Set.fromList $ map (packageName . lpPackage) locals

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -88,4 +88,5 @@ upgrade fromGit mresolver = withSystemTempDirectory "stack-upgrade" $ \tmp' -> d
             , boptsTestArgs = []
             , boptsOnlySnapshot = False
             , boptsCoverage = False
+            , boptsNoTests = False
             }

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -590,7 +590,7 @@ buildOpts :: Command -> Parser BuildOpts
 buildOpts cmd = fmap process $
             BuildOpts <$> target <*> libProfiling <*> exeProfiling <*>
             optimize <*> haddock <*> haddockDeps <*> finalAction <*> dryRun <*> ghcOpts <*>
-            flags <*> installExes <*> preFetch <*> testArgs <*> onlySnapshot <*> coverage
+            flags <*> installExes <*> preFetch <*> testArgs <*> onlySnapshot <*> coverage <*> noTests
   where process bopts =
             if boptsCoverage bopts
                then bopts { boptsExeProfile = True
@@ -668,6 +668,12 @@ buildOpts cmd = fmap process $
                then flag False True
                         (long "coverage" <>
                          help "Generate a code coverage report")
+               else pure False
+        noTests =
+            if cmd == Test
+               then flag False True
+                        (long "no-tests" <>
+                         help "Disable running of tests")
                else pure False
 
 -- | Parser for docker cleanup arguments.


### PR DESCRIPTION
The addresses #430. I've also split out the actual "run tests" part of `singleTest`. I can undo that if you'd prefer.