### PR TITLE
Add flag "--bare" to stack new #965

### DIFF
--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -664,6 +664,9 @@ newOptsParser = (,) <$> newOpts <*> initOptsParser
         NewOpts <$>
         packageNameArgument
             (metavar "PACKAGE_NAME" <> help "A valid package name.") <*>
+        switch
+            (long "bare" <>
+             help "Do not create a subdirectory for the project") <*>
         templateNameArgument
             (metavar "TEMPLATE_NAME" <>
              help "Name of a template, for example: foo or foo.hsfiles" <>


### PR DESCRIPTION
Following #965, I added a new option "--bare" to stack new that causes the new project to be created in the current directory rather than in a subdirectory.