### PR TITLE
New command `list-dependencies`

### DIFF
--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -125,11 +125,12 @@ listDependencies :: (HasEnvConfig env
                  -> m ()
 listDependencies sep = do
   (locals,_,_) <- loadLocals defaultBuildOpts Map.empty
-  let localNames = Set.fromList (map (packageNameString . packageName . lpPackageFinal) locals)
-      dotOpts = DotOpts True True Nothing localNames
+  let localNames = Set.fromList (map (packageName . lpPackageFinal) locals)
+      dotOpts = DotOpts True True Nothing Set.empty
 
   resultGraph <- createDependencyGraph dotOpts locals
-  void (Map.traverseWithKey go (snd <$> resultGraph))
+  let graphWithoutLocals = F.foldl' (flip Map.delete) resultGraph localNames
+  void (Map.traverseWithKey go (snd <$> graphWithoutLocals))
     where go name v = liftIO (Text.putStrLn $
                                 Text.pack (packageNameString name) <>
                                 sep <>

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -38,7 +38,7 @@ import           Stack.Package
 import           Stack.Types
 import           Stack.Types.Internal (HasLogLevel)
 
--- | Options record for `stack dot`
+-- | Options record for @stack dot@
 data DotOpts = DotOpts
     { dotIncludeExternal :: Bool
     -- ^ Include external dependencies
@@ -73,6 +73,10 @@ dot dotOpts = do
         prunedGraph = pruneGraph localNames pkgsToPrune resultGraph
     printGraph dotOpts locals prunedGraph
 
+-- | Create the dependency graph, the result is a map from a package
+-- name to a tuple of dependencies and a version if available.  This
+-- function mainly gathers the required arguments for
+-- @resolveDependencies@.
 createDependencyGraph :: (HasEnvConfig env
                          ,HasHttpManager env
                          ,HasLogLevel env
@@ -82,8 +86,8 @@ createDependencyGraph :: (HasEnvConfig env
                          ,MonadIO m
                          ,MonadMask m
                          ,MonadReader env m)
-                      => DotOpts
-                      -> m (Map PackageName (Set PackageName, Maybe Version))
+                       => DotOpts
+                       -> m (Map PackageName (Set PackageName, Maybe Version))
 createDependencyGraph dotOpts = do
   (_,locals,_,sourceMap) <- loadSourceMap defaultBuildOpts
   let graph = Map.fromList (localDependencies dotOpts locals)
@@ -104,6 +108,7 @@ createDependencyGraph dotOpts = do
         thrd :: (a,b,c) -> c
         thrd (_,_,x) = x
 
+-- Given an 'Installed' try to get the 'Version'
 libVersionFromInstalled :: Installed -> Maybe Version
 libVersionFromInstalled (Library ghcPkgId) =
     case ghcPkgIdPackageIdentifier ghcPkgId of
@@ -120,8 +125,8 @@ listDependencies :: (HasEnvConfig env
                     ,MonadIO m
                     ,MonadReader env m
                     )
-                 => Text
-                 -> m ()
+                  => Text
+                  -> m ()
 listDependencies sep = do
   let dotOpts = DotOpts True True Nothing Set.empty
   resultGraph <- createDependencyGraph dotOpts
@@ -131,9 +136,9 @@ listDependencies sep = do
                                 sep <>
                                 maybe "<unknown>" (Text.pack . show) v)
 
--- | `pruneGraph dontPrune toPrune graph` prunes all packages in
--- `graph` with a name in `toPrune` and removes resulting orphans
--- unless they are in `dontPrune`
+-- | @pruneGraph dontPrune toPrune graph@ prunes all packages in
+-- @graph@ with a name in @toPrune@ and removes resulting orphans
+-- unless they are in @dontPrune@
 pruneGraph :: (F.Foldable f, F.Foldable g, Eq a)
            => f PackageName
            -> g String
@@ -240,7 +245,7 @@ printLeaves :: (Applicative m, MonadIO m)
             -> m ()
 printLeaves = F.traverse_ printLeaf . Map.keysSet . Map.filter Set.null . fmap fst
 
--- | `printDedges p ps` prints an edge from p to every ps
+-- | @printDedges p ps@ prints an edge from p to every ps
 printEdges :: (Applicative m, MonadIO m) => PackageName -> Set PackageName -> m ()
 printEdges package deps = F.for_ deps (printEdge package)
 

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -9,6 +9,7 @@ module Stack.Dot (dot
                  ) where
 
 import           Control.Applicative
+import           Control.Arrow ((&&&))
 import           Control.Monad (void)
 import           Control.Monad.Catch (MonadCatch)
 import           Control.Monad.IO.Class
@@ -59,18 +60,33 @@ dot :: (HasEnvConfig env
     -> m ()
 dot dotOpts = do
     (locals,_,_) <- loadLocals defaultBuildOpts Map.empty
-    (_,_,_,sourceMap) <- loadSourceMap defaultBuildOpts
-    let graph = Map.fromList (localDependencies dotOpts locals)
-    menv <- getMinimalEnvOverride
-    resultGraph <- withLoadPackage menv (\loader -> do
-      let depLoader = createDepLoader sourceMap (fmap3 packageAllDeps loader)
-      liftIO $ resolveDependencies (dotDependencyDepth dotOpts) graph depLoader)
+    resultGraph <- createDependencyGraph dotOpts locals
     let pkgsToPrune = if dotIncludeBase dotOpts
                          then dotPrune dotOpts
                          else Set.insert "base" (dotPrune dotOpts)
         localNames = Set.fromList (map (packageName . lpPackage) locals)
         prunedGraph = pruneGraph localNames pkgsToPrune resultGraph
     printGraph dotOpts locals prunedGraph
+
+createDependencyGraph :: (HasEnvConfig env
+                         ,HasHttpManager env
+                         ,MonadLogger m
+                         ,MonadBaseControl IO m
+                         ,MonadCatch m
+                         ,MonadIO m
+                         ,MonadReader env m)
+                      => DotOpts
+                      -> [LocalPackage]
+                      -> m (Map PackageName (Set PackageName, Maybe Version))
+createDependencyGraph dotOpts locals = do
+  (_,_,_,sourceMap) <- loadSourceMap defaultBuildOpts
+  let graph = Map.fromList (localDependencies dotOpts locals)
+  menv <- getMinimalEnvOverride
+  withLoadPackage menv (\loader -> do
+    let depLoader =
+          createDepLoader sourceMap
+                          (fmap3 (packageAllDeps &&& (Just . packageVersion)) loader)
+    liftIO $ resolveDependencies (dotDependencyDepth dotOpts) graph depLoader)
   where -- fmap a function over the result of a function with 3 arguments
         fmap3 :: Functor f => (d -> e) -> (a -> b -> c -> f d) -> a -> b -> c -> f e
         fmap3 f g a b c = f <$> g a b c
@@ -78,42 +94,42 @@ dot dotOpts = do
 -- | `pruneGraph dontPrune toPrune graph` prunes all packages in
 -- `graph` with a name in `toPrune` and removes resulting orphans
 -- unless they are in `dontPrune`
-pruneGraph :: (F.Foldable f, F.Foldable g)
+pruneGraph :: (F.Foldable f, F.Foldable g, Eq a)
            => f PackageName
            -> g String
-           -> Map PackageName (Set PackageName)
-           -> Map PackageName (Set PackageName)
+           -> Map PackageName (Set PackageName, a)
+           -> Map PackageName (Set PackageName, a)
 pruneGraph dontPrune names =
-  pruneUnreachable dontPrune . Map.mapMaybeWithKey (\pkg pkgDeps ->
+  pruneUnreachable dontPrune . Map.mapMaybeWithKey (\pkg (pkgDeps,x) ->
     if show pkg `F.elem` names
       then Nothing
       else let filtered = Set.filter (\n -> show n `F.notElem` names) pkgDeps
            in if Set.null filtered && not (Set.null pkgDeps)
                 then Nothing
-                else Just filtered)
+                else Just (filtered,x))
 
 -- | Make sure that all unreachable nodes (orphans) are pruned
-pruneUnreachable :: F.Foldable f
+pruneUnreachable :: (Eq a, F.Foldable f)
                  => f PackageName
-                 -> Map PackageName (Set PackageName)
-                 -> Map PackageName (Set PackageName)
+                 -> Map PackageName (Set PackageName, a)
+                 -> Map PackageName (Set PackageName, a)
 pruneUnreachable dontPrune = fixpoint prune
   where fixpoint :: Eq a => (a -> a) -> a -> a
         fixpoint f v = if f v == v then v else fixpoint f (f v)
         prune graph' = Map.filterWithKey (\k _ -> reachable k) graph'
           where reachable k = k `F.elem` dontPrune || k `Set.member` reachables
-                reachables = F.fold graph'
+                reachables = F.fold (fst <$> graph')
 
 
 -- | Resolve the dependency graph up to (Just depth) or until fixpoint is reached
 resolveDependencies :: (Applicative m, Monad m)
                     => Maybe Int
-                    -> Map PackageName (Set PackageName)
-                    -> (PackageName -> m (Set PackageName))
-                    -> m (Map PackageName (Set PackageName))
+                    -> Map PackageName (Set PackageName,Maybe Version)
+                    -> (PackageName -> m (Set PackageName, Maybe Version))
+                    -> m (Map PackageName (Set PackageName,Maybe Version))
 resolveDependencies (Just 0) graph _ = return graph
 resolveDependencies limit graph loadPackageDeps = do
-  let values = Set.unions (Map.elems graph)
+  let values = Set.unions (fst <$> Map.elems graph)
       keys = Map.keysSet graph
       next = Set.difference values keys
   if Set.null next
@@ -121,41 +137,44 @@ resolveDependencies limit graph loadPackageDeps = do
      else do
        x <- T.traverse (\name -> (name,) <$> loadPackageDeps name) (F.toList next)
        resolveDependencies (subtract 1 <$> limit)
-                      (Map.unionWith Set.union graph (Map.fromList x))
+                      (Map.unionWith unifier graph (Map.fromList x))
                       loadPackageDeps
+  where unifier (pkgs1,v1) (pkgs2,_) = (Set.union pkgs1 pkgs2, v1)
 
 -- | Given a SourceMap and a dependency loader, load the set of dependencies for a package
 createDepLoader :: Applicative m
                 => Map PackageName PackageSource
-                -> (PackageName -> Version -> Map FlagName Bool -> m (Set PackageName))
+                -> (PackageName -> Version -> Map FlagName Bool -> m (Set PackageName,Maybe Version))
                 -> PackageName
-                -> m (Set PackageName)
+                -> m (Set PackageName, Maybe Version)
 createDepLoader sourceMap loadPackageDeps pkgName =
   case Map.lookup pkgName sourceMap of
-    Just (PSLocal lp) -> pure (packageAllDeps (lpPackage lp))
+    Just (PSLocal lp) -> pure ((packageAllDeps &&& (Just . packageVersion)) (lpPackage lp))
     Just (PSUpstream version _ flags) -> loadPackageDeps pkgName version flags
-    Nothing -> pure Set.empty
+    Nothing -> pure (Set.empty,Nothing)
 
 -- | Resolve the direct (depth 0) external dependencies of the given local packages
-localDependencies :: DotOpts -> [LocalPackage] -> [(PackageName,Set PackageName)]
-localDependencies dotOpts locals = map (\lp -> (packageName (lpPackage lp), deps lp)) locals
+localDependencies :: DotOpts -> [LocalPackage] -> [(PackageName,(Set PackageName,Maybe Version))]
+localDependencies dotOpts locals =
+    map (\lp -> (packageName (lpPackage lp), (deps lp,Just (lpVersion lp)))) locals
   where deps lp = if dotIncludeExternal dotOpts
                 then Set.delete (lpName lp) (packageAllDeps (lpPackage lp))
                 else Set.intersection localNames (packageAllDeps (lpPackage lp))
         lpName lp = packageName (lpPackage lp)
         localNames = Set.fromList $ map (packageName . lpPackage) locals
+        lpVersion lp = packageVersion (lpPackage lp)
 
 -- | Print a graphviz graph of the edges in the Map and highlight the given local packages
 printGraph :: (Applicative m, MonadIO m)
            => DotOpts
            -> [LocalPackage]
-           -> Map PackageName (Set PackageName)
+           -> Map PackageName (Set PackageName, Maybe Version)
            -> m ()
 printGraph dotOpts locals graph = do
   liftIO $ Text.putStrLn "strict digraph deps {"
   printLocalNodes dotOpts filteredLocals
   printLeaves graph
-  void (Map.traverseWithKey printEdges graph)
+  void (Map.traverseWithKey printEdges (fst <$> graph))
   liftIO $ Text.putStrLn "}"
   where filteredLocals = filter (\local ->
           show (packageName (lpPackage local)) `Set.notMember` dotPrune dotOpts) locals
@@ -174,8 +193,10 @@ printLocalNodes dotOpts locals = liftIO $ Text.putStrLn (Text.intercalate "\n" l
         lpNodes = map (applyStyle . nodeName . packageName . lpPackage) (F.toList locals)
 
 -- | Print nodes without dependencies
-printLeaves :: (Applicative m, MonadIO m) => Map PackageName (Set PackageName) -> m ()
-printLeaves = F.traverse_ printLeaf . Map.keysSet . Map.filter Set.null
+printLeaves :: (Applicative m, MonadIO m)
+            => Map PackageName (Set PackageName,Maybe Version)
+            -> m ()
+printLeaves = F.traverse_ printLeaf . Map.keysSet . Map.filter Set.null . fmap fst
 
 -- | `printDedges p ps` prints an edge from p to every ps
 printEdges :: (Applicative m, MonadIO m) => PackageName -> Set PackageName -> m ()

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -711,12 +711,12 @@ solverCmd fixStackYaml go =
 
 -- | Visualize dependencies
 dotCmd :: DotOpts -> GlobalOpts -> IO ()
-dotCmd dotOpts go = withBuildConfig go ThrowException (dot dotOpts)
+dotCmd dotOpts go = withBuildConfig go (dot dotOpts)
 
 ifaceCmd :: () -> GlobalOpts -> IO ()
 ifaceCmd () go = withBuildConfig go iface
 
 -- | List the dependencies
 listDependenciesCmd :: Text -> GlobalOpts -> IO ()
-listDependenciesCmd sep go = withBuildConfig go ThrowException (listDependencies sep')
+listDependenciesCmd sep go = withBuildConfig go (listDependencies sep')
   where sep' = T.replace "\\t" "\t" (T.replace "\\n" "\n" sep)

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -228,6 +228,10 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter ->
                         "Display TH dependencies"
                         ifaceCmd
                         (pure ())
+             addCommand "list-dependencies"
+                        "List the dependencies"
+                        listDependenciesCmd
+                        (pure ())
              addSubCommands
                Docker.dockerCmdName
                "Subcommands specific to Docker use"
@@ -702,7 +706,11 @@ solverCmd fixStackYaml go =
 
 -- | Visualize dependencies
 dotCmd :: DotOpts -> GlobalOpts -> IO ()
-dotCmd dotOpts go = withBuildConfig go (dot dotOpts)
+dotCmd dotOpts go = withBuildConfig go ThrowException (dot dotOpts)
 
 ifaceCmd :: () -> GlobalOpts -> IO ()
 ifaceCmd () go = withBuildConfig go iface
+
+-- | List the dependencies
+listDependenciesCmd :: () -> GlobalOpts -> IO ()
+listDependenciesCmd _ go = withBuildConfig go ThrowException listDependencies

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -231,7 +231,12 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter ->
              addCommand "list-dependencies"
                         "List the dependencies"
                         listDependenciesCmd
-                        (pure ())
+                        (T.pack <$> strOption (long "separator" <>
+                                               metavar "SEP" <>
+                                               help ("Separator between package name " <>
+                                                     "and package version.") <>
+                                               value " " <>
+                                               showDefault))
              addSubCommands
                Docker.dockerCmdName
                "Subcommands specific to Docker use"
@@ -712,5 +717,6 @@ ifaceCmd :: () -> GlobalOpts -> IO ()
 ifaceCmd () go = withBuildConfig go iface
 
 -- | List the dependencies
-listDependenciesCmd :: () -> GlobalOpts -> IO ()
-listDependenciesCmd _ go = withBuildConfig go ThrowException listDependencies
+listDependenciesCmd :: Text -> GlobalOpts -> IO ()
+listDependenciesCmd sep go = withBuildConfig go ThrowException (listDependencies sep')
+  where sep' = T.replace "\\t" "\t" (T.replace "\\n" "\n" sep)


### PR DESCRIPTION
Implements #638 .

Adds a new command `stack list-dependencies` that will list all transitive dependencies for the local packages.

It's not able to show dependencies for the test and benchmark packages, because I could not figure out how to do it, nevertheless I though I should probably pr this as is for the added functionality.

The problem I had with test/benchmark in a nutshell: 

> It seems like `loadSourceMap` and `loadLocals` by default assume that they are not enabled (package config sets it to false). Once I changed that it seems like it somehow does not pickup the dependencies for test packages like QuickCheck when using `withLoadPackage`'s function to load packages...

If you see what I am doing wrong I'd be happy to change this :)

The nice part is that it reuses the structure generated by `Stack.Dot` so in theory we could also display versions for the `stack dot` output.