### PR TITLE
Log LevelError and LevelWarn to stderr

### DIFF
--- a/src/Stack/Types/StackT.hs
+++ b/src/Stack/Types/StackT.hs
@@ -224,8 +224,11 @@ loggerFunc loc _src level msg =
   do maxLogLevel <- asks getLogLevel
      when (level >= maxLogLevel)
           (liftIO (do out <- getOutput maxLogLevel
-                      S8.putStrLn (S8.pack out)))
-  where getOutput maxLogLevel =
+                      S8.hPutStrLn outputChannel (S8.pack out)))
+  where outputChannel = if level `elem` [LevelError,LevelWarn]
+                           then stderr
+                           else stdout
+        getOutput maxLogLevel =
           do date <- getDate
              l <- getLevel
              lc <- getLoc


### PR DESCRIPTION
Usurpation of #446.

Assumption: Only `LevelError` and `LevelWarn` are logged to stderr, the rest (`LevelInfo`, `LevelOther "sticky[-done]"` and **`LevelDebug`**) go to stdout. Or should `LevelDebug` go to stderr as well?