### PR TITLE
Add --no-tests parameter to stack test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.swp
 *.tag
 *~
+*_flymake.hs
 .hsenv
 .stack-work/
 /.cabal-sandbox/

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -721,15 +721,19 @@ singleTest rerunTests ac ee task =
             setTestBuilt pkgDir
 
         toRun <-
-            if rerunTests
-                then return True
-                else do
-                    success <- checkTestSuccess pkgDir
-                    if success
-                        then do
-                            unless (null testsToRun) $ announce "skipping already passed test"
-                            return False
-                        else return True
+            if (boptsNoTests (eeBuildOpts ee))
+                then do
+                    announce "Test running disabled by --no-tests flag."
+                    return False
+                else if rerunTests
+                    then return True
+                    else do
+                        success <- checkTestSuccess pkgDir
+                        if success
+                            then do
+                                unless (null testsToRun) $ announce "skipping already passed test"
+                                return False
+                            else return True
 
         when toRun $ do
             bconfig <- asks getBuildConfig

--- a/src/Stack/Build/Types.hs
+++ b/src/Stack/Build/Types.hs
@@ -301,6 +301,8 @@ data BuildOpts =
             -- ^ Watch files for changes and automatically rebuild
             ,boptsKeepGoing :: !(Maybe Bool)
             -- ^ Keep building/running after failure
+            ,boptsNoTests :: !Bool
+            -- ^ If set, don't run the tests
             }
   deriving (Show)
 
@@ -323,6 +325,7 @@ defaultBuildOpts = BuildOpts
     , boptsCoverage = False
     , boptsFileWatch = False
     , boptsKeepGoing = Nothing
+    , boptsNoTests = False
     }
 
 -- | Run a Setup.hs action after building a package, before installing.

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -669,7 +669,7 @@ buildOpts cmd = fmap process $
             BuildOpts <$> target <*> libProfiling <*> exeProfiling <*>
             optimize <*> haddock <*> haddockDeps <*> finalAction <*> dryRun <*> ghcOpts <*>
             flags <*> installExes <*> preFetch <*> testArgs <*> onlySnapshot <*> coverage <*>
-            fileWatch' <*> keepGoing
+            fileWatch' <*> keepGoing <*> noTests
   where process bopts =
             if boptsCoverage bopts
                then bopts { boptsExeProfile = True
@@ -747,6 +747,12 @@ buildOpts cmd = fmap process $
                then flag False True
                         (long "coverage" <>
                          help "Generate a code coverage report")
+               else pure False
+        noTests =
+            if cmd == Test
+               then flag False True
+                        (long "no-run-tests" <>
+                         help "Disable running of tests. (Tests will still be built.)")
                else pure False
 
         fileWatch' = flag False True


### PR DESCRIPTION
New version of the PR addressing #430. Piggybacks on the `toRun` concept introduced in the last week now. No large scale splitting out of existing code. 