### PR TITLE
fix wrong image command in docs

### DIFF
--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -102,7 +102,7 @@ Flags will only affect packages in your `packages` and `extra-deps` settings.
 Packages that come from the snapshot global database or are not affected.
 
 ### image
-The image settings are used for the creation of container images using `stack container image`, e.g.
+The image settings are used for the creation of container images using `stack image container`, e.g.
 ```yaml
 image:
   container:


### PR DESCRIPTION
There's no `stack container image` command.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/commercialhaskell/stack/1168)
<!-- Reviewable:end -->
