### PR TITLE
Simplify the Appveyor before_test setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,8 @@ cache:
 build: off
 
 before_test:
-- ps: Invoke-WebRequest "https://github.com/commercialhaskell/stack/releases/download/v0.1.4.0/stack-0.1.4.0-x86_64-windows.zip" -OutFile stack.zip
-- ps: Invoke-WebRequest "https://github.com/fpco/minghc/blob/master/bin/7z.exe?raw=true" -OutFile 7z.exe
-- ps: Invoke-WebRequest "https://github.com/fpco/minghc/blob/master/bin/7z.dll?raw=true" -OutFile 7z.dll
-- 7z x stack.zip
-- move stack.exe.exe stack.exe
+- curl -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
+- 7z x stack.zip stack.exe
 
 clone_folder: "c:\\stack"
 environment:


### PR DESCRIPTION
Appveyor guarantees `curl` and `7z` on the PATH, so use the default tools, makes it easier to understand for non-Appveyor experts. I stole the appveyor code for HLint from Stack, then modified it in HLint, so this is me returning my changes.

cc @snoyberg who seems to be your Appveyor guy.