### PR TITLE
Propose fuzzy-matched versions

### DIFF
--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -62,7 +62,7 @@ import           Data.Typeable                  (Typeable)
 import           Data.Word                      (Word64)
 import           Network.HTTP.Download
 import           Path
-import           Prelude
+import           Prelude -- Fix AMP warning
 import           Stack.GhcPkg
 import           Stack.PackageIndex
 import           Stack.Types


### PR DESCRIPTION
Fixes #504.

When you get a "Didn't see pkg-<ver> in your package indices" message,
also see list of candidates with same major version. Might be that you
forgot some minor thing like ".0" in the end of a version string.