### PR TITLE
Flip order of build and test/bench opts parser

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -99,18 +99,18 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter ->
                         (buildOpts Build)
              addCommand "test"
                         "Build and test the project(s) in this directory/configuration"
-                        (\(topts, bopts) ->
+                        (\(bopts, topts) ->
                              let bopts' = if toCoverage topts
                                              then bopts { boptsExeProfile = True
                                                         , boptsLibProfile = True
                                                         , boptsGhcOptions = "-fhpc" : boptsGhcOptions bopts}
                                              else bopts
                              in buildCmd (DoTests topts) bopts')
-                        ((,) <$> testOpts <*> buildOpts Test)
+                        ((,) <$> buildOpts Test <*> testOpts)
              addCommand "bench"
                         "Build and benchmark the project(s) in this directory/configuration"
-                        (\(beopts, bopts) -> buildCmd (DoBenchmarks beopts) bopts)
-                        ((,) <$> benchOpts <*> buildOpts Bench)
+                        (\(bopts, beopts) -> buildCmd (DoBenchmarks beopts) bopts)
+                        ((,) <$> buildOpts Bench <*> benchOpts)
              addCommand "haddock"
                         "Generate haddocks for the project(s) in this directory/configuration"
                         (buildCmd DoNothing)


### PR DESCRIPTION
Just noticed that the arguments parser order matters for the `--help` flag.  Due to #512 currently the specific flags are at the front, e.g.

```
stack bench -h
Usage: stack bench [--benchmark-arguments BENCH_ARGS] [TARGET]
                   ([--library-profiling] | [--no-library-profiling])
                   ([--executable-profiling] | [--no-executable-profiling])
                   ([--optimizations] | [--no-optimizations]) ([--haddock] |
                   [--no-haddock]) [--dry-run] [--pedantic]
                   [--ghc-options OPTION] [--flag PACKAGE:[-]FLAG] [--prefetc
h]
                   [--only-snapshot] [--file-watch] ([--keep-going] |
                   [--no-keep-going])
  Build and benchmark the project(s) in this directory/configuration
```

notice the `[--benchmark-arguments BENCH_ARGS]` before `[TARGET]`, I think it looks better like this (which is why this pr flips the order):

```
stack bench -h
Usage: stack bench [TARGET] ([--library-profiling] | [--no-library-profiling]
)
                   ([--executable-profiling] | [--no-executable-profiling])
                   ([--optimizations] | [--no-optimizations]) ([--haddock] |
                   [--no-haddock]) [--dry-run] [--pedantic]
                   [--ghc-options OPTION] [--flag PACKAGE:[-]FLAG] [--prefetc
h]
                   [--only-snapshot] [--file-watch] ([--keep-going] |
                   [--no-keep-going]) [--benchmark-arguments BENCH_ARGS]
  Build and benchmark the project(s) in this directory/configuration
```