### PR TITLE
Show debug timestamps in user's local time

### DIFF
--- a/src/Stack/Types/StackT.hs
+++ b/src/Stack/Types/StackT.hs
@@ -300,7 +300,7 @@ loggerFunc loc _src level msg =
              return (T.pack timestamp <> T.pack l <> T.decodeUtf8 (fromLogStr (toLogStr msg)) <> T.pack lc)
           where getTimestamp
                   | maxLogLevel <= LevelDebug =
-                    do now <- getCurrentTime
+                    do now <- getZonedTime
                        return (formatTime' now ++ ": ")
                   | otherwise = return ""
                   where


### PR DESCRIPTION
Resolves #1227.

I figure local times make much more sense than keeping UTC and adding on a timezone, similar to how other command line tools behave locally (I'm in AEST/GMT+11).