### PR TITLE
Preserve file permissions when unpacking sources

### DIFF
--- a/stack.cabal
+++ b/stack.cabal
@@ -153,6 +153,7 @@ library
                    , time >= 1.4.2
                    , transformers >= 0.3.0.0
                    , transformers-base >= 0.4.4
+                   , unix-compat
                    , unordered-containers >= 0.2.5.1
                    , vector >= 0.10.12.3
                    , vector-binary-instances


### PR DESCRIPTION
The `tar` package, in name of portability, doesn't preserve file
permissions when creating and unpacking archives. A sample package which
relies on permissions to be kept as they were packed with is
`ghc-parser` which executes a bash script as part of its build process.

Before this patch we'd get

```
    /run/user/1000/stack26234/ghc-parser-0.1.7.0/Setup.hs:2:1: Warning:
        Module ‘System.Cmd’ is deprecated: Use "System.Process" instead
    /bin/sh: ./build-parser.sh: Permission denied
    Configuring ghc-parser-0.1.7.0...
    Warning: 'hs-source-dirs: src-7.8.3' directory does not exist.
```

but now the package builds fine.

cc @mboes 