### PR TITLE
Show a message when resetting git commit fails

### DIFF
--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -477,7 +477,8 @@ resolvePackageLocation menv projRoot (PLRemote url remotePackageType) = do
                     Nothing
                 readInNull dirTmp commandName menv
                     (resetCommand ++ [T.unpack commit])
-                    Nothing
+                    (Just $ "Please ensure that commit " <> commit <>
+                      " exists within " <> url)
 
         case remotePackageType of
             RPTHttpTarball -> do

--- a/src/System/Process/Read.hs
+++ b/src/System/Process/Read.hs
@@ -141,7 +141,7 @@ readProcessNull wd menv name args =
     sinkProcessStdout wd menv name args CL.sinkNull
 
 -- | Run the given command in the given directory. If it exits with anything
--- but success, prints an error and then calls 'exitWith' to exit the program.
+-- but success, print an error and then call 'exitWith' to exit the program.
 readInNull :: (MonadIO m, MonadLogger m, MonadBaseControl IO m, MonadCatch m)
            => Path Abs Dir -- ^ Directory to run in
            -> FilePath -- ^ Command to run


### PR DESCRIPTION
See #1453. It should be as simple as this, but it doesn't work. According to actual message the whole `Left` pattern in `readInNull` is not executed (otherwise error message would be different), so that additional message is not logged. I grepped all places where `ProcessExistedUnsuccessfully` is caught, everywhere it's handled similarly to how it's done in `readInNull`. Are you sure it ever works?

Perhaps `Left (ProcessExitedUnsuccessfully _ ec)` is not correct approach here? Shouldn't we get existentially qualified `SomeException` with actual typeable exception inside it which then can be extracted with help of `fromException`? Maybe that's why pattern matching fails?

Maybe I'm wrong, I'll return to this later.