### PR TITLE
Addition of ‘--work-dir’ option to override working directory, #1178

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -91,7 +91,7 @@ import           System.Process.Run
 import           System.Process.Internals (createProcess_)
 #endif
 
-type M env m = (MonadIO m,MonadReader env m,HasHttpManager env,HasBuildConfig env,MonadLogger m,MonadBaseControl IO m,MonadCatch m,MonadMask m,HasLogLevel env,HasEnvConfig env,HasTerminal env)
+type M env m = (MonadIO m,MonadReader env m,HasHttpManager env,HasBuildConfig env,MonadLogger m,MonadBaseControl IO m,MonadCatch m,MonadMask m,HasLogLevel env,HasEnvConfig env,HasTerminal env, HasConfig env)
 
 -- | Fetch the packages necessary for a build, for example in combination with a dry run.
 preFetch :: M env m => Plan -> m ()

--- a/src/Stack/Image.hs
+++ b/src/Stack/Image.hs
@@ -43,10 +43,9 @@ type Assemble e m = (HasConfig e, HasTerminal e, MonadBaseControl IO m, MonadCat
 
 -- | Stages the executables & additional content in a staging
 -- directory under '.stack-work'
-stageContainerImageArtifacts :: Build e m
-                             => m ()
+stageContainerImageArtifacts :: Build e m => m ()
 stageContainerImageArtifacts = do
-    imageDir <- imageStagingDir <$> getWorkingDir
+    imageDir <- getWorkingDir >>= imageStagingDir
     removeTreeIfExists imageDir
     createTree imageDir
     stageExesInDir imageDir
@@ -56,10 +55,9 @@ stageContainerImageArtifacts = do
 -- specified in the project's stack.yaml.  Then new image will be
 -- extended with an ENTRYPOINT specified for each `entrypoint` listed
 -- in the config file.
-createContainerImageFromStage :: Assemble e m
-                              => m ()
+createContainerImageFromStage :: Assemble e m => m ()
 createContainerImageFromStage = do
-    imageDir <- imageStagingDir <$> getWorkingDir
+    imageDir <- getWorkingDir >>= imageStagingDir
     createDockerImage imageDir
     extendDockerImageWithEntrypoint imageDir
 

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -232,8 +232,9 @@ cleanOptsParser = CleanOpts <$> packages
 -- | Command-line arguments parser for configuration.
 configOptsParser :: Bool -> Parser ConfigMonoid
 configOptsParser hide0 =
-    (\opts systemGHC installGHC arch os ghcVariant jobs includes libs skipGHCCheck skipMsys localBin modifyCodePage -> mempty
-        { configMonoidDockerOpts = opts
+    (\workDir opts systemGHC installGHC arch os ghcVariant jobs includes libs skipGHCCheck skipMsys localBin modifyCodePage -> mempty
+        { configMonoidWorkDir = workDir
+        , configMonoidDockerOpts = opts
         , configMonoidSystemGHC = systemGHC
         , configMonoidInstallGHC = installGHC
         , configMonoidSkipGHCCheck = skipGHCCheck
@@ -247,7 +248,13 @@ configOptsParser hide0 =
         , configMonoidLocalBinPath = localBin
         , configMonoidModifyCodePage = modifyCodePage
         })
-    <$> dockerOptsParser True
+    <$> optional (strOption
+            ( long "work-dir"
+            <> metavar "WORK-DIR"
+            <> help "Override work directory (default: .stack-work)"
+            <> hide
+            ))
+    <*> dockerOptsParser True
     <*> maybeBoolFlags
             "system-ghc"
             "using the system installed GHC (on the PATH) if available and a matching version"
@@ -566,6 +573,7 @@ globalOptsFromMonoid defaultTerminal GlobalOptsMonoid{..} = GlobalOpts
     , globalResolver = globalMonoidResolver
     , globalCompiler = globalMonoidCompiler
     , globalTerminal = fromMaybe defaultTerminal globalMonoidTerminal
+    , globalStackYaml = globalMonoidStackYaml }
 
 initOptsParser :: Parser InitOpts
 initOptsParser =

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -561,12 +561,11 @@ globalOptsFromMonoid :: Bool -> GlobalOptsMonoid -> GlobalOpts
 globalOptsFromMonoid defaultTerminal GlobalOptsMonoid{..} = GlobalOpts
     { globalReExecVersion = globalMonoidReExecVersion
     , globalDockerEntrypoint = globalMonoidDockerEntrypoint
-    , globalLogLevel = fromMaybe defaultLogLevel (globalMonoidLogLevel)
+    , globalLogLevel = fromMaybe defaultLogLevel globalMonoidLogLevel
     , globalConfigMonoid = globalMonoidConfigMonoid
     , globalResolver = globalMonoidResolver
     , globalCompiler = globalMonoidCompiler
-    , globalTerminal = fromMaybe defaultTerminal (globalMonoidTerminal)
-    , globalStackYaml = globalMonoidStackYaml }
+    , globalTerminal = fromMaybe defaultTerminal globalMonoidTerminal
 
 initOptsParser :: Parser InitOpts
 initOptsParser =
@@ -599,7 +598,7 @@ initOptsParser =
          metavar "RESOLVER" <>
          help "Use the given resolver, even if not all dependencies are met")
 
--- | Parse for a logging level.
+-- | Parser for a logging level.
 logLevelOptsParser :: Bool -> Parser (Maybe LogLevel)
 logLevelOptsParser hide =
   fmap (Just . parse)

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -114,7 +114,7 @@ data SetupOpts = SetupOpts
     -- version. Only works reliably with a stack-managed installation.
     , soptsResolveMissingGHC :: !(Maybe Text)
     -- ^ Message shown to user for how to resolve the missing GHC
-    , soptsStackSetupYaml :: !String
+    , soptsStackSetupYaml :: !FilePath
     -- ^ Location of the main stack-setup.yaml file
     , soptsGHCBindistURL :: !(Maybe String)
     -- ^ Alternate GHC binary distribution (requires custom GHCVariant)

--- a/src/Stack/Types/StackT.hs
+++ b/src/Stack/Types/StackT.hs
@@ -89,8 +89,8 @@ instance (MonadIO m) => MonadLogger (StackT config m) where
 -- | Run a Stack action, using global options.
 runStackTGlobal :: (MonadIO m,MonadBaseControl IO m)
                 => Manager -> config -> GlobalOpts -> StackT config m a -> m a
-runStackTGlobal manager config GlobalOpts{..} m =
-    runStackT manager globalLogLevel config globalTerminal (isJust globalReExecVersion) m
+runStackTGlobal manager config GlobalOpts{..} =
+    runStackT manager globalLogLevel config globalTerminal (isJust globalReExecVersion)
 
 -- | Run a Stack action.
 runStackT :: (MonadIO m,MonadBaseControl IO m)
@@ -188,8 +188,8 @@ runInnerStackLoggingT inner = do
 -- | Run the logging monad, using global options.
 runStackLoggingTGlobal :: MonadIO m
                        => Manager -> GlobalOpts -> StackLoggingT m a -> m a
-runStackLoggingTGlobal manager GlobalOpts{..} m =
-    runStackLoggingT manager globalLogLevel globalTerminal (isJust globalReExecVersion) m
+runStackLoggingTGlobal manager GlobalOpts{..} =
+    runStackLoggingT manager globalLogLevel globalTerminal (isJust globalReExecVersion)
 
 -- | Run the logging monad.
 runStackLoggingT :: MonadIO m
@@ -317,15 +317,15 @@ loggerFunc loc _src level msg =
                     return (" @(" ++ fileLocStr ++ ")")
                   | otherwise = return ""
                 fileLocStr =
-                  (loc_package loc) ++
+                  loc_package loc ++
                   ':' :
-                  (loc_module loc) ++
+                  loc_module loc ++
                   ' ' :
-                  (loc_filename loc) ++
+                  loc_filename loc ++
                   ':' :
-                  (line loc) ++
+                  line loc ++
                   ':' :
-                  (char loc)
+                  char loc
                   where line = show . fst . loc_start
                         char = show . snd . loc_start
 

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -414,16 +414,16 @@ main = withInterpreterArgs stackProgName $ \args isInterpreter -> do
                Sig.sigCmdName
                "Subcommands specific to package signatures (EXPERIMENTAL)"
                cmdFooter
-               (do addSubCommands'
-                     Sig.sigSignCmdName
-                     "Sign a a single package or all your packages"
+               (addSubCommands'
+                  Sig.sigSignCmdName
+                  "Sign a a single package or all your packages"
+                  cmdFooter
+                  (addCommand'
+                     Sig.sigSignSdistCmdName
+                     "Sign a single sdist package file"
                      cmdFooter
-                     (do addCommand'
-                           Sig.sigSignSdistCmdName
-                           "Sign a single sdist package file"
-                           cmdFooter
-                           sigSignSdistCmd
-                           Sig.sigSignSdistOpts)))
+                     sigSignSdistCmd
+                     Sig.sigSignSdistOpts)))
      case eGlobalRun of
        Left (exitCode :: ExitCode) -> do
          when isInterpreter $
@@ -631,7 +631,7 @@ setupCmd :: SetupCmdOpts -> GlobalOpts -> IO ()
 setupCmd SetupCmdOpts{..} go@GlobalOpts{..} = do
   (manager,lc) <- loadConfigWithOpts go
   withUserFileLock go (configStackRoot $ lcConfig lc) $ \lk ->
-   runStackTGlobal manager (lcConfig lc) go $
+    runStackTGlobal manager (lcConfig lc) go $
       Docker.reexecWithOptionalContainer
           (lcProjectRoot lc)
           Nothing
@@ -1066,7 +1066,7 @@ imgDockerCmd rebuild go@GlobalOpts{..} =
         (Just Image.createContainerImageFromStage)
 
 sigSignSdistCmd :: (String, String) -> GlobalOpts -> IO ()
-sigSignSdistCmd (url,path) go = do
+sigSignSdistCmd (url,path) go =
     withConfigAndLock
         go
         (do (manager,lc) <- liftIO (loadConfigWithOpts go)

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -1030,7 +1030,7 @@ dockerResetCmd keepHome go@GlobalOpts{..} = do
     (manager,lc) <- liftIO (loadConfigWithOpts go)
     -- TODO: can we eliminate this lock if it doesn't touch ~/.stack/?
     withUserFileLock go (configStackRoot $ lcConfig lc) $ \_ ->
-     runStackLoggingTGlobal manager go $
+      runStackTGlobal manager (lcConfig lc) go $
         Docker.preventInContainer $ Docker.reset (lcProjectRoot lc) keepHome
 
 -- | Cleanup Docker images and containers.


### PR DESCRIPTION
Here I've started to work on this. Currently I've added `--work-dir` option represented by `globalWorkDir` in `GlobalOpts`. Please correct me if this is a wrong place to put this option.

Now my plan is:

1. Store this option is Stack monadic environment (`Config`?), so functions that need to know stack working directory could query it. I think `HasConfig env, MonadReader env` can be used.

2. Instead of `workDirRel` constant, use that value from config, this will probably add `HasConfig, MonadReader env` or similar constraint to some functions that previously didn't need it.

3. Take care of `ignoreDirs` which specifies which directories shouldn't be searched for `.cabal` files. It currently lists `".stack-work"`. With this change it would need to construct the list more “dynamically”.

My questions:

1. Is `GlobalOpts` is the right place to add `--work-dir` option?

2. In case `GlobalOpts` is the right place, where is the best place to pass the value `globalWorkDir` from `GlobalOpts` to `Config` so the rest of Stack can query it?

Well, the rest seems to be pretty easy to do (at least for now).
