### PR TITLE
Don't rebuild stack if it is up-to-date

### DIFF
--- a/stack.cabal
+++ b/stack.cabal
@@ -128,6 +128,7 @@ library
                    , filelock >= 0.1.0.1
                    , filepath >= 1.3.0.2
                    , fsnotify >= 0.2.1
+                   , gitrev >= 1.1
                    , hashable >= 1.2.3.2
                    , http-client >= 0.4.17
                    , http-client-tls >= 0.2.2


### PR DESCRIPTION
Ref #811

I've tested on my local fork, it works. But I am not sure if I am doing it in a robust way. Perhaps I could have made a customised `readProcess` just like what you have as [`callProcess`](https://github.com/commercialhaskell/stack/blob/master/src/System/Process/Run.hs#L63).