### PR TITLE
Add stack path --global-pkg-db / --ghc-package-path

### DIFF
--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -66,7 +66,7 @@ import           Stack.Types.Build
 import           Stack.Config (resolvePackageEntry)
 import           Stack.Constants (distRelativeDir)
 import           Stack.Fetch
-import           Stack.GhcPkg (createDatabase, getCabalPkgVer, getGlobalDB)
+import           Stack.GhcPkg (createDatabase, getCabalPkgVer, getGlobalDB, mkGhcPackagePath)
 import           Stack.Solver (getCompilerVersion)
 import           Stack.Types
 import           Stack.Types.StackT
@@ -198,12 +198,8 @@ setupEnv mResolveMissingGHC = do
     createDatabase menv wc deps
     localdb <- runReaderT packageDatabaseLocal envConfig0
     createDatabase menv wc localdb
-    globalDB <- getGlobalDB menv wc
-    let mkGPP locals = T.pack $ intercalate [searchPathSeparator] $ concat
-            [ [toFilePathNoTrailingSlash localdb | locals]
-            , [toFilePathNoTrailingSlash deps]
-            , [toFilePathNoTrailingSlash globalDB]
-            ]
+    globaldb <- getGlobalDB menv wc
+    let mkGPP locals = mkGhcPackagePath locals localdb deps globaldb
 
     distDir <- runReaderT distRelativeDir envConfig0
 

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -61,6 +61,7 @@ import           Stack.Options
 import           Stack.Package (getCabalFileName)
 import qualified Stack.PackageIndex
 import           Stack.Ghci
+import           Stack.GhcPkg (getGlobalDB, mkGhcPackagePath)
 import           Stack.SDist (getSDistTarball)
 import           Stack.Setup
 import           Stack.Solver (solveExtraDeps)
@@ -372,6 +373,7 @@ pathCmd keys go =
             menv <- getMinimalEnvOverride
             snap <- packageDatabaseDeps
             local <- packageDatabaseLocal
+            global <- getGlobalDB menv =<< getWhichCompiler
             snaproot <- installationRootDeps
             localroot <- installationRootLocal
             distDir <- distRelativeDir
@@ -391,6 +393,7 @@ pathCmd keys go =
                                     menv
                                     snap
                                     local
+                                    global
                                     snaproot
                                     localroot
                                     distDir))))
@@ -401,6 +404,7 @@ data PathInfo = PathInfo
     ,piEnvOverride :: EnvOverride
     ,piSnapDb :: Path Abs Dir
     ,piLocalDb :: Path Abs Dir
+    ,piGlobalDb :: Path Abs Dir
     ,piSnapRoot :: Path Abs Dir
     ,piLocalRoot :: Path Abs Dir
     ,piDistDir :: Path Rel Dir
@@ -459,6 +463,13 @@ paths =
       , "local-pkg-db"
       , \pi ->
              T.pack (toFilePathNoTrailing (piLocalDb pi)))
+    , ( "Global package database"
+      , "global-pkg-db"
+      , \pi ->
+             T.pack (toFilePathNoTrailing (piGlobalDb pi)))
+    , ( "GHC_PACKAGE_PATH environment variable"
+      , "ghc-package-path"
+      , \pi -> mkGhcPackagePath True (piLocalDb pi) (piSnapDb pi) (piGlobalDb pi))
     , ( "Snapshot installation root"
       , "snapshot-install-root"
       , \pi ->


### PR DESCRIPTION
It can be handy to know which global db stack is using.  In order to add some hacks for xmonad recompilation, I needed to hardcode a global db path and compute my own GHC_PACKAGE_PATH (https://github.com/mgsloan/compconfig/blob/master/xmonad.hs#L505).  This patch also adds `stack path --ghc-package-path`.

One downside of this is that it adds an additional invocation of `ghc-pkg`.  Benchmarked with `time`, this seems to have a very negligible affect on speed of the `stack path` command.