### PR TITLE
Accept multiple instance of same cli option flag

### DIFF
--- a/src/Options/Applicative/Builder/Extra.hs
+++ b/src/Options/Applicative/Builder/Extra.hs
@@ -36,6 +36,10 @@ enableDisableFlags defaultValue enabledValue disabledValue name helpSuffix mods 
 -- | Enable/disable flags for any type, without a default (to allow chaining @<|>@s)
 enableDisableFlagsNoDefault :: a -> a -> String -> String -> Mod FlagFields a -> Parser a
 enableDisableFlagsNoDefault enabledValue disabledValue name helpSuffix mods =
+  last <$> some (enableDisableFlagsNoDefault' enabledValue disabledValue name helpSuffix mods)
+
+enableDisableFlagsNoDefault' :: a -> a -> String -> String -> Mod FlagFields a -> Parser a
+enableDisableFlagsNoDefault' enabledValue disabledValue name helpSuffix mods =
   flag' enabledValue
         (long name <>
          help ("Enable " ++ helpSuffix) <>


### PR DESCRIPTION
Before this PR:

```
% stack --no-system-ghc --system-ghc path
Invalid option `--system-ghc'

Usage: stack [--version] [--help] [--docker*] ([--verbosity VERBOSITY] |
             [-v|--verbose]) ([--system-ghc] | [--no-system-ghc])
...
```

After:

```
% .../bin/stack --help                           
stack - The Haskell Tool Stack

Usage: stack [--version] [--help] [--docker*] ([--verbosity VERBOSITY] |
             [-v|--verbose]) ([--system-ghc] | [--no-system-ghc])
...
```

```
% .../bin/stack --no-system-ghc --system-ghc path
global-stack-root: /Users/phadej/.stack
project-root: /Users/phadej/Coding/stack
...
```

This is useful in scripting, where one have alias with some default flags, but later want to override them