### PR TITLE
Show available flags if flag not found

### DIFF
--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -270,7 +270,7 @@ loadLocals bopts latestVersion = do
                             -- All flags are defined, nothing to do
                             then Nothing
                             -- Error about the undefined flags
-                            else Just $ UFFlagsNotDefined source name unused
+                            else Just $ UFFlagsNotDefined source pkg unused
 
         unusedFlags = mapMaybe checkFlagUsed flags
 


### PR DESCRIPTION
Adds a little helpful information if the flags are invalid.  Implemented by using `Package` instead of only `PackageName` in the `UnusedFlags` constructor `UFFlagsNotDefined`.

Output before:
```
$ stack build --flag stack:foo --flag stack:bar --flag foo:bar
Invalid flag specification:
- Package 'foo' not found (specified on command line)
- Package 'stack' does not define the following flags (specified on command line): bar, foo
```

Output after:
```
$ stack build --flag stack:foo --flag stack:bar --flag foo:bar
Invalid flag specification:
- Package 'foo' not found (specified on command line)
- Package 'stack' does not define the following flags (specified on command line):
  bar
  foo
- Flags defined by package 'stack':
  stack:integration-tests
```