### PR TITLE
Update travis instructions to use stack-0.1.5.0

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1603,7 +1603,7 @@ before_install:
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
-- travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.4.0/stack-0.1.4.0-x86_64-linux.tar.gz | tar xz -C ~/.local/bin
+- travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.5.0/stack-0.1.5.0-x86_64-linux.tar.gz | tar xz -C ~/.local/bin
 
 # This line does all of the work: installs GHC if necessary, build the library,
 # executables, and test suites, and runs the test suites. --no-terminal works


### PR DESCRIPTION
I looked if there was a way to just link to the latest version, but I didn't find anything useful.
