### PR TITLE
mark executable-only packages as installed when copied from cache

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -896,6 +896,9 @@ singleBuild runInBase ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} in
             D.createDirectoryIfMissing True bindir
             let dst = bindir FP.</> FP.takeFileName exe
             createLink exe dst `catchIO` \_ -> D.copyFile exe dst
+        case (mlib, exes) of
+            (Nothing, _:_) -> markExeInstalled (taskLocation task) taskProvides
+            _ -> return ()
 
         -- Find the package in the database
         wc <- getWhichCompiler


### PR DESCRIPTION
Executable only packages don't get an entry in the pkgdb. Instead stack marks them via a dummy file in installed-packages. If a package is copied from another snapshot it gets registered if it has library, but when it has not the binaries are copied but the snapshot, which they are copied to doesn't get to know this. That means every time you do stack build they get copied again. That alone isn't a big problem, but they can trigger rebuilds of other packages, which can get out of hand. A solution would be to mark them as installed. Writing this in copyPreCompiled does the trick:
```
case (mlib, exes) of
    (Nothing, _:_) -> markExeInstalled (taskLocation task) taskProvides
    _ -> return ()
```
But I wasn't sure about the full implications of this. So I opted for simply not caching them instead. The downside is that people who already cached executable-only packages need to nuke them manually from the cache.