### PR TITLE
Restrict commands allowed in interpreter mode

### DIFF
--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -9,6 +9,7 @@ module Stack.Docker
   ,CleanupAction(..)
   ,dockerCleanupCmdName
   ,dockerCmdName
+  ,dockerHelpOptName
   ,dockerPullCmdName
   ,entrypoint
   ,preventInContainer
@@ -845,6 +846,9 @@ inContainerEnvVar = stackProgNameUpper ++ "_IN_CONTAINER"
 -- | Command-line argument for "docker"
 dockerCmdName :: String
 dockerCmdName = "docker"
+
+dockerHelpOptName :: String
+dockerHelpOptName = dockerCmdName ++ "-help"
 
 -- | Command-line argument for @docker pull@.
 dockerPullCmdName :: String

--- a/src/Stack/Nix.hs
+++ b/src/Stack/Nix.hs
@@ -6,6 +6,7 @@
 module Stack.Nix
   (reexecWithOptionalShell
   ,nixCmdName
+  ,nixHelpOptName
   ) where
 
 import           Control.Applicative
@@ -116,6 +117,9 @@ inShellEnvVar = concat [map toUpper stackProgName,"_IN_NIXSHELL"]
 -- | Command-line argument for "nix"
 nixCmdName :: String
 nixCmdName = "nix"
+
+nixHelpOptName :: String
+nixHelpOptName = nixCmdName ++ "-help"
 
 type M env m =
   (MonadIO m


### PR DESCRIPTION
Stack interpreter comment annotation allows arbitrary commands to be
written and executed when the file is run. It can lead to confusing
and surprising behavior if mistakes are made in writing a proper
comment.

This change restricts the interpreter mode commands to runghc and
runhaskell. This change moves add-commands to a separate function.

Closes #1504