### PR TITLE
Hacky workaround for optparse-applicative issue with stack exec --help

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,7 @@ Bug fixes:
 * Create missing directories for `stack sdist`
 * Don't ignore .cabal files with extra periods [#895](https://github.com/commercialhaskell/stack/issues/895)
 * Deprecate unused `--optimizations` flag
+* Hacky workaround for optparse-applicative issue with `stack exec --help` [#806](https://github.com/commercialhaskell/stack/issues/806)
 
 ## 0.1.3.1
 

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -445,18 +445,19 @@ execOptsParser :: Maybe String -- ^ command
                -> Parser ExecOpts
 execOptsParser mcmd =
     ExecOpts
-        <$> maybe eoCmdParser pure mcmd
+        <$> pure mcmd
         <*> eoArgsParser
         <*> (eoPlainParser <|>
              ExecOptsEmbellished
                 <$> eoEnvSettingsParser
                 <*> eoPackagesParser)
   where
-    eoCmdParser :: Parser String
-    eoCmdParser = strArgument (metavar "CMD")
-
     eoArgsParser :: Parser [String]
-    eoArgsParser = many (strArgument (metavar "-- ARGS (e.g. stack ghc -- X.hs -o x)"))
+    eoArgsParser = many (strArgument (metavar meta))
+      where
+        meta =
+            (maybe ("CMD ") (const "") mcmd) ++
+            "-- ARGS (e.g. stack ghc -- X.hs -o x)"
 
     eoEnvSettingsParser :: Parser EnvSettings
     eoEnvSettingsParser = EnvSettings

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -196,7 +196,10 @@ data EnvSettings = EnvSettings
     deriving (Show, Eq, Ord)
 
 data ExecOpts = ExecOpts
-    { eoCmd :: !String
+    { eoCmd :: !(Maybe String)
+    -- ^ Usage of @Maybe@ here is nothing more than a hack, to avoid some weird
+    -- bug in optparse-applicative. See:
+    -- https://github.com/commercialhaskell/stack/issues/806
     , eoArgs :: ![String]
     , eoExtra :: !ExecOptsExtra
     }


### PR DESCRIPTION
Fixes #806

Downside: usage information now looks like:

Usage: stack exec [CMD -- ARGS (e.g. stack ghc -- X.hs -o x)]

Notice how "CMD" is inside the square brackets. Still seems like a
worthwhile tradeoff to me.