### PR TITLE
Add --build-ghc-options flag for stack ghci (#971)

### DIFF
--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -42,6 +42,7 @@ import           Stack.Types.Internal
 data GhciOpts = GhciOpts
     {ghciTargets            :: ![Text]
     ,ghciArgs               :: ![String]
+    ,ghciBuildGhcArgs       :: ![Text]
     ,ghciGhcCommand         :: !(Maybe FilePath)
     ,ghciNoLoadModules      :: !Bool
     ,ghciAdditionalPackages :: ![String]
@@ -65,7 +66,7 @@ ghci
     :: (HasConfig r, HasBuildConfig r, HasHttpManager r, MonadMask m, HasLogLevel r, HasTerminal r, HasEnvConfig r, MonadReader r m, MonadIO m, MonadThrow m, MonadLogger m, MonadCatch m, MonadBaseControl IO m)
     => GhciOpts -> m ()
 ghci GhciOpts{..} = do
-    (targets,mainIsTargets,pkgs) <- ghciSetup ghciMainIs ghciTargets
+    (targets,mainIsTargets,pkgs) <- ghciSetup ghciMainIs ghciTargets ghciBuildGhcArgs
     bconfig <- asks getBuildConfig
     mainFile <- figureOutMainFile mainIsTargets targets pkgs
     wc <- getWhichCompiler
@@ -154,13 +155,15 @@ ghciSetup
     :: (HasConfig r, HasHttpManager r, HasBuildConfig r, MonadMask m, HasTerminal r, HasLogLevel r, HasEnvConfig r, MonadReader r m, MonadIO m, MonadThrow m, MonadLogger m, MonadCatch m, MonadBaseControl IO m)
     => Maybe Text
     -> [Text]
+    -> [Text]
     -> m (Map PackageName SimpleTarget, Maybe (Map PackageName SimpleTarget), [GhciPkgInfo])
-ghciSetup mainIs stringTargets = do
+ghciSetup mainIs stringTargets buildGhcOpts = do
     (_,_,targets) <-
         parseTargetsFromBuildOpts
             AllowNoTargets
             defaultBuildOpts
             { boptsTargets = stringTargets
+            , boptsGhcOptions = buildGhcOpts
             }
     mainIsTargets <-
         case mainIs of
@@ -208,6 +211,7 @@ ghciSetup mainIs stringTargets = do
           { beoDisableRun = True
           }
         , boptsBuildSubset = BSOnlyDependencies
+        , boptsGhcOptions = buildGhcOpts
         }
       where
         base = defaultBuildOpts

--- a/src/Stack/Ide.hs
+++ b/src/Stack/Ide.hs
@@ -49,9 +49,10 @@ ide
     :: (HasConfig r, HasBuildConfig r, HasTerminal r, HasLogLevel r, MonadMask m, HasEnvConfig r, MonadReader r m, MonadIO m, MonadThrow m, MonadLogger m, MonadCatch m, MonadBaseControl IO m, HasHttpManager r)
     => [Text] -- ^ Targets.
     -> [String] -- ^ GHC options.
+    -> [Text] -- ^ Build GHC options.
     -> m ()
-ide targets useropts = do
-    (_realTargets,_,pkgs) <- ghciSetup Nothing targets
+ide targets useropts buildArgs = do
+    (_realTargets,_,pkgs) <- ghciSetup Nothing targets buildArgs
     pwd <- getWorkingDir
     (pkgopts,srcfiles) <-
         liftM mconcat $

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -429,9 +429,9 @@ ghciOptsParser = GhciOpts
                         ( long "pedantic"
                        <> help "Turn on -Wall and -Werror (note: option name may change in the future"
                         )
-                    <*> many (textOption (long "ghc-options" <>
+                    <*> many (textOption (long "build-ghc-options" <>
                                           metavar "OPTION" <>
-                                          help "Additional options passed to GHC")))
+                                          help "Additional options passed to GHC for the build")))
              <*> optional
                      (strOption (long "with-ghc" <>
                                  metavar "GHC" <>

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -424,9 +424,14 @@ ghciOptsParser = GhciOpts
              <*> fmap concat (many (argsOption (long "ghc-options" <>
                                        metavar "OPTION" <>
                                        help "Additional options passed to GHCi")))
-             <*> many (textOption (long "build-ghc-options" <>
-                                   metavar "OPTION" <>
-                                   help "Additional options passed to GHC"))
+             <*> ((++)
+                    <$> flag [] ["-Wall", "-Werror"]
+                        ( long "pedantic"
+                       <> help "Turn on -Wall and -Werror (note: option name may change in the future"
+                        )
+                    <*> many (textOption (long "ghc-options" <>
+                                          metavar "OPTION" <>
+                                          help "Additional options passed to GHC")))
              <*> optional
                      (strOption (long "with-ghc" <>
                                  metavar "GHC" <>

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -424,6 +424,9 @@ ghciOptsParser = GhciOpts
              <*> fmap concat (many (argsOption (long "ghc-options" <>
                                        metavar "OPTION" <>
                                        help "Additional options passed to GHCi")))
+             <*> many (textOption (long "build-ghc-options" <>
+                                   metavar "OPTION" <>
+                                   help "Additional options passed to GHC"))
              <*> optional
                      (strOption (long "with-ghc" <>
                                  metavar "GHC" <>

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -300,14 +300,17 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter -> do
                          "start"
                          "Start the ide-backend service"
                          ideCmd
-                         ((,) <$> many (textArgument
-                                          (metavar "TARGET" <>
-                                           help ("If none specified, use all " <>
-                                                 "packages defined in current directory")))
-                              <*> argsOption (long "ghc-options" <>
-                                              metavar "OPTION" <>
-                                              help "Additional options passed to GHCi" <>
-                                              value []))
+                         ((,,) <$> many (textArgument
+                                           (metavar "TARGET" <>
+                                            help ("If none specified, use all " <>
+                                                  "packages defined in current directory")))
+                               <*> argsOption (long "ghc-options" <>
+                                               metavar "OPTION" <>
+                                               help "Additional options passed to GHCi" <>
+                                               value [])
+                               <*> many (textOption (long "build-ghc-options" <>
+                                                     metavar "OPTION" <>
+                                                     help "Additional options passed to GHC")))
                      addCommand
                          "packages"
                          "List all available local loadable packages"
@@ -824,10 +827,10 @@ ghciCmd ghciOpts go@GlobalOpts{..} =
     ghci ghciOpts
 
 -- | Run ide-backend in the context of a project.
-ideCmd :: ([Text], [String]) -> GlobalOpts -> IO ()
-ideCmd (targets,args) go@GlobalOpts{..} =
+ideCmd :: ([Text], [String], [Text]) -> GlobalOpts -> IO ()
+ideCmd (targets,args,buildArgs) go@GlobalOpts{..} =
     withBuildConfig go $ -- No locking needed.
-      ide targets args
+      ide targets args buildArgs
 
 -- | Run ide-backend in the context of a project.
 packagesCmd :: () -> GlobalOpts -> IO ()

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -308,9 +308,14 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter -> do
                                                metavar "OPTION" <>
                                                help "Additional options passed to GHCi" <>
                                                value [])
-                               <*> many (textOption (long "build-ghc-options" <>
-                                                     metavar "OPTION" <>
-                                                     help "Additional options passed to GHC")))
+                               <*> ((++)
+                                      <$> flag [] ["-Wall", "-Werror"]
+                                          ( long "pedantic"
+                                         <> help "Turn on -Wall and -Werror (note: option name may change in the future"
+                                          )
+                                      <*> many (textOption (long "ghc-options" <>
+                                                            metavar "OPTION" <>
+                                                            help "Additional options passed to GHC"))))
                      addCommand
                          "packages"
                          "List all available local loadable packages"


### PR DESCRIPTION
@bergmark 

Now with `--build-ghc-options` you can retain the build flags:

```
bash-3.2$ stack build --test --ghc-options="-Wall -Werror"
stack-0.1.4.1: unregistering (components added: test:stack-test)
stack-0.1.4.1: configure
Configuring stack-0.1.4.1...
stack-0.1.4.1: build
[...]
Completed all 2 actions.
bash-3.2$ stack ghci --build-ghc-options="-Wall -Werror"
* * * * * * * *
The main module to load is ambiguous. Candidates are: 
Package `stack' component exe:stack with main-is file: /Users/chris/Work/stack/src/main/Main.hs
Package `stack' component test:stack-integration-test with main-is file: /Users/chris/Work/stack/test/integration/IntegrationSpec.hs
Package `stack' component test:stack-test with main-is file: /Users/chris/Work/stack/src/test/Test.hs
None will be loaded. You can specify which one to pick by: 
 1) Specifying targets to stack ghci e.g. stack ghci stack:exe:stack
 2) Specifying what the main is e.g. stack ghci --main-is stack:exe:stack
* * * * * * * *
Configuring GHCi with the following packages: stack
GHCi, version 7.10.2: http://www.haskell.org/ghc/  :? for help
unknown option: 'c'
[...]
*Control.Concurrent.Execute> :q
Leaving GHCi.
bash-3.2$ 
```

Also added a `--pedantic` arg:

```
bash-3.2$ stack build --test --pedantic
stack-0.1.4.1: unregistering (components added: test:stack-test)
stack-0.1.4.1: configure
Configuring stack-0.1.4.1...
stack-0.1.4.1: build
Preprocessing library stack-0.1.4.1...
[..]
Completed all 2 actions.
bash-3.2$ stack ghci --pedantic
* * * * * * * *
The main module to load is ambiguous. Candidates are: 
Package `stack' component exe:stack with main-is file: /Users/chris/Work/stack/src/main/Main.hs
Package `stack' component test:stack-integration-test with main-is file: /Users/chris/Work/stack/test/integration/IntegrationSpec.hs
Package `stack' component test:stack-test with main-is file: /Users/chris/Work/stack/src/test/Test.hs
None will be loaded. You can specify which one to pick by: 
 1) Specifying targets to stack ghci e.g. stack ghci stack:exe:stack
 2) Specifying what the main is e.g. stack ghci --main-is stack:exe:stack
* * * * * * * *
Configuring GHCi with the following packages: stack
GHCi, version 7.10.2: http://www.haskell.org/ghc/  :? for help
unknown option: 'c'
[...]
*Control.Concurrent.Execute> :q
Leaving GHCi.
bash-3.2$ 
```

If this sounds good I'll merge the redundant parts.