### PR TITLE
Addition of ‘--check’ option for ‘upload’ and ‘sdist’

### DIFF
--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -151,11 +151,11 @@ buildOptsParser cmd =
                 (long "dependencies-only" <>
                  help "A synonym for --only-dependencies")
             <|> flag' BSOnlySnapshot
-                (long ("only-snapshot") <>
-                 help ("Only build packages for the snapshot database, not the local database"))
+                (long "only-snapshot" <>
+                 help "Only build packages for the snapshot database, not the local database")
             <|> flag' BSOnlyDependencies
-                (long ("only-dependencies") <>
-                 help ("Only build packages that are dependencies of targets on the command line"))
+                (long "only-dependencies" <>
+                 help "Only build packages that are dependencies of targets on the command line")
             <|> pure BSAll
 
         fileWatch' =

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -16,7 +16,7 @@
 module Stack.Package
   (readPackage
   ,readPackageBS
-  ,readPackageDir
+  ,readPackageDescriptionDir
   ,readPackageUnresolved
   ,readPackageUnresolvedBS
   ,resolvePackage
@@ -133,17 +133,16 @@ readPackageBS packageConfig bs =
   do (warnings,gpkg) <- readPackageUnresolvedBS Nothing bs
      return (warnings,resolvePackage packageConfig gpkg)
 
--- | Convenience wrapper around @readPackage@ that first finds the cabal file
--- in the given directory.
-readPackageDir :: (MonadLogger m, MonadIO m, MonadThrow m, MonadCatch m)
-               => PackageConfig
-               -> Path Abs Dir
-               -> m (Path Abs File, [PWarning], Package)
-readPackageDir packageConfig dir = do
-    cabalfp <- getCabalFileName dir
-    (warnings,pkg) <- readPackage packageConfig cabalfp
-    checkCabalFileName (packageName pkg) cabalfp
-    return (cabalfp, warnings, pkg)
+-- | Get 'GenericPackageDescription' and 'PackageDescription' reading info
+-- from given directory.
+readPackageDescriptionDir :: (MonadLogger m, MonadIO m, MonadThrow m, MonadCatch m)
+  => PackageConfig
+  -> Path Abs Dir
+  -> m (GenericPackageDescription, PackageDescription)
+readPackageDescriptionDir config pkgDir = do
+    cabalfp <- getCabalFileName pkgDir
+    gdesc   <- liftM snd (readPackageUnresolved cabalfp)
+    return (gdesc, resolvePackageDescription config gdesc)
 
 -- | Print cabal file warnings.
 printCabalFileWarning

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -62,10 +62,11 @@ type M env m = (MonadIO m,MonadReader env m,HasHttpManager env,MonadLogger m,Mon
 -- While this yields a 'FilePath', the name of the tarball, this
 -- tarball is not written to the disk and instead yielded as a lazy
 -- bytestring.
-getSDistTarball :: M env m
-                => Maybe PvpBounds -- ^ override Config value
-                -> Path Abs Dir
-                -> m (FilePath, L.ByteString)
+getSDistTarball
+  :: M env m
+  => Maybe PvpBounds            -- ^ Override Config value
+  -> Path Abs Dir               -- ^ Path to local package
+  -> m (FilePath, L.ByteString) -- ^ Filename and tarball contents
 getSDistTarball mpvpBounds pkgDir = do
     config <- asks getConfig
     let pvpBounds = fromMaybe (configPvpBounds config) mpvpBounds
@@ -149,7 +150,7 @@ gtraverseT f =
                  Nothing -> gtraverseT f x
                  Just b  -> fromMaybe x (cast (f b)))
 
--- Read in a 'LocalPackage' config.  This makes some default decisions
+-- | Read in a 'LocalPackage' config.  This makes some default decisions
 -- about 'LocalPackage' fields that might not be appropriate for other
 -- usecases.
 --
@@ -219,8 +220,8 @@ getSDistFileList lp =
 
 normalizeTarballPaths :: M env m => [FilePath] -> m [FilePath]
 normalizeTarballPaths fps = do
-    --TODO: consider whether erroring out is better - otherwise the
-    --user might upload an incomplete tar?
+    -- TODO: consider whether erroring out is better - otherwise the
+    -- user might upload an incomplete tar?
     unless (null outsideDir) $
         $logWarn $ T.concat
             [ "Warning: These files are outside of the package directory, and will be omitted from the tarball: "

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -4,9 +4,12 @@
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE ViewPatterns          #-}
+{-# LANGUAGE DeriveDataTypeable    #-}
 -- Create a source distribution tarball
 module Stack.SDist
     ( getSDistTarball
+    , checkSDistTarball
+    , checkSDistTarball'
     ) where
 
 import qualified Codec.Archive.Tar as Tar
@@ -14,8 +17,8 @@ import qualified Codec.Archive.Tar.Entry as Tar
 import qualified Codec.Compression.GZip as GZip
 import           Control.Applicative
 import           Control.Concurrent.Execute (ActionContext(..))
-import           Control.Monad (unless, void)
-import           Control.Monad.Catch (MonadMask)
+import           Control.Monad (unless, void, liftM)
+import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import           Control.Monad.Reader (MonadReader, asks)
@@ -26,6 +29,8 @@ import qualified Data.ByteString.Lazy as L
 import           Data.Data (Data, Typeable, cast, gmapT)
 import           Data.Either (partitionEithers)
 import           Data.List
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Monoid ((<>))
@@ -35,6 +40,9 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
 import           Data.Time.Clock.POSIX
 import           Distribution.Package (Dependency (..))
+import qualified Distribution.Package as P
+import qualified Distribution.PackageDescription as PD
+import qualified Distribution.PackageDescription.Check as Check
 import           Distribution.PackageDescription.PrettyPrint (showGenericPackageDescription)
 import           Distribution.Version (simplifyVersionRange, orLaterVersion, earlierVersion)
 import           Distribution.Version.Extra
@@ -45,14 +53,29 @@ import           Prelude -- Fix redundant import warnings
 import           Stack.Build (mkBaseConfigOpts)
 import           Stack.Build.Execute
 import           Stack.Build.Installed
-import           Stack.Build.Source (loadSourceMap, localFlags)
+import           Stack.Build.Source (loadSourceMap, getPackageConfig)
 import           Stack.Build.Target
 import           Stack.Constants
 import           Stack.Package
 import           Stack.Types
 import           Stack.Types.Internal
 import           System.Directory (getModificationTime, getPermissions, Permissions(..))
+import           System.IO.Temp (withSystemTempDirectory)
 import qualified System.FilePath as FP
+
+-- | Special exception to throw when you want to fail because of bad results
+-- of package check.
+
+data CheckException
+  = CheckException (NonEmpty Check.PackageCheck)
+  deriving (Typeable)
+
+instance Exception CheckException
+
+instance Show CheckException where
+  show (CheckException xs) =
+    "Package check reported the following errors:\n" ++
+    (intercalate "\n" . fmap show . NE.toList $ xs)
 
 type M env m = (MonadIO m,MonadReader env m,HasHttpManager env,MonadLogger m,MonadBaseControl IO m,MonadMask m,HasLogLevel env,HasEnvConfig env,HasTerminal env)
 
@@ -152,22 +175,12 @@ gtraverseT f =
 
 -- | Read in a 'LocalPackage' config.  This makes some default decisions
 -- about 'LocalPackage' fields that might not be appropriate for other
--- usecases.
---
--- TODO: Dedupe with similar code in "Stack.Build.Source".
+-- use-cases.
 readLocalPackage :: M env m => Path Abs Dir -> m LocalPackage
 readLocalPackage pkgDir = do
-    econfig <- asks getEnvConfig
-    bconfig <- asks getBuildConfig
     cabalfp <- getCabalFileName pkgDir
-    name <- parsePackageNameFromFilePath cabalfp
-    let config = PackageConfig
-            { packageConfigEnableTests = False
-            , packageConfigEnableBenchmarks = False
-            , packageConfigFlags = localFlags Map.empty bconfig name
-            , packageConfigCompilerVersion = envConfigCompilerVersion econfig
-            , packageConfigPlatform = configPlatform $ getConfig bconfig
-            }
+    name    <- parsePackageNameFromFilePath cabalfp
+    config  <- getPackageConfig name
     (warnings,package) <- readPackage config cabalfp
     mapM_ (printCabalFileWarning cabalfp) warnings
     return LocalPackage
@@ -246,6 +259,61 @@ dirsFromFiles dirs = Set.toAscList (Set.delete "." results)
     go s x
       | Set.member x s = s
       | otherwise = go (Set.insert x s) (FP.takeDirectory x)
+
+-- | Check package in given tarball. This will log all warnings
+-- and will throw an exception in case of critical errors.
+--
+-- Note that we temporarily decompress the archive to analyze it.
+checkSDistTarball :: (MonadIO m, MonadMask m, MonadThrow m, MonadCatch m, MonadLogger m, MonadReader env m, HasEnvConfig env)
+  => Path Abs File -- ^ Absolute path to tarball
+  -> m ()
+checkSDistTarball tarball = withTempTarGzContents tarball $ \pkgDir' -> do
+    pkgDir  <- (pkgDir' </>) `liftM`
+        (parseRelDir . FP.takeBaseName . FP.takeBaseName . toFilePath $ tarball)
+    --               ^ drop ".tar"     ^ drop ".gz"
+    cabalfp <- getCabalFileName pkgDir
+    name    <- parsePackageNameFromFilePath cabalfp
+    config  <- getPackageConfig name
+    (gdesc, pkgDesc) <- readPackageDescriptionDir config pkgDir
+    $logInfo $ "Checking package '" <>
+               (T.pack . P.unPackageName . P.pkgName . PD.package $ pkgDesc) <>
+               "' for common mistakes"
+    let pkgChecks = Check.checkPackage gdesc (Just pkgDesc)
+    fileChecks <- liftIO $ Check.checkPackageFiles pkgDesc (toFilePath pkgDir)
+    let checks = pkgChecks ++ fileChecks
+        (errors, warnings) =
+          let criticalIssue (Check.PackageBuildImpossible _) = True
+              criticalIssue (Check.PackageDistInexcusable _) = True
+              criticalIssue _ = False
+          in partition criticalIssue checks
+    unless (null warnings) $
+        $logWarn $ "Package check reported the following warnings:\n" <>
+                   T.pack (intercalate "\n" . fmap show $ warnings)
+    case NE.nonEmpty errors of
+        Nothing -> return ()
+        Just ne -> throwM $ CheckException ne
+
+-- | Version of 'checkSDistTarball' that first saves lazy bytestring to
+-- temporary directory and then calls 'checkSDistTarball' on it.
+checkSDistTarball' :: (MonadIO m, MonadMask m, MonadThrow m, MonadCatch m, MonadLogger m, MonadReader env m, HasEnvConfig env)
+  => String       -- ^ Tarball name
+  -> L.ByteString -- ^ Tarball contents as a byte string
+  -> m ()
+checkSDistTarball' name bytes = withSystemTempDirectory "stack" $ \tdir -> do
+    tpath   <- parseAbsDir tdir
+    npath   <- (tpath </>) `liftM` parseRelFile name
+    liftIO $ L.writeFile (toFilePath npath) bytes
+    checkSDistTarball npath
+
+withTempTarGzContents :: (MonadIO m, MonadMask m, MonadThrow m)
+  => Path Abs File         -- ^ Location of tarball
+  -> (Path Abs Dir -> m a) -- ^ Perform actions given dir with tarball contents
+  -> m a
+withTempTarGzContents apath f = withSystemTempDirectory "stack" $ \tdir -> do
+    tpath   <- parseAbsDir tdir
+    archive <- liftIO $ L.readFile (toFilePath apath)
+    liftIO . Tar.unpack (toFilePath tpath) . Tar.read . GZip.decompress $ archive
+    f tpath
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
See #1183. Here I've added `--check` switch. Previously simple tuple was used to hold options for `upload` and `sdist` commands. Now with the addition of `--check` option, I switched to `(,,)`. Is it OK? Should some data structure be defined instead of tuple? This is very beginning of my work, so I create this PR early to ask questions along the way.