### PR TITLE
Rename config files and clarify their purposes (#969)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,12 @@
 
 Major changes:
 
-* "stack setup" now supports building and booting GHCJS from source tarball.
+* "stack setup" now supports building and booting GHCJS from source tarball
+* Rename config files and clarify their purposes (#969)
+    * `~/.stack/stack.yaml` --> `~/.stack/config.yaml`
+    * `~/.stack/global` --> `~/.stack/global-project`
+    * `/etc/stack/config` --> `/etc/stack/config.yaml`
+    * Old locations still supported, with deprecation warnings
 
 ## 0.1.5.0
 

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -103,7 +103,7 @@ Downloading template "new-template" to create project "helloworld" in helloworld
 Using the following authorship configuration:
 author-email: example@example.com
 author-name: Example Author Name
-Copy these to /home/michael/.stack/stack.yaml and edit to use different values.
+Copy these to /home/michael/.stack/config.yaml and edit to use different values.
 Writing default config file to: /home/michael/helloworld/stack.yaml
 Basing on cabal files:
 - /home/michael/helloworld/helloworld.cabal
@@ -1321,7 +1321,7 @@ follows the Unix convention of `--` to separate these, e.g.:
 
 ```
 michael@d30748af6d3d:~$ stack exec --package stm -- echo I installed the stm package via --package stm
-Run from outside a project, using implicit global config
+Run from outside a project, using implicit global project config
 Using latest snapshot resolver: lts-3.2
 Writing global (non-project-specific) config file to: /home/michael/.stack/global/stack.yaml
 Note: You can change the snapshot via the resolver field there.
@@ -1368,14 +1368,14 @@ import Turtle
 main = echo "Hello World!"
 michael@d30748af6d3d:~$ chmod +x turtle.hs
 michael@d30748af6d3d:~$ ./turtle.hs
-Run from outside a project, using implicit global config
+Run from outside a project, using implicit global project config
 Using resolver: lts-3.2 specified on command line
 hashable-1.2.3.3: configure
 # installs some more dependencies
 Completed all 22 actions.
 Hello World!
 michael@d30748af6d3d:~$ ./turtle.hs
-Run from outside a project, using implicit global config
+Run from outside a project, using implicit global project config
 Using resolver: lts-3.2 specified on command line
 Hello World!
 ```
@@ -1545,7 +1545,7 @@ Downloading template "yesod-simple" to create project "my-yesod-project" in my-y
 Using the following authorship configuration:
 author-email: example@example.com
 author-name: Example Author Name
-Copy these to /home/michael/.stack/stack.yaml and edit to use different values.
+Copy these to /home/michael/.stack/config.yaml and edit to use different values.
 Writing default config file to: /home/michael/my-yesod-project/stack.yaml
 Basing on cabal files:
 - /home/michael/my-yesod-project/my-yesod-project.cabal

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -78,7 +78,7 @@ stack has two layers of configuration: project and non-project. All of these
 are stored in stack.yaml files, but the former has extra fields (resolver,
 packages, extra-deps, and flags). The latter can be monoidally combined so that
 a system config file provides defaults, which a user can override with
-~/.stack/stack.yaml, and a project can further customize. In addition,
+`~/.stack/config.yaml`, and a project can further customize. In addition,
 environment variables STACK\_ROOT and STACK\_YAML can be used to tweak where
 stack gets its configuration from.
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -6,8 +6,8 @@ The stack.yaml configuration options break down into [project specific](#project
 
 and [non-project specific](#non-project-config) options in:
 
-- `/etc/stack/config` -- for system global non-project default options
--  `~/.stack/stack.yaml` -- for user non-project default options
+- `/etc/stack/config.yaml` -- for system global non-project default options
+-  `~/.stack/config.yaml` -- for user non-project default options
 - The project file itself may also contain non-project specific options
 
 *Note:* When stack is invoked outside a stack project it will source project specific options from `~/.stack/global/stack.yaml`.  Options in this file will be ignored for a project with its own `<project dir>/stack.yaml`.
@@ -115,7 +115,7 @@ image:
 
 ## Non-project config
 
-Non-project config options may go in the global config (`/etc/stack/config`) or the user config (`~/.stack/stack.yaml`).
+Non-project config options may go in the global config (`/etc/stack/config.yaml`) or the user config (`~/.stack/config.yaml`).
 
 ### docker
 

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -275,7 +275,7 @@ data NeedTargets
 
 parseTargets :: (MonadThrow m, MonadIO m)
              => NeedTargets -- ^ need at least one target
-             -> Bool -- ^ using implicit global?
+             -> Bool -- ^ using implicit global project?
              -> Map PackageName Version -- ^ snapshot
              -> Map PackageName Version -- ^ extra deps
              -> Map PackageName LocalPackageView

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -565,7 +565,7 @@ getDefaultGlobalConfigPath
 getDefaultGlobalConfigPath =
     case (defaultGlobalConfigPath, defaultGlobalConfigPathDeprecated) of
         (Just new,Just old) ->
-            (Just . fst ) <$>
+            liftM (Just . fst ) $
             tryDeprecatedPath
                 (Just "non-project global configuration file")
                 fileExists

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -324,19 +324,19 @@ loadBuildConfig mproject config mresolver = do
                            , projectResolver = r
                            }
                    liftIO $ do
-                       S.writeFile dest'
-                           ("# This is the implicit global project's config file, which is only used when\n" <>
-                            "# 'stack' is run outside of a real project.  Settings here do _not_ act as\n" <>
-                            "# defaults for all projects.  To change stack's default settings, edit\n" <>
-                            "# '" <> encodeUtf8 (T.pack $ toFilePath $ configUserConfigPath config) <> "' instead.\n" <>
-                            "#\n" <>
-                            "# For more information about stack's configuration, see\n" <>
-                            "# https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md\n" <>
-                            "#\n" <>
-                            Yaml.encode p)
-                       S.writeFile (toFilePath $ parent dest </> $(mkRelFile "README.txt")) $
-                           "This is the implicit global project, which is used only when 'stack' is run\n" <>
-                           "outside of a real project.\n"
+                       S.writeFile dest' $ S.concat
+                           [ "# This is the implicit global project's config file, which is only used when\n"
+                           , "# 'stack' is run outside of a real project.  Settings here do _not_ act as\n"
+                           , "# defaults for all projects.  To change stack's default settings, edit\n"
+                           , "# '", encodeUtf8 (T.pack $ toFilePath $ configUserConfigPath config), "' instead.\n"
+                           , "#\n"
+                           , "# For more information about stack's configuration, see\n"
+                           , "# https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md\n"
+                           , "#\n"
+                           , Yaml.encode p]
+                       S.writeFile (toFilePath $ parent dest </> $(mkRelFile "README.txt")) $ S.concat
+                           [ "This is the implicit global project, which is used only when 'stack' is run\n"
+                           , "outside of a real project.\n" ]
                    return (p, dest)
     resolver <-
         case mresolver of
@@ -588,12 +588,12 @@ getDefaultUserConfigPath stackRoot = do
         (defaultUserConfigPathDeprecated stackRoot)
     unless exists $ do
         createTree (parent path)
-        liftIO $ S.writeFile (toFilePath path) $
-            "# This file contains default non-project-specific settings for 'stack', used\n" <>
-            "# in all projects.  For more information about stack's configuration, see\n" <>
-            "# https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md\n" <>
-            "#\n" <>
-            Yaml.encode (mempty :: Object)
+        liftIO $ S.writeFile (toFilePath path) $ S.concat
+            [ "# This file contains default non-project-specific settings for 'stack', used\n"
+            , "# in all projects.  For more information about stack's configuration, see\n"
+            , "# https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md\n"
+            , "#\n"
+            , Yaml.encode (mempty :: Object) ]
     return path
 
 

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -26,13 +26,17 @@ module Stack.Constants
     ,stackProgName
     ,wiredInPackages
     ,cabalPackageName
-    ,implicitGlobalDir
+    ,implicitGlobalProjectDirDeprecated
+    ,implicitGlobalProjectDir
     ,hpcRelativeDir
     ,hpcDirFromDir
     ,dotHpc
     ,objectInterfaceDir
     ,templatesDir
-    ,globalConfigPath
+    ,defaultUserConfigPathDeprecated
+    ,defaultUserConfigPath
+    ,defaultGlobalConfigPathDeprecated
+    ,defaultGlobalConfigPath
     )
     where
 
@@ -285,17 +289,41 @@ cabalPackageName :: PackageName
 cabalPackageName =
     $(mkPackageName "Cabal")
 
--- | Implicit global directory used when outside of a project.
-implicitGlobalDir :: Path Abs Dir -- ^ Stack root.
-                  -> Path Abs Dir
-implicitGlobalDir p =
+-- | Deprecated implicit global project directory used when outside of a project.
+implicitGlobalProjectDirDeprecated :: Path Abs Dir -- ^ Stack root.
+                                   -> Path Abs Dir
+implicitGlobalProjectDirDeprecated p =
     p </>
     $(mkRelDir "global")
+
+-- | Implicit global project directory used when outside of a project.
+-- Normally, @getImplicitGlobalProjectDir@ should be used instead.
+implicitGlobalProjectDir :: Path Abs Dir -- ^ Stack root.
+                         -> Path Abs Dir
+implicitGlobalProjectDir p =
+    p </>
+    $(mkRelDir "global-project")
 
 -- | Where .mix files go.
 dotHpc :: Path Rel Dir
 dotHpc = $(mkRelDir ".hpc")
 
--- | Global config path.
-globalConfigPath :: Config -> Path Abs File
-globalConfigPath = (</> $(mkRelFile "stack.yaml")) . configStackRoot
+-- | Deprecated default global config path.
+defaultUserConfigPathDeprecated :: Path Abs Dir -> Path Abs File
+defaultUserConfigPathDeprecated = (</> $(mkRelFile "stack.yaml"))
+
+-- | Default global config path.
+-- Normally, @getDefaultUserConfigPath@ should be used instead.
+defaultUserConfigPath :: Path Abs Dir -> Path Abs File
+defaultUserConfigPath = (</> $(mkRelFile "config.yaml"))
+
+-- | Deprecated default global config path.
+-- Note that this will be @Nothing@ on Windows, which is by design.
+defaultGlobalConfigPathDeprecated :: Maybe (Path Abs File)
+defaultGlobalConfigPathDeprecated = parseAbsFile "/etc/stack/config"
+
+-- | Default global config path.
+-- Normally, @getDefaultGlobalConfigPath@ should be used instead.
+-- Note that this will be @Nothing@ on Windows, which is by design.
+defaultGlobalConfigPath :: Maybe (Path Abs File)
+defaultGlobalConfigPath = parseAbsFile "/etc/stack/config.yaml"

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -46,7 +46,7 @@ import           Data.Typeable (Typeable)
 import           Path
 import           Path.IO (getWorkingDir,listDirectory,createTree,removeFile,removeTree,dirExists)
 import           Prelude -- Fix redundant import warnings
-import           Stack.Constants (projectDockerSandboxDir,stackProgName,stackDotYaml,stackRootEnvVar)
+import           Stack.Constants (projectDockerSandboxDir,stackProgName,stackRootEnvVar)
 import           Stack.Types
 import           Stack.Types.Internal
 import           Stack.Docker.GlobalDB
@@ -816,14 +816,13 @@ instance Exception StackDockerException
 -- | Show instance for StackDockerException.
 instance Show StackDockerException where
   show DockerMustBeEnabledException =
-    concat ["Docker must be enabled in your ",toFilePath stackDotYaml," to use this command."]
+    concat ["Docker must be enabled in your configuration file to use this command."]
   show OnlyOnHostException =
     "This command must be run on host OS (not in a Docker container)."
   show (InspectFailedException image) =
     concat ["'docker inspect' failed for image after pull: ",image,"."]
   show (NotPulledException image) =
-    concat ["The Docker image referenced by "
-           ,toFilePath stackDotYaml
+    concat ["The Docker image referenced by your configuration file"
            ," has not\nbeen downloaded:\n    "
            ,image
            ,"\n\nRun '"
@@ -841,8 +840,7 @@ instance Show StackDockerException where
     concat ["Could not pull Docker image:\n    "
            ,image
            ,"\nThere may not be an image on the registry for your resolver's LTS version in\n"
-           ,toFilePath stackDotYaml
-           ,"."]
+           ,"your configuration file."]
   show (DockerTooOldException minVersion haveVersion) =
     concat ["Minimum docker version '"
            ,versionString minVersion
@@ -884,9 +882,7 @@ instance Show StackDockerException where
            ,show resolver
            ,"\nUse an LTS resolver, or set the '"
            ,T.unpack dockerImageArgName
-           ,"' explicitly, in "
-           ,toFilePath stackDotYaml
-           ,"."]
+           ,"' explicitly, in your configuration file."]
   show CannotDetermineProjectRootException =
     "Cannot determine project root directory for Docker sandbox."
   show DockerNotInstalledException=

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -302,7 +302,7 @@ getImplicitGlobalProjectDir
     => Config -> m (Path Abs Dir)
 getImplicitGlobalProjectDir config =
     --TEST no warning printed
-    fst <$> tryDeprecatedPath
+    liftM fst $ tryDeprecatedPath
         Nothing
         dirExists
         (implicitGlobalProjectDir stackRoot)

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -330,11 +330,11 @@ tryDeprecatedPath mWarningDesc exists new old = do
                     case mWarningDesc of
                         Nothing -> return ()
                         Just desc ->
-                            $logWarn
-                                ("Warning: Location of " <> desc <> " at '" <>
-                                 T.pack (toFilePath old) <>
-                                 "' is deprecated; rename it to '" <>
-                                 T.pack (toFilePath new) <>
-                                 "' instead")
+                            $logWarn $ T.concat
+                                [ "Warning: Location of ", desc, " at '"
+                                , T.pack (toFilePath old)
+                                , "' is deprecated; rename it to '"
+                                , T.pack (toFilePath new)
+                                , "' instead" ]
                     return (old, True)
                 else return (new, False)

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -150,7 +150,7 @@ instance Show SetupException where
         [ "The GHC located at "
         , toFilePath ghc
         , " failed to compile a sanity check. Please see:\n\n"
-        , "    https://github.com/commercialhaskell/stack/blob/master/doc/install_and_upgrade.md\n\n"
+        , "    https://github.com/commercialhaskell/stack/blob/release/doc/install_and_upgrade.md\n\n"
         , "for more information. Exception was:\n"
         , show e
         ]

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -66,7 +66,10 @@ import           System.Process.Read (EnvOverride)
 data Config =
   Config {configStackRoot           :: !(Path Abs Dir)
          -- ^ ~/.stack more often than not
+         ,configUserConfigPath      :: !(Path Abs File)
+         -- ^ Path to user configuration file (usually ~/.stack/config.yaml)
          ,configDocker              :: !DockerOpts
+         -- ^ Docker configuration
          ,configEnvOverride         :: !(EnvSettings -> IO EnvOverride)
          -- ^ Environment variables to be passed to external tools
          ,configLocalPrograms       :: !(Path Abs Dir)
@@ -719,7 +722,7 @@ instance Show ConfigException where
         , toFilePath configFile
         , "':\n"
         , show exception
-        , "\nSee https://github.com/commercialhaskell/stack/blob/master/doc/yaml_configuration.md."
+        , "\nSee https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md."
         ]
     show (ParseResolverException t) = concat
         [ "Invalid resolver value: "
@@ -757,7 +760,7 @@ instance Show ConfigException where
             (\name -> "    stack init --resolver " ++ T.unpack (renderSnapName name))
             names
         , "\nYou'll then need to add some extra-deps. See:\n\n"
-        , "    https://github.com/commercialhaskell/stack/blob/master/doc/yaml_configuration.md#extra-deps"
+        , "    https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md#extra-deps"
         , "\n\nYou can also try falling back to a dependency solver with:\n\n"
         , "    stack init --solver"
         ]

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -355,7 +355,7 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter -> do
              , " as a script interpreter, a\n'-- "
              , stackProgName
              , " [options] runghc [options]' comment is required."
-             , "\nSee https://github.com/commercialhaskell/stack/blob/master/doc/GUIDE.md#ghcrunghc" ]
+             , "\nSee https://github.com/commercialhaskell/stack/blob/release/doc/GUIDE.md#ghcrunghc" ]
          throwIO exitCode
        Right (global,run) -> do
          when (globalLogLevel global == LevelDebug) $ hPutStrLn stderr versionString'


### PR DESCRIPTION
* Rename `~/.stack/stack.yaml` to `~/.stack/config.yaml`
* Rename `~/.stack/global` to `~/.stack/global-project`
* Rename `/etc/stack/config` to `/etc/stack/config.yaml`
* Support old locations of the renamed paths, with deprecation warnings
* Clarify wording of some messages
* Write comment to top of new `~/.stack/config.yaml` describing its purpose
* Write comment to top of new `~/.stack/global-project/stack.yaml` describing its purpose
* Write `~/.stack/global-project/README` describing the purpose of the directory