### PR TITLE
Typo recommendations

### DIFF
--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -51,7 +51,7 @@ import           Data.IORef                     (newIORef, readIORef,
                                                  writeIORef)
 import           Data.List                      (intercalate)
 import           Data.List.NonEmpty             (NonEmpty)
-import qualified Data.List.NonEmpty             as NonEmpty
+import qualified Data.List.NonEmpty             as NE
 import           Data.Map                       (Map)
 import qualified Data.Map                       as Map
 import           Data.Maybe                     (maybeToList, catMaybes)
@@ -79,6 +79,9 @@ import           System.IO                      (IOMode (ReadMode),
                                                  SeekMode (AbsoluteSeek), hSeek,
                                                  withBinaryFile)
 import           System.PosixCompat             (setFileMode)
+import           Text.EditDistance              as ED
+
+type PackageCaches = Map PackageIdentifier (PackageIndex, PackageCache)
 
 data FetchException
     = Couldn'tReadIndexTarball FilePath Tar.FormatError
@@ -194,14 +197,11 @@ resolvePackages menv idents0 names0 = do
             go >>= either throwM return
         Right x -> return x
   where
-    go = do
-        (missingNames, missingIdents, idents) <- resolvePackagesAllowMissing menv idents0 names0
-        return $
-            case () of
-                ()
-                    | not $ Set.null missingNames -> Left $ UnknownPackageNames missingNames
-                    | not $ Set.null missingIdents -> Left $ UnknownPackageIdentifiers missingIdents
-                    | otherwise -> Right idents
+    go = r <$> resolvePackagesAllowMissing menv idents0 names0
+    r (missingNames, missingIdents, idents)
+      | not $ Set.null missingNames  = Left $ UnknownPackageNames       missingNames
+      | not $ Set.null missingIdents = Left $ UnknownPackageIdentifiers missingIdents
+      | otherwise                    = Right idents
 
 resolvePackagesAllowMissing
     :: (MonadIO m, MonadReader env m, HasHttpManager env, HasConfig env, MonadLogger m, MonadThrow m, MonadBaseControl IO m, MonadCatch m)
@@ -290,37 +290,40 @@ withCabalLoader menv inner = do
                 -- Update the cache and try again
                 Nothing -> do
                     let fuzzy = fuzzyLookupCandidates ident cachesCurr
-                        fuzzyCandidatesText = case fuzzy of
-                            Nothing -> ""
-                            Just cs -> "Possible candidates: "
-                                       <> commaSeparatedIdents cs
-                                       <> ". "
+                        candidatesText = case fuzzy of
+                            Nothing ->
+                              case typoCorrectionCandidates ident cachesCurr of
+                                  Nothing -> ""
+                                  Just cs -> "Perhaps you meant " <>
+                                    orSeparated (show <$> cs) <> "?\n"
+                            Just cs -> "Possible candidates: " <>
+                              commaSeparated (NE.map packageIdentifierString cs)
+                              <> ".\n"
                     join $ modifyMVar updateRef $ \toUpdate ->
                         if toUpdate then do
                             runInBase $ do
                                 $logInfo $ T.concat
                                     [ "Didn't see "
                                     , T.pack $ packageIdentifierString ident
-                                    , " in your package indices. "
-                                    , T.pack fuzzyCandidatesText
+                                    , " in your package indices.\n"
+                                    , T.pack candidatesText
                                     , "Updating and trying again."
                                     ]
                                 updateAllIndices menv
                                 caches <- getPackageCaches menv
                                 liftIO $ writeIORef icaches caches
                             return (False, doLookup ident)
-                        else return (toUpdate, throwM (unknownIdent ident))
+                        else return (toUpdate, throwM .
+                                               UnknownPackageIdentifiers .
+                                               Set.singleton $ ident)
     inner doLookup
-  where
-    unknownIdent = UnknownPackageIdentifiers . Set.singleton
-    commaSeparatedIdents =
-        F.fold . NonEmpty.intersperse ", " . NonEmpty.map packageIdentifierString
 
-type PackageCaches = Map PackageIdentifier (PackageIndex, PackageCache)
-
-lookupPackageIdentifierExact :: HasConfig env
-                             => PackageIdentifier -> env -> PackageCaches
-                             -> IO (Maybe ByteString)
+lookupPackageIdentifierExact
+  :: HasConfig env
+  => PackageIdentifier
+  -> env
+  -> PackageCaches
+  -> IO (Maybe ByteString)
 lookupPackageIdentifierExact ident env caches =
     case Map.lookup ident caches of
         Nothing -> return Nothing
@@ -330,21 +333,35 @@ lookupPackageIdentifierExact ident env caches =
                   $ \_ _ bs -> return bs
             return $ Just bs
 
-fuzzyLookupCandidates :: PackageIdentifier -> PackageCaches
-                      -> Maybe (NonEmpty PackageIdentifier)
+-- | Given package identifier and package caches, return list of packages
+-- with the same name and the same two first version number components found
+-- in the caches.
+fuzzyLookupCandidates
+  :: PackageIdentifier
+  -> PackageCaches
+  -> Maybe (NonEmpty PackageIdentifier)
 fuzzyLookupCandidates (PackageIdentifier name ver) caches =
-    NonEmpty.nonEmpty (map fst sameMajor)
-  where
-    sameMajor = filter (\(PackageIdentifier _ v, _) ->
-                             toMajorVersion ver == toMajorVersion v)
-                       sameIdentCaches
-    sameIdentCaches = maybe biggerFiltered
-                            (\z -> (zeroIdent, z) : biggerFiltered)
-                            zeroVer
-    biggerFiltered = takeWhile (\(PackageIdentifier n _, _) -> name == n)
-                               (Map.toList bigger)
-    zeroIdent = PackageIdentifier name $(mkVersion "0.0")
-    (_, zeroVer, bigger) = Map.splitLookup zeroIdent caches
+  let (_, zero, bigger) = Map.splitLookup zeroIdent caches
+      zeroIdent         = PackageIdentifier name $(mkVersion "0.0")
+      sameName  (PackageIdentifier n _) = n == name
+      sameMajor (PackageIdentifier _ v) = toMajorVersion v == toMajorVersion ver
+  in NE.nonEmpty . filter sameMajor $ maybe [] (pure . const zeroIdent) zero
+         <> takeWhile sameName (Map.keys bigger)
+
+-- | Try to come up with typo corrections for given package identifier using
+-- package caches. This should be called before giving up, i.e. when
+-- 'fuzzyLookupCandidates' cannot return anything.
+typoCorrectionCandidates
+  :: PackageIdentifier
+  -> PackageCaches
+  -> Maybe (NonEmpty String)
+typoCorrectionCandidates ident =
+  let getName = packageNameString . packageIdentifierName
+      name    = getName ident
+  in  NE.nonEmpty
+    . Map.keys
+    . Map.filterWithKey (const . (== 1) . damerauLevenshtein name)
+    . Map.mapKeys getName
 
 -- | Figure out where to fetch from.
 getToFetch :: (MonadThrow m, MonadIO m, MonadReader env m, HasConfig env)
@@ -522,3 +539,15 @@ parMapM_ cnt f xs0 = do
         workers 1 = Concurrently worker
         workers i = Concurrently worker *> workers (i - 1)
     liftIO $ runConcurrently $ workers cnt
+
+damerauLevenshtein :: String -> String -> Int
+damerauLevenshtein = ED.restrictedDamerauLevenshteinDistance ED.defaultEditCosts
+
+orSeparated :: NonEmpty String -> String
+orSeparated xs
+  | NE.length xs == 1 = NE.head xs
+  | NE.length xs == 2 = NE.head xs <> " or " <> NE.last xs
+  | otherwise = intercalate ", " (NE.init xs) <> ", or " <> NE.last xs
+
+commaSeparated :: NonEmpty String -> String
+commaSeparated = F.fold . NE.intersperse ", "

--- a/src/Stack/Types/PackageIdentifier.hs
+++ b/src/Stack/Types/PackageIdentifier.hs
@@ -6,16 +6,14 @@
 -- | Package identifier (name-version).
 
 module Stack.Types.PackageIdentifier
-  (PackageIdentifier(..)
-  ,toTuple
-  ,fromTuple
-  ,parsePackageIdentifier
-  ,parsePackageIdentifierFromString
-  ,packageIdentifierVersion
-  ,packageIdentifierName
-  ,packageIdentifierParser
-  ,packageIdentifierString
-  ,packageIdentifierText)
+  ( PackageIdentifier(..)
+  , toTuple
+  , fromTuple
+  , parsePackageIdentifier
+  , parsePackageIdentifierFromString
+  , packageIdentifierParser
+  , packageIdentifierString
+  , packageIdentifierText )
   where
 
 import           Control.Applicative
@@ -46,10 +44,12 @@ instance Show PackageIdentifierParseFail where
 instance Exception PackageIdentifierParseFail
 
 -- | A pkg-ver combination.
-data PackageIdentifier =
-  PackageIdentifier !PackageName
-                    !Version
-  deriving (Eq,Ord,Generic,Data,Typeable)
+data PackageIdentifier = PackageIdentifier
+  { -- | Get the name part of the identifier.
+    packageIdentifierName    :: !PackageName
+    -- | Get the version part of the identifier.
+  , packageIdentifierVersion :: !Version
+  } deriving (Eq,Ord,Generic,Data,Typeable)
 
 instance NFData PackageIdentifier where
   rnf (PackageIdentifier !p !v) =
@@ -77,14 +77,6 @@ toTuple (PackageIdentifier n v) = (n,v)
 -- | Convert from a tuple to a package identifier.
 fromTuple :: (PackageName,Version) -> PackageIdentifier
 fromTuple (n,v) = PackageIdentifier n v
-
--- | Get the version part of the identifier.
-packageIdentifierVersion :: PackageIdentifier -> Version
-packageIdentifierVersion (PackageIdentifier _ ver) = ver
-
--- | Get the name part of the identifier.
-packageIdentifierName :: PackageIdentifier -> PackageName
-packageIdentifierName (PackageIdentifier name _) = name
 
 -- | A parser for a package-version pair.
 packageIdentifierParser :: Parser PackageIdentifier

--- a/stack.cabal
+++ b/stack.cabal
@@ -142,6 +142,7 @@ library
                    , cryptohash >= 0.11.6
                    , cryptohash-conduit
                    , directory >= 1.2.1.0
+                   , edit-distance >= 0.2
                    , either
                    , enclosed-exceptions
                    , exceptions >= 0.8.0.2


### PR DESCRIPTION
This implements thing described in #158. I've chosen to stay conservative with threshold 1. Limiting number of matches can be confusing because desired package name can be eliminated from list of suggestions. With current implementation number of matches won't ever be too big to limit it.

Here is example of how it works:

```
[mark@arch ~]$ stack build stackage-metdata-0.3.0.0
Run from outside a project, using implicit global project config
Using resolver: lts-3.9 from implicit global project's config file: /home/mark/.stack/global-project/stack.yaml
Didn't see stackage-metdata-0.3.0.0 in your package indices.
Perhaps you meant "stackage-metadata"?
Updating and trying again.
Updating package index Hackage (mirrored at https://github.com/commercialhaskell                                                                                Fetched package index.
Populated index cache.
The following package identifiers were not found in your indices: stackage-metdata-0.3.0.0
[mark@arch ~]$ stack build parses-3.1.9
Run from outside a project, using implicit global project config
Using resolver: lts-3.9 from implicit global project's config file: /home/mark/.stack/global-project/stack.yaml
Didn't see parses-3.1.9 in your package indices.
Perhaps you meant "parsec", "parsek", or "parsers"?
Updating and trying again.
Updating package index Hackage (mirrored at https://github.com/commercialhaskell                                                                                Fetched package index.
Populated index cache.
The following package identifiers were not found in your indices: parses-3.1.9
[mark@arch ~]$
```

I also tested various edge cases and it behaves normally.

The refactoring should make some parts of code easier to read. I've also added comments describing what some functions do.
