### PR TITLE
Fix `awaiting pr` label link

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ installed.
 4. Once `stack` finishes building, check the stack version with
    `stack --version`. Make sure the version is the latest.
 5. Look for issues tagged with
-   [`newcomer` and `awaiting-pr` labels](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3Anewcomer+label%3Aawaiting-pr)
+   [`newcomer` and `awaiting-pr` labels](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3Anewcomer+label%3A%22awaiting+pr%22)
 
 Build from source as a one-liner:
 


### PR DESCRIPTION
The previous link was giving back no results.
It seems like the label was changed.