### PR TITLE
build the ignore library w/o pcre support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - travis_retry cabal update
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0
+ - cabal install --only-dependencies --constraint="ignore +without-pcre" --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0
 
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
@@ -69,4 +69,3 @@ script:
 # `cabal install --force-reinstalls dist/*-*.tar.gz`
  - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
    (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
-

--- a/stack.cabal
+++ b/stack.cabal
@@ -133,7 +133,7 @@ library
                    , http-client-tls >= 0.2.2
                    , http-conduit >= 2.1.7
                    , http-types >= 0.8.6
-                   , ignore >= 0.1
+                   , ignore >= 0.1.1
                    , lifted-base
                    , monad-control
                    , monad-logger >= 0.3.13.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,9 @@
 resolver: lts-3.0
 extra-deps:
-- ignore-0.1.0.0
+- ignore-0.1.1.0
+flags:
+  ignore:
+    without-pcre: true
 image:
   container:
     base: "fpco/ubuntu-with-libgmp:14.04"


### PR DESCRIPTION
Quickfix to #831 - will build the `ignore` library w/o pcre for now.