### PR TITLE
Add executable fall-through

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,9 @@ Other enhancements:
   [#1412](https://github.com/commercialhaskell/stack/issues/1412)
 * Add optional GPG signing on `stack upload --sign` or with
   `stack sig sign ...`
+* Support git-style executable fall-through (`stack something` executes
+  `stack-something` if present)
+  [#1433](https://github.com/commercialhaskell/stack/issues/1433)
 
 Bug fixes:
 

--- a/src/Stack/Exec.hs
+++ b/src/Stack/Exec.hs
@@ -14,6 +14,7 @@ import           Control.Monad.Catch hiding (try)
 import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Stack.Types
 import           System.Process.Log
+import           System.Process.Read (EnvOverride)
 
 #ifdef WINDOWS
 import           Control.Exception.Lifted
@@ -44,11 +45,9 @@ plainEnvSettings = EnvSettings
     }
 
 -- | Execute a process within the Stack configured environment.
-exec :: (HasConfig r, MonadReader r m, MonadIO m, MonadLogger m, MonadThrow m, MonadBaseControl IO m)
-     => EnvSettings -> String -> [String] -> m b
-exec envSettings cmd0 args = do
-    config <- asks getConfig
-    menv <- liftIO (configEnvOverride config envSettings)
+exec :: (MonadIO m, MonadLogger m, MonadThrow m, MonadBaseControl IO m)
+     => EnvOverride -> String -> [String] -> m b
+exec menv cmd0 args = do
     $logProcessRun cmd0 args
 #ifdef WINDOWS
     e <- try (callProcess Nothing menv cmd0 args)

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -116,8 +116,9 @@ ghci GhciOpts{..} = do
     $logInfo
         ("Configuring GHCi with the following packages: " <>
          T.intercalate ", " (map (packageNameText . ghciPkgName) pkgs))
-    let execGhci extras =
-            exec defaultEnvSettings
+    let execGhci extras = do
+            menv <- liftIO $ configEnvOverride config defaultEnvSettings
+            exec menv
                  (fromMaybe (compilerExeName wc) ghciGhcCommand)
                  ("--interactive" :
                  -- This initial "-i" resets the include directories to not


### PR DESCRIPTION
Uses `System.Directory.findExecutable`. Adds a `mOnInvalidArgs` callback to the
`complicatedOptions` function on `Options.Applicative.Complicated` the rest of
the logic is centralized on `Main`.

I didn't use `System.Process.Read.findExecutable` because I'd then need
`getMinimalEnvOverride`, which would require `GlobalOpts` I think. I'm not sure,
but I don't understand what'd give at the moment.

Will rebase after discussion.

This closes #1433.