### PR TITLE
--file-watch should respect VCS boring/ignore files

### DIFF
--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -154,7 +154,7 @@ buildOptsParser cmd =
 
         fileWatch' = flag False True
             (long "file-watch" <>
-             help "Watch for changes in local files and automatically rebuild")
+             help "Watch for changes in local files and automatically rebuild. Ignores files in VCS boring/ignore file")
 
         keepGoing = maybeBoolFlags
             "keep-going"

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -666,7 +666,14 @@ cleanCmd () go = withBuildConfigAndLock go (\_ -> clean)
 buildCmd :: Maybe (Text, Text) -- ^ option synonym
          -> BuildOpts -> GlobalOpts -> IO ()
 buildCmd moptionSynonym opts go
-    | boptsFileWatch opts = fileWatch inner
+    | boptsFileWatch opts =
+        let getProjectRoot =
+                do (manager, lc) <- loadConfigWithOpts go
+                   bconfig <-
+                       runStackLoggingTGlobal manager go $
+                       lcLoadBuildConfig lc (globalResolver go)
+                   return (bcRoot bconfig)
+        in fileWatch getProjectRoot inner
     | otherwise = inner $ const $ return ()
   where
     inner setLocalFiles = withBuildConfigAndLock go $ \lk -> do

--- a/stack.cabal
+++ b/stack.cabal
@@ -133,6 +133,7 @@ library
                    , http-client-tls >= 0.2.2
                    , http-conduit >= 2.1.7
                    , http-types >= 0.8.6
+                   , ignore >= 0.1
                    , lifted-base
                    , monad-control
                    , monad-logger >= 0.3.13.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,6 @@
 resolver: lts-3.0
-
+extra-deps:
+- ignore-0.1.0.0
 image:
   container:
     base: "fpco/ubuntu-with-libgmp:14.04"


### PR DESCRIPTION
( A first attempt of Part 1 for #703 )

This is a very basic implementation and I've moved out most of the logic to a separate package ( http://hackage.haskell.org/package/ignore ) as I would like to reuse it for other projects. Don't know if this is the desired approach, looking for feedback :-)