### PR TITLE
Do all-in-one package builds when there are no cyclic dependencies

### DIFF
--- a/src/Control/Concurrent/Execute.hs
+++ b/src/Control/Concurrent/Execute.hs
@@ -24,6 +24,7 @@ import           Stack.Types
 
 data ActionType
     = ATBuild
+    | ATBuildFinal
     | ATFinal
     deriving (Show, Eq, Ord)
 data ActionId = ActionId !PackageIdentifier !ActionType

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -21,12 +21,6 @@ module Stack.Build.Cache
     , setTestSuccess
     , unsetTestSuccess
     , checkTestSuccess
-    , setTestBuilt
-    , unsetTestBuilt
-    , checkTestBuilt
-    , setBenchBuilt
-    , unsetBenchBuilt
-    , checkBenchBuilt
     , writePrecompiledCache
     , readPrecompiledCache
     ) where
@@ -228,64 +222,6 @@ checkTestSuccess dir =
     liftM
         (fromMaybe False)
         (tryGetCache testSuccessFile dir)
-
--- | Mark a test suite as having built
-setTestBuilt :: (MonadIO m, MonadLogger m, MonadThrow m, MonadReader env m, HasConfig env, HasEnvConfig env)
-               => Path Abs Dir
-               -> m ()
-setTestBuilt dir =
-    writeCache
-        dir
-        testBuiltFile
-        True
-
--- | Mark a test suite as not having built
-unsetTestBuilt :: (MonadIO m, MonadLogger m, MonadThrow m, MonadReader env m, HasConfig env, HasEnvConfig env)
-                 => Path Abs Dir
-                 -> m ()
-unsetTestBuilt dir =
-    writeCache
-        dir
-        testBuiltFile
-        False
-
--- | Check if the test suite already built
-checkTestBuilt :: (MonadIO m, MonadLogger m, MonadThrow m, MonadReader env m, HasConfig env, HasEnvConfig env)
-                 => Path Abs Dir
-                 -> m Bool
-checkTestBuilt dir =
-    liftM
-        (fromMaybe False)
-        (tryGetCache testBuiltFile dir)
-
--- | Mark a bench suite as having built
-setBenchBuilt :: (MonadIO m, MonadLogger m, MonadThrow m, MonadReader env m, HasConfig env, HasEnvConfig env)
-               => Path Abs Dir
-               -> m ()
-setBenchBuilt dir =
-    writeCache
-        dir
-        benchBuiltFile
-        True
-
--- | Mark a bench suite as not having built
-unsetBenchBuilt :: (MonadIO m, MonadLogger m, MonadThrow m, MonadReader env m, HasConfig env, HasEnvConfig env)
-                 => Path Abs Dir
-                 -> m ()
-unsetBenchBuilt dir =
-    writeCache
-        dir
-        benchBuiltFile
-        False
-
--- | Check if the bench suite already built
-checkBenchBuilt :: (MonadIO m, MonadLogger m, MonadThrow m, MonadReader env m, HasConfig env, HasEnvConfig env)
-                 => Path Abs Dir
-                 -> m Bool
-checkBenchBuilt dir =
-    liftM
-        (fromMaybe False)
-        (tryGetCache benchBuiltFile dir)
 
 --------------------------------------
 -- Precompiled Cache

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1063,7 +1063,10 @@ singleBuild runInBase ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} in
 
         unless isFinalBuild $ withMVar eeInstallLock $ \() -> do
             announce "copy/register"
-            cabal False ["copy"]
+            let shouldCopy = case taskType of
+                    TTUpstream{} -> True
+                    TTLocal lp -> not (Set.null (exesToBuild lp))
+            when shouldCopy $ cabal False ["copy"]
             when (packageHasLibrary package) $ cabal False ["register"]
 
         let (installedPkgDb, installedDumpPkgsTVar, dumpPkgsTVars) =

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -329,11 +329,7 @@ loadLocalPackage bopts targets (name, (lpv, gpkg)) = do
 
         btpkg
             | Set.null tests && Set.null benches = Nothing
-            | otherwise = Just LocalPackageTB
-                { lptbPackage = resolvePackage btconfig gpkg
-                , lptbTests = tests
-                , lptbBenches = benches
-                }
+            | otherwise = Just (resolvePackage btconfig gpkg)
         testpkg = resolvePackage testconfig gpkg
         benchpkg = resolvePackage benchconfig gpkg
     mbuildCache <- tryGetBuildCache $ lpvRoot lpv
@@ -350,10 +346,6 @@ loadLocalPackage bopts targets (name, (lpv, gpkg)) = do
         { lpPackage = pkg
         , lpTestDeps = packageDeps testpkg
         , lpBenchDeps = packageDeps benchpkg
-        , lpExeComponents =
-            case mtarget of
-                Nothing -> Nothing
-                Just _ -> Just exes
         , lpTestBench = btpkg
         , lpFiles = files
         , lpDirtyFiles =
@@ -365,6 +357,7 @@ loadLocalPackage bopts targets (name, (lpv, gpkg)) = do
         , lpNewBuildCache = newBuildCache
         , lpCabalFile = lpvCabalFP lpv
         , lpDir = lpvRoot lpv
+        , lpWanted = isJust mtarget
         , lpComponents = Set.unions
             [ Set.map CExe exes
             , Set.map CTest tests

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -264,18 +264,6 @@ ghciSetup mbuildFirst mainIs stringTargets = do
             STLocalComps s -> any p (S.toList s)
             STLocalAll -> True
             _ -> False
-    isCLib nc =
-        case nc of
-            CLib{} -> True
-            _ -> False
-    isCTest nc =
-        case nc of
-            CTest{} -> True
-            _ -> False
-    isCBench nc =
-        case nc of
-            CBench{} -> True
-            _ -> False
 
 -- | Make information necessary to load the given package in GHCi.
 makeGhciPkgInfo

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -171,7 +171,7 @@ readLocalPackage pkgDir = do
     mapM_ (printCabalFileWarning cabalfp) warnings
     return LocalPackage
         { lpPackage = package
-        , lpExeComponents = Nothing -- HACK: makes it so that sdist output goes to a log instead of a file.
+        , lpWanted = False -- HACK: makes it so that sdist output goes to a log instead of a file.
         , lpDir = pkgDir
         , lpCabalFile = cabalfp
         -- NOTE: these aren't the 'correct values, but aren't used in

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -213,6 +213,7 @@ getSDistFileList lp =
             , tcoOpts = \_ -> ConfigureOpts [] []
             }
         , taskPresent = Map.empty
+        , taskAllInOne = True
         }
 
 normalizeTarballPaths :: M env m => [FilePath] -> m [FilePath]

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -559,10 +559,15 @@ instance HasSemanticVersion ConfigCache
 
 -- | A task to perform when building
 data Task = Task
-    { taskProvides        :: !PackageIdentifier        -- ^ the package/version to be built
-    , taskType            :: !TaskType                 -- ^ the task type, telling us how to build this
+    { taskProvides        :: !PackageIdentifier
+    -- ^ the package/version to be built
+    , taskType            :: !TaskType
+    -- ^ the task type, telling us how to build this
     , taskConfigOpts      :: !TaskConfigOpts
-    , taskPresent         :: !(Map PackageIdentifier GhcPkgId)           -- ^ GhcPkgIds of already-installed dependencies
+    , taskPresent         :: !(Map PackageIdentifier GhcPkgId)
+    -- ^ GhcPkgIds of already-installed dependencies
+    , taskAllInOne        :: !Bool
+    -- ^ indicates that the package can be built in one step
     }
     deriving Show
 

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -596,7 +596,7 @@ taskLocation task =
 -- | A complete plan of what needs to be built and how to do it
 data Plan = Plan
     { planTasks :: !(Map PackageName Task)
-    , planFinals :: !(Map PackageName (Task, LocalPackageTB))
+    , planFinals :: !(Map PackageName Task)
     -- ^ Final actions to be taken (test, benchmark, etc)
     , planUnregisterLocal :: !(Map GhcPkgId (PackageIdentifier, Maybe Text))
     -- ^ Text is reason we're unregistering, for display only


### PR DESCRIPTION
Third swing at this worked out well!

One issue this has is that in the presence of cyclic dependencies, it will rebuild each time.  I'm looking into this, but really it's not so bad since it's pretty rare to do this.

Here's the output of running `stack test` on my [https://github.com/mgsloan/multi-test-suite](multi-test-suite) repo, which originally was for testing test coverage with multiple test suites.  It now also includes an example of a cyclic dependency.  Specifically, `multi-test-suite` depends on `cyclic`, and `cyclic`'s test-suite depends on `multi-test-suite`.

```
cyclic-0.1.0.0: unregistering (dependencies changed)
multi-test-suite-0.1.0.0: unregistering (missing dependencies: cyclic)
cyclic-0.1.0.0: configure
cyclic-0.1.0.0: build
cyclic-0.1.0.0: copy/register
multi-test-suite-0.1.0.0: build
multi-test-suite-0.1.0.0: copy/register
multi-test-suite-0.1.0.0: test (suite: multi-test-suite-test)
multi-test-suite-0.1.0.0: test (suite: multi-test-suite-test-2)
sub-package-0.1.0.0: build (exe + test)
cyclic-0.1.0.0: configure (test)
cyclic-0.1.0.0: build (test)
Warning: module not listed in sub-package.cabal for 'sub-package-test' component (add to other-modules): Lib2
sub-package-0.1.0.0: copy/register
sub-package-0.1.0.0: test (suite: sub-package-test)
cyclic-0.1.0.0: test (suite: cyclic-test-suite)
Completed all 7 actions.
```