### PR TITLE
Use exact GHC versions rather than major-version #736

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 ## 0.1.3.1
 
+Major changes:
+
+* You now have more control over how GHC versions are matched, e.g. "use exactly this version," "use the specified minor version, but allow patches," or "use the given minor version or any later minor in the given major release." The default has switched from allowing newer later minor versions to a specific minor version allowing patches. For more information, see [#736](https://github.com/commercialhaskell/stack/issues/736) and [#784](https://github.com/commercialhaskell/stack/pull/784).
+
 Bug fixes:
 
 * Ignore disabled executables [#763](https://github.com/commercialhaskell/stack/issues/763)

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -143,10 +143,13 @@ parseTargetsFromBuildOpts needTargets bopts = do
             ResolverSnapshot snapName -> do
                 $logDebug $ "Checking resolver: " <> renderSnapName snapName
                 loadMiniBuildPlan snapName
-            ResolverGhc ghc ->
-                return
-                    MiniBuildPlan
-                    { mbpGhcVersion = fromMajorVersion ghc
+            ResolverCompiler _ -> do
+                -- We ignore the resolver version, as it might be
+                -- GhcMajorVersion, and we want the exact version
+                -- we're using.
+                version <- asks (envConfigGhcVersion . getEnvConfig)
+                return MiniBuildPlan
+                    { mbpGhcVersion = version
                     , mbpPackages = Map.empty
                     }
             ResolverCustom _ url -> do

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -735,7 +735,8 @@ data CustomSnapshot = CustomSnapshot
 instance FromJSON CustomSnapshot where
     parseJSON = withObject "CustomSnapshot" $ \o -> CustomSnapshot
         <$> ((o .: "compiler") >>= (\t -> maybe (fail $ "Invalid compiler: " ++ T.unpack t) return $ do
-                GhcVersion v <- parseCompilerVersion t
-                return v))
+                cv <- parseCompilerVersion t
+                case cv of
+                    GhcVersion v -> return v))
         <*> o .: "packages"
         <*> o .:? "flags" .!= Map.empty

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -735,7 +735,7 @@ data CustomSnapshot = CustomSnapshot
 instance FromJSON CustomSnapshot where
     parseJSON = withObject "CustomSnapshot" $ \o -> CustomSnapshot
         <$> ((o .: "compiler") >>= (\t -> maybe (fail $ "Invalid compiler: " ++ T.unpack t) return $ do
-                t' <- T.stripPrefix "ghc-" t
-                parseVersionFromString $ T.unpack t'))
+                GhcVersion v <- parseCompilerVersion t
+                return v))
         <*> o .: "packages"
         <*> o .:? "flags" .!= Map.empty

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -335,14 +335,14 @@ fuzzyLookupCandidates (PackageIdentifier name ver) caches =
     if null sameMajor then Nothing else Just (map fst sameMajor)
   where
     sameMajor = filter (\(PackageIdentifier _ v, _) ->
-                             getMajorVersion ver == getMajorVersion v)
+                             toMajorVersion ver == toMajorVersion v)
                        sameIdentCaches
     sameIdentCaches = maybe biggerFiltered
                             (\z -> (zeroIdent, z) : biggerFiltered)
                             zeroVer
     biggerFiltered = takeWhile (\(PackageIdentifier n _, _) -> name == n)
                                (Map.toList bigger)
-    zeroIdent = PackageIdentifier name (fromMajorVersion (MajorVersion 0 0))
+    zeroIdent = PackageIdentifier name $(mkVersion "0.0")
     (_, zeroVer, bigger) = Map.splitLookup zeroIdent caches
 
 -- | Figure out where to fetch from.

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -148,7 +148,7 @@ getDefaultResolver cabalfps gpds initOpts =
             mpair <-
                 case resolver of
                     ResolverSnapshot name -> findBuildPlan gpds [name]
-                    ResolverGhc _ -> return Nothing
+                    ResolverCompiler _ -> return Nothing
                     ResolverCustom _ _ -> return Nothing
             case mpair of
                 Just (snap, flags) ->
@@ -157,7 +157,7 @@ getDefaultResolver cabalfps gpds initOpts =
         MethodSolver -> do
             (ghcVersion, extraDeps) <- cabalSolver (map parent cabalfps) Map.empty []
             return
-                ( ResolverGhc ghcVersion
+                ( ResolverCompiler (GhcVersion ghcVersion)
                 , Map.filter (not . Map.null) $ fmap snd extraDeps
                 , fmap fst extraDeps
                 )

--- a/src/Stack/Types.hs
+++ b/src/Stack/Types.hs
@@ -15,3 +15,4 @@ import Stack.Types.Docker as X
 import Stack.Types.Image as X
 import Stack.Types.Build as X
 import Stack.Types.Package as X
+import Stack.Types.Compiler as X

--- a/src/Stack/Types/Compiler.hs
+++ b/src/Stack/Types/Compiler.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Stack.Types.Compiler where
+
+import           Data.Monoid ((<>))
+import qualified Data.Text as T
+import           Stack.Types.Version
+
+-- | Specifies a compiler and its version number(s).
+--
+-- Note that despite having this datatype, stack isn't in a hurry to
+-- support compilers other than GHC.
+data CompilerVersion
+    = GhcVersion {-# UNPACK #-} !Version
+    deriving (Show, Eq, Ord)
+
+parseCompilerVersion :: T.Text -> Maybe CompilerVersion
+parseCompilerVersion t
+    | Just t' <- T.stripPrefix "ghc-" t
+    , Just v <- parseVersionFromString $ T.unpack t'
+        = Just (GhcVersion v)
+    | otherwise
+        = Nothing
+
+compilerVersionName :: CompilerVersion -> T.Text
+compilerVersionName (GhcVersion vghc) =
+    "ghc-" <> versionText vghc
+
+isWantedCompiler :: VersionCheck -> CompilerVersion -> CompilerVersion -> Bool
+isWantedCompiler check (GhcVersion wanted) (GhcVersion actual) =
+    checkVersion check wanted actual

--- a/stack.cabal
+++ b/stack.cabal
@@ -60,6 +60,7 @@ library
                      Stack.Types
                      Stack.Types.Internal
                      Stack.Types.BuildPlan
+                     Stack.Types.Compiler
                      Stack.Types.Config
                      Stack.Types.Docker
                      Stack.Types.FlagName


### PR DESCRIPTION
To test before https://github.com/fpco/stackage-content/pull/8 is merged, replace [this line](https://github.com/commercialhaskell/stack/blob/736-exact-ghc-versions/src/Stack/Setup.hs#L497) with

```
    req = "https://raw.githubusercontent.com/fpco/stackage-content/c9165a5845370cf83b2dd373a66cb9a80f9bf74d/stack/stack-setup-2.yaml"
```

Description from the commit:

* Requires the exact GHC version specified by the snapshot.

* Deprecates major-version (ghc-7.10, ghc-7.8) resolvers, but still
  supports them.  They resolve to the newest installed / available ghc
  matching that number.

* Changes the format of stack-setup.yaml, and so changes which URL is
  used to find it (in order to not break old stack versions).

* Refactors ensureTool code, as it already had a lot of special cases,
  which I found confusing.  Main cause is that I needed to pass in a
  'CompilerVersion' instead of 'Version', but just for installing ghc,
  not for git.

* Introduces a 'CompilerVersion' type, and changes some naming to
  specify that compiler versions are being passed around rather than ghc
  versions.  The change could be a simpler without this, but this will
  be helpful for GHCJS support.