### PR TITLE
Add text versions of strArgument and strOption

### DIFF
--- a/src/Options/Applicative/Builder/Extra.hs
+++ b/src/Options/Applicative/Builder/Extra.hs
@@ -7,13 +7,18 @@ module Options.Applicative.Builder.Extra
   ,enableDisableFlags
   ,enableDisableFlagsNoDefault
   ,extraHelpOption
-  ,execExtraHelp)
+  ,execExtraHelp
+  ,textOption
+  ,textArgument)
   where
 
 import Control.Monad (when)
 import Options.Applicative
+import Options.Applicative.Types (readerAsk)
 import System.Environment (withArgs)
 import System.FilePath (takeBaseName)
+import Data.Text (Text)
+import qualified Data.Text as T
 
 -- | Enable/disable flags for a @Bool@.
 boolFlags :: Bool -> String -> String -> Mod FlagFields Bool -> Parser Bool
@@ -71,7 +76,7 @@ extraHelpOption progName fakeName helpName =
 -- Since optparse-applicative doesn't allow an arbirary IO action for an 'abortOption', this
 -- was the best way I found that doesn't require manually formatting the help.
 execExtraHelp :: [String] -> String -> Parser a -> String -> IO ()
-execExtraHelp args helpOpt parser pd = do
+execExtraHelp args helpOpt parser pd =
     when (args == ["--" ++ helpOpt]) $
       withArgs ["--help"] $ do
         _ <- execParser (info (hiddenHelper <*>
@@ -81,3 +86,9 @@ execExtraHelp args helpOpt parser pd = do
                         (fullDesc <> progDesc pd))
         return ()
   where hiddenHelper = abortOption ShowHelpText (long "help" <> hidden <> internal)
+
+textOption :: Mod OptionFields Text -> Parser Text
+textOption = option (T.pack <$> readerAsk)
+
+textArgument :: Mod ArgumentFields Text -> Parser Text
+textArgument = argument (T.pack <$> readerAsk)

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -81,10 +81,9 @@ buildOptsParser cmd =
   where optimize =
           maybeBoolFlags "optimizations" "optimizations for TARGETs and all its dependencies" idm
         target =
-          fmap (map T.pack)
-                (many (strArgument
-                         (metavar "TARGET" <>
-                          help "If none specified, use all packages")))
+           many (textArgument
+                   (metavar "TARGET" <>
+                    help "If none specified, use all packages"))
         libProfiling =
           boolFlags False
                     "library-profiling"
@@ -120,18 +119,16 @@ buildOptsParser cmd =
               ( long "pedantic"
              <> help "Turn on -Wall and -Werror (note: option name may change in the future"
               )
-          <*> many (fmap T.pack
-                     (strOption (long "ghc-options" <>
-                                 metavar "OPTION" <>
-                                 help "Additional options passed to GHC")))
+          <*> many (textOption (long "ghc-options" <>
+                                metavar "OPTION" <>
+                                help "Additional options passed to GHC"))
 
-        flags =
-          fmap (Map.unionsWith Map.union) $ many
-            (option readFlag
-                ( long "flag"
-               <> metavar "PACKAGE:[-]FLAG"
-               <> help "Override flags set in stack.yaml (applies to local packages and extra-deps)"
-                ))
+        flags = Map.unionsWith Map.union <$> many
+                  (option readFlag
+                      (long "flag" <>
+                       metavar "PACKAGE:[-]FLAG" <>
+                       help ("Override flags set in stack.yaml " <>
+                             "(applies to local packages and extra-deps)")))
 
         preFetch = flag False True
             (long "prefetch" <>
@@ -239,16 +236,16 @@ configOptsParser docker =
            <> metavar "JOBS"
            <> help "Number of concurrent jobs to run"
             ))
-    <*> fmap (Set.fromList . map T.pack) (many $ strOption
+    <*> fmap Set.fromList (many (textOption
             ( long "extra-include-dirs"
            <> metavar "DIR"
            <> help "Extra directories to check for C header files"
-            ))
-    <*> fmap (Set.fromList . map T.pack) (many $ strOption
+            )))
+    <*> fmap Set.fromList (many (textOption
             ( long "extra-lib-dirs"
            <> metavar "DIR"
            <> help "Extra directories to check for libraries"
-            ))
+            )))
     <*> maybeBoolFlags
             "skip-ghc-check"
             "skipping the GHC version and architecture check"
@@ -403,14 +400,13 @@ dotOptsParser = DotOpts
 
 ghciOptsParser :: Parser GhciOpts
 ghciOptsParser = GhciOpts
-             <$> fmap (map T.pack)
-                   (many (strArgument
-                            (metavar "TARGET" <>
-                             help ("If none specified, " <>
-                                   "use all packages defined in current directory"))))
+             <$> many (textArgument
+                         (metavar "TARGET" <>
+                          help ("If none specified, " <>
+                                "use all packages defined in current directory")))
              <*> fmap concat (many (argsOption (long "ghc-options" <>
-                    metavar "OPTION" <>
-                    help "Additional options passed to GHCi")))
+                                       metavar "OPTION" <>
+                                       help "Additional options passed to GHCi")))
              <*> strOption (long "with-ghc" <>
                             metavar "GHC" <>
                             help "Use this command for the GHC to run" <>
@@ -476,10 +472,10 @@ globalOptsParser defaultTerminal =
         (long "no-terminal" <>
          help
              "Override terminal detection in the case of running in a false terminal") <*>
-    (optional (strOption
-        (long "stack-yaml" <>
-         metavar "STACK-YAML" <>
-         help "Override project stack.yaml file (overrides any STACK_YAML environment variable)")))
+    optional (strOption (long "stack-yaml" <>
+                         metavar "STACK-YAML" <>
+                         help ("Override project stack.yaml file " <>
+                               "(overrides any STACK_YAML environment variable)")))
 
 initOptsParser :: Parser InitOpts
 initOptsParser =

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -257,12 +257,12 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter -> do
              addCommand "list-dependencies"
                         "List the dependencies"
                         listDependenciesCmd
-                        (T.pack <$> strOption (long "separator" <>
-                                               metavar "SEP" <>
-                                               help ("Separator between package name " <>
-                                                     "and package version.") <>
-                                               value " " <>
-                                               showDefault))
+                        (textOption (long "separator" <>
+                                     metavar "SEP" <>
+                                     help ("Separator between package name " <>
+                                           "and package version.") <>
+                                     value " " <>
+                                     showDefault))
              addSubCommands
                  "ide"
                  "IDE-specific commands"
@@ -270,15 +270,14 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter -> do
                          "start"
                          "Start the ide-backend service"
                          ideCmd
-                         (((,) <$>
-                           fmap (map T.pack)
-                                (many (strArgument
-                                         (metavar "TARGET" <>
-                                          help "If none specified, use all packages defined in current directory"))) <*>
-                           argsOption (long "ghc-options" <>
-                                       metavar "OPTION" <>
-                                       help "Additional options passed to GHCi" <>
-                                       value [])))
+                         ((,) <$> many (textArgument
+                                          (metavar "TARGET" <>
+                                           help ("If none specified, use all " <>
+                                                 "packages defined in current directory")))
+                              <*> argsOption (long "ghc-options" <>
+                                              metavar "OPTION" <>
+                                              help "Additional options passed to GHCi" <>
+                                              value []))
                      addCommand
                          "packages"
                          "List all available local loadable packages"


### PR DESCRIPTION
A common pattern found repeatedly is:

`fmap T.pack (strArgument _)` or `fmap T.pack (strOption _)`

This pr adds two functions in `Options/Applicative/Builder/Extra`, `textOption` and `textArgument` which are like  `strArgument` and `strOption` just for Text instead of String.  
It might be possible to instead use an upper bound on `optparse-applicative` depending on the outcome of pcapriotti/optparse-applicative#147, though it might be easier to just maintain local copies for now inside `stack`.  In order to prevent conflicts in the near future the local versions are called `text-` instead of `txt-` as in the  `optparse-applicative` pr.