### PR TITLE
Allow stack path to release the lock immediately.  Fixes #872

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -333,10 +333,9 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter -> do
 -- support others later).
 pathCmd :: [Text] -> GlobalOpts -> IO ()
 pathCmd keys go =
-    withBuildConfigAndLock
+    withBuildConfig
         go
-        (\_ ->
-         do env <- ask
+        (do env <- ask
             let cfg = envConfig env
                 bc = envConfigBuildConfig cfg
             menv <- getMinimalEnvOverride


### PR DESCRIPTION
@snoyberg vouched for stack path definitely not needing locking.  (Which makes intuitive sense, but I was conservative initially, and only opted out commands where after someone vouched for them or I read the relevant code.)

Note that as of the current release this only affects runs with `STACK_LOCK=true`.
