### PR TITLE
Improved efficiency for getPackageCaches

### DIFF
--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -45,7 +45,6 @@ import           Stack.Types.Build
 import           Stack.BuildPlan
 import           Stack.Package
 import           Stack.PackageDump
-import           Stack.PackageIndex
 import           Stack.Types
 
 data PackageInfo
@@ -134,9 +133,11 @@ constructPlan :: forall env m.
               -> m Plan
 constructPlan mbp0 baseConfigOpts0 locals extraToBuild0 localDumpPkgs loadPackage0 sourceMap installedMap = do
     let locallyRegistered = Map.fromList $ map (dpGhcPkgId &&& dpPackageIdent) localDumpPkgs
-    menv <- getMinimalEnvOverride
-    caches <- getPackageCaches menv
-    let latest = Map.fromListWith max $ map toTuple $ Map.keys caches
+    bconfig <- asks getBuildConfig
+    let latest =
+            Map.fromListWith max $
+            map toTuple $
+            Map.keys (bcPackageCaches bconfig)
 
     econfig <- asks getEnvConfig
     let onWanted lp = do

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -60,7 +60,6 @@ import           Stack.BuildPlan (loadMiniBuildPlan, shadowMiniBuildPlan,
                                   parseCustomMiniBuildPlan)
 import           Stack.Constants (wiredInPackages)
 import           Stack.Package
-import           Stack.PackageIndex
 import           Stack.Types
 
 import           System.Directory
@@ -80,9 +79,10 @@ loadSourceMap needTargets bopts = do
     bconfig <- asks getBuildConfig
     rawLocals <- getLocalPackageViews
     (mbp0, cliExtraDeps, targets) <- parseTargetsFromBuildOpts needTargets bopts
-    menv <- getMinimalEnvOverride
-    caches <- getPackageCaches menv
-    let latestVersion = Map.fromListWith max $ map toTuple $ Map.keys caches
+    let latestVersion =
+            Map.fromListWith max $
+            map toTuple $
+            Map.keys (bcPackageCaches bconfig)
 
     -- Extend extra-deps to encompass targets requested on the command line
     -- that are not in the snapshot.

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -187,11 +187,13 @@ resolveBuildPlan :: (MonadThrow m, MonadIO m, MonadReader env m, HasBuildConfig 
 resolveBuildPlan menv mbp isShadowed packages
     | Map.null (rsUnknown rs) && Map.null (rsShadowed rs) = return (rsToInstall rs, rsUsedBy rs)
     | otherwise = do
-        cache <- getPackageCaches menv
-        let maxVer = Map.fromListWith max $ map toTuple $ Map.keys cache
+        bconfig <- asks getBuildConfig
+        let maxVer =
+                Map.fromListWith max $
+                map toTuple $
+                Map.keys (bcPackageCaches bconfig)
             unknown = flip Map.mapWithKey (rsUnknown rs) $ \ident x ->
                 (Map.lookup ident maxVer, x)
-        bconfig <- asks getBuildConfig
         throwM $ UnknownPackages
             (bcStackYaml bconfig)
             unknown

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -76,7 +76,6 @@ import           Path.IO
 import           Prelude -- Fix AMP warning
 import           Stack.Constants
 import           Stack.Fetch
-import           Stack.GhcPkg
 import           Stack.Package
 import           Stack.Types
 import           Stack.Types.StackT
@@ -176,14 +175,13 @@ instance Show BuildPlanException where
 --
 -- This may fail if a target package is not present in the @BuildPlan@.
 resolveBuildPlan :: (MonadThrow m, MonadIO m, MonadReader env m, HasBuildConfig env, MonadLogger m, HasHttpManager env, MonadBaseControl IO m,MonadCatch m)
-                 => EnvOverride
-                 -> MiniBuildPlan
+                 => MiniBuildPlan
                  -> (PackageName -> Bool) -- ^ is it shadowed by a local package?
                  -> Map PackageName (Set PackageName) -- ^ required packages, and users of it
                  -> m ( Map PackageName (Version, Map FlagName Bool)
                       , Map PackageName (Set PackageName)
                       )
-resolveBuildPlan menv mbp isShadowed packages
+resolveBuildPlan mbp isShadowed packages
     | Map.null (rsUnknown rs) && Map.null (rsShadowed rs) = return (rsToInstall rs, rsUsedBy rs)
     | otherwise = do
         bconfig <- asks getBuildConfig

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -78,7 +78,6 @@ import           Stack.Constants
 import           Stack.Fetch
 import           Stack.GhcPkg
 import           Stack.Package
-import           Stack.PackageIndex
 import           Stack.Types
 import           Stack.Types.StackT
 import           System.Directory (canonicalizePath)

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -70,6 +70,7 @@ import           Stack.Constants
 import           Stack.Config.Docker
 import qualified Stack.Image as Image
 import           Stack.Init
+import           Stack.PackageIndex
 import           Stack.Types
 import           Stack.Types.Internal
 import           System.Directory (getAppUserDataDirectory, createDirectoryIfMissing, canonicalizePath)
@@ -380,6 +381,8 @@ loadBuildConfig mproject config mresolver mcompiler = do
 
     extraPackageDBs <- mapM parseRelAsAbsDir (projectExtraPackageDBs project)
 
+    packageCaches <- runReaderT (getMinimalEnvOverride >>= getPackageCaches) miniConfig
+
     return BuildConfig
         { bcConfig = config
         , bcResolver = projectResolver project
@@ -391,6 +394,7 @@ loadBuildConfig mproject config mresolver mcompiler = do
         , bcFlags = projectFlags project
         , bcImplicitGlobal = isNothing mproject
         , bcGHCVariant = getGHCVariant miniConfig
+        , bcPackageCaches = packageCaches
         }
 
 -- | Resolve a PackageEntry into a list of paths, downloading and cloning as

--- a/src/Stack/PackageIndex.hs
+++ b/src/Stack/PackageIndex.hs
@@ -47,7 +47,7 @@ import           Data.Foldable (forM_)
 import           Data.Int (Int64)
 import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Monoid ((<>))
+import           Data.Monoid
 import           Data.Text (Text)
 import qualified Data.Text as T
 

--- a/src/Stack/PackageIndex.hs
+++ b/src/Stack/PackageIndex.hs
@@ -47,7 +47,7 @@ import           Data.Foldable (forM_)
 import           Data.Int (Int64)
 import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Monoid
+import           Data.Monoid ((<>))
 import           Data.Text (Text)
 import qualified Data.Text as T
 

--- a/src/Stack/Types.hs
+++ b/src/Stack/Types.hs
@@ -8,6 +8,7 @@ import Stack.Types.BuildPlan as X
 import Stack.Types.FlagName as X
 import Stack.Types.GhcPkgId as X
 import Stack.Types.PackageIdentifier as X
+import Stack.Types.PackageIndex as X
 import Stack.Types.PackageName as X
 import Stack.Types.Version as X
 import Stack.Types.Config as X

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -58,6 +58,7 @@ import           Stack.Types.Docker
 import           Stack.Types.FlagName
 import           Stack.Types.Image
 import           Stack.Types.PackageIdentifier
+import           Stack.Types.PackageIndex
 import           Stack.Types.PackageName
 import           Stack.Types.Version
 import           System.Process.Read (EnvOverride)
@@ -346,6 +347,8 @@ data BuildConfig = BuildConfig
       -- for providing better error messages.
     , bcGHCVariant :: !GHCVariant
       -- ^ The variant of GHC used to select a GHC bindist.
+    , bcPackageCaches :: !(Map PackageIdentifier (PackageIndex, PackageCache))
+      -- ^ Shared package cache map
     }
 
 -- | Directory containing the project's stack.yaml file

--- a/src/Stack/Types/PackageIndex.hs
+++ b/src/Stack/Types/PackageIndex.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Stack.Types.PackageIndex
+    ( PackageDownload (..)
+    , PackageCache (..)
+    , PackageCacheMap (..)
+    ) where
+
+import           Control.Monad (mzero)
+import           Data.Aeson.Extended
+import qualified Data.Binary as Binary
+import           Data.Binary.VersionTagged
+import           Data.ByteString (ByteString)
+import           Data.Int (Int64)
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Text (Text)
+import           Data.Text.Encoding (encodeUtf8)
+import           Data.Word (Word64)
+import           GHC.Generics (Generic)
+import           Stack.Types.PackageIdentifier
+
+data PackageCache = PackageCache
+    { pcOffset :: !Int64
+    -- ^ offset in bytes into the 00-index.tar file for the .cabal file contents
+    , pcSize :: !Int64
+    -- ^ size in bytes of the .cabal file
+    , pcDownload :: !(Maybe PackageDownload)
+    }
+    deriving (Generic)
+
+instance Binary PackageCache
+instance NFData PackageCache
+instance HasStructuralInfo PackageCache
+
+newtype PackageCacheMap = PackageCacheMap (Map PackageIdentifier PackageCache)
+    deriving (Generic, Binary, NFData)
+instance HasStructuralInfo PackageCacheMap
+instance HasSemanticVersion PackageCacheMap
+
+data PackageDownload = PackageDownload
+    { pdSHA512 :: !ByteString
+    , pdUrl    :: !ByteString
+    , pdSize   :: !Word64
+    }
+    deriving (Show, Generic)
+instance Binary.Binary PackageDownload
+instance HasStructuralInfo PackageDownload
+instance NFData PackageDownload
+instance FromJSON PackageDownload where
+    parseJSON = withObject "Package" $ \o -> do
+        hashes <- o .: "package-hashes"
+        sha512 <- maybe mzero return (Map.lookup ("SHA512" :: Text) hashes)
+        locs <- o .: "package-locations"
+        url <-
+            case reverse locs of
+                [] -> mzero
+                x:_ -> return x
+        size <- o .: "package-size"
+        return PackageDownload
+            { pdSHA512 = encodeUtf8 sha512
+            , pdUrl = encodeUtf8 url
+            , pdSize = size
+            }

--- a/src/test/Stack/BuildPlanSpec.hs
+++ b/src/test/Stack/BuildPlanSpec.hs
@@ -56,10 +56,8 @@ spec = beforeAll setup $ afterAll teardown $ do
         LoadConfig{..} <- loadConfig' manager
         bconfig <- loadBuildConfigRest manager (lcLoadBuildConfig Nothing Nothing)
         runStackT manager logLevel bconfig False False $ do
-            menv <- getMinimalEnvOverride
             mbp <- loadMiniBuildPlan $ LTS 2 9
             eres <- try $ resolveBuildPlan
-                menv
                 mbp
                 (const False)
                 (Map.fromList

--- a/stack.cabal
+++ b/stack.cabal
@@ -86,6 +86,7 @@ library
                      Stack.Types.GhcPkgId
                      Stack.Types.Image
                      Stack.Types.PackageIdentifier
+                     Stack.Types.PackageIndex
                      Stack.Types.PackageName
                      Stack.Types.TemplateName
                      Stack.Types.Version


### PR DESCRIPTION
This PR covers issues uncovered by profiling the noopt build case. Results found that `Stack.PackageIndex.getPackageCaches`
was a costly function taking approx `%8-9` of total execution time. In additional
it was called three times by the following functions:
- `Stack.Build.ConstructPlan.constructPlan`
- `Stack.Build.Source.loadSourceMap`
- `Stack.Fetch.withCabalLoader`
taken together this would mean that the total time is around `%25` spent in this function. This PR makes improvements to the efficiency of this operation.

This PR makes two changes:

1. runOnce for withCabalLoader action in build config.
2. Safe invocations of getPackagesCaches should instead get a stored copy of the package caches from the build config. These are:
- `Stack.Build.ConstructPlan.constructPlan`
- `Stack.Build.Source.loadSourceMap`
- `Stack.BuildPlan.resolveBuildPlan`

Some functions which don't use the build config packageCaches introduced with this change are in `Stack.Upgrade.upgrade` `Stack.Fetch.resolvePackagesAllowMissing` , which relies on an environment that has indices updated; `Stack.Fegtch.withCabalLoader` which invalidates caches;