### PR TITLE
Simplify a part of conduitDumpPackage a little bit

### DIFF
--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -45,7 +45,7 @@ import           Data.Either (partitionEithers)
 import           Data.IORef
 import           Data.Map (Map)
 import qualified Data.Map as Map
-import           Data.Maybe (catMaybes, listToMaybe, fromMaybe)
+import           Data.Maybe (catMaybes, listToMaybe)
 import qualified Data.Set as Set
 import qualified Data.Text.Encoding as T
 import           Data.Typeable (Typeable)
@@ -305,7 +305,7 @@ conduitDumpPackage = (=$= CL.catMaybes) $ eachSection $ do
                 _ -> throwM $ MissingSingleField k m
         -- Can't fail: if not found, same as an empty list. See:
         -- https://github.com/fpco/stack/issues/182
-        parseM k = fromMaybe [] (Map.lookup k m)
+        parseM k = Map.findWithDefault [] k m
 
         parseDepend :: MonadThrow m => ByteString -> m (Maybe GhcPkgId)
         parseDepend "builtin_rts" = return Nothing


### PR DESCRIPTION
`fromMaybe x (Map.lookup y z)` is equivalent to `Map.findWithDefault x y z`