### PR TITLE
Improve `stack setup --help` output.

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -125,7 +125,7 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter ->
                         solverCmd
                         solverOptsParser
              addCommand "setup"
-                        "Get the appropriate ghc for your project"
+                        "Get the appropriate GHC for your project"
                         setupCmd
                         setupParser
              addCommand "path"
@@ -404,7 +404,10 @@ data SetupCmdOpts = SetupCmdOpts
 
 setupParser :: Parser SetupCmdOpts
 setupParser = SetupCmdOpts
-    <$> (optional $ argument readVersion (metavar "VERSION"))
+    <$> (optional $ argument readVersion
+            (metavar "GHC_MAJOR_VERSION" <>
+             help ("Major version of GHC to install, e.g. 7.10. " ++
+                   "The default is to install the version implied by the resolver.")))
     <*> boolFlags False
             "reinstall"
             "Reinstall GHC, even if available (implies no-system-ghc)"


### PR DESCRIPTION
It was not clear to me what `VERSION` meant -- it had no documentation
-- so I changed it to `GHC_MAJOR_VERSION` and added documentation.

Before:

    $ stack setup --help
    Usage: stack setup [VERSION] ([--reinstall] | [--no-reinstall])
      Get the appropriate ghc for your project

    Available options:
      --reinstall              Enable Reinstall GHC, even if available (implies
                               no-system-ghc)
      --no-reinstall           Disable Reinstall GHC, even if available (implies
                               no-system-ghc)

After:

    $ stack setup --help
    Usage: stack setup [GHC_MAJOR_VERSION] ([--reinstall] | [--no-reinstall])
      Get the appropriate GHC for your project

    Available options:
      GHC_MAJOR_VERSION        Major version of GHC to install, e.g. 7.10. The
                               default is to install the version implied by the
                               resolver.
      --reinstall              Enable Reinstall GHC, even if available (implies
                               no-system-ghc)
      --no-reinstall           Disable Reinstall GHC, even if available (implies
                               no-system-ghc)

Related, I was also surprised that e.g. `stack setup 7.10` fails when `STACK_YAML` points to a broken stack.yaml file. Would it make sense for `stack setup` to ignore the `STACK_YAML` when an explicit GHC version is specified?