### PR TITLE
add flag to allow disabling compile-time git status checks

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -34,7 +34,7 @@ import qualified Data.Text.IO as T
 import           Data.Traversable
 import           Data.Typeable (Typeable)
 import           Data.Version (showVersion)
-import           Development.GitRev (gitCommitCount)
+import           Development.GitRev (gitCommitCount, gitHash)
 import           Distribution.System (buildArch)
 import           Distribution.Text (display)
 import           GHC.IO.Encoding (mkTextEncoding, textEncodingName)
@@ -797,7 +797,9 @@ updateCmd () go = withConfigAndLock go $
 
 upgradeCmd :: (Bool, String) -> GlobalOpts -> IO ()
 upgradeCmd (fromGit, repo) go = withConfigAndLock go $
-    upgrade (if fromGit then Just repo else Nothing) (globalResolver go)
+    upgrade (if fromGit then Just repo else Nothing)
+            (globalResolver go)
+            (find (/= "UNKNOWN") [$gitHash])
 
 -- | Upload to Hackage
 uploadCmd :: ([String], Maybe PvpBounds, Bool) -> GlobalOpts -> IO ()

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -34,7 +34,9 @@ import qualified Data.Text.IO as T
 import           Data.Traversable
 import           Data.Typeable (Typeable)
 import           Data.Version (showVersion)
+#ifdef USE_GIT_INFO
 import           Development.GitRev (gitCommitCount, gitHash)
+#endif
 import           Distribution.System (buildArch)
 import           Distribution.Text (display)
 import           GHC.IO.Encoding (mkTextEncoding, textEncodingName)
@@ -43,7 +45,9 @@ import           Options.Applicative
 import           Options.Applicative.Args
 import           Options.Applicative.Builder.Extra
 import           Options.Applicative.Complicated
+#ifdef USE_GIT_INFO
 import           Options.Applicative.Simple (simpleVersion)
+#endif
 import           Options.Applicative.Types (readerAsk)
 import           Path
 import           Path.Extra (toFilePathNoTrailingSep)
@@ -114,6 +118,7 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter -> do
                    dockerHelpOptName
                    (dockerOptsParser False)
                    ("Only showing --" ++ Docker.dockerCmdName ++ "* options.")
+#ifdef USE_GIT_INFO
      let commitCount = $gitCommitCount
          versionString' = concat $ concat
             [ [$(simpleVersion Meta.version)]
@@ -123,6 +128,9 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter -> do
                                                     commitCount /= ("UNKNOWN" :: String)]
             , [" ", display buildArch]
             ]
+#else
+     let versionString' = showVersion Meta.version ++ ' ' : display buildArch
+#endif
 
      let globalOpts hide =
              extraHelpOption hide progName (Docker.dockerCmdName ++ "*") dockerHelpOptName <*>
@@ -799,7 +807,11 @@ upgradeCmd :: (Bool, String) -> GlobalOpts -> IO ()
 upgradeCmd (fromGit, repo) go = withConfigAndLock go $
     upgrade (if fromGit then Just repo else Nothing)
             (globalResolver go)
+#ifdef USE_GIT_INFO
             (find (/= "UNKNOWN") [$gitHash])
+#else
+            Nothing
+#endif
 
 -- | Upload to Hackage
 uploadCmd :: ([String], Maybe PvpBounds, Bool) -> GlobalOpts -> IO ()

--- a/stack.cabal
+++ b/stack.cabal
@@ -32,6 +32,15 @@ flag integration-tests
   default: False
   description: Run the integration test suite
 
+flag disable-git-info
+  manual: True
+  default: False
+  description: Disable compile-time inclusion of current git info in stack
+  -- disabling git info can lead to a quicker workflow in certain
+  -- scenarios when you're developing on stack itself, but
+  -- should otherwise be avoided
+  -- see: https://github.com/commercialhaskell/stack/issues/1425
+
 library
   hs-source-dirs:    src/
   ghc-options:       -Wall
@@ -141,7 +150,6 @@ library
                    , filelock >= 0.1.0.1
                    , filepath >= 1.3.0.2
                    , fsnotify >= 0.2.1
-                   , gitrev >= 1.1
                    , hashable >= 1.2.3.2
                    , hpc
                    , http-client >= 0.4.17
@@ -207,7 +215,6 @@ executable stack
                 , exceptions
                 , filepath
                 , filelock >= 0.1.0.1
-                , gitrev >= 1.1
                 , http-conduit >= 2.1.5
                 , lifted-base
                 , monad-control
@@ -215,7 +222,6 @@ executable stack
                 , mtl >= 2.1.3.1
                 , old-locale >= 1.0.0.6
                 , optparse-applicative >= 0.11.0.2
-                , optparse-simple >= 0.0.3
                 , path
                 , process
                 , resourcet >= 1.1.4.1
@@ -233,6 +239,10 @@ executable stack
   if os(windows)
     build-depends:   Win32
     cpp-options:     -DWINDOWS
+  if !flag(disable-git-info)
+    cpp-options:     -DUSE_GIT_INFO
+    build-depends:   gitrev >= 1.1
+                   , optparse-simple >= 0.0.3
 
 test-suite stack-test
   type:           exitcode-stdio-1.0


### PR DESCRIPTION
fixes issue #1425

Without the new flag, stack rebuilds a couple of modules when the git index changes:
```
~/projects/stack (flag_use_git_status_in_version)$ stack build
~/projects/stack (flag_use_git_status_in_version)$ touch bogus.txt                                                   
~/projects/stack (flag_use_git_status_in_version %)$ git add bogus.txt                                               
~/projects/stack (flag_use_git_status_in_version +)$ stack build
stack-0.1.9.0: unregistering (local file changes: .git/index)
stack-0.1.9.0: build
Preprocessing library stack-0.1.9.0...
[73 of 76] Compiling Stack.Upgrade    ( src/Stack/Upgrade.hs, .stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/Stack/Upgrade.o ) [/home/mud/projects/stack/.git/index changed]
In-place registering stack-0.1.9.0...
Preprocessing executable 'stack' for stack-0.1.9.0...
[2 of 2] Compiling Main             ( src/main/Main.hs, .stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/stack/stack-tmp/Main.o ) [/home/mud/projects/stack/.git/index changed]
Linking .stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/stack/stack ...
stack-0.1.9.0: copy/register
Installing library in
/home/mud/projects/stack/.stack-work/install/x86_64-linux/lts-3.14/7.10.2/lib/x86_64-linux-ghc-7.10.2/stack-0.1.9.0-K5i01b4VNwNJsmjPkKylJf
Installing executable(s) in
/home/mud/projects/stack/.stack-work/install/x86_64-linux/lts-3.14/7.10.2/bin
Registering stack-0.1.9.0...
```

With the flag, the git index changing doesn't cause rebuilding on its own (and commits or changing branches don't necessarily either):
```
~/projects/stack (flag_use_git_status_in_version +)$ stack build --flag stack:disable-git-info
~/projects/stack (flag_use_git_status_in_version +)$ touch bogus.txt                                                 
~/projects/stack (flag_use_git_status_in_version +)$ git add bogus.txt                                               
~/projects/stack (flag_use_git_status_in_version +)$ stack build --flag stack:disable-git-info                       
~/projects/stack (flag_use_git_status_in_version +)$ git commit -m "temp commit"
[flag_use_git_status_in_version 7f5194e] temp commit
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 bogus.txt
~/projects/stack (flag_use_git_status_in_version)$ stack build --flag stack:disable-git-info
~/projects/stack (flag_use_git_status_in_version)$
```

Of course changing a file that stack actually *is* dependent on still correctly causes rebuilding:
```
~/projects/stack (flag_use_git_status_in_version)$ stack build --flag stack:disable-git-info
~/projects/stack (flag_use_git_status_in_version)$ echo "-- nonsense" >> src/main/Main.hs                            
~/projects/stack (flag_use_git_status_in_version *)$ stack build --flag stack:disable-git-info
stack-0.1.9.0: unregistering (local file changes: src/main/Main.hs)
stack-0.1.9.0: build
Preprocessing library stack-0.1.9.0...
In-place registering stack-0.1.9.0...
Preprocessing executable 'stack' for stack-0.1.9.0...
[2 of 2] Compiling Main             ( src/main/Main.hs, .stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/stack/stack-tmp/Main.o )
Linking .stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/stack/stack ...
stack-0.1.9.0: copy/register
Installing library in
/home/mud/projects/stack/.stack-work/install/x86_64-linux/lts-3.14/7.10.2/lib/x86_64-linux-ghc-7.10.2/stack-0.1.9.0-3UM6IwMtAE82KY5FnDpl4M
Installing executable(s) in
/home/mud/projects/stack/.stack-work/install/x86_64-linux/lts-3.14/7.10.2/bin
Registering stack-0.1.9.0...
```

`stack --version` clearly shows that the flag was used when building, and if for some odd reason someone submits an issue with that version, it will be obvious (and they can be told not to do that if necessary):
```
~/projects/stack (flag_use_git_status_in_version)$ stack exec -- stack --version
0.1.9.0 (git version info disabled) x86_64
```

`stack upgrade` will still work fine, the only caveat there is that if stack was built with the new flag and they use `--git`, it will always build stack anew, since there's no way to know if it should be or not. I added a warning in that case.