### PR TITLE
Bump lower bound of deepseq to >=1.4

### DIFF
--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -1,4 +1,4 @@
-resolver: lts-2.17
+resolver: lts-2.22
 extra-deps:
 - path-0.5.2
 - Win32-notify-0.3.0.1
@@ -12,3 +12,12 @@ extra-deps:
 - binary-tagged-0.1.1.0
 - fsnotify-0.2.1
 - ansi-terminal-0.6.2.3
+# For deepseq-1.4
+- deepseq-1.4.1.2
+- aeson-0.8.0.2
+- bytestring-0.10.6.0
+- Cabal-1.18.1.6
+- containers-0.5.6.3
+- hpc-0.6.0.2
+- process-1.2.1.0
+- time-1.5.0.1

--- a/stack.cabal
+++ b/stack.cabal
@@ -193,7 +193,7 @@ library
                    , void >= 0.7
                    , yaml >= 0.8.10.1
                    , zlib >= 0.5.4.2
-                   , deepseq >= 1.3
+                   , deepseq >= 1.4
                    , file-embed
                    , word8
                    , hastache


### PR DESCRIPTION
Generic derivation in <1.4 is

    rnf x = seq x ()

which is not what we want.

Previously the deepseq-generics package was used, but not everywhere.  I
unfortunately dropped it. OTOH there were fair amount of wrong instances
defined without using the deepseq-generics. It's less error-prone to
simply bump lower bound.

One way to resolve https://github.com/commercialhaskell/stack/issues/1351