### PR TITLE
Support for detailed-0.9 test type

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,8 @@ Other enhancements:
   [#584](https://github.com/commercialhaskell/stack/issues/584)
 * `--work-dir` option for overriding `.stack-work`
   [#1178](https://github.com/commercialhaskell/stack/issues/1178)
+* Support `detailed-0.9` tests
+  [#1429](https://github.com/commercialhaskell/stack/issues/1429)
 
 Bug fixes:
 

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -298,7 +298,7 @@ loadLocalPackage bopts targets (name, (lpv, gpkg)) = do
                 Just STLocalAll ->
                     ( packageExes pkg
                     , if boptsTests bopts
-                        then packageTests pkg
+                        then Map.keysSet (packageTests pkg)
                         else Set.empty
                     , if boptsBenchmarks bopts
                         then packageBenchmarks pkg
@@ -367,7 +367,7 @@ loadLocalPackage bopts targets (name, (lpv, gpkg)) = do
         -- present, then they must not be buildable.
         , lpUnbuildable = toComponents
             (exes `Set.difference` packageExes pkg)
-            (tests `Set.difference` packageTests pkg)
+            (tests `Set.difference` Map.keysSet (packageTests pkg))
             (benches `Set.difference` packageBenchmarks pkg)
         }
 

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -322,7 +322,7 @@ wantedPackageComponents _ (STLocalComps cs) _ = cs
 wantedPackageComponents bopts STLocalAll pkg = S.fromList $
     (if packageHasLibrary pkg then [CLib] else []) ++
     map CExe (S.toList (packageExes pkg)) <>
-    (if boptsTests bopts then map CTest (S.toList (packageTests pkg)) else []) <>
+    (if boptsTests bopts then map CTest (M.keys (packageTests pkg)) else []) <>
     (if boptsBenchmarks bopts then map CBench (S.toList (packageBenchmarks pkg)) else [])
 wantedPackageComponents _ _ _ = S.empty
 

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -196,9 +196,9 @@ resolvePackage packageConfig gpkg =
     , packageFlags = packageConfigFlags packageConfig
     , packageAllDeps = S.fromList (M.keys deps)
     , packageHasLibrary = maybe False (buildable . libBuildInfo) (library pkg)
-    , packageTests = S.fromList
-      [T.pack (testName t) | t <- testSuites pkg
-                           , buildable (testBuildInfo t)]
+    , packageTests = M.fromList
+      [(T.pack (testName t), testInterface t) | t <- testSuites pkg
+                                              , buildable (testBuildInfo t)]
     , packageBenchmarks = S.fromList
       [T.pack (benchmarkName b) | b <- benchmarks pkg
                                 , buildable (benchmarkBuildInfo b)]

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -30,6 +30,7 @@ import           Data.Text.Encoding (encodeUtf8, decodeUtf8)
 import           Distribution.InstalledPackageInfo (PError)
 import           Distribution.ModuleName (ModuleName)
 import           Distribution.Package hiding (Package,PackageName,packageName,packageVersion,PackageIdentifier)
+import           Distribution.PackageDescription (TestSuiteInterface)
 import           Distribution.System (Platform (..))
 import           Distribution.Text (display)
 import           GHC.Generics
@@ -87,7 +88,7 @@ data Package =
           ,packageAllDeps :: !(Set PackageName)           -- ^ Original dependencies (not sieved).
           ,packageFlags :: !(Map FlagName Bool)           -- ^ Flags used on package.
           ,packageHasLibrary :: !Bool                     -- ^ does the package have a buildable library stanza?
-          ,packageTests :: !(Set Text)                    -- ^ names of test suites
+          ,packageTests :: !(Map Text TestSuiteInterface) -- ^ names and interfaces of test suites
           ,packageBenchmarks :: !(Set Text)               -- ^ names of benchmarks
           ,packageExes :: !(Set Text)                     -- ^ names of executables
           ,packageOpts :: !GetPackageOpts                 -- ^ Args to pass to GHC.


### PR DESCRIPTION
[WIP] resolves #1429

##### TODO:

- [x] ~~clean up test [output](http://lpaste.net/6907924690493243392#line23)~~ (related to #1302) 
- [x] choose a proper log filepath to [pass](https://github.com/haskell/cabal/blob/e99ed843539efd868af593c0c9e4c51d1defaf39/Cabal/Distribution/Simple/Test/LibV09.hs#L104) to the testStub?
- [x] Throw an error on [unsupported](https://github.com/luigy/stack/commit/04f6d12814d3ab12ebbe8ef6ae4ca5bd887efd72?diff=unified#diff-890614cc04afa326f5d48aac897e4aa8R1191) `TestType`
- [x] Extend package info for tests to include `TestSuiteInterface`

**`stack test --coverage`**
- [x] fix [linking errors](http://lpaste.net/8491049734583091200) with [-fforce-recomp flag](https://github.com/commercialhaskell/stack/commit/fb92cd408dbb071d3b5d99656faa44f934667c4b#diff-03a05256bcce52ae851feb3a1d0753b8R730)
