### PR TITLE
`stack path` shows documentation roots.

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -483,6 +483,14 @@ paths =
       , "local-install-root"
       , \pi ->
              T.pack (toFilePathNoTrailing (piLocalRoot pi)))
+    , ( "Snapshot documentation root"
+      , "snapshot-doc-root"
+      , \pi ->
+             T.pack (toFilePathNoTrailing (piSnapRoot pi </> docDirSuffix)))
+    , ( "Local project documentation root"
+      , "local-doc-root"
+      , \pi ->
+             T.pack (toFilePathNoTrailing (piLocalRoot pi </> docDirSuffix)))
     , ( "Dist work directory"
       , "dist-dir"
       , \pi ->


### PR DESCRIPTION
New options: `--snapshot-doc-root` and `--local-doc-root`

Motivation:
* Troubleshooting info; and
* Quick access to the documentation (e.g. `elinks $(stack path --snapshot-doc-root)/index.html`).

Coding style note: I was unsure about whether you'd rather have me adding reader monad actions to `Stack.Types.Config`, just like to those for the other paths. In the end, I went for the least invasive option, simply concatenating the paths *in situ*, imitating `Stack.Build.Haddock.snapDocDir`.