### PR TITLE
Remove unnecessary pkgs from ghcjs-boot list

### DIFF
--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -315,44 +315,31 @@ ghcjsBootPackages =
     maybe (error "Parse error in ghcjsBootPackages") HashSet.fromList mparsed
   where
     mparsed = mapM parsePackageName
-      -- stage1a
-      [ "array"
+      -- This list consists of packages from stage 1 of ghcjs-boot -
+      -- things that get patched, along with their unpatched
+      -- dependencies.
+      --
+      -- Here are the packages that get patched:
+      [ "Win32"
       , "base"
-      , "binary"
       , "bytestring"
-      , "containers"
-      , "deepseq"
-      , "integer-gmp"
-      , "pretty"
-      , "primitive"
-      , "integer-gmp"
-      , "pretty"
-      , "primitive"
-      , "template-haskell"
-      , "transformers"
-      -- stage1b
       , "directory"
       , "filepath"
-      , "old-locale"
-      , "process"
-      , "time"
-      -- stage2
-      , "async"
-      , "aeson"
-      , "attoparsec"
-      , "case-insensitive"
-      , "dlist"
-      , "extensible-exceptions"
+      , "ghc-prim"
       , "hashable"
-      , "mtl"
+      , "integer-gmp"
       , "old-time"
-      , "parallel"
-      , "scientific"
-      , "stm"
-      , "syb"
-      , "text"
-      , "unordered-containers"
-      , "vector"
+      , "primitive"
+      , "process"
+      , "unix"
+      -- Dependencies of packages that get patched
+      , "rts" -- dep of base etc
+      , "deepseq" -- dep of bytestring etc
+      , "time" -- dep of directory etc
+      , "text" -- dep of hashable etc
+      , "old-locale" -- dep of old-time etc
+      , "transformers" -- dep of primitive etc
+      , "time" -- dep of unix etc
       ]
 
 -- | Just to avoid repetition and magic strings.


### PR DESCRIPTION
See [this comment](https://github.com/ghcjs/ghcjs/issues/448#issuecomment-164260475) - turns out not all the members of [`ghcjsBootPackages`](https://github.com/fpco/stack/blob/e43d6bf8fb1463841ce57162986d2927b0e0d747/src/Stack/Constants.hs#L313) are necessary.  Instead, just the patched packages and their dependencies are needed.