### PR TITLE
Fix warning about unicode specifier

### DIFF
--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -570,7 +570,7 @@ pullImage envOverride docker image =
                 "docker"
                 (concat
                    [["login"]
-                   ,maybe [] (\u -> ["--username=" ++ u]) (dockerRegistryUsername docker)
+                   ,maybe [] (\n -> ["--username=" ++ n]) (dockerRegistryUsername docker)
                    ,maybe [] (\p -> ["--password=" ++ p]) (dockerRegistryPassword docker)
                    ,[takeWhile (/= '/') image]]))
      e <- try (callProcess Nothing envOverride "docker" ["pull",image])


### PR DESCRIPTION
src/Stack/Docker.hs:573:31:
     warning: \u used with no following hex digits; treating as '\' followed by identifier [-Wunicode]
                       ,maybe [] (\u -> ["--username=" ++ u]) (dockerRegistryUsername docker)