### PR TITLE
Full msys2 support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,7 @@ Other enhancements:
 * Check for duplicate local package names
 * Stop nagging people that call `stack test` [#845](https://github.com/commercialhaskell/stack/issues/845)
 * `--file-watch` will ignore files that are in your VCS boring/ignore files [#703](https://github.com/commercialhaskell/stack/issues/703)
+* `stack setup` takes a `--stack-setup-yaml` argument
 
 Bug fixes:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Major changes:
 * You now have more control over how GHC versions are matched, e.g. "use exactly this version," "use the specified minor version, but allow patches," or "use the given minor version or any later minor in the given major release." The default has switched from allowing newer later minor versions to a specific minor version allowing patches. For more information, see [#736](https://github.com/commercialhaskell/stack/issues/736) and [#784](https://github.com/commercialhaskell/stack/pull/784).
 * Support added for compiling with GHCJS
 * stack can now reuse prebuilt binaries between snapshots. That means that, if you build package foo in LTS-3.1, that binary version can be reused in LTS-3.2, assuming it uses the same dependencies and flags. [#878](https://github.com/commercialhaskell/stack/issues/878)
+* On Windows, we now use a full MSYS2 installation in place of the previous PortableGit. This gives you access to the pacman package manager for more easily installing libraries.
 
 Other enhancements:
 

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -484,12 +484,13 @@ data SetupCmdOpts = SetupCmdOpts
     { scoCompilerVersion :: !(Maybe CompilerVersion)
     , scoForceReinstall :: !Bool
     , scoUpgradeCabal :: !Bool
+    , scoStackSetupYaml :: !String
     }
 
 setupParser :: Parser SetupCmdOpts
 setupParser = SetupCmdOpts
     <$> (optional $ argument readVersion
-            (metavar "GHC_MAJOR_VERSION" <>
+            (metavar "GHC_VERSION" <>
              help ("Version of GHC to install, e.g. 7.10.2. " ++
                    "The default is to install the version implied by the resolver.")))
     <*> boolFlags False
@@ -500,6 +501,12 @@ setupParser = SetupCmdOpts
             "upgrade-cabal"
             "installing the newest version of the Cabal library globally"
             idm
+    <*> strOption
+            ( long "stack-setup-yaml"
+           <> help "Location of the stack-setup.yaml file"
+           <> value defaultStackSetupYaml
+           <> showDefault
+            )
   where
     readVersion = do
         s <- readerAsk
@@ -540,6 +547,7 @@ setupCmd SetupCmdOpts{..} go@GlobalOpts{..} = do
                   , soptsSkipMsys = configSkipMsys $ lcConfig lc
                   , soptsUpgradeCabal = scoUpgradeCabal
                   , soptsResolveMissingGHC = Nothing
+                  , soptsStackSetupYaml = scoStackSetupYaml
                   }
               case mpaths of
                   Nothing -> $logInfo "stack will use the GHC on your PATH"


### PR DESCRIPTION
Instead of using PortableGit, this moves stack over to using the full msys2. The advantage: it comes with pacman. This change also makes it so that the relevant --extra-lib-dirs and --extra-include-dirs are automatically set, meaning the following actually works:

    stack exec -- pacman -S mingw64/mingw-w64-x86_64-icu
    stack build text-icu. It's working on the msys2 branch

Props to @ygale for the thread at http://sourceforge.net/p/icu/mailman/message/34125921/.

I'd like to get some Windows user tests of this besides myself before this is merged.