### PR TITLE
Canonicalises path from withSystemTempDirectory

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -287,7 +287,7 @@ withExecuteEnv :: M env m
                -> m a
 withExecuteEnv menv bopts baseConfigOpts locals globals sourceMap inner = do
     withSystemTempDirectory stackProgName $ \tmpdir -> do
-        tmpdir' <- parseAbsDir tmpdir
+        tmpdir' <- parseAbsDir =<< liftIO (D.canonicalizePath tmpdir)
         configLock <- newMVar ()
         installLock <- newMVar ()
         idMap <- liftIO $ newTVarIO Map.empty

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -439,7 +439,7 @@ upgradeCabal menv wc = do
                 , " to replace "
                 , T.pack $ versionString installed
                 ]
-            tmpdir' <- parseAbsDir tmpdir
+            tmpdir' <- parseAbsDir =<< liftIO (D.canonicalizePath tmpdir)
             let ident = PackageIdentifier name newest
             m <- unpackPackageIdents menv tmpdir' Nothing (Set.singleton ident)
 
@@ -766,7 +766,7 @@ installGHCPosix _ archiveFile archiveType destDir ident = do
     $logDebug $ "tar: " <> T.pack tarTool
 
     withSystemTempDirectory "stack-setup" $ \root' -> do
-        root <- parseAbsDir root'
+        root <- parseAbsDir =<< liftIO (D.canonicalizePath root')
         dir <-
             liftM (root Path.</>) $
             parseRelDir $
@@ -1069,7 +1069,7 @@ sanityCheck :: (MonadIO m, MonadMask m, MonadLogger m, MonadBaseControl IO m)
             => EnvOverride
             -> m ()
 sanityCheck menv = withSystemTempDirectory "stack-sanity-check" $ \dir -> do
-    dir' <- parseAbsDir dir
+    dir' <- parseAbsDir =<< liftIO (D.canonicalizePath dir)
     let fp = toFilePath $ dir' </> $(mkRelFile "Main.hs")
     liftIO $ writeFile fp $ unlines
         [ "import Distribution.Simple" -- ensure Cabal library is present


### PR DESCRIPTION
… Stack.Setup

The System.IO.Temp withSystemTempDirectory function from
System.IO.Temp used in Stack.Setup returns a non-canonicalised
path. However, the parseAbsDir function in the Path module of the path
library expects canonicalised paths.

The change is applied to stack setup, `sanityCheck` and stack upgrade
in Stack.Setup .

Fixes commercialhaskell/stack#1017