### PR TITLE
Create tarballs rather than gzipping naked binaries during release.

### DIFF
--- a/scripts/release/release.hs
+++ b/scripts/release/release.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --install-ghc runghc --package=shake --package=extra --package=zip-archive --package=mime-types --package=http-types --package=http-conduit --package=text --package=conduit-combinators --package=conduit --package=case-insensitive --package=aeson --package=zlib --package executable-path
+-- stack --install-ghc runghc --package=shake --package=extra --package=zip-archive --package=mime-types --package=http-types --package=http-conduit --package=text --package=conduit-combinators --package=conduit --package=case-insensitive --package=aeson --package=zlib --package executable-path --package tar
 {-# OPTIONS_GHC -Wall -Werror #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -23,6 +23,7 @@ import System.Directory
 import System.IO.Error
 import System.Process
 
+import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Archive.Zip as Zip
 import qualified Codec.Compression.GZip as GZip
 import Data.Aeson
@@ -171,12 +172,12 @@ rules global@Global{..} args = do
                 archive = Zip.addEntryToArchive entry' Zip.emptyArchive
             L8.writeFile out (Zip.fromArchive archive)
 
-    releaseDir </> binaryExeGzFileName %> \out -> do
+    releaseDir </> binaryExeTarGzFileName %> \out -> do
         need [releaseDir </> binaryExeFileName]
-        putNormal $ "gzip " ++ (releaseDir </> binaryExeFileName)
+        putNormal $ "tar gzip " ++ (releaseDir </> binaryExeFileName)
         liftIO $ do
-            fc <- L8.readFile (releaseDir </> binaryExeFileName)
-            L8.writeFile out $ GZip.compress fc
+            content <- Tar.pack releaseDir [binaryExeFileName]
+            L8.writeFile out $ GZip.compress $ Tar.write content
 
     releaseDir </> binaryExeFileName %> \out -> do
         need [installBinDir </> stackOrigExeFileName]
@@ -280,11 +281,11 @@ rules global@Global{..} args = do
     binaryExeCompressedFileName =
         case platformOS of
             Windows -> binaryExeZipFileName
-            _ -> binaryExeGzFileName
-    binaryExeZipFileName = binaryExeFileNameNoExt <.> zipExt
-    binaryExeGzFileName = binaryExeFileName <.> gzExt
+            _ -> binaryExeTarGzFileName
+    binaryExeZipFileName = binaryName global <.> zipExt
+    binaryExeTarGzFileName = binaryName global <.> tarGzExt
     binaryExeFileName = binaryExeFileNameNoExt <.> exe
-    binaryExeFileNameNoExt = binaryName global
+    binaryExeFileNameNoExt = stackOrigExeFileName
     distroPackageFileName distro
         | distroPackageExt distro == debExt =
             concat [stackProgName, "_", distroPackageVersionStr distro, "_amd64"] <.> debExt


### PR DESCRIPTION
This has several advantages:
* The executable bit is set by default, so no need to `chmod +x` after
  decompressing.
* No need to rename binary to `stack` after decompressing.
* Can use tarball as the source argument for Docker `ADD` commands,
  for conveniently installing a stack binary into a docker image when
  the package manager not appropriate / not available.

The tarball still only contains just the `stack` binary.