### PR TITLE
Filter the cabal_macros.h file when checking for dirty files

### DIFF
--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -338,9 +338,13 @@ loadLocalPackage bopts targets (name, (lpv, gpkg)) = do
         benchpkg = resolvePackage benchconfig gpkg
     mbuildCache <- tryGetBuildCache $ lpvRoot lpv
     (files,_) <- getPackageFilesSimple pkg (lpvCabalFP lpv)
+    
+    -- Filter out the cabal_macros file to avoid spurious recompilations
+    let filteredFiles = Set.filter ((/= $(mkRelFile "cabal_macros.h")) . filename) files
+    
     (dirtyFiles, newBuildCache) <- checkBuildCache
         (fromMaybe Map.empty mbuildCache)
-        (map toFilePath $ Set.toList files)
+        (map toFilePath $ Set.toList filteredFiles)
 
     return LocalPackage
         { lpPackage = pkg


### PR DESCRIPTION
Re: #1195 — let me know if there's a better place to do this!

(I also noticed a couple of .git files in the list returned from `getPackageFilesSimple`, maybe we should filter those too?)

