### PR TITLE
Stack config add resolver command

### DIFF
--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Make changes to the stack yaml file
+
+module Stack.ConfigCmd
+       (ConfigCmdSet(..)
+       ,cfgCmdSet
+       ,cfgCmdSetName
+       ,cfgCmdName) where
+
+import           Control.Monad.Catch (MonadMask, throwM, MonadThrow)
+import           Control.Monad.IO.Class
+import           Control.Monad.Logger
+import           Control.Monad.Reader (MonadReader, asks)
+import           Control.Monad.Trans.Control (MonadBaseControl)
+import qualified Data.ByteString.Builder         as B
+import qualified Data.ByteString.Lazy            as L
+import qualified Data.HashMap.Strict as HMap
+import qualified Data.Yaml as Yaml
+import           Network.HTTP.Client.Conduit (HasHttpManager)
+import           Path
+import           Stack.BuildPlan
+import           Stack.Init
+import           Stack.Types
+
+data ConfigCmdSet = ConfigCmdSetResolver AbstractResolver
+
+cfgCmdSet :: ( MonadIO m
+             , MonadBaseControl IO m
+             , MonadMask m
+             , MonadReader env m
+             , HasConfig env
+             , HasBuildConfig env
+             , HasHttpManager env
+             , HasGHCVariant env
+             , MonadThrow m
+             , MonadLogger m)
+             => ConfigCmdSet -> m ()
+cfgCmdSet (ConfigCmdSetResolver newResolver) = do
+    stackYaml <- bcStackYaml <$> asks getBuildConfig
+    let stackYamlFp =
+            toFilePath stackYaml
+    -- We don't need to worry about checking for a valid yaml here
+    (projectYamlConfig :: Yaml.Object) <-
+        liftIO (Yaml.decodeFileEither stackYamlFp) >>=
+        either throwM return
+    newResolverText <- resolverName <$> makeConcreteResolver newResolver
+    -- We checking here that the snapshot actually exists
+    snap <- parseSnapName newResolverText
+    _ <- loadMiniBuildPlan snap
+
+    let projectYamlConfig' =
+            HMap.insert
+                "resolver"
+                (Yaml.String newResolverText)
+                projectYamlConfig
+    liftIO
+        (L.writeFile
+             stackYamlFp
+             (B.toLazyByteString
+                  (B.byteString
+                       (Yaml.encode projectYamlConfig'))))
+    return ()
+
+cfgCmdName :: String
+cfgCmdName = "config"
+
+cfgCmdSetName :: String
+cfgCmdSetName = "set"

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -15,8 +15,7 @@ import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import           Control.Monad.Reader (MonadReader, asks)
 import           Control.Monad.Trans.Control (MonadBaseControl)
-import qualified Data.ByteString.Builder         as B
-import qualified Data.ByteString.Lazy            as L
+import qualified Data.ByteString as S
 import qualified Data.HashMap.Strict as HMap
 import qualified Data.Yaml as Yaml
 import           Network.HTTP.Client.Conduit (HasHttpManager)
@@ -39,14 +38,14 @@ cfgCmdSet :: ( MonadIO m
              , MonadLogger m)
              => ConfigCmdSet -> m ()
 cfgCmdSet (ConfigCmdSetResolver newResolver) = do
-    stackYaml <- bcStackYaml <$> asks getBuildConfig
+    stackYaml <- fmap bcStackYaml (asks getBuildConfig)
     let stackYamlFp =
             toFilePath stackYaml
     -- We don't need to worry about checking for a valid yaml here
     (projectYamlConfig :: Yaml.Object) <-
         liftIO (Yaml.decodeFileEither stackYamlFp) >>=
         either throwM return
-    newResolverText <- resolverName <$> makeConcreteResolver newResolver
+    newResolverText <- fmap resolverName (makeConcreteResolver newResolver)
     -- We checking here that the snapshot actually exists
     snap <- parseSnapName newResolverText
     _ <- loadMiniBuildPlan snap
@@ -57,11 +56,9 @@ cfgCmdSet (ConfigCmdSetResolver newResolver) = do
                 (Yaml.String newResolverText)
                 projectYamlConfig
     liftIO
-        (L.writeFile
+        (S.writeFile
              stackYamlFp
-             (B.toLazyByteString
-                  (B.byteString
-                       (Yaml.encode projectYamlConfig'))))
+             (Yaml.encode projectYamlConfig'))
     return ()
 
 cfgCmdName :: String

--- a/stack.cabal
+++ b/stack.cabal
@@ -52,6 +52,7 @@ library
                      Stack.BuildPlan
                      Stack.Config
                      Stack.Config.Docker
+                     Stack.ConfigCmd
                      Stack.Constants
                      Stack.Docker
                      Stack.Docker.GlobalDB

--- a/test/integration/lib/StackTest.hs
+++ b/test/integration/lib/StackTest.hs
@@ -71,3 +71,17 @@ copy :: FilePath -> FilePath -> IO ()
 copy src dest = do
     putStrLn ("Copy " ++ show src ++ " to " ++ show dest)
     System.Directory.copyFile src dest
+
+fileContentsMatch :: FilePath -> FilePath -> IO ()
+fileContentsMatch f1 f2 = do
+    doesExist f1
+    doesExist f2
+    f1Contents <- readFile f1
+    f2Contents <- readFile f2
+    if f1Contents == f2Contents
+          then return ()
+          else error
+                   ("contents do not match for " ++
+                    show f1 ++
+                    " " ++
+                    show f2)


### PR DESCRIPTION
config selects the projects stack.yaml, regardless of directory

Parsing of config add command

Integration test helper (will be used to compare stack.yaml files)

Check to see if snapshot exists before writing

TODO:
Adding differnet fields
Additional subcommands for git