### PR TITLE
Restore install command

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -94,7 +94,7 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter ->
                         (buildCmd DoNothing)
                         (buildOptsParser Build False)
              addCommand "install"
-                        "Identical to 'build --copy-bins', not actually a managed installation tool!"
+                        "Copy binaries to the target prefix location, presently hardcoded to ~/.local/bin. This is the only command that will mutate your system outside of this project directory"
                         installCmd
                         (buildOptsParser Build True)
              addCommand "uninstall"
@@ -509,12 +509,7 @@ buildCmd = buildCmdHelper (return ()) ThrowException
 -- | Install
 installCmd :: BuildOpts -> GlobalOpts -> IO ()
 installCmd =
-    buildCmdHelper warning ExecStrategy DoNothing
-  where
-    warning = do
-        $logWarn "NOTE: stack is not a package manager"
-        $logWarn "The install command is only used to copy executables to a destination directory, not manage them"
-        $logWarn "You may want to use 'stack build --copy-bins' for clarity"
+    buildCmdHelper (return ()) ExecStrategy DoNothing
 
 copyCmd :: BuildOpts -> GlobalOpts -> IO ()
 copyCmd opts = buildCmdHelper (return ()) ExecStrategy DoNothing opts { boptsInstallExes = True }

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -94,7 +94,7 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter ->
                         (buildCmd DoNothing)
                         (buildOptsParser Build False)
              addCommand "install"
-                        "Copy binaries to the target prefix location, presently hardcoded to ~/.local/bin. This is the only command that will mutate your system outside of this project directory"
+                        "Copy binaries to the target prefix location. The default is ~/.local/bin; you can change it with `--local-bin-path`. This is the only command that will mutate your system outside of this project directory"
                         installCmd
                         (buildOptsParser Build True)
              addCommand "uninstall"


### PR DESCRIPTION
Revert addition of a warning not to use install command. Explain that the install prefix defaults to _~/.local/bin_ and is overridable with `--local-bin-path`.

The next step is to add `--prefix` and some notion of `DESTDIR` to change that default across both binaries and other installation artifacts.

AfC