### PR TITLE
Fix #959: Inline haskell on the command-line

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ Major changes:
     * `~/.stack/global` --> `~/.stack/global-project`
     * `/etc/stack/config` --> `/etc/stack/config.yaml`
     * Old locations still supported, with deprecation warnings
+* New command "stack eval CODE", which evaluates to "stack exec ghc -- -e CODE".
 
 Other enhancements:
 

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -450,8 +450,9 @@ ghciOptsParser = GhciOpts
 
 -- | Parser for exec command
 execOptsParser :: Maybe String -- ^ command
+               -> Maybe String -- ^ metavar for arguments
                -> Parser ExecOpts
-execOptsParser mcmd =
+execOptsParser mcmd mmvr =
     ExecOpts
         <$> pure mcmd
         <*> eoArgsParser
@@ -463,9 +464,10 @@ execOptsParser mcmd =
     eoArgsParser :: Parser [String]
     eoArgsParser = many (strArgument (metavar meta))
       where
-        meta =
-            (maybe ("CMD ") (const "") mcmd) ++
-            "-- ARGS (e.g. stack ghc -- X.hs -o x)"
+        meta = case mmvr of
+                   Nothing -> (maybe ("CMD ") (const "") mcmd) ++
+                              "-- ARGS (e.g. stack ghc -- X.hs -o x)"
+                   Just x -> x
 
     eoEnvSettingsParser :: Parser EnvSettings
     eoEnvSettingsParser = EnvSettings

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -226,6 +226,12 @@ data ExecOptsExtra
         { eoEnvSettings :: !EnvSettings
         , eoPackages :: ![String]
         }
+
+data EvalOpts = EvalOpts
+    { evalArg :: !String
+    , evalExtra :: !ExecOptsExtra
+    }
+
 -- | Parsed global command-line options.
 data GlobalOpts = GlobalOpts
     { globalReExec       :: !Bool

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -854,12 +854,12 @@ execCmd ExecOpts {..} go@GlobalOpts{..} = do
 
 -- | Evaluate some haskell code inline.
 evalCmd :: EvalOpts -> GlobalOpts -> IO ()
-evalCmd eopts go@GlobalOpts {..} = execCmd execOpts go
+evalCmd EvalOpts {..} go@GlobalOpts {..} = execCmd execOpts go
     where
       execOpts =
           ExecOpts { eoCmd = Just "ghc"
-                   , eoArgs = ["-e", evalArg eopts]
-                   , eoExtra = evalExtra eopts
+                   , eoArgs = ["-e", evalArg]
+                   , eoExtra = evalExtra
                    }
 
 -- | Run GHCi in the context of a project.

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -271,11 +271,11 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter -> do
              addCommand "exec"
                         "Execute a command"
                         execCmd
-                        (execOptsParser Nothing Nothing)
+                        (execOptsParser Nothing)
              addCommand "ghc"
                         "Run ghc"
                         execCmd
-                        (execOptsParser (Just "ghc") Nothing)
+                        (execOptsParser $ Just "ghc")
              addCommand "ghci"
                         "Run ghci in the context of project(s) (experimental)"
                         ghciCmd
@@ -283,11 +283,11 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter -> do
              addCommand "runghc"
                         "Run runghc"
                         execCmd
-                        (execOptsParser (Just "runghc") Nothing)
+                        (execOptsParser $ Just "runghc")
              addCommand "eval"
                         "Evaluate some haskell code inline. Shortcut for 'stack exec ghc -- -e CODE'"
                         evalCmd
-                        (execOptsParser Nothing (Just "CODE"))
+                        (evalOptsParser $ Just "CODE") -- metavar = "CODE"
              addCommand "clean"
                         "Clean the local packages"
                         cleanCmd
@@ -853,12 +853,14 @@ execCmd ExecOpts {..} go@GlobalOpts{..} = do
                exec eoEnvSettings cmd args
 
 -- | Evaluate some haskell code inline.
-evalCmd :: ExecOpts -> GlobalOpts -> IO ()
-evalCmd e@ExecOpts { eoArgs = [arg] } go@GlobalOpts {..} = execCmd execOpts go
-    where execOpts = e { eoCmd = Just "ghc"
-                       , eoArgs = ["-e", arg]
-                       }
-evalCmd _ _ = error "Expecting ONE string argument to 'eval'"
+evalCmd :: EvalOpts -> GlobalOpts -> IO ()
+evalCmd eopts go@GlobalOpts {..} = execCmd execOpts go
+    where
+      execOpts =
+          ExecOpts { eoCmd = Just "ghc"
+                   , eoArgs = ["-e", evalArg eopts]
+                   , eoExtra = evalExtra eopts
+                   }
 
 -- | Run GHCi in the context of a project.
 ghciCmd :: GhciOpts -> GlobalOpts -> IO ()


### PR DESCRIPTION
+ Generalize `execOptsParser` to accept a second optional argument for metavar.

+ Add a new command `eval`, where `stack eval CODE [ARGS]` evaluates to `stack ghc -- -e CODE [ARGS]`.