### PR TITLE
Refactor findTransitiveGhcPkgDepends

### DIFF
--- a/src/Data/Set/Monad.hs
+++ b/src/Data/Set/Monad.hs
@@ -3,11 +3,13 @@
 module Data.Set.Monad
   (mapM
   ,mapM_
+  ,mapMaybeM
   ,filterM)
   where
 
 import           Control.Monad (liftM)
 import qualified Control.Monad as L
+import           Data.Maybe (catMaybes)
 import           Data.Set (Set)
 import qualified Data.Set as S
 import           Prelude hiding (mapM,mapM_)
@@ -21,6 +23,11 @@ mapM f = liftM S.fromList . L.mapM f . S.toList
 mapM_ :: (Ord a,Ord b,Monad m)
        => (a -> m b) -> Set a -> m ()
 mapM_ f = L.mapM_ f . S.toList
+
+-- | Map over a 'Set' in a monad, keeping the 'Just's and throwing out the 'Nothing's.
+mapMaybeM :: (Ord a,Ord b,Monad m)
+          => (a -> m (Maybe b)) -> Set a -> m (Set b)
+mapMaybeM f = liftM (S.fromList . catMaybes) . L.mapM f . S.toList
 
 -- | Filter elements of a 'Set' in a monad.
 filterM :: (Ord a,Monad m)

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -37,6 +37,7 @@ import           Data.List
 import           Data.Maybe
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import qualified Data.Set.Monad as Set
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -194,8 +195,7 @@ findTransitiveGhcPkgDepends
     -> m (Set PackageIdentifier)
 findTransitiveGhcPkgDepends menv wc pkgDbs pkgId0 = do
     deps <- go (packageIdentifierString pkgId0) Set.empty
-    mpkgIds <- mapM (getPackageIdentifier menv wc pkgDbs) (Set.toList deps)
-    (return . Set.fromList . catMaybes) mpkgIds
+    Set.mapMaybeM (getPackageIdentifier menv wc pkgDbs) deps
   where
     go pkgId res = do
         deps <- findGhcPkgDepends menv wc pkgDbs pkgId


### PR DESCRIPTION
Regarding the FIXME:
res' is entirely contained in res''. Therefore the Map.union is
redundant.