### PR TITLE
add some wording to soothe users about installing GHC

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ projects. It is aimed at Haskellers both new and experienced.
 
 It features:
 
-* Installing GHC automatically.
+* Installing GHC automatically, in an isolated location.
 * Installing packages needed for your project.
 * Building your project.
 * Testing your project.
@@ -48,7 +48,8 @@ You may be prompted to run some of the following along the way:
 * `stack init` to create a stack configuration file for an existing project.
   stack will figure out what Stackage release (LTS or nightly) is appropriate
   for the dependencies.
-* `stack setup` to download and install the correct GHC version. (For
+* `stack setup` to download and install the correct GHC version in an isolated
+  location that won't interfere with any system-level installations. (For
   information on installation paths, please use the `stack path` command.)
 
 If you just want to install an executable using stack, then all you have

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -610,6 +610,8 @@ downloadAndInstallGHC menv si wanted versionCheck = do
             case platform of
                 Platform _ os | isWindows os -> installGHCWindows
                 _ -> installGHCPosix
+    $logInfo "Preparing to install GHC to an isolated location."
+    $logInfo "This will not interfere with any system-level installation."
     downloadAndInstallTool si downloadInfo $(mkPackageName "ghc") selectedVersion installer
 
 getOSKey :: (MonadReader env m, MonadThrow m, HasConfig env, MonadLogger m, MonadIO m, MonadCatch m, MonadBaseControl IO m)


### PR DESCRIPTION
To address the concern that some users have had about stack installing GHC and potentially messing up their existing installations, this PR updates the README slightly to be more explicit about that, and also adds some output to the "setup" command so that they hopefully won't panic and try to interrupt the installation.

I thought of doing this while reading the intro to Snoyman's new Stack guide, where it says:

> Finally, stack is isolated: it will not make changes outside of specific stack directories (described below). Do not be worried if you see comments like "Installing GHC": stack will not tamper with your system packages at all. Additionally, stack packages will not interfere with packages installed by other build tools like cabal.

I also wanted to refer to a reddit thread I remember seeing where a user described their experience of running "stack setup" after being instructed to do so, and then panicking when they saw what it was doing, since they were afraid that it would mess up their existing GHC installation. I can't find the thread, though. :P