### PR TITLE
Display the architecture properly

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -33,6 +33,7 @@ import qualified Data.Text.IO as T
 import           Data.Traversable
 import           Data.Version (showVersion)
 import           Distribution.System (buildArch)
+import           Distribution.Text (display)
 import           Development.GitRev (gitCommitCount)
 import           GHC.IO.Encoding (mkTextEncoding, textEncodingName)
 import           Network.HTTP.Client
@@ -157,7 +158,7 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter -> do
               -- See https://github.com/commercialhaskell/stack/issues/792
             , [" (" ++ $gitCommitCount ++ " commits)" | $gitCommitCount /= ("1"::String) &&
                                                         $gitCommitCount /= ("UNKNOWN" :: String)]
-            , [" ", show buildArch]
+            , [" ", display buildArch]
             ]
 
      let numericVersion :: Parser (a -> a)


### PR DESCRIPTION
Fixes #1063.
Now it displays: 
```
> stack --version
Version 0.1.5.0, Git revision 06a4b270de2d2dcbd3ee8abe98078151c4a8f075 (dirty) (2204 commits) i386
```