### PR TITLE
Filelock3 -- release snapshot lock early for local-only builds

### DIFF
--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -474,10 +474,3 @@ stripLocals plan = plan
             TTLocal _ -> False
             TTUpstream _ Local -> False
             TTUpstream _ Snap -> True
-
-taskLocation :: Task -> InstallLocation
-taskLocation =
-    go . taskType
-  where
-    go (TTLocal _) = Local
-    go (TTUpstream _ loc) = loc

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -969,12 +969,6 @@ printBuildOutput excludeTHLoading makeAbsolute level outH = void $ fork $
     stripCarriageReturn :: ByteString -> ByteString
     stripCarriageReturn = S8.filter (not . (=='\r'))
 
-taskLocation :: Task -> InstallLocation
-taskLocation task =
-    case taskType task of
-        TTLocal _ -> Local
-        TTUpstream _ loc -> loc
-
 -- | Find the Setup.hs or Setup.lhs in the given directory. If none exists,
 -- throw an exception.
 getSetupHs :: Path Abs Dir -- ^ project directory

--- a/src/Stack/Build/Types.hs
+++ b/src/Stack/Build/Types.hs
@@ -19,6 +19,7 @@ module Stack.Build.Types
     ,Installed(..)
     ,PackageInstallInfo(..)
     ,Task(..)
+    ,taskLocation
     ,LocalPackage(..)
     ,BaseConfigOpts(..)
     ,Plan(..)
@@ -485,6 +486,12 @@ instance Show TaskConfigOpts where
 data TaskType = TTLocal LocalPackage
               | TTUpstream Package InstallLocation
     deriving Show
+
+taskLocation :: Task -> InstallLocation
+taskLocation task =
+    case taskType task of
+        TTLocal _ -> Local
+        TTUpstream _ loc -> loc
 
 -- | A complete plan of what needs to be built and how to do it
 data Plan = Plan

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -85,7 +85,8 @@ upgrade fromGit mresolver = withSystemTempDirectory "stack-upgrade" $ \tmp' -> d
                 (Just $ dir </> $(mkRelFile "stack.yaml"))
             lcLoadBuildConfig lc mresolver
         envConfig1 <- runStackT manager logLevel bconfig terminal reExec setupEnv
-        runStackT manager logLevel envConfig1 terminal reExec $ build (const $ return ()) defaultBuildOpts
+        runStackT manager logLevel envConfig1 terminal reExec $
+          build (const $ return ()) Nothing defaultBuildOpts
             { boptsTargets = ["stack"]
             , boptsInstallExes = True
             }

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -601,9 +601,9 @@ buildCmdHelper beforeBuild finalAction opts go
     | boptsFileWatch opts = fileWatch inner
     | otherwise = inner $ const $ return ()
   where
-    inner setLocalFiles = withBuildConfigAndLock go $ \_ -> do
+    inner setLocalFiles = withBuildConfigAndLock go $ \lk -> do
         beforeBuild
-        Stack.Build.build setLocalFiles opts { boptsFinalAction = finalAction }
+        Stack.Build.build setLocalFiles (Just lk) opts { boptsFinalAction = finalAction }
 
 -- | Build the project.
 buildCmd :: FinalAction -> BuildOpts -> GlobalOpts -> IO ()
@@ -711,7 +711,7 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
            withBuildConfigAndLock go $ \lk -> do
                let targets = concatMap words eoPackages
                unless (null targets) $
-                   Stack.Build.build (const $ return ()) defaultBuildOpts
+                   Stack.Build.build (const $ return ()) (Just lk) defaultBuildOpts
                        { boptsTargets = map T.pack targets
                        }
                liftIO $ unlockFile lk -- Unlock before transferring control away.
@@ -723,7 +723,7 @@ replCmd (targets,args,path,noload,packages) go@GlobalOpts{..} = do
   withBuildConfigAndLock go $ \lk -> do
     let packageTargets = concatMap words packages
     unless (null packageTargets) $
-       Stack.Build.build (const $ return ()) defaultBuildOpts
+       Stack.Build.build (const $ return ()) (Just lk) defaultBuildOpts
            { boptsTargets = map T.pack packageTargets
            }
     liftIO $ unlockFile lk -- Don't hold the lock while in the REPL.
@@ -768,9 +768,10 @@ imgDockerCmd () go@GlobalOpts{..} = do
     withBuildConfigExt
         go
         Nothing
-        (\_ ->
+        (\lk ->
          do Stack.Build.build
                 (const (return ()))
+                (Just lk)
                 defaultBuildOpts
             Image.stageContainerImageArtifacts)
         (Just Image.createContainerImageFromStage)

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -10,10 +10,12 @@
 module Main where
 
 import           Control.Exception
+import qualified Control.Exception.Lifted as EL
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import           Control.Monad.Reader (ask, asks)
+import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Data.Attoparsec.Args (withInterpreterArgs)
 import qualified Data.ByteString.Lazy as L
 import           Data.List
@@ -63,7 +65,7 @@ import qualified Stack.Upload as Upload
 import           System.Directory (canonicalizePath, doesFileExist, doesDirectoryExist, createDirectoryIfMissing)
 import           System.Environment (getArgs, getProgName)
 import           System.Exit
-import           System.FileLock (withFileLock, tryLockFile, unlockFile, SharedExclusive(Exclusive), FileLock)
+import           System.FileLock (lockFile, tryLockFile, unlockFile, SharedExclusive(Exclusive), FileLock)
 import           System.FilePath (dropTrailingPathSeparator)
 import           System.IO (hIsTerminalDevice, stderr, stdin, stdout, hSetBuffering, BufferMode(..))
 import           System.Process.Read
@@ -453,7 +455,7 @@ setupParser = SetupCmdOpts
 setupCmd :: SetupCmdOpts -> GlobalOpts -> IO ()
 setupCmd SetupCmdOpts{..} go@GlobalOpts{..} = do
   (manager,lc) <- loadConfigWithOpts go
-  withUserFileLock (lcConfig lc) $ \_ ->
+  withUserFileLock (configStackRoot $ lcConfig lc) $ \_ ->
    runStackTGlobal manager (lcConfig lc) go $
       Docker.reexecWithOptionalContainer
           (lcProjectRoot lc)
@@ -488,36 +490,43 @@ setupCmd SetupCmdOpts{..} go@GlobalOpts{..} = do
               )
           Nothing
 
--- | Enforce mutual exclusion of every action running via this function
--- on this users account.  Currently, stack uses this to completely
--- exclude concurrent execution of stack commands.  In the future,
--- stack may refine this to a finer-grained locking approach.
-withUserFileLock :: Config
-                 -> (FileLock -> IO a)
-                 -> IO a
-withUserFileLock cfg act = do
+-- | Enforce mutual exclusion of every action running via this
+-- function, on this path, on this users account.
+--
+-- A lock file is created inside the given directory.  Currently,
+-- stack uses locks per-snapshot.  In the future, stack may refine
+-- this to an even more fine-grain locking approach.
+--
+withUserFileLock :: (MonadBaseControl IO m, MonadIO m)
+                 => Path Abs Dir
+                 -> (FileLock -> m a)
+                 -> m a
+withUserFileLock dir act = do
     let lockfile = $(mkRelFile "lockfile")
-    let pth = configStackRoot cfg </> lockfile
-    createDirectoryIfMissing True (toFilePath $ configStackRoot cfg)
+    let pth = dir </> lockfile
+    liftIO $ createDirectoryIfMissing True (toFilePath dir)
     -- Just in case of asynchronous exceptions, we need to be careful
     -- when using tryLockFile here:
-    bracket (tryLockFile (toFilePath pth) Exclusive)
-            (\fstTry -> maybe (return ()) unlockFile fstTry)
-            (\fstTry ->
-             case fstTry of
-               Just lk -> finally (act lk) (unlockFile lk)
-               Nothing ->
-                 do putStrLn $ "Failed to grab lock ("++show pth++"); other stack instance running.  Waiting..."
-                    withFileLock (toFilePath pth) Exclusive $ \lk -> do
-                      putStrLn "Lock acquired, proceeding."
-                      act lk)
+    EL.bracket (liftIO $ tryLockFile (toFilePath pth) Exclusive)
+               (\fstTry -> maybe (return ()) (liftIO . unlockFile) fstTry)
+               (\fstTry ->
+                case fstTry of
+                  Just lk -> EL.finally (act lk) (liftIO $ unlockFile lk)
+                  Nothing ->
+                    do liftIO $ putStrLn $ "Failed to grab lock ("++show pth++
+                                           "); other stack instance running.  Waiting..."
+                       EL.bracket (liftIO $ lockFile (toFilePath pth) Exclusive)
+                                  (liftIO . unlockFile)
+                                  (\lk -> do
+                                    liftIO $ putStrLn "Lock acquired, proceeding."
+                                    act lk))
 
 withConfigAndLock :: GlobalOpts
            -> StackT Config IO ()
            -> IO ()
 withConfigAndLock go@GlobalOpts{..} inner = do
     (manager, lc) <- loadConfigWithOpts go
-    withUserFileLock (lcConfig lc) $ \_lk ->
+    withUserFileLock (configStackRoot $ lcConfig lc) $ \_lk ->
      runStackTGlobal manager (lcConfig lc) go $
         Docker.reexecWithOptionalContainer (lcProjectRoot lc)
             Nothing
@@ -537,7 +546,16 @@ withBuildConfigAndLock :: GlobalOpts
                  -> (FileLock -> StackT EnvConfig IO ())
                  -> IO ()
 withBuildConfigAndLock go inner =
-    withBuildConfigExt go Nothing inner Nothing
+    withBuildConfigExt go Nothing
+      -- Locking policy:  This is only used for build commands, which
+      -- only need to lock the snapshot, not the global lock.  We
+      -- trade in the lock here.
+       (\lk -> do dir <- installationRootDeps
+                  -- A little bit of hand-over-hand locking:
+                  withUserFileLock dir $ \lk2 -> do
+                    liftIO $ unlockFile lk
+                    inner lk2)
+       Nothing
 
 withBuildConfigExt
     :: GlobalOpts
@@ -569,7 +587,7 @@ withBuildConfigExt go@GlobalOpts{..} mbefore inner mafter = do
                 envConfig
                 go
                 (inner lk)
-    withUserFileLock (lcConfig lc) $ \lk ->
+    withUserFileLock (configStackRoot $ lcConfig lc) $ \lk ->
      runStackTGlobal manager (lcConfig lc) go $
         Docker.reexecWithOptionalContainer (lcProjectRoot lc) mbefore (inner' lk) mafter
 
@@ -679,7 +697,7 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
     case eoExtra of
         ExecOptsPlain -> do
             (manager,lc) <- liftIO $ loadConfigWithOpts go
-            withUserFileLock (lcConfig lc) $ \lk ->
+            withUserFileLock (configStackRoot $ lcConfig lc) $ \lk ->
              runStackTGlobal manager (lcConfig lc) go $
                 Docker.execWithOptionalContainer
                     (lcProjectRoot lc)
@@ -722,7 +740,7 @@ dockerPullCmd :: () -> GlobalOpts -> IO ()
 dockerPullCmd _ go@GlobalOpts{..} = do
     (manager,lc) <- liftIO $ loadConfigWithOpts go
     -- TODO: can we eliminate this lock if it doesn't touch ~/.stack/?
-    withUserFileLock (lcConfig lc) $ \_ ->
+    withUserFileLock (configStackRoot $ lcConfig lc) $ \_ ->
      runStackTGlobal manager (lcConfig lc) go $
        Docker.preventInContainer Docker.pull
 
@@ -731,7 +749,7 @@ dockerResetCmd :: Bool -> GlobalOpts -> IO ()
 dockerResetCmd keepHome go@GlobalOpts{..} = do
     (manager,lc) <- liftIO (loadConfigWithOpts go)
     -- TODO: can we eliminate this lock if it doesn't touch ~/.stack/?
-    withUserFileLock (lcConfig lc) $ \_ ->
+    withUserFileLock (configStackRoot $ lcConfig lc) $ \_ ->
      runStackLoggingTGlobal manager go $
         Docker.preventInContainer $ Docker.reset (lcProjectRoot lc) keepHome
 
@@ -740,7 +758,7 @@ dockerCleanupCmd :: Docker.CleanupOpts -> GlobalOpts -> IO ()
 dockerCleanupCmd cleanupOpts go@GlobalOpts{..} = do
     (manager,lc) <- liftIO $ loadConfigWithOpts go
     -- TODO: can we eliminate this lock if it doesn't touch ~/.stack/?
-    withUserFileLock (lcConfig lc) $ \_ ->
+    withUserFileLock (configStackRoot $ lcConfig lc) $ \_ ->
      runStackTGlobal manager (lcConfig lc) go $
         Docker.preventInContainer $
             Docker.cleanup cleanupOpts

--- a/stack.cabal
+++ b/stack.cabal
@@ -1,5 +1,5 @@
 name:                stack
-version:             0.1.2.4
+version:             0.1.2.5
 synopsis:            The Haskell Tool Stack
 description:         Please see the README.md for usage information, and
                      the wiki on Github for more details.  Also, note that
@@ -185,6 +185,8 @@ executable stack
                 , filepath
                 , filelock >= 0.1.0.1
                 , http-conduit >= 2.1.5
+                , lifted-base
+                , monad-control
                 , monad-logger >= 0.3.13.1
                 , mtl >= 2.1.3.1
                 , old-locale >= 1.0.0.6

--- a/stack.cabal
+++ b/stack.cabal
@@ -1,5 +1,5 @@
 name:                stack
-version:             0.1.2.5
+version:             0.1.2.6
 synopsis:            The Haskell Tool Stack
 description:         Please see the README.md for usage information, and
                      the wiki on Github for more details.  Also, note that

--- a/stack.cabal
+++ b/stack.cabal
@@ -121,6 +121,7 @@ library
                    , exceptions >= 0.8.0.2
                    , extra
                    , fast-logger >= 2.3.1
+                   , filelock >= 0.1.0.1
                    , filepath >= 1.3.0.2
                    , fsnotify
                    , hashable >= 1.2.3.2


### PR DESCRIPTION
This is the third and final (for now) refinement of the locking mechanism.

"Filelock2" (#700) refines the locking to be per-snapshot, rather than global/per-user.  This patch goes further and allows the snapshot lock to be released early by any build command whose actions are *all local*.

The next reasonable step would be to allow mixed snapshot/local builds to release early once the snapshot portion of the build is done.  (This could be accomplished simply by making the unlock itself an `Action`, and scheduled as part of the dependence graph of actions.)

That last refinement would be nice to have, but "filelock3" already handles the most important common case -- a server running CI jobs again and again builds the snapshot bits only on the first execution (and occasionally thereafter).  The vast majority of the time it runs local-only builds.

Thus, with this patch a CI server can run many local-only builds at the same time, safely, while still protecting the shared snapshot state.






