### PR TITLE
Use `value` instead of fromMaybe for arguments

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -183,14 +183,15 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter ->
                               (many (strArgument
                                        (metavar "TARGET" <>
                                         help "If none specified, use all packages defined in current directory"))) <*>
-                         fmap (fromMaybe [])
-                              (optional (argsOption (long "ghc-options" <>
-                                                     metavar "OPTION" <>
-                                                     help "Additional options passed to GHCi"))) <*>
-                         fmap (fromMaybe "ghc")
-                              (optional (strOption (long "with-ghc" <>
-                                                    metavar "GHC" <>
-                                                    help "Use this command for the GHC to run"))) <*>
+                         argsOption (long "ghc-options" <>
+                                      metavar "OPTION" <>
+                                      help "Additional options passed to GHCi" <>
+                                      value []) <*>
+                         strOption (long "with-ghc" <>
+                                    metavar "GHC" <>
+                                    help "Use this command for the GHC to run" <>
+                                    value "ghc" <>
+                                    showDefault) <*>
                          flag False True (long "no-load" <>
                                          help "Don't load modules on start-up") <*>
                          packagesParser)
@@ -202,10 +203,10 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter ->
                               (many (strArgument
                                        (metavar "TARGET" <>
                                         help "If none specified, use all packages defined in current directory"))) <*>
-                         fmap (fromMaybe [])
-                              (optional (argsOption (long "ghc-options" <>
-                                                     metavar "OPTION" <>
-                                                     help "Additional options passed to GHCi"))))
+                         argsOption (long "ghc-options" <>
+                                     metavar "OPTION" <>
+                                     help "Additional options passed to GHCi" <>
+                                     value []))
              addCommand "runghc"
                         "Run runghc"
                         execCmd
@@ -682,10 +683,10 @@ testOpts = TestOpts
                      "rerun-tests"
                      "running already successful tests"
                      idm
-       <*> fmap (fromMaybe [])
-                (optional (argsOption(long "test-arguments" <>
-                                      metavar "TEST_ARGS" <>
-                                      help "Arguments passed in to the test suite program")))
+       <*> argsOption(long "test-arguments" <>
+                      metavar "TEST_ARGS" <>
+                      help "Arguments passed in to the test suite program" <>
+                      value [])
       <*> flag False
                True
                (long "coverage" <>


### PR DESCRIPTION
Instead of using the pattern:

```haskell
fmap (fromMaybe "default value")
     (optional (_parser (_meta)))
```

we can use `optparse-applicative`'s [value](http://hackage.haskell.org/package/optparse-applicative-0.11.0.2/docs/Options-Applicative-Builder.html#v:value) function to specify a default value:

```haskell
_parser (_meta <> value "default value")
```

This is the benefit of being able to show defaults automatically by enabling it with [showDefault](http://hackage.haskell.org/package/optparse-applicative-0.11.0.2/docs/Options-Applicative-Builder.html#v:showDefault) in the help text, e.g. for `stack ghci --help` we now get (note the help for `--with-ghc`):

```
Usage: stack ghci [TARGET] [--ghc-options OPTION] [--with-ghc GHC] [--no-load]
                  [--package ARG]
  Run ghci in the context of project(s)

Available options:
  TARGET                   If none specified, use all packages defined in
                           current directory
  --ghc-options OPTION     Additional options passed to GHCi
  --with-ghc GHC           Use this command for the GHC to run (default: "ghc")
  --no-load                Don't load modules on start-up
  --package ARG            Additional packages that must be installed
```