### PR TITLE
Fixes #1067, failure to start ghci on Windows

### DIFF
--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -339,7 +339,7 @@ generateBuildInfoOpts sourceMap installedMap mcabalmacros cabalDir distDir omitP
     extOpts = map (("-X" ++) . display) . usedExtensions
     srcOpts =
         map
-            (("-i" <>) . toFilePath)
+            (("-i" <>) . FilePath.dropTrailingPathSeparator . toFilePath)
             ((if null (hsSourceDirs b) then [cabalDir] else []) <>
              map (cabalDir </>) (mapMaybe parseRelDir (hsSourceDirs b)) <>
              [autogenDir distDir,buildDir distDir]) ++

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -343,7 +343,7 @@ generateBuildInfoOpts sourceMap installedMap mcabalmacros cabalDir distDir omitP
             ((if null (hsSourceDirs b) then [cabalDir] else []) <>
              map (cabalDir </>) (mapMaybe parseRelDir (hsSourceDirs b)) <>
              [autogenDir distDir,buildDir distDir]) ++
-        ["-stubdir=" ++ toFilePath (buildDir distDir)]
+        ["-stubdir=" ++ FilePath.dropTrailingPathSeparator (toFilePath $ buildDir distDir)]
     includeOpts =
         [ "-I" <> toFilePath absDir
         | dir <- includeDirs b


### PR DESCRIPTION
I remove the slash after stubdir, and it works.

I also removed them after -i, since it's cleaner, and it doesn't seem to make it worse.