### PR TITLE
Set lower dependency restrictions on project-template.

### DIFF
--- a/stack.cabal
+++ b/stack.cabal
@@ -160,7 +160,7 @@ library
                    , file-embed
                    , word8
                    , hastache
-                   , project-template
+                   , project-template >= 0.2
   if !os(windows)
     build-depends:   unix >= 2.7.0.1
   default-language:    Haskell2010


### PR DESCRIPTION
project-template version is not precise so dependency
solver could chose older version that stack is incompatible
with.