### PR TITLE
Some refactorings in Stack.Build.Haddock

### DIFF
--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -210,7 +210,7 @@ generateHaddockIndex descr envOverride wc dumpPackages docRelFP destDir = do
                                 , srcInterfaceAbsFile
                                 , destInterfaceAbsFile )
     copyPkgDocs (_,srcInterfaceModTime,srcInterfaceAbsFile,destInterfaceAbsFile) = do
-        -- | Copy dependencies' haddocks to documentation directory.  This way, relative @../$pkg-$ver@
+        -- Copy dependencies' haddocks to documentation directory.  This way, relative @../$pkg-$ver@
         -- links work and it's easy to upload docs to a web server or otherwise view them in a
         -- non-local-filesystem context. We copy instead of symlink for two reasons: (1) symlinks
         -- aren't reliably supported on Windows, and (2) the filesystem containing dependencies'

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -48,7 +48,12 @@ import           System.IO.Error                (isDoesNotExistError)
 import           System.Process.Read
 
 -- | Determine whether we should haddock for a package.
-shouldHaddockPackage :: BuildOpts -> Set PackageName -> PackageName -> Bool
+shouldHaddockPackage :: BuildOpts
+                     -> Set PackageName  -- ^ Packages that we want to generate haddocks for
+                                         -- in any case (whether or not we are going to generate
+                                         -- haddocks for dependencies)
+                     -> PackageName
+                     -> Bool
 shouldHaddockPackage bopts wanted name =
     if Set.member name wanted
         then boptsHaddock bopts
@@ -64,7 +69,7 @@ generateLocalHaddockIndex
     => EnvOverride
     -> WhichCompiler
     -> BaseConfigOpts
-    -> Map GhcPkgId (DumpPackage () ())
+    -> Map GhcPkgId (DumpPackage () ())  -- ^ Local package dump
     -> [LocalPackage]
     -> m ()
 generateLocalHaddockIndex envOverride wc bco localDumpPkgs locals = do
@@ -133,8 +138,8 @@ generateSnapHaddockIndex
     => EnvOverride
     -> WhichCompiler
     -> BaseConfigOpts
-    -> Map GhcPkgId (DumpPackage () ())
-    -> Map GhcPkgId (DumpPackage () ())
+    -> Map GhcPkgId (DumpPackage () ())  -- ^ Global package dump
+    -> Map GhcPkgId (DumpPackage () ())  -- ^ Snapshot package dump
     -> m ()
 generateSnapHaddockIndex envOverride wc bco globalDumpPkgs snapshotDumpPkgs =
     generateHaddockIndex


### PR DESCRIPTION
Among other things:

* Fix a comment that breaks haddocks generation for stack

* Rename the `generate*HaddockIndex` functions to `generate*Haddocks` as they generate both the index as well as the actual haddocks