### PR TITLE
 enable-split-objs #1284

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -653,10 +653,12 @@ ensureConfig newConfigCache pkgDir ExecuteEnv {..} announce cabal cabalfp = do
             return $ case mpath of
                 Nothing -> []
                 Just x -> return $ concat ["--with-", name, "=", toFilePath x]
+        enableSplitObjs <- asks $ configEnableSplitObjs . getConfig
         cabal False $ "configure" : concat
             [ concat exes
             , dirs
             , nodirs
+            , if enableSplitObjs then ["--enable-split-objs"] else []
             ]
         writeConfigCache pkgDir newConfigCache
         writeCabalMod pkgDir newCabalMod
@@ -886,6 +888,7 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
                             Ghc -> []
                             Ghcjs -> ["-build-runner"])
                     return (outputFile, setupArgs)
+
             runExe exeName $ (if boptsCabalVerbose eeBuildOpts then ("--verbose":) else id) fullArgs
 
     maybePrintBuildOutput stripTHLoading makeAbsolute pkgDir level mlogFile mh =

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -190,6 +190,7 @@ configFromConfigMonoid configStackRoot configUserConfigPath mproject configMonoi
          configRebuildGhcOptions = fromMaybe False configMonoidRebuildGhcOptions
          configApplyGhcOptions = fromMaybe AGOLocals configMonoidApplyGhcOptions
          configAllowNewer = fromMaybe False configMonoidAllowNewer
+         configEnableSplitObjs = fromMaybe False configMonoidEnableSplitObjs
 
      return Config {..}
 

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -261,6 +261,8 @@ data Config =
          ,configAllowNewer          :: !Bool
          -- ^ Ignore version ranges in .cabal files. Funny naming chosen to
          -- match cabal.
+         ,configEnableSplitObjs     :: !Bool
+         -- ^ Build libraries with split objects
          }
 
 -- | Which packages to ghc-options on the command line apply to?
@@ -750,6 +752,8 @@ data ConfigMonoid =
     -- ^ See 'configApplyGhcOptions'
     ,configMonoidAllowNewer          :: !(Maybe Bool)
     -- ^ See 'configMonoidAllowNewer'
+    ,configMonoidEnableSplitObjs     :: !(Maybe Bool)
+    -- ^ Build libraries with split objects
     }
   deriving Show
 
@@ -786,6 +790,7 @@ instance Monoid ConfigMonoid where
     , configMonoidRebuildGhcOptions = Nothing
     , configMonoidApplyGhcOptions = Nothing
     , configMonoidAllowNewer = Nothing
+    , configMonoidEnableSplitObjs = Nothing
     }
   mappend l r = ConfigMonoid
     { configMonoidDockerOpts = configMonoidDockerOpts l <> configMonoidDockerOpts r
@@ -820,6 +825,7 @@ instance Monoid ConfigMonoid where
     , configMonoidRebuildGhcOptions = configMonoidRebuildGhcOptions l <|> configMonoidRebuildGhcOptions r
     , configMonoidApplyGhcOptions = configMonoidApplyGhcOptions l <|> configMonoidApplyGhcOptions r
     , configMonoidAllowNewer = configMonoidAllowNewer l <|> configMonoidAllowNewer r
+    , configMonoidEnableSplitObjs = configMonoidEnableSplitObjs l <|> configMonoidEnableSplitObjs r
     }
 
 instance FromJSON (ConfigMonoid, [JSONWarning]) where
@@ -881,6 +887,7 @@ parseConfigMonoidJSON obj = do
     configMonoidRebuildGhcOptions <- obj ..:? configMonoidRebuildGhcOptionsName
     configMonoidApplyGhcOptions <- obj ..:? configMonoidApplyGhcOptionsName
     configMonoidAllowNewer <- obj ..:? configMonoidAllowNewerName
+    configMonoidEnableSplitObjs <- obj ..:? configMonoidEnableSplitObjsName
 
     return ConfigMonoid {..}
   where
@@ -999,6 +1006,9 @@ configMonoidApplyGhcOptionsName = "apply-ghc-options"
 
 configMonoidAllowNewerName :: Text
 configMonoidAllowNewerName = "allow-newer"
+
+configMonoidEnableSplitObjsName :: Text
+configMonoidEnableSplitObjsName = "enable-split-objs"
 
 data ConfigException
   = ParseConfigFileException (Path Abs File) ParseException


### PR DESCRIPTION
Issue #1284 enable-split-objs

This PR adds an `enable-split-objs` option to `config` which takes a `boolean` value (defaulting to `false`).

When set `true`, `stack` builds new libraries passing the `--enable-split-objs` option to `cabal`. 

The result is that these libraries are built with multiple object files per module which results in unused functions not being linked into final executables. It's been reported that this can result in significantly reduced size binaries which can be advantageous in some deployments.

The correctness of the change can be confirmed by running `ar -t` on the resulting new library builds with the option set `true`, set `false`, or removed from `config.yaml`.

Use:
1.  start from a clean `~/.stack/` (previously built libraries need to be removed and rebuilt)
2.  add `enable-split-objs: true` to a newly created `~/.stack/config.yaml`
3.  in project directory: `stack clean`, `stack build`