### PR TITLE
canonicalize environment paths before executing

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -328,8 +328,9 @@ executePlan menv bopts baseConfigOpts locals sourceMap installedMap plan = do
         destDir <- asks $ configLocalBin . getConfig
         createTree destDir
 
-        let destDir' = toFilePath destDir
-        when (not $ any (FP.equalFilePath destDir') (envSearchPath menv)) $
+        destDir' <- liftIO $ D.canonicalizePath (toFilePath destDir)
+        envSearchPaths <- liftIO $ mapM D.canonicalizePath (envSearchPath menv)
+        when (not $ any (FP.equalFilePath destDir') envSearchPaths) $
             $logWarn $ T.concat
                 [ "Installation path "
                 , T.pack destDir'


### PR DESCRIPTION
fixes #840 

As discussed in #928, @snoyberg pointed me to this issue. 