### PR TITLE
Add filesystem polling via --file-watch-poll flag

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@ Other enhancements:
 * Cached data is written with a checksum of its structure [#889](https://github.com/commercialhaskell/stack/issues/889)
 * Fully removed `--optimizations` flag
 * Added `--cabal-verbose` flag
+* Added `--file-watch-poll` flag for polling instead of using filesystem events (useful for running tests in a Docker container while modifying code in the host environment. When code is injected into the container via a volume, the container won't propagate filesystem events).
 
 Bug fixes:
 

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -80,7 +80,7 @@ buildOptsParser cmd =
             haddock <*> haddockDeps <*> dryRun <*> ghcOpts <*>
             flags <*> copyBins <*> preFetch <*>
             buildSubset <*>
-            fileWatch' <*> keepGoing <*> forceDirty <*>
+            fileWatch' <*> fileWatchPoll' <*> keepGoing <*> forceDirty <*>
             tests <*> testOptsParser <*>
             benches <*> benchOptsParser <*>
             many exec <*> onlyConfigure <*> reconfigure <*>
@@ -151,6 +151,10 @@ buildOptsParser cmd =
         fileWatch' = flag False True
             (long "file-watch" <>
              help "Watch for changes in local files and automatically rebuild. Ignores files in VCS boring/ignore file")
+
+        fileWatchPoll' = flag False True
+            (long "file-watch-poll" <>
+             help "Same as --file-watch, except polling files for changes instead of listening for events")
 
         keepGoing = maybeBoolFlags
             "keep-going"

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -78,13 +78,10 @@ buildOptsParser cmd =
             fmap addCoverageFlags $
             BuildOpts <$> target <*> libProfiling <*> exeProfiling <*>
             haddock <*> haddockDeps <*> dryRun <*> ghcOpts <*>
-            flags <*> copyBins <*> preFetch <*>
-            buildSubset <*>
-            fileWatch' <*> fileWatchPoll' <*> keepGoing <*> forceDirty <*>
-            tests <*> testOptsParser <*>
-            benches <*> benchOptsParser <*>
-            many exec <*> onlyConfigure <*> reconfigure <*>
-            cabalVerbose
+            flags <*> copyBins <*> preFetch <*> buildSubset <*>
+            fileWatch' <*> keepGoing <*> forceDirty <*> tests <*>
+            testOptsParser <*> benches <*> benchOptsParser <*>
+            many exec <*> onlyConfigure <*> reconfigure <*> cabalVerbose
   where target =
            many (textArgument
                    (metavar "TARGET" <>
@@ -148,13 +145,14 @@ buildOptsParser cmd =
                  help "A synonym for --only-dependencies")
             <|> pure BSAll
 
-        fileWatch' = flag False True
-            (long "file-watch" <>
-             help "Watch for changes in local files and automatically rebuild. Ignores files in VCS boring/ignore file")
-
-        fileWatchPoll' = flag False True
-            (long "file-watch-poll" <>
-             help "Same as --file-watch, except polling files for changes instead of listening for events")
+        fileWatch' =
+            flag' FileWatch
+                (long "file-watch" <>
+                 help "Watch for changes in local files and automatically rebuild. Ignores files in VCS boring/ignore file")
+            <|> flag' FileWatchPoll
+                (long "file-watch-poll" <>
+                 help "Like --file-watch, but polling the filesystem instead of using events")
+            <|> pure NoFileWatch
 
         keepGoing = maybeBoolFlags
             "keep-going"
@@ -164,7 +162,6 @@ buildOptsParser cmd =
         forceDirty = flag False True
             (long "force-dirty" <>
              help "Force treating all local packages as having dirty files (useful for cases where stack can't detect a file change)")
-
 
         tests = boolFlags (cmd == Test)
             "test"

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -25,6 +25,7 @@ module Stack.Types.Build
     ,Plan(..)
     ,TestOpts(..)
     ,BenchmarkOpts(..)
+    ,FileWatchOpts(..)
     ,BuildOpts(..)
     ,BuildSubset(..)
     ,defaultBuildOpts
@@ -407,8 +408,7 @@ data BuildOpts =
             ,boptsPreFetch :: !Bool
             -- ^ Fetch all packages immediately
             ,boptsBuildSubset :: !BuildSubset
-            ,boptsFileWatch :: !Bool
-            ,boptsFileWatchPoll :: !Bool
+            ,boptsFileWatch :: !FileWatchOpts
             -- ^ Watch files for changes and automatically rebuild
             ,boptsKeepGoing :: !(Maybe Bool)
             -- ^ Keep building/running after failure
@@ -448,8 +448,7 @@ defaultBuildOpts = BuildOpts
     , boptsInstallExes = False
     , boptsPreFetch = False
     , boptsBuildSubset = BSAll
-    , boptsFileWatch = False
-    , boptsFileWatchPoll = False
+    , boptsFileWatch = NoFileWatch
     , boptsKeepGoing = Nothing
     , boptsForceDirty = False
     , boptsTests = False
@@ -489,6 +488,12 @@ defaultBenchmarkOpts = BenchmarkOpts
     { beoAdditionalArgs = Nothing
     , beoDisableRun = False
     }
+
+data FileWatchOpts
+  = NoFileWatch
+  | FileWatch
+  | FileWatchPoll
+  deriving (Show,Eq)
 
 -- | Package dependency oracle.
 newtype PkgDepsOracle =

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -408,6 +408,7 @@ data BuildOpts =
             -- ^ Fetch all packages immediately
             ,boptsBuildSubset :: !BuildSubset
             ,boptsFileWatch :: !Bool
+            ,boptsFileWatchPoll :: !Bool
             -- ^ Watch files for changes and automatically rebuild
             ,boptsKeepGoing :: !(Maybe Bool)
             -- ^ Keep building/running after failure
@@ -448,6 +449,7 @@ defaultBuildOpts = BuildOpts
     , boptsPreFetch = False
     , boptsBuildSubset = BSAll
     , boptsFileWatch = False
+    , boptsFileWatchPoll = False
     , boptsKeepGoing = Nothing
     , boptsForceDirty = False
     , boptsTests = False

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -687,10 +687,11 @@ cleanCmd () go = withBuildConfigAndLock go (\_ -> clean)
 
 -- | Helper for build and install commands
 buildCmd :: BuildOpts -> GlobalOpts -> IO ()
-buildCmd opts go
-    | boptsFileWatchPoll opts = fileWatchPoll getProjectRoot inner
-    | boptsFileWatch opts = fileWatch getProjectRoot inner
-    | otherwise = inner $ const $ return ()
+buildCmd opts go =
+  case boptsFileWatch opts of
+    FileWatchPoll -> fileWatchPoll getProjectRoot inner
+    FileWatch -> fileWatch getProjectRoot inner
+    NoFileWatch -> inner $ const $ return ()
   where
     inner setLocalFiles = withBuildConfigAndLock go $ \lk ->
         globalFixCodePage go $ Stack.Build.build setLocalFiles (Just lk) opts

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -688,18 +688,18 @@ cleanCmd () go = withBuildConfigAndLock go (\_ -> clean)
 -- | Helper for build and install commands
 buildCmd :: BuildOpts -> GlobalOpts -> IO ()
 buildCmd opts go
-    | boptsFileWatch opts =
-        let getProjectRoot =
-                do (manager, lc) <- loadConfigWithOpts go
-                   bconfig <-
-                       runStackLoggingTGlobal manager go $
-                       lcLoadBuildConfig lc (globalResolver go)
-                   return (bcRoot bconfig)
-        in fileWatch getProjectRoot inner
+    | boptsFileWatchPoll opts = fileWatchPoll getProjectRoot inner
+    | boptsFileWatch opts = fileWatch getProjectRoot inner
     | otherwise = inner $ const $ return ()
   where
     inner setLocalFiles = withBuildConfigAndLock go $ \lk ->
         globalFixCodePage go $ Stack.Build.build setLocalFiles (Just lk) opts
+    getProjectRoot = do
+        (manager, lc) <- loadConfigWithOpts go
+        bconfig <-
+            runStackLoggingTGlobal manager go $
+            lcLoadBuildConfig lc (globalResolver go)
+        return (bcRoot bconfig)
 
 globalFixCodePage :: (Catch.MonadMask m, MonadIO m, MonadLogger m)
                   => GlobalOpts


### PR DESCRIPTION
When developing in a Docker container with code injected using a volume, `stack test --file-watch` run from inside the container won't register changes to the code made in the host environment because fsnotify events don't propagate down into the Docker container. This patch gives the option to poll the filesystem instead of relying on events, which is the less performant but more portable option. It's a pretty concise change to make since polling is already built into fsnotify - literally just flipping a bool.

I've sanity checked it against the example above (tests running in Docker container, code being edited outside the container) and it works like a charm. Let me know what you think!