### PR TITLE
Refactor `allGhcOptions` helper

### DIFF
--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -721,8 +721,8 @@ configureOptsNoDir econfig bco deps wanted isLocal package = concat
 
     ghcOptionsMap = configGhcOptions $ getConfig econfig
     allGhcOptions = concat
-        [ fromMaybe [] $ Map.lookup Nothing ghcOptionsMap
-        , fromMaybe [] $ Map.lookup (Just $ packageName package) ghcOptionsMap
+        [ Map.findWithDefault [] Nothing ghcOptionsMap
+        , Map.findWithDefault [] (Just $ packageName package) ghcOptionsMap
         , if includeExtraOptions
             then boptsGhcOptions bopts
             else []


### PR DESCRIPTION
[Data.Map.findWithDefault](http://hackage.haskell.org/package/containers-0.5.6.3/docs/Data-Map-Strict.html#v:findWithDefault) to the rescue.