### PR TITLE
Remove ignore package dependency

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -701,18 +701,12 @@ buildCmd opts go = do
     hPutStrLn stderr "See: https://github.com/commercialhaskell/stack/issues/1015"
     error "-prof GHC option submitted"
   case boptsFileWatch opts of
-    FileWatchPoll -> fileWatchPoll getProjectRoot inner
-    FileWatch -> fileWatch getProjectRoot inner
+    FileWatchPoll -> fileWatchPoll inner
+    FileWatch -> fileWatch inner
     NoFileWatch -> inner $ const $ return ()
   where
     inner setLocalFiles = withBuildConfigAndLock go $ \lk ->
         Stack.Build.build setLocalFiles lk opts
-    getProjectRoot = do
-        (manager, lc) <- loadConfigWithOpts go
-        bconfig <-
-            runStackLoggingTGlobal manager go $
-            lcLoadBuildConfig lc (globalResolver go)
-        return (bcRoot bconfig)
 
 uninstallCmd :: [String] -> GlobalOpts -> IO ()
 uninstallCmd _ go = withConfigAndLock go $ do

--- a/stack.cabal
+++ b/stack.cabal
@@ -139,7 +139,6 @@ library
                    , http-client-tls >= 0.2.2
                    , http-conduit >= 2.1.7
                    , http-types >= 0.8.6
-                   , ignore >= 0.1.1
                    , lifted-base
                    , monad-control
                    , monad-logger >= 0.3.13.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,6 @@
 resolver: lts-3.7
 extra-deps:
-- ignore-0.1.1.0
 - binary-tagged-0.1.1.0
-flags:
-  ignore:
-    without-pcre: true
 image:
   container:
     base: "fpco/ubuntu-with-libgmp:14.04"


### PR DESCRIPTION
Pinging @agrafix. I believe that this is no longer necessary in Stack
since the file-watch code only monitors files which are actually used by
the build process. Can you confirm that this doesn't break your
workflow?