### PR TITLE
Move options to ghci into ReplOpts and add parser

### DIFF
--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -13,6 +13,7 @@ module Stack.Options
     ,initOptsParser
     ,newOptsParser
     ,logLevelOptsParser
+    ,ghciOptsParser
     ,abstractResolverOptsParser
     ,solverOptsParser
     ,testOptsParser
@@ -33,11 +34,13 @@ import           Options.Applicative.Builder.Extra
 import           Options.Applicative.Simple
 import           Options.Applicative.Types (readerAsk)
 import           Stack.Build.Types
+import           Stack.Config (packagesParser)
 import           Stack.Docker
 import qualified Stack.Docker as Docker
 import           Stack.Dot
 import           Stack.Init
 import           Stack.New (NewOpts(..))
+import           Stack.Ghci (GhciOpts(..))
 import           Stack.Types
 
 -- | Command sum type for conditional arguments.
@@ -370,6 +373,27 @@ dotOptsParser = DotOpts
 
         splitNames :: String -> [String]
         splitNames = map (takeWhile (not . isSpace) . dropWhile isSpace) . splitOn ","
+
+ghciOptsParser :: Parser GhciOpts
+ghciOptsParser = GhciOpts
+             <$> fmap (map T.pack)
+                   (many (strArgument
+                            (metavar "TARGET" <>
+                             help ("If none specified, " <>
+                                   "use all packages defined in current directory"))))
+             <*> argsOption (long "ghc-options" <>
+                    metavar "OPTION" <>
+                    help "Additional options passed to GHCi" <>
+                    value [])
+             <*> strOption (long "with-ghc" <>
+                            metavar "GHC" <>
+                            help "Use this command for the GHC to run" <>
+                            value "ghc" <>
+                            showDefault)
+             <*> flag False True (long "no-load" <>
+                   help "Don't load modules on start-up")
+             <*> packagesParser
+
 
 -- | Parser for exec command
 execOptsParser :: Maybe String -- ^ command


### PR DESCRIPTION
Replaces the use of `(,,,,)` with a dedicated ADT for the `stack ghci` options and extract the parser to `Stack.Options` where all the other cool kids hang out.