### PR TITLE
Enable tests whenever possible

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,7 @@ Other enhancements:
 * Code page changes on Windows only apply to the build command (and its synonyms), and can be controlled via a command line flag (still defaults to on) [#757](https://github.com/commercialhaskell/stack/issues/757)
 * Implicitly add packages to extra-deps when a flag for them is set [#807](https://github.com/commercialhaskell/stack/issues/807)
 * Use a precompiled Setup.hs for simple build types [#801](https://github.com/commercialhaskell/stack/issues/801)
+* Set --enable-tests and --enable-benchmarks optimistically [#805](https://github.com/commercialhaskell/stack/issues/805)
 
 Bug fixes:
 

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -98,7 +98,7 @@ build setLocalFiles mbuildLk bopts = do
 
     if boptsDryrun bopts
         then printPlan plan
-        else executePlan menv bopts baseConfigOpts locals sourceMap plan
+        else executePlan menv bopts baseConfigOpts locals sourceMap installedMap plan
   where
     profiling = boptsLibProfile bopts || boptsExeProfile bopts
 

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -476,6 +476,8 @@ describeConfigDiff old new
         , "--package-db="
         , "--libdir="
         , "--bindir="
+        , "--enable-tests"
+        , "--enable-benchmarks"
         ]
 
     userOpts = filter (not . isStackOpt)

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -132,20 +132,13 @@ constructPlan mbp0 baseConfigOpts0 locals extraToBuild0 locallyRegistered loadPa
 
     econfig <- asks getEnvConfig
     let onWanted lp = do
-            {-
-             - Arguably this is the right thing to do. However, forcing the
-             - library to rebuild causes the cabal_macros.h file to change,
-             - which makes GHC rebuild everything...
-
             case lpExeComponents lp of
                 Nothing -> return ()
-                Just _ -> void $ addDep $ packageName $ lpPackage lp
-            -}
+                Just _ -> void $ addDep False $ packageName $ lpPackage lp
 
             case lpTestBench lp of
                 Just tb -> addFinal lp tb
-                -- See comment above
-                Nothing -> void $ addDep False $ packageName $ lpPackage lp
+                Nothing -> return ()
     let inner = do
             mapM_ onWanted $ filter lpWanted locals
             mapM_ (addDep False) $ Set.toList extraToBuild0

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -316,10 +316,11 @@ executePlan :: M env m
             -> BaseConfigOpts
             -> [LocalPackage]
             -> SourceMap
+            -> InstalledMap
             -> Plan
             -> m ()
-executePlan menv bopts baseConfigOpts locals sourceMap plan = do
-    withExecuteEnv menv bopts baseConfigOpts locals sourceMap (executePlan' plan)
+executePlan menv bopts baseConfigOpts locals sourceMap installedMap plan = do
+    withExecuteEnv menv bopts baseConfigOpts locals sourceMap (executePlan' installedMap plan)
 
     unless (Map.null $ planInstallExes plan) $ do
         snapBin <- (</> bindirSuffix) `liftM` installationRootDeps
@@ -399,10 +400,11 @@ windowsRenameCopy src dest = do
 
 -- | Perform the actual plan (internal)
 executePlan' :: M env m
-             => Plan
+             => InstalledMap
+             -> Plan
              -> ExecuteEnv
              -> m ()
-executePlan' plan ee@ExecuteEnv {..} = do
+executePlan' installedMap plan ee@ExecuteEnv {..} = do
     wc <- getWhichCompiler
     case Map.toList $ planUnregisterLocal plan of
         [] -> return ()
@@ -423,7 +425,7 @@ executePlan' plan ee@ExecuteEnv {..} = do
     -- stack always using transformer stacks that are safe for this use case.
     runInBase <- liftBaseWith $ \run -> return (void . run)
 
-    let actions = concatMap (toActions runInBase ee) $ Map.elems $ Map.mergeWithKey
+    let actions = concatMap (toActions installedMap' runInBase ee) $ Map.elems $ Map.mergeWithKey
             (\_ b f -> Just (Just b, Just f))
             (fmap (\b -> (Just b, Nothing)))
             (fmap (\f -> (Nothing, Just f)))
@@ -465,13 +467,20 @@ executePlan' plan ee@ExecuteEnv {..} = do
         generateDepsHaddockIndex eeEnvOverride wc eeBaseConfigOpts eeLocals
         generateSnapHaddockIndex eeEnvOverride wc eeBaseConfigOpts eeGlobalDB
     when (toCoverage $ boptsTestOpts eeBuildOpts) generateHpcMarkupIndex
+  where
+    installedMap' = Map.difference installedMap
+                  $ Map.fromList
+                  $ map (\gid -> (packageIdentifierName $ ghcPkgIdPackageIdentifier gid, ()))
+                  $ Map.keys
+                  $ planUnregisterLocal plan
 
 toActions :: M env m
-          => (m () -> IO ())
+          => InstalledMap
+          -> (m () -> IO ())
           -> ExecuteEnv
           -> (Maybe Task, Maybe (Task, LocalPackageTB)) -- build and final
           -> [Action]
-toActions runInBase ee (mbuild, mfinal) =
+toActions installedMap runInBase ee (mbuild, mfinal) =
     abuild ++ afinal
   where
     abuild =
@@ -482,7 +491,7 @@ toActions runInBase ee (mbuild, mfinal) =
                     { actionId = ActionId taskProvides ATBuild
                     , actionDeps =
                         (Set.map (\ident -> ActionId ident ATBuild) (tcoMissing taskConfigOpts))
-                    , actionDo = \ac -> runInBase $ singleBuild ac ee task
+                    , actionDo = \ac -> runInBase $ singleBuild ac ee task installedMap
                     }
                 ]
     afinal =
@@ -495,9 +504,9 @@ toActions runInBase ee (mbuild, mfinal) =
                         (Set.map (\ident -> ActionId ident ATBuild) (tcoMissing taskConfigOpts))
                     , actionDo = \ac -> runInBase $ do
                         unless (Set.null $ lptbTests lptb) $ do
-                            singleTest topts lptb ac ee task
+                            singleTest topts lptb ac ee task installedMap
                         unless (Set.null $ lptbBenches lptb) $ do
-                            singleBench beopts lptb ac ee task
+                            singleBench beopts lptb ac ee task installedMap
                     }
                 ]
       where
@@ -751,10 +760,22 @@ singleBuild :: M env m
             => ActionContext
             -> ExecuteEnv
             -> Task
+            -> InstalledMap
             -> m ()
-singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} =
+singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} installedMap =
   withSingleContext ac ee task Nothing $ \package cabalfp pkgDir cabal announce console _mlogFile -> do
-    (cache, _neededConfig) <- ensureConfig pkgDir ee task (announce "configure") cabal cabalfp []
+    (cache, _neededConfig) <- ensureConfig pkgDir ee task (announce "configure") cabal cabalfp $
+        -- We enable tests if the test suite dependencies are already
+        -- installed, so that we avoid unnecessary recompilation based on
+        -- cabal_macros.h changes when switching between 'stack build' and
+        -- 'stack test'. See:
+        -- https://github.com/commercialhaskell/stack/issues/805
+        case taskType of
+            TTLocal lp -> concat
+                [ ["--enable-tests" | depsPresent installedMap $ lpTestDeps lp]
+                , ["--enable-benchmarks" | depsPresent installedMap $ lpBenchDeps lp]
+                ]
+            _ -> []
     wc <- getWhichCompiler
 
     markExeNotInstalled (taskLocation task) taskProvides
@@ -826,16 +847,32 @@ singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} =
                 (PackageIdentifier (packageName package) (packageVersion package))
                 Set.empty
 
+-- | Determine if all of the dependencies given are installed
+depsPresent :: InstalledMap -> Map PackageName VersionRange -> Bool
+depsPresent installedMap deps = all
+    (\(name, range) ->
+        case Map.lookup name installedMap of
+            Just (version, _, _) -> version `withinRange` range
+            Nothing -> False)
+    (Map.toList deps)
+
 singleTest :: M env m
            => TestOpts
            -> LocalPackageTB
            -> ActionContext
            -> ExecuteEnv
            -> Task
+           -> InstalledMap
            -> m ()
-singleTest topts lptb ac ee task =
+singleTest topts lptb ac ee task installedMap =
     withSingleContext ac ee task (Just "test") $ \package cabalfp pkgDir cabal announce console mlogFile -> do
-        (_cache, neededConfig) <- ensureConfig pkgDir ee task (announce "configure (test)") cabal cabalfp ["--enable-tests"]
+        (_cache, neededConfig) <- ensureConfig pkgDir ee task (announce "configure (test)") cabal cabalfp $
+            case taskType task of
+                TTLocal lp -> concat
+                    [ ["--enable-tests"]
+                    , ["--enable-benchmarks" | depsPresent installedMap $ lpBenchDeps lp]
+                    ]
+                _ -> []
         config <- asks getConfig
 
         testBuilt <- checkTestBuilt pkgDir
@@ -973,10 +1010,17 @@ singleBench :: M env m
             -> ActionContext
             -> ExecuteEnv
             -> Task
+            -> InstalledMap
             -> m ()
-singleBench beopts _lptb ac ee task =
+singleBench beopts _lptb ac ee task installedMap =
     withSingleContext ac ee task (Just "bench") $ \_package cabalfp pkgDir cabal announce console _mlogFile -> do
-        (_cache, neededConfig) <- ensureConfig pkgDir ee task (announce "configure (benchmarks)") cabal cabalfp ["--enable-benchmarks"]
+        (_cache, neededConfig) <- ensureConfig pkgDir ee task (announce "configure (benchmarks)") cabal cabalfp $
+            case taskType task of
+                TTLocal lp -> concat
+                    [ ["--enable-tests" | depsPresent installedMap $ lpTestDeps lp]
+                    , ["--enable-benchmarks"]
+                    ]
+                _ -> []
 
         benchBuilt <- checkBenchBuilt pkgDir
 

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -302,6 +302,15 @@ loadLocalPackage bopts targets (name, (lpv, gpkg)) = do
             { packageConfigEnableTests = not $ Set.null tests
             , packageConfigEnableBenchmarks = not $ Set.null benches
             }
+        testconfig = config
+            { packageConfigEnableTests = True
+            , packageConfigEnableBenchmarks = False
+            }
+        benchconfig = config
+            { packageConfigEnableTests = False
+            , packageConfigEnableBenchmarks = True
+            }
+
         btpkg
             | Set.null tests && Set.null benches = Nothing
             | otherwise = Just $ LocalPackageTB
@@ -309,6 +318,8 @@ loadLocalPackage bopts targets (name, (lpv, gpkg)) = do
                 , lptbTests = tests
                 , lptbBenches = benches
                 }
+        testpkg = resolvePackage testconfig gpkg
+        benchpkg = resolvePackage benchconfig gpkg
     mbuildCache <- tryGetBuildCache $ lpvRoot lpv
     (_,modFiles,otherFiles,mainFiles,extraFiles) <- getPackageFiles (packageFiles pkg) (lpvCabalFP lpv)
     let files =
@@ -322,6 +333,8 @@ loadLocalPackage bopts targets (name, (lpv, gpkg)) = do
 
     return LocalPackage
         { lpPackage = pkg
+        , lpTestDeps = packageDeps $ testpkg
+        , lpBenchDeps = packageDeps $ benchpkg
         , lpExeComponents =
             case mtarget of
                 Nothing -> Nothing

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -95,6 +95,8 @@ readLocalPackage pkgDir = do
         , lpCabalFile = cabalfp
         -- NOTE: these aren't the 'correct values, but aren't used in
         -- the usage of this function in this module.
+        , lpTestDeps = Map.empty
+        , lpBenchDeps = Map.empty
         , lpTestBench = Nothing
         , lpDirtyFiles = True
         , lpNewBuildCache = Map.empty

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -182,6 +182,10 @@ data LocalPackageTB = LocalPackageTB
 -- | Information on a locally available package of source code
 data LocalPackage = LocalPackage
     { lpPackage        :: !Package         -- ^ The @Package@ info itself, after resolution with package flags, not including any tests or benchmarks
+    , lpTestDeps       :: !(Map PackageName VersionRange)
+    -- ^ Used for determining if we can use --enable-tests in a normal build
+    , lpBenchDeps      :: !(Map PackageName VersionRange)
+    -- ^ Used for determining if we can use --enable-benchmarks in a normal build
     , lpExeComponents  :: !(Maybe (Set Text)) -- ^ Executable components to build, Nothing if not a target
 
     , lpTestBench      :: !(Maybe LocalPackageTB)


### PR DESCRIPTION
See #805. Motivation: when you switch between `cabal configure` and `cabal configure --enable-tests`, the cabal_macros.h file is changed, leading to the library to be recompiled needlessly. Based on an idea from @gregwebs, this change makes it so that, whenever the test suite and benchmark dependencies are present, `--enable-tests` and `--enable-benchmarks` are passed in, respectively. We use components as a parameter to `cabal build` to control which components are built (unfortunately, there's no way to simply say "don't rebuild the library"...).

Pinging @chrisdone and @borsboom. @Fuuzetsu could you test out this branch and let me know if it helps out your `stack build && stack test` use case?