### PR TITLE
copyFile can't handle directories

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -883,7 +883,7 @@ singleBuild runInBase ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} in
         liftIO $ forM_ exes $ \exe -> do
             D.createDirectoryIfMissing True bindir
             let dst = bindir FP.</> FP.takeFileName exe
-            createLink exe dst `catchIO` \_ -> D.copyFile exe bindir
+            createLink exe dst `catchIO` \_ -> D.copyFile exe dst
 
         -- Find the package in the database
         wc <- getWhichCompiler


### PR DESCRIPTION
When I upgraded to stack 0.1.4.1, switched to LTS-3.4 and back to LTS 3.0, this happened:
```
> stack build
...
alex-3.1.4: copying precompiled package
happy-1.19.5: copying precompiled package
...
Pr/Users/johndoe/.stack/snapshots/x86_64-osx/lts-3.0/7.10.2/bin/: copyFile: inappropriate type (is a directory)
/Users/johndoe/.stack/snapshots/x86_64-osx/lts-3.0/7.10.2/bin/: copyFile: inappropriate type (is a directory)
```

This commit fixed it for me.