### PR TITLE
Fix stack ide crash when not using stty

### DIFF
--- a/src/Stack/Ide.hs
+++ b/src/Stack/Ide.hs
@@ -69,7 +69,7 @@ ide targets useropts = do
     when
         (os == OSX)
         (catch (callProcess (Just pwd) menv "stty" ["cbreak", "-imaxbel"])
-               (\(_ :: ProcessExitedUnsuccessfully) -> undefined))
+               (\(_ :: ProcessExitedUnsuccessfully) -> return ()))
     callProcess (Just pwd) menv "stack-ide" args
   where
     includeDirs pkgopts =


### PR DESCRIPTION
The fix mentioned here https://github.com/lukexi/stack-ide-sublime/issues/17#issuecomment-142949632 still caused crashes since undefined was being evaluated. This makes it work as intended by changing it to `return ()` (and lets stack-ide-sublime work again)