### PR TITLE
Slightly less confusing language in the documentation for `ghc-options`.

### DIFF
--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -255,7 +255,7 @@ ghc-options:
 Caveat emptor: setting options like this will affect your snapshot packages,
 which can lead to unpredictable behavior versus official Stackage snapshots.
 This is in contrast to the `ghc-options` command line flag, which will only
-affect local targets.
+affect local packages.
 
 ### ghc-variant
 


### PR DESCRIPTION
Less confusing. The documentation for the `apply-ghc-options` uses "targets" to mean something else.