### PR TITLE
Fix haddocks copy bug (#1105) (nearly)

### DIFF
--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -29,7 +29,6 @@ import           Data.Set                       (Set)
 import qualified Data.Set                       as Set
 import           Data.Text                      (Text)
 import qualified Data.Text                      as T
-import           Debug.Trace
 import           Path
 import           Path.IO
 import           Prelude
@@ -46,7 +45,7 @@ import           System.Process.Read
 -- | Determine whether we should haddock for a package.
 shouldHaddockPackage :: BuildOpts -> Set PackageName -> PackageName -> Bool
 shouldHaddockPackage bopts wanted name =
-    trace "shouldHaddockPackage" $ if Set.member name wanted
+    if Set.member name wanted
         then boptsHaddock bopts
         else shouldHaddockDeps bopts
 
@@ -68,11 +67,7 @@ copyDepHaddocks :: (MonadIO m, MonadLogger m, MonadThrow m, MonadCatch m, MonadB
                 -> Set (Path Abs Dir)
                 -> m ()
 copyDepHaddocks envOverride wc bco pkgDbs pkgId extraDestDirs = do
-    let f = "copyDepHaddocks: "
-    traceM $ f ++ "begin"
     mpkgHtmlDir <- findGhcPkgHaddockHtml envOverride wc pkgDbs pkgId
-    traceM "mpkgHtmlDir:"
-    traceShowM mpkgHtmlDir
     case mpkgHtmlDir of
         Nothing -> return ()
         Just (_pkgId, pkgHtmlDir) -> do

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -29,6 +29,7 @@ import           Data.Set                       (Set)
 import qualified Data.Set                       as Set
 import           Data.Text                      (Text)
 import qualified Data.Text                      as T
+import           Debug.Trace
 import           Path
 import           Path.IO
 import           Prelude
@@ -45,7 +46,7 @@ import           System.Process.Read
 -- | Determine whether we should haddock for a package.
 shouldHaddockPackage :: BuildOpts -> Set PackageName -> PackageName -> Bool
 shouldHaddockPackage bopts wanted name =
-    if Set.member name wanted
+    trace "shouldHaddockPackage" $ if Set.member name wanted
         then boptsHaddock bopts
         else shouldHaddockDeps bopts
 
@@ -67,7 +68,11 @@ copyDepHaddocks :: (MonadIO m, MonadLogger m, MonadThrow m, MonadCatch m, MonadB
                 -> Set (Path Abs Dir)
                 -> m ()
 copyDepHaddocks envOverride wc bco pkgDbs pkgId extraDestDirs = do
+    let f = "copyDepHaddocks: "
+    traceM $ f ++ "begin"
     mpkgHtmlDir <- findGhcPkgHaddockHtml envOverride wc pkgDbs $ packageIdentifierString pkgId
+    traceM "mpkgHtmlDir:"
+    traceShowM mpkgHtmlDir
     case mpkgHtmlDir of
         Nothing -> return ()
         Just (_pkgId, pkgHtmlDir) -> do

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -70,17 +70,18 @@ copyDepHaddocks :: (MonadIO m, MonadLogger m, MonadThrow m, MonadCatch m, MonadB
 copyDepHaddocks envOverride wc bco pkgDbs pkgId extraDestDirs = do
     let f = "copyDepHaddocks: "
     traceM $ f ++ "begin"
-    mpkgHtmlDir <- findGhcPkgHaddockHtml envOverride wc pkgDbs $ packageIdentifierString pkgId
+    mpkgHtmlDir <- findGhcPkgHaddockHtml envOverride wc pkgDbs pkgId
     traceM "mpkgHtmlDir:"
     traceShowM mpkgHtmlDir
     case mpkgHtmlDir of
         Nothing -> return ()
         Just (_pkgId, pkgHtmlDir) -> do
-            depGhcIds <- findGhcPkgDepends envOverride wc pkgDbs $ packageIdentifierString pkgId
+            depGhcIds <- findGhcPkgDepends envOverride wc pkgDbs (packageIdentifierName pkgId)
             forM_ depGhcIds $ copyDepWhenNeeded pkgHtmlDir
   where
     copyDepWhenNeeded pkgHtmlDir depGhcId = do
-        mDepOrigDir <- findGhcPkgHaddockHtml envOverride wc pkgDbs $ ghcPkgIdString depGhcId
+        depPkgId <- parsePackageIdentifierFromGhcPkgId depGhcId
+        mDepOrigDir <- findGhcPkgHaddockHtml envOverride wc pkgDbs depPkgId
         case mDepOrigDir of
             Nothing -> return ()
             Just (depId, depOrigDir) -> do

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -80,8 +80,8 @@ copyDepHaddocks envOverride wc bco pkgDbs pkgId extraDestDirs = do
             forM_ depGhcIds $ copyDepWhenNeeded pkgHtmlDir
   where
     copyDepWhenNeeded pkgHtmlDir depGhcId = do
-        depPkgId <- parsePackageIdentifierFromGhcPkgId depGhcId
-        mDepOrigDir <- findGhcPkgHaddockHtml envOverride wc pkgDbs depPkgId
+        let mdepPkgId = parsePackageIdentifierFromGhcPkgId depGhcId
+        mDepOrigDir <- (findGhcPkgHaddockHtml envOverride wc pkgDbs) =<< mdepPkgId
         case mDepOrigDir of
             Nothing -> return ()
             Just (depId, depOrigDir) -> do

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -61,7 +61,6 @@ import qualified Data.Text                      as T
 import           Data.Text.Encoding             (decodeUtf8)
 import           Data.Typeable                  (Typeable)
 import           Data.Word                      (Word64)
-import           Debug.Trace
 import           Network.HTTP.Download
 import           Path
 import           Path.IO                         (dirExists, createTree)
@@ -135,7 +134,6 @@ unpackPackages :: (MonadIO m, MonadBaseControl IO m, MonadReader env m, HasHttpM
                -> [String] -- ^ names or identifiers
                -> m ()
 unpackPackages menv dest input = do
-    traceM "unpackPackages"
     dest' <- liftIO (canonicalizePath dest) >>= parseAbsDir
     (names, idents) <- case partitionEithers $ map parse input of
         ([], x) -> return $ partitionEithers x

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -61,6 +61,7 @@ import qualified Data.Text                      as T
 import           Data.Text.Encoding             (decodeUtf8)
 import           Data.Typeable                  (Typeable)
 import           Data.Word                      (Word64)
+import           Debug.Trace
 import           Network.HTTP.Download
 import           Path
 import           Path.IO                         (dirExists, createTree)
@@ -134,6 +135,7 @@ unpackPackages :: (MonadIO m, MonadBaseControl IO m, MonadReader env m, HasHttpM
                -> [String] -- ^ names or identifiers
                -> m ()
 unpackPackages menv dest input = do
+    traceM "unpackPackages"
     dest' <- liftIO (canonicalizePath dest) >>= parseAbsDir
     (names, idents) <- case partitionEithers $ map parse input of
         ([], x) -> return $ partitionEithers x

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -40,7 +40,6 @@ import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import           Debug.Trace
 import           Path (Path, Abs, Dir, toFilePath, parent, parseAbsDir)
 import           Path.Extra (toFilePathNoTrailingSep)
 import           Path.IO (dirExists, createTree)
@@ -168,14 +167,11 @@ findGhcPkgHaddockHtml :: (MonadIO m, MonadLogger m, MonadBaseControl IO m, Monad
                       -> PackageIdentifier
                       -> m (Maybe (PackageIdentifier, Path Abs Dir))
 findGhcPkgHaddockHtml menv wc pkgDbs pkgId = do
-    traceM $ unwords ["findGhcPkgHaddockHtml:", show pkgDbs, show pkgId]
     mpath <- findGhcPkgField menv wc pkgDbs (packageIdentifierName pkgId) "haddock-html"
-    traceShowM mpath
     case mpath of
         Just path0 -> do
             let path = T.unpack path0
             exists <- liftIO $ doesDirectoryExist path
-            traceShowM exists
             path' <- if exists
                 then liftIO $ canonicalizePath path
                 else return path

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -120,10 +120,9 @@ cabalSolver wc cabalfps constraints userFlags cabalArgs = withSystemTempDirector
     parseLine t0 = maybe (Left t0) Right $ do
         -- get rid of (new package) and (latest: ...) bits
         ident':flags' <- Just $ T.words $ T.takeWhile (/= '(') t0
-        PackageIdentifier name version <-
-            parsePackageIdentifierFromString $ T.unpack ident'
+        let mpkgId = parsePackageIdentifierFromString $ T.unpack ident'
         flags <- mapM parseFlag flags'
-        Just (name, (version, Map.fromList flags))
+        liftA (\(PackageIdentifier n v) -> (n, (v, Map.fromList flags))) mpkgId
     parseFlag t0 = do
         flag <- parseFlagNameFromString $ T.unpack t1
         return (flag, enabled)

--- a/src/Stack/Types/GhcPkgId.hs
+++ b/src/Stack/Types/GhcPkgId.hs
@@ -5,7 +5,7 @@
 -- | A ghc-pkg id.
 
 module Stack.Types.GhcPkgId
-  (GhcPkgId
+  (GhcPkgId(..)
   ,ghcPkgIdParser
   ,parseGhcPkgId
   ,ghcPkgIdString)

--- a/src/Stack/Types/PackageIdentifier.hs
+++ b/src/Stack/Types/PackageIdentifier.hs
@@ -11,6 +11,7 @@ module Stack.Types.PackageIdentifier
   ,toTuple
   ,fromTuple
   ,parsePackageIdentifier
+  ,parsePackageIdentifierFromGhcPkgId
   ,parsePackageIdentifierFromString
   ,packageIdentifierVersion
   ,packageIdentifierName
@@ -35,6 +36,7 @@ import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8)
 import           GHC.Generics
 import           Prelude hiding (FilePath)
+import           Stack.Types.GhcPkgId
 import           Stack.Types.PackageName
 import           Stack.Types.Version
 
@@ -101,6 +103,13 @@ parsePackageIdentifier x = go x
   where go =
           either (const (throwM (PackageIdentifierParseFail x))) return .
           parseOnly (packageIdentifierParser <* endOfInput)
+
+-- | Parse a package identifier from a ghc-pkg id.
+parsePackageIdentifierFromGhcPkgId :: MonadThrow m => GhcPkgId -> m PackageIdentifier
+parsePackageIdentifierFromGhcPkgId (GhcPkgId bs) = go bs
+  where go =
+          either (const (throwM (PackageIdentifierParseFail bs))) return .
+          parseOnly (packageIdentifierParser <* char8 '-')
 
 -- | Migration function.
 parsePackageIdentifierFromString :: MonadThrow m => String -> m PackageIdentifier


### PR DESCRIPTION
_Please don't merge this yet!_

This is simply to share some ideas on this problem before I go to sleep. :)

At this point, `stack` does generate haddocks for the dependencies and copies them too.
But now it tends to hit the following problem:

```
~/s/tasty (master) $ stack haddock
clock-0.5.1: configure
clock-0.5.1: build
clock-0.5.1: haddock
clock-0.5.1: install
tasty-0.11.0.1: configure
tasty-0.11.0.1: build
tasty-0.11.0.1: haddock
tasty-0.11.0.1: install
ProInvalid package identifier: "builtin_rts"
gress: 2⏎  
```

I'm not sure where in the code this error happens. Are there any tricks to get a line number or a something similar?

Please note that ghc-pkg seems to handle `builtin_rts` in a rather peculiar way too:

```
~/src $ ghc-pkg --version 
GHC package manager version 7.8.4
~/src $ stack exec ghc-pkg -- --version
Run from outside a project, using implicit global project config
Using resolver: lts-3.10 from implicit global project's config file: /home/simon/.stack/global/stack.yaml
GHC package manager version 7.10.2

~/src $ ghc-pkg field base depends
depends: ghc-prim-0.3.1.0-a24f9c14c632d75b683d0f93283aea37
         integer-gmp-0.5.1.0-26579559b3647acf4f01d5edd9491a46 builtin_rts
~/src $ stack exec ghc-pkg -- field base depends
Run from outside a project, using implicit global project config
Using resolver: lts-3.10 from implicit global project's config file: /home/simon/.stack/global/stack.yaml
depends:
    builtin_rts ghc-prim-0.4.0.0-af16264bc80979d06e37ac63e3ba9a21
    integer-gmp-1.0.0.0-8e0f14d0262184533b417ca1f8b44482

~/src $ ghc-pkg field builtin_rts id
ghc-pkg: cannot parse 'builtin_rts' as a package identifier
~/src $ stack exec ghc-pkg -- field builtin_rts id
Run from outside a project, using implicit global project config
Using resolver: lts-3.10 from implicit global project's config file: /home/simon/.stack/global/stack.yaml
ghc-pkg: cannot parse 'builtin_rts' as a package identifier
```

Note the strange alignment when asking for the dependencies of `base`.

(Referencing #1105)