### PR TITLE
More appveyor improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 cache:
 - "c:\\sr" # stack root, short paths == less problems
-- "%LOCALAPPDATA%\\Programs\\stack"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
     STACK_ROOT: "c:\\sr"
 
 test_script:
+- stack setup > nul
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
-- echo "" | stack --arch i386 --no-terminal --install-ghc test
+- echo "" | stack --no-terminal test


### PR DESCRIPTION
The first commit saves me somewhere in the 1-3 minute range under good scenarios, but occasionally appveyor goes nuts and takes over an hour, which no longer happens with the new formulation.

The second makes it possible to actually navigate the appveyor page. Note that the `--arch i386` flag has disappeared. I think that's OK because stack binary i386 will default to i386. If not, perhaps there is a need for it to go in a `stack setup` flag?

Since Appveyor already has MSYS and 7zip installed, we could skip them with a suitable flag to `stack setup` (or by default), which would shave another minute or so off appveyor builds. I'm quite keen for stack to become the de facto appveyor toolkit, because its much easier than any alternative.

CC @snoyberg 