### PR TITLE
Use partial SHA1 instead of full platform name and Cabal version on Windows

### DIFF
--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -47,6 +48,13 @@ import           Prelude
 import           Stack.Types.Config
 import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageName
+#ifdef mingw32_HOST_OS
+import qualified Crypto.Hash.SHA1 as SHA1
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text.Encoding as T
+#endif
 
 -- | Extensions for anything that can be a Haskell module.
 haskellModuleExts :: [Text]
@@ -205,11 +213,22 @@ distRelativeDir = do
         parseRelDir $
         packageIdentifierString
             (PackageIdentifier cabalPackageName cabalPkgVer)
+
+#ifdef mingw32_HOST_OS
+    -- This is an attempt to shorten path to stack build artifacts dir on Windows to
+    -- decrease our chances of hitting 260 symbol path limit.
+    -- The idea is to calculate SHA1 hash from concatenated platform and cabal strings,
+    -- encode with base 16 and take first 8 symbols of it.
+    let concatenatedText = T.pack . toFilePath $ platform </> cabal
+        sha1 = SHA1.hash $ T.encodeUtf8 concatenatedText
+    platformAndCabal <- parseRelDir . B8.unpack . B.take 8 $ Base16.encode sha1
+#else
+    let platformAndCabal = platform </> cabal
+#endif
     return $
         workDirRel </>
         $(mkRelDir "dist") </>
-        platform </>
-        cabal
+        platformAndCabal
 
 -- | Get a URL for a raw file on Github
 rawGithubUrl :: Text -- ^ user/org name


### PR DESCRIPTION
I've had problems using Stack with our project on Windows. The issue was that when installing dependencies (in particular, aeson-pretty-0.7.2), Stack failed to compile Paths_aeson_pretty module because full path to intermediate files exceeded Windows 260 characters limit.

This pull request makes build artifacts path shorter by replacing "platform/cabal" part of it with first 8 characters of Base16-encoded SHA1 of it. In my case, this helped to get aeson-pretty succesfully installed.