### PR TITLE
Apply various hlint hints

### DIFF
--- a/src/Data/Attoparsec/Args.hs
+++ b/src/Data/Attoparsec/Args.hs
@@ -96,7 +96,7 @@ argsParser mode = many (P.skipSpace *> (quoted <|> unquoted)) <*
                      Escaping -> escaped <|> nonquote
                      NoEscaping -> nonquote)
     escaped = P.char '\\' *> P.anyChar
-    nonquote = P.satisfy (not . (=='"'))
+    nonquote = P.satisfy (/= '"')
     naked = P.satisfy (not . flip elem ("\" " :: String))
 
 -- | Parser to extract the stack command line embedded inside a comment

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -201,7 +201,7 @@ warnIfExecutablesWithSameNameCouldBeOverwritten locals plan =
     localExes =
         collect
             [ (exe,packageName pkg)
-            | pkg <- map (lpPackage) locals
+            | pkg <- map lpPackage locals
             , exe <- Set.toList (packageExes pkg)
             ]
     collect :: Ord k => [(k,v)] -> Map k (NonEmpty v)

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -21,6 +21,7 @@ import           Control.Monad.Trans.Resource
 import           Data.Conduit
 import qualified Data.Conduit.List            as CL
 import           Data.Function
+import qualified Data.Foldable                as F
 import qualified Data.HashSet                 as HashSet
 import           Data.List
 import           Data.Map.Strict              (Map)
@@ -87,9 +88,7 @@ getInstalled menv opts sourceMap = do
         loadDatabase' (Just (InstalledTo Local, localDBPath)) installedLibs2
     let installedLibs = M.fromList $ map lhPair installedLibs3
 
-    case mcache of
-        Nothing -> return ()
-        Just pcache -> saveInstalledCache (configInstalledCache bconfig) pcache
+    F.forM_ mcache (saveInstalledCache (configInstalledCache bconfig))
 
     -- Add in the executables that are installed, making sure to only trust a
     -- listed installation under the right circumstances (see below)
@@ -191,7 +190,7 @@ processLoadResult mdb _ (reason, lh) = do
         [ "Ignoring package "
         , packageNameText (fst (lhPair lh))
         ] ++
-        (maybe [] (\db -> [", from ", T.pack (show db), ","]) mdb) ++
+        maybe [] (\db -> [", from ", T.pack (show db), ","]) mdb ++
         [ " due to "
         , case reason of
             Allowed -> " the impossible?!?!"

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -145,7 +145,7 @@ loadSourceMap needTargets bopts = do
                  in (packageName p, PSLocal lp)
             , extraDeps3
             , flip fmap (mbpPackages mbp) $ \mpi ->
-                (PSUpstream (mpiVersion mpi) Snap (mpiFlags mpi))
+                PSUpstream (mpiVersion mpi) Snap (mpiFlags mpi)
             ] `Map.difference` Map.fromList (map (, ()) (HashSet.toList wiredInPackages))
 
     return (targets, mbp, locals, nonLocalTargets, sourceMap)
@@ -205,8 +205,7 @@ convertSnapshotToExtra
     -> Map PackageName a -- ^ locals
     -> [PackageName] -- ^ packages referenced by a flag
     -> m (Map PackageName Version)
-convertSnapshotToExtra snapshot extra0 locals flags0 =
-    go Map.empty flags0
+convertSnapshotToExtra snapshot extra0 locals = go Map.empty
   where
     go !extra [] = return extra
     go extra (flag:flags)
@@ -417,7 +416,7 @@ checkFlagsUsed bopts lps extraDeps snapshot = do
         $ Set.fromList unusedFlags
 
 -- | All flags for a local package
-localFlags :: (Map (Maybe PackageName) (Map FlagName Bool))
+localFlags :: Map (Maybe PackageName) (Map FlagName Bool)
            -> BuildConfig
            -> PackageName
            -> Map FlagName Bool

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -84,7 +84,7 @@ import qualified System.FilePath as FP
 data BuildPlanException
     = UnknownPackages
         (Path Abs File) -- stack.yaml file
-        (Map PackageName (Maybe Version, (Set PackageName))) -- truly unknown
+        (Map PackageName (Maybe Version, Set PackageName)) -- truly unknown
         (Map PackageName (Set PackageIdentifier)) -- shadowed
     | SnapshotNotFound SnapName
     deriving (Typeable)
@@ -406,8 +406,7 @@ instance FromJSON Snapshots where
     parseJSON = withObject "Snapshots" $ \o -> Snapshots
         <$> (o .: "nightly" >>= parseNightly)
         <*> (fmap IntMap.unions
-                $ mapM parseLTS
-                $ map snd
+                $ mapM (parseLTS . snd)
                 $ filter (isLTS . fst)
                 $ HM.toList o)
       where

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -277,7 +277,7 @@ loadConfig :: (MonadLogger m,MonadIO m,MonadCatch m,MonadThrow m,MonadBaseContro
            -- ^ Config monoid from parsed command-line arguments
            -> Maybe (Path Abs File)
            -- ^ Override stack.yaml
-           -> Maybe (AbstractResolver)
+           -> Maybe AbstractResolver
            -- ^ Override resolver
            -> m (LoadConfig m)
 loadConfig configArgs mstackYaml mresolver = do

--- a/src/Stack/Config/Nix.hs
+++ b/src/Stack/Config/Nix.hs
@@ -6,6 +6,7 @@ module Stack.Config.Nix
        ,StackNixException(..)
        ) where
 
+import Control.Monad (when)
 import Data.Text (pack)
 import Data.Maybe
 import Data.Typeable
@@ -35,9 +36,8 @@ nixOptsFromMonoid mproject maresolver NixOptsMonoid{..} = do
               _ -> pack "ghc"]
         nixInitFile = nixMonoidInitFile
         nixShellOptions = nixMonoidShellOptions
-    if not (null nixMonoidPackages) && isJust nixInitFile then
+    when (not (null nixMonoidPackages) && isJust nixInitFile) $
        throwM NixCannotUseShellFileAndPackagesException
-       else return ()
     return NixOpts{..}
 
 -- Exceptions thown specifically by Stack.Nix

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -202,7 +202,7 @@ generateHpcReportInternal tixSrc reportDir report extraMarkupArgs extraReportArg
                     generateHpcErrorReport reportDir (msg True)
                 else do
                     -- Print output, stripping @\r@ characters because Windows.
-                    forM_ outputLines ($logInfo . T.decodeUtf8 . S8.filter (not . (=='\r')))
+                    forM_ outputLines ($logInfo . T.decodeUtf8 . S8.filter (/= '\r'))
                     $logInfo
                         ("The " <> report <> " is available at " <>
                          T.pack (toFilePath (reportDir </> $(mkRelFile "hpc_index.html"))))

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -297,7 +297,7 @@ runContainerAndExit getCmdArgs
      pwd <- getWorkingDir
      liftIO
        (do updateDockerImageLastUsed config iiId (toFilePath projectRoot)
-           mapM_ createTree ([sandboxHomeDir, stackRoot]))
+           mapM_ createTree [sandboxHomeDir, stackRoot])
      containerID <- (trim . decodeUtf8) <$> readDockerProcess
        envOverride
        (concat
@@ -332,7 +332,7 @@ runContainerAndExit getCmdArgs
      before
 #ifndef WINDOWS
      runInBase <- liftBaseWith $ \run -> return (void . run)
-     oldHandlers <- forM ([sigINT,sigABRT,sigHUP,sigPIPE,sigTERM,sigUSR1,sigUSR2]) $ \sig -> do
+     oldHandlers <- forM [sigINT,sigABRT,sigHUP,sigPIPE,sigTERM,sigUSR1,sigUSR2] $ \sig -> do
        let sigHandler = runInBase $ do
              readProcessNull Nothing envOverride "docker"
                              ["kill","--signal=" ++ show sig,containerID]
@@ -530,10 +530,10 @@ cleanup opts =
             Nothing -> return ()
         sortCreated =
             sortWith (\(_,_,x) -> Down x) .
-            (mapMaybe (\(h,r) ->
+             mapMaybe (\(h,r) ->
                 case Map.lookup h inspectMap of
                     Nothing -> Nothing
-                    Just ii -> Just (h,r,iiCreated ii)))
+                    Just ii -> Just (h,r,iiCreated ii))
         buildSection sectionHead items itemBuilder =
           do let (anyWrote,b) = runWriter (forM items itemBuilder)
              when (or anyWrote) $
@@ -571,7 +571,7 @@ cleanup opts =
                      projectPath)
         buildInspect hash =
           case Map.lookup hash inspectMap of
-            Just (Inspect{iiCreated,iiVirtualSize}) ->
+            Just Inspect{iiCreated,iiVirtualSize} ->
               buildInfo ("Created " ++
                          showDaysAgo iiCreated ++
                          maybe ""

--- a/src/Stack/Docker/GlobalDB.hs
+++ b/src/Stack/Docker/GlobalDB.hs
@@ -16,7 +16,7 @@ module Stack.Docker.GlobalDB
   where
 
 import           Control.Exception (IOException,catch,throwIO)
-import           Control.Monad (forM_)
+import           Control.Monad (forM_, when)
 import           Control.Monad.Logger (NoLoggingT)
 import           Control.Monad.Trans.Resource (ResourceT)
 import           Data.List (sortBy, isInfixOf, stripPrefix)
@@ -76,11 +76,11 @@ getDockerImagesLastUsed config =
 pruneDockerImagesLastUsed :: Config -> [String] -> IO ()
 pruneDockerImagesLastUsed config existingHashes =
   withGlobalDB config go
-  where go = do l <- selectList [] []
-                forM_ l (\(Entity k (DockerImageProject{dockerImageProjectImageHash = h})) ->
-                           if h `elem` existingHashes
-                             then return ()
-                             else delete k)
+  where
+    go = do
+      l <- selectList [] []
+      forM_ l (\(Entity k DockerImageProject{dockerImageProjectImageHash = h}) ->
+                   when (h `notElem` existingHashes) $ delete k)
 
 -- | Get the record of whether an executable is compatible with a Docker image
 getDockerImageExe :: Config -> String -> FilePath -> UTCTime -> IO (Maybe Bool)

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -438,7 +438,7 @@ getIntermediateDeps sourceMap targets =
 
 preprocessCabalMacros :: MonadIO m => [GhciPkgInfo] -> Path Abs File -> m [String]
 preprocessCabalMacros pkgs out = liftIO $ do
-    let fps = nubOrd (concatMap (catMaybes . map (bioCabalMacros . snd) . ghciPkgOpts) pkgs)
+    let fps = nubOrd (concatMap (mapMaybe (bioCabalMacros . snd) . ghciPkgOpts) pkgs)
     files <- mapM (S8.readFile . toFilePath) fps
     if null files then return [] else do
         S8.writeFile (toFilePath out) $ S8.intercalate "\n#undef CURRENT_PACKAGE_KEY\n" files


### PR DESCRIPTION
Appy various hlint hints:
- Attoparsec.Args: Replace not . (==) with (/=)
- Stack.Build: redundant brackets
- Stack.Build.Installed: use `forM_`, redundant bracket
- Stack.BuildPlan: fuse mapM and map, use const
- Stack.Build.Source: redundant bracket, eta reduce
- Stack.Config: Redundant brackets
- Stack.Config.Nix: use when
- Stack.Coverage: use (/=)
- Stack.Docker.GlobalDB: use unless
- Stack.Docker: redundant brackets
- Stack.Ghci:  use mapMaybe
- Stack.Image: reduce duplication

-- 24pullrequests
[![](http://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png)](http://24pullrequests.com/)