### PR TITLE
Allow "--force" with `stack new` (#575)

### DIFF
--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -199,7 +199,7 @@ data InitOpts = InitOpts
     { ioMethod :: !Method
     -- ^ Preferred snapshots
     , forceOverwrite :: Bool
-    -- ^ Force overwrite of existing stack.yaml
+    -- ^ Overwrite existing files
     , includeSubDirs :: Bool
     -- ^ If True, include all .cabal files found in any sub directories
     }

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -24,19 +24,22 @@ import           System.FilePath        (takeDirectory,
 import           Text.Hastache
 import           Text.Hastache.Context
 
+import           Stack.Init (InitOpts(forceOverwrite))
+
 newProject :: (MonadIO m, MonadLogger m)
-           => m ()
-newProject = do
+           => InitOpts
+           -> m ()
+newProject initOpts = do
     $logInfo "NOTE: Currently stack new functionality is very rudimentary"
     $logInfo "There are plans to make this feature more useful in the future"
     $logInfo "For more information, see: https://github.com/commercialhaskell/stack/issues/137"
     $logInfo "For now, we'll just be generating a basic project structure in your current directory"
 
     exist <- filterM (liftIO . doesFileExist) (Map.keys files)
-    unless (null exist) $
-        error $ unlines
-            $ "The following files already exist, refusing to overwrite:"
-            : map ("- " ++) exist
+    unless (forceOverwrite initOpts || null exist) $
+       error $ unlines
+           $ "The following files already exist, refusing to overwrite (no --force):"
+           : map ("- " ++) exist
 
     $logInfo ""
 

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -915,7 +915,7 @@ initCmd initOpts go = withConfig go $ initProject initOpts
 -- | Project creation
 newCmd :: InitOpts -> GlobalOpts -> IO ()
 newCmd initOpts go@GlobalOpts{..} = withConfig go $ do
-    newProject
+    newProject initOpts
     initProject initOpts
 
 -- | Fix up extra-deps for a project


### PR DESCRIPTION
Resolves #575.

`new` was already using the `initOptsParser` which has the `forceOverwrite` option, so I just forwarded that to `Stack.New.newProject` and check for that options value before refusing the overwrite.