### PR TITLE
Make stack-ide receive a path where the correct ide-backend-server is installed

### DIFF
--- a/src/Stack/Ide.hs
+++ b/src/Stack/Ide.hs
@@ -108,14 +108,19 @@ ide targets useropts = do
                     else return Nothing
     localdb <- packageDatabaseLocal
     depsdb <- packageDatabaseDeps
+    bindirs <- extraBinDirs `ap` return True {- include local bin -}
     let pkgopts = concat (map _2 pkgs)
         srcfiles = concatMap (map toFilePath . _3) pkgs
         pkgdbs =
             ["--package-db=" <> toFilePath depsdb <> ":" <> toFilePath localdb]
+        paths =
+            ["--ide-backend-tools-path=" <> intercalate ":" (map toFilePath bindirs)
+            ]
     exec
         "stack-ide"
         (["--local-work-dir=" ++ toFilePath pwd] ++
          map ("--ghc-option=" ++) (filter (not . badForGhci) useropts) <>
+         paths <>
          pkgopts <>
          pkgdbs)
         (encode (initialRequest srcfiles))


### PR DESCRIPTION
_NB._ See [this pull request](https://github.com/commercialhaskell/stack-ide/pull/35), which would first need to be applied to `stack-ide`.

This PR would be a step into having `stack` provide the appropriate version of `ide-backend-server` to each project where `stack-ide` is used.

What the patch does is simply make `stack-ide` look for `ide-backend-server` and `ide-backend-exe-cabal` in the `bin` directory of the local and snapshot databases, respectively. If, for every project, one can then persuade `stack` to build `ide-backend-server` and `ide-backend` in addition to the project packages, then one gets the right ghc-version of `ide-backend-server` for free. At the moment, I achieve this rather crudely by adding the following package entry in the `stack.yaml` file of every project I want to work on:
````
- location:
    git: git@github.com:fpco/ide-backend.git
    commit: 329e7670388428709158d33b3e74959671afc345
  subdirs:
  - ide-backend-common
  - ide-backend
  - ide-backend-server
````
I imagine the stack.yaml format being then extended to allow for a non-project config option that would roughly say: "when building a project _for development_, also build these packages". That way one could put an entry for `ide-backend-server` in `~/.stack/stack.yaml` and forget about it (it would be also handy to  include other "ide tools" there, such as  `hlint`, `HaRe`, `hindent`, etc.). Does a setting like that make sense to you?

Anyway, already with the crude version I'm now using, my experience with the Sublime plugin (https://github.com/lukexi/stack-ide-sublime) has improved quite a bit: I just need to remember to paste the above package entry the first time I work on a project, rebuild and everything then just works (if I switch resolvers, change versions of ghc, etc., I just need to restart Sublime).
