### PR TITLE
Still start up stack-ide and stack ghci even if there are project compilation errors.

### DIFF
--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -207,6 +207,7 @@ ghciSetup mainIs stringTargets = do
         , boptsBenchmarkOpts = (boptsBenchmarkOpts base)
           { beoDisableRun = True
           }
+        , boptsBuildSubset = BSOnlyDependencies
         }
       where
         base = defaultBuildOpts


### PR DESCRIPTION
See issue #810.