### PR TITLE
Make `stack path` output independent of logging. (Issue #604)

### DIFF
--- a/src/Stack/Types/StackT.hs
+++ b/src/Stack/Types/StackT.hs
@@ -225,9 +225,7 @@ loggerFunc loc _src level msg =
      when (level >= maxLogLevel)
           (liftIO (do out <- getOutput maxLogLevel
                       S8.hPutStrLn outputChannel (S8.pack out)))
-  where outputChannel = if level `elem` [LevelError,LevelWarn]
-                           then stderr
-                           else stdout
+  where outputChannel = stderr
         getOutput maxLogLevel =
           do date <- getDate
              l <- getLevel

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -307,7 +307,7 @@ pathCmd keys go =
                            null keys || elem key keys)
                      paths)
                 (\(_,key,path) ->
-                      $logInfo
+                      liftIO $ T.putStrLn
                           ((if length keys == 1
                                then ""
                                else key <> ": ") <>


### PR DESCRIPTION
E.g.

    $ (export STACK_YAML=stack.yaml && stack path --local-install-root)
    Getting project config file from STACK_YAML environment
    /home/conathan/Desktop/mirrored/stack-fix/stack.git/.stack-work/install/x86_64-linux/lts-2.17/7.8.4

    $ (export STACK_YAML=stack.yaml && stack --verbosity silent path --local-install-root)
    /home/conathan/Desktop/mirrored/stack-fix/stack.git/.stack-work/install/x86_64-linux/lts-2.17/7.8.4

but I still think it's a good idea to also send log messages to stderr.