### PR TITLE
Support for dependent packages in Mercurial

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ Other enhancements:
 
 * Print latest applicable version of packages on conflicts
   [#508](https://github.com/commercialhaskell/stack/issues/508)
+* Support for packages located in Mercurial repositories
+  [#1397](https://github.com/commercialhaskell/stack/issues/1397)
 
 Bug fixes:
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -18,6 +18,8 @@ Project specific options are only valid in the `stack.yaml` file local to a proj
 
 ### packages
 
+(Mercurial support since 0.1.9.0)
+
 This lists all local packages. In the simplest usage, it will be a list of directories, e.g.:
 
 ```yaml

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -27,7 +27,7 @@ packages:
 - dir3
 ```
 
-However, it supports two other location types: an HTTP URL referring to a tarball that can be downloaded, and information on a Git repo to clone, together with this SHA1 commit. For example:
+However, it supports three other location types: an HTTP URL referring to a tarball that can be downloaded, and information on a Git or Mercurial repo to clone, together with this SHA1 commit. For example:
 
 ```yaml
 packages:
@@ -36,9 +36,12 @@ packages:
 - location:
     git: git@github.com:commercialhaskell/stack
     commit: 6a86ee32e5b869a877151f74064572225e1a0398
+- location:
+    hg: https://example.com/hg/repo
+    commit: da39a3ee5e6b4b0d3255bfef95601890afd80709
 ```
 
-Note: it is highly recommended that you only use SHA1 values for a Git commit. Other values may work, but they are not officially supported, and may result in unexpected behavior (namely, stack will not automatically pull to update to new versions).
+Note: it is highly recommended that you only use SHA1 values for a Git or Mercurial commit. Other values may work, but they are not officially supported, and may result in unexpected behavior (namely, stack will not automatically pull to update to new versions).
 
 stack further allows you to tweak your packages by specifying two additional
 settings:

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -434,7 +434,7 @@ resolvePackageLocation
     -> PackageLocation
     -> m (Path Abs Dir)
 resolvePackageLocation _ projRoot (PLFilePath fp) = resolveDir projRoot fp
-resolvePackageLocation _ projRoot (PLHttpTarball url) = do
+resolvePackageLocation _ projRoot (PLRemote url RPTHttpTarball) = do
     let name = T.unpack $ decodeUtf8 $ B16.encode $ SHA256.hash $ encodeUtf8 url
         root = projRoot </> workDirRel </> $(mkRelDir "downloaded")
     fileRel <- parseRelFile $ name ++ ".tar.gz"
@@ -464,7 +464,7 @@ resolvePackageLocation _ projRoot (PLHttpTarball url) = do
             removeTreeIfExists dir
             throwM $ UnexpectedTarballContents dirs files
 
-resolvePackageLocation menv projRoot (PLGit url commit) = do
+resolvePackageLocation menv projRoot (PLRemote url (RPTGit commit)) = do
     let name = T.unpack $ decodeUtf8 $ B16.encode $ SHA256.hash $ encodeUtf8 $ T.unwords [url, commit]
         root = projRoot </> workDirRel </> $(mkRelDir "downloaded")
     dirRel <- parseRelDir $ name ++ ".git"

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -62,6 +62,7 @@ module Stack.Types.Config
   ,PackageEntry(..)
   ,peExtraDep
   ,PackageLocation(..)
+  ,RemotePackageType(..)
   -- ** PackageIndex, IndexName & IndexLocation
   ,PackageIndex(..)
   ,IndexName(..)
@@ -551,14 +552,20 @@ data PackageLocation
     = PLFilePath FilePath
     -- ^ Note that we use @FilePath@ and not @Path@s. The goal is: first parse
     -- the value raw, and then use @canonicalizePath@ and @parseAbsDir@.
-    | PLHttpTarball Text
-    | PLGit Text Text
-    -- ^ URL and commit
+    | PLRemote Text RemotePackageType
+     -- ^ URL and further details
     deriving Show
+
+data RemotePackageType
+    = RPTHttpTarball
+    | RPTGit Text -- ^ Commit
+    deriving Show
+
 instance ToJSON PackageLocation where
     toJSON (PLFilePath fp) = toJSON fp
-    toJSON (PLHttpTarball t) = toJSON t
-    toJSON (PLGit x y) = toJSON $ T.unwords ["git", x, y]
+    toJSON (PLRemote t RPTHttpTarball) = toJSON t
+    toJSON (PLRemote x (RPTGit y)) = toJSON $ T.unwords ["git", x, y]
+
 instance FromJSON (PackageLocation, [JSONWarning]) where
     parseJSON v = ((,[]) <$> withText "PackageLocation" (\t -> http t <|> file t) v) <|> git v
       where
@@ -566,10 +573,10 @@ instance FromJSON (PackageLocation, [JSONWarning]) where
         http t =
             case parseUrl $ T.unpack t of
                 Left _ -> mzero
-                Right _ -> return $ PLHttpTarball t
-        git = withObjectWarnings "PackageGitLocation" $ \o -> PLGit
+                Right _ -> return $ PLRemote t RPTHttpTarball
+        git = withObjectWarnings "PackageGitLocation" $ \o -> PLRemote
             <$> o ..: "git"
-            <*> o ..: "commit"
+            <*> (RPTGit <$> o ..: "commit")
 
 -- | A project is a collection of packages. We can have multiple stack.yaml
 -- files, but only one of them may contain project information.


### PR DESCRIPTION
Hi,

The ability to refer to a dependency on a git commit is useful, and I'd quite like to add support for the same thing for Mercurial repositories.

Firstly, would that be useful?

Secondly, I think all I'd have to do would be to add a new constructor to `Stack.Types.Config.PackageLocation`, implement `ToJSON` and `FromJSON`, and add a new case to `Stack.Config.resolvePackageLocation` that would look very similar to the git one except would run `hg clone` and then `hg update -C` instead of `git clone` and `git reset --hard` respectively. I've not actually tried it so perhaps there's more, but it'd be useful to know I'm on the right lines.

Thirdly, the cases for `PLHttpTarball` and `PLGit` are already rather similar and I'd feel bad adding a third case just like them. Would it be ok to extract the common code into one place too?

Cheers,

David