### PR TITLE
Now can specify a template in any local subdirectory to use

### DIFF
--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -110,12 +110,18 @@ loadTemplate name = do
     req <-
         parseUrl (defaultTemplateUrl <> "/" <> toFilePath (templatePath name))
     config <- asks getConfig
-    let path = templatesDir config </> templatePath name
-    _ <- catch (redownload req path) (throwM . FailedToDownloadTemplate name)
-    exists <- fileExists path
-    if exists
-        then liftIO (T.readFile (toFilePath path))
-        else throwM (FailedToLoadTemplate name path)
+    localExists <- fileExists . templatePath $ name
+    if localExists
+        then liftIO . T.readFile . toFilePath . templatePath $ name
+        else do
+            let path = templatesDir config </> templatePath name
+            _ <- catch
+                 (redownload req path)
+                 (throwM . FailedToDownloadTemplate name)
+            pathExists <- fileExists path
+            if pathExists
+                then liftIO . T.readFile . toFilePath $ path
+                else throwM $ FailedToLoadTemplate name path
 
 -- | Apply and unpack a template into a directory.
 applyTemplate

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -665,7 +665,8 @@ newOptsParser = (,) <$> newOpts <*> initOptsParser
             (metavar "PACKAGE_NAME" <> help "A valid package name.") <*>
         templateNameArgument
             (metavar "TEMPLATE_NAME" <>
-             help "Name of a template, for example: foo or foo.hsfiles" <>
+             help "Name of a template or a local template in a subdirectory,\
+                  \ for example: foo or foo.hsfiles" <>
              value defaultTemplateName) <*>
         fmap
             M.fromList


### PR DESCRIPTION
In reference to #783, added the ability to use any local template in the current directory or any subdirectory, for instance

`stack new project bar` or `stack new project ./foo/bar`

I could not include the ability to get a local template from a non local or subdirectory where the project was not located (e.g. ~/my_local_templates/bar) because the TemplateName type is for relative paths only. Is there a reason for this restriction? Why not have absolute paths for everything?

Also, loadTemplate is now, thanks to me, on the verge of getting a bit messy. Let me know if you would like me to clean it up.