### PR TITLE
Use Setup.hs to get sdist list + add tar.gz code #313

### DIFF
--- a/src/Path/IO.hs
+++ b/src/Path/IO.hs
@@ -4,6 +4,8 @@
 
 module Path.IO
   (getWorkingDir
+  ,parseRelAsAbsDir
+  ,parseRelAsAbsFile
   ,listDirectory
   ,resolveDir
   ,resolveFile
@@ -57,6 +59,16 @@ instance Show ResolveException where
 -- | Get the current working directory.
 getWorkingDir :: (MonadIO m) => m (Path Abs Dir)
 getWorkingDir = liftIO (D.canonicalizePath "." >>= parseAbsDir)
+
+-- | Parse a directory path. If it's relative, then the absolute version
+-- is yielded, based off the working directory.
+parseRelAsAbsDir :: (MonadThrow m, MonadIO m) => FilePath -> m (Path Abs Dir)
+parseRelAsAbsDir fp = parseAbsDir =<< liftIO (D.canonicalizePath fp)
+
+-- | Parse a file path. If it's relative, then the absolute version is
+-- yielded, based off the working directory.
+parseRelAsAbsFile :: (MonadThrow m, MonadIO m) => FilePath -> m (Path Abs File)
+parseRelAsAbsFile fp = parseAbsFile =<< liftIO (D.canonicalizePath fp)
 
 -- | Appends a stringly-typed relative path to an absolute path, and then
 -- canonicalizes it.

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -15,7 +15,8 @@
 module Stack.Build
   (build
   ,clean
-  ,withLoadPackage)
+  ,withLoadPackage
+  ,mkBaseConfigOpts)
   where
 
 import           Control.Monad

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -14,8 +14,8 @@ module Stack.Build.Execute
     ) where
 
 import           Control.Applicative            ((<$>), (<*>))
-import           Control.Concurrent.Lifted (fork)
 import           Control.Concurrent.Execute
+import           Control.Concurrent.Lifted      (fork)
 import           Control.Concurrent.MVar.Lifted
 import           Control.Concurrent.STM
 import           Control.Exception.Enclosed     (tryIO)

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -793,16 +793,13 @@ getCabalFileName pkgDir = do
 
 -- | Path for the package's build log.
 buildLogPath :: (MonadReader env m, HasBuildConfig env, MonadThrow m)
-             => Package -> m (Path Abs File)
-buildLogPath package' = do
+             => Package -> Maybe String -> m (Path Abs File)
+buildLogPath package' msuffix = do
   env <- ask
   let stack = configProjectWorkDir env
-  fp <- parseRelFile $ concat
-    [ packageNameString $ packageName package'
-    , "-"
-    , versionString $ packageVersion package'
-    , ".log"
-    ]
+  fp <- parseRelFile $ concat $
+    (packageIdentifierString (packageIdentifier package')) :
+    (maybe id (\suffix -> ("-" :) . (suffix :)) msuffix) [".log"]
   return $ stack </> $(mkRelDir "logs") </> fp
 
 -- Internal helper to define resolveFileOrWarn and resolveDirOrWarn

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TemplateHaskell       #-}
+-- Create a source distribution tarball
+module Stack.SDist
+    ( getSDistTarball
+    ) where
+
+import qualified Codec.Archive.Tar as Tar
+import qualified Codec.Archive.Tar.Entry as Tar
+import qualified Codec.Compression.GZip as GZip
+import           Control.Applicative ((<$>))
+import           Control.Concurrent.Execute (ActionContext(..))
+import           Control.Monad (when)
+import           Control.Monad.Catch (MonadCatch, MonadMask)
+import           Control.Monad.IO.Class
+import           Control.Monad.Logger
+import           Control.Monad.Reader (MonadReader, asks)
+import           Control.Monad.Trans.Resource
+import qualified Data.ByteString.Lazy as L
+import           Data.Either (partitionEithers)
+import           Data.List
+import qualified Data.Map.Strict as Map
+import           Data.Monoid ((<>))
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import           Network.HTTP.Client.Conduit (HasHttpManager)
+import           Path
+import           Path.IO
+import           Stack.Build (mkBaseConfigOpts)
+import           Stack.Build.Execute
+import           Stack.Build.Source (loadSourceMap, localFlags)
+import           Stack.Build.Types
+import           Stack.Constants
+import           Stack.Package
+import           Stack.Types
+import           Stack.Types.Internal
+import qualified System.FilePath as FP
+import           System.IO.Temp (withSystemTempDirectory)
+
+type M env m = (MonadIO m,MonadReader env m,HasHttpManager env,HasBuildConfig env,MonadLogger m,MonadBaseControl IO m,MonadCatch m,MonadMask m,HasLogLevel env,HasEnvConfig env,HasTerminal env)
+
+-- | Given the path to a local package, creates its source
+-- distribution tarball.
+--
+-- While this yields a 'FilePath', the name of the tarball, this
+-- tarball is not written to the disk and instead yielded as a lazy
+-- bytestring.
+getSDistTarball :: M env m => FilePath -> m (FilePath, L.ByteString)
+getSDistTarball pkgDir = do
+    pkgDir' <- parseRelAsAbsDir pkgDir
+    lp <- readLocalPackage pkgDir'
+    $logInfo $ "Getting file list for " <> T.pack pkgDir
+    fileList <-  getSDistFileList lp
+    $logInfo $ "Building sdist tarball for " <> T.pack pkgDir
+    files <- normalizeTarballPaths (lines fileList)
+    liftIO $ do
+        -- NOTE: Could make this use lazy I/O to only read files as needed
+        -- for upload (both GZip.compress and Tar.write are lazy).
+        -- However, it seems less error prone and more predictable to read
+        -- everything in at once, so that's what we're doing for now:
+        let packWith f isDir fp =
+               f (pkgDir FP.</> fp)
+                 (either error id (Tar.toTarPath isDir (pkgId FP.</> fp)))
+            tarName = pkgId FP.<.> "tar.gz"
+            pkgId = packageIdentifierString (packageIdentifier (lpPackage lp))
+        dirEntries <- mapM (packWith Tar.packDirectoryEntry True) (dirsFromFiles files)
+        fileEntries <- mapM (packWith Tar.packFileEntry False) files
+        return (tarName, GZip.compress (Tar.write (dirEntries ++ fileEntries)))
+
+-- Read in a 'LocalPackage' config.  This makes some default decisions
+-- about 'LocalPackage' fields that might not be appropriate for other
+-- usecases.
+--
+-- TODO: Dedupe with similar code in "Stack.Build.Source".
+readLocalPackage :: M env m => Path Abs Dir -> m LocalPackage
+readLocalPackage pkgDir = do
+    econfig <- asks getEnvConfig
+    bconfig <- asks getBuildConfig
+    cabalfp <- getCabalFileName pkgDir
+    name <- parsePackageNameFromFilePath cabalfp
+    let config = PackageConfig
+            { packageConfigEnableTests = False
+            , packageConfigEnableBenchmarks = False
+            , packageConfigFlags = localFlags Map.empty bconfig name
+            , packageConfigGhcVersion = envConfigGhcVersion econfig
+            , packageConfigPlatform = configPlatform $ getConfig bconfig
+            }
+    package <- readPackage config cabalfp
+    return LocalPackage
+        { lpPackage = package
+        , lpWanted = False -- HACK: makes it so that sdist output goes to a log instead of a file.
+        , lpDir = pkgDir
+        , lpCabalFile = cabalfp
+        -- NOTE: these aren't the 'correct values, but aren't used in
+        -- the usage of this function in this module.
+        , lpPackageFinal = package
+        , lpDirtyFiles = True
+        , lpNewBuildCache = Map.empty
+        , lpFiles = Set.empty
+        , lpComponents = Set.empty
+        }
+
+getSDistFileList :: M env m => LocalPackage -> m String
+getSDistFileList lp =
+    withSystemTempDirectory (stackProgName <> "-sdist") $ \tmpdir -> do
+        menv <- getMinimalEnvOverride
+        let bopts = defaultBuildOpts
+        baseConfigOpts <- mkBaseConfigOpts bopts
+        (_mbp, locals, _extraToBuild, sourceMap) <- loadSourceMap bopts
+        withExecuteEnv menv bopts baseConfigOpts locals sourceMap $ \ee -> do
+            withSingleContext ac ee task (Just "sdist") $ \_package _cabalfp _pkgDir cabal _announce _console _mlogFile -> do
+                let outFile = tmpdir FP.</> "source-files-list"
+                cabal False ["sdist", "--list-sources", outFile]
+                liftIO (readFile outFile)
+  where
+    package = lpPackage lp
+    ac = ActionContext Set.empty
+    task = Task
+        { taskProvides = PackageIdentifier (packageName package) (packageVersion package)
+        , taskType = TTLocal lp
+        , taskConfigOpts = TaskConfigOpts
+            { tcoMissing = Set.empty
+            , tcoOpts = \_ -> []
+            }
+        , taskPresent = Set.empty
+        }
+
+normalizeTarballPaths :: M env m => [FilePath] -> m [FilePath]
+normalizeTarballPaths fps = do
+    --TODO: consider whether erroring out is better - otherwise the
+    --user might upload an incomplete tar?
+    when (not (null outsideDir)) $
+        $logWarn $ T.concat
+            [ "Warning: These files are outside of the package directory, and will be omitted from the tarball: "
+            , T.pack (show outsideDir)]
+    return files
+  where
+    (outsideDir, files) = partitionEithers (map pathToEither fps)
+    pathToEither fp = maybe (Left fp) Right (normalizePath fp)
+
+normalizePath :: FilePath -> (Maybe FilePath)
+normalizePath = fmap FP.joinPath . go . FP.splitDirectories . FP.normalise
+  where
+    go [] = Just []
+    go ("..":_) = Nothing
+    go (_:"..":xs) = go xs
+    go (x:xs) = (x :) <$> go xs
+
+dirsFromFiles :: [FilePath] -> [FilePath]
+dirsFromFiles dirs = Set.toAscList (Set.delete "." results)
+  where
+    results = foldl' (\s -> go s . FP.takeDirectory) Set.empty dirs
+    go s x
+      | Set.member x s = s
+      | otherwise = go (Set.insert x s) (FP.takeDirectory x)

--- a/stack.cabal
+++ b/stack.cabal
@@ -54,6 +54,7 @@ library
                      Stack.Repl
                      Stack.Ide
                      Stack.Image
+                     Stack.SDist
                      Stack.Setup
                      Stack.Solver
                      Stack.Types


### PR DESCRIPTION
Instead of using the `cabal` binary to create sdists, this uses `runhaskell Setup.hs sdist --list-sources` to get a list of paths to include in the tarball.  It then uploads this tarball without writing it to a file.