### PR TITLE
Use `retry` package for download retry logic

### DIFF
--- a/src/Network/HTTP/Download.hs
+++ b/src/Network/HTTP/Download.hs
@@ -4,7 +4,7 @@
 module Network.HTTP.Download
     ( verifiedDownload
     , DownloadRequest(..)
-    , drRetriesDefault
+    , drRetryPolicyDefault
     , HashCheck(..)
     , CheckHexDigest(..)
     , LengthCheck
@@ -70,7 +70,7 @@ download req destpath = do
             { drRequest = req
             , drHashChecks = []
             , drLengthCheck = Nothing
-            , drRetries = drRetriesDefault
+            , drRetryPolicy = drRetryPolicyDefault
             }
     let progressHook = return ()
     verifiedDownload downloadReq destpath progressHook

--- a/src/Network/HTTP/Download/Verified.hs
+++ b/src/Network/HTTP/Download/Verified.hs
@@ -91,8 +91,6 @@ data VerifiedDownloadException
           String -- algorithm
           CheckHexDigest -- expected
           String -- actual (shown)
-    | ZeroTries
-          Request
   deriving (Typeable)
 instance Show VerifiedDownloadException where
     show (WrongContentLength req expected actual) =
@@ -109,10 +107,6 @@ instance Show VerifiedDownloadException where
         "Download expectation failure: content hash (" ++ algo ++  ")\n"
         ++ "Expected: " ++ displayCheckHexDigest expected ++ "\n"
         ++ "Actual:   " ++ actual ++ "\n"
-        ++ "For: " ++ show (getUri req)
-    show (ZeroTries req) =
-        "Download expectation failure:\n"
-        ++ "Download was needed but <= 0 retries were requested.\n"
         ++ "For: " ++ show (getUri req)
 
 instance Exception VerifiedDownloadException

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -397,7 +397,7 @@ fetchPackages' mdistDir toFetchAll = do
                 { drRequest = req
                 , drHashChecks = map toHashCheck $ maybeToList (tfSHA512 toFetch)
                 , drLengthCheck = fmap fromIntegral $ tfSize toFetch
-                , drRetries = drRetriesDefault
+                , drRetryPolicy = drRetryPolicyDefault
                 }
         let progressSink = do
                 liftIO $ runInBase $ $logInfo $ packageIdentifierText ident <> ": download"

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -47,7 +47,7 @@ import qualified Data.Yaml as Yaml
 import           Distribution.System (OS (..), Arch (..), Platform (..))
 import           Distribution.Text (simpleParse)
 import           Network.HTTP.Client.Conduit
-import           Network.HTTP.Download (verifiedDownload, DownloadRequest(..), drRetriesDefault)
+import           Network.HTTP.Download (verifiedDownload, DownloadRequest(..), drRetryPolicyDefault)
 import           Path
 import           Path.IO
 import           Prelude -- Fix AMP warning
@@ -695,7 +695,7 @@ chattyDownload label url path = do
             { drRequest = req
             , drHashChecks = []
             , drLengthCheck = Nothing
-            , drRetries = drRetriesDefault
+            , drRetryPolicy = drRetryPolicyDefault
             }
     runInBase <- liftBaseWith $ \run -> return (void . run)
     x <- verifiedDownload dReq path (chattyDownloadProgress runInBase)

--- a/src/test/Network/HTTP/Download/VerifiedSpec.hs
+++ b/src/test/Network/HTTP/Download/VerifiedSpec.hs
@@ -4,6 +4,7 @@ module Network.HTTP.Download.VerifiedSpec where
 import Crypto.Hash
 import Control.Monad (unless)
 import Control.Monad.Trans.Reader
+import Control.Retry (limitRetries)
 import Data.Maybe
 import Network.HTTP.Client.Conduit
 import Network.HTTP.Download.Verified
@@ -34,7 +35,7 @@ exampleReq = fromMaybe (error "exampleReq") $ do
         { drRequest = req
         , drHashChecks = [exampleHashCheck]
         , drLengthCheck = Just exampleLengthCheck
-        , drRetries = 1
+        , drRetryPolicy = limitRetries 1
         }
 
 exampleHashCheck :: HashCheck
@@ -155,7 +156,7 @@ spec = beforeAll setup $ afterAll teardown $ do
             { drRequest = req
             , drHashChecks = []
             , drLengthCheck = Nothing
-            , drRetries = 1
+            , drRetryPolicy = limitRetries 1
             }
       let progressHook = return ()
       let go = runWith manager $ verifiedDownload dReq dest progressHook

--- a/stack.cabal
+++ b/stack.cabal
@@ -237,6 +237,7 @@ test-suite stack-test
                 , optparse-applicative
                 , bytestring
                 , QuickCheck
+                , retry >= 0.6
   default-language:    Haskell2010
 
 test-suite stack-integration-test

--- a/stack.cabal
+++ b/stack.cabal
@@ -144,6 +144,7 @@ library
                    , pretty
                    , process >= 1.2.0.0
                    , resourcet >= 1.1.4.1
+                   , retry >= 0.6
                    , safe >= 0.3
                    , split
                    , stm >= 2.4.4


### PR DESCRIPTION
I hope @DanBurton doesn't mind me stealing his todos ;)

Background: I saw the todo in `Network.HTTP.Download.Verified`:
```
-- TODO(DanBurton): use Control.Retry instead.
```
and I didn't know that package but I also had some personal code where I went with the custom `retry` function approach so I was curious about `Control.Retry`.  Turns out the `retry` package is pretty nice!

Changes:
1. add dependency on `retry >= 0.6` because the retry policy was improved starting with 0.6
2. replace the custom retry function with [Control.Retry.recovering](http://hackage.haskell.org/package/retry-0.6/docs/Control-Retry.html#v:recovering), using `limitRetries 3` as policy, so no delay (**do we want delay?**)
3. **remove the `ZeroRetries` constructor from `VerifiedDownloadException`**

The semantics of the old `retry` function should be kept, e.g. the last exception is rethrown by `recovering` if all retries fail.

My understanding of 3.:
The `ZeroRetries` case was meant to be used in case the number of retries is <= 0.  But from my point of view that is not a problem even if it is negative: that just means we won't *retry* the action at all.  Due to this reasoning I just removed it completely. If I got anything wrong please correct me here.