### PR TITLE
Update LICENCE to correct the project name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -8,7 +8,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of stackage-common nor the
+    * Neither the name of stack nor the
       names of its contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.
 


### PR DESCRIPTION
This fixes #1020 by changing the name from stackage-common to stack.