### PR TITLE
Interpreter error messages

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1361,7 +1361,15 @@ ghc` or `stack exec runghc` for that. As simple helpers, we also provide the
 stack also offers a very useful feature for running files: a script
 interpreter. For too long have Haskellers felt shackled to bash or Python
 because it's just too hard to create reusable source-only Haskell scripts.
-stack attempts to solve that. An example will be easiest to understand:
+stack attempts to solve that.
+
+You can use `stack <file name>` to execute a Haskell source file or specify
+`stack` as the interpreter using a shebang line on a Unix like operating systems.
+Additional stack options can be specified using a special Haskell comment in
+the source file to specify dependencies and automatically install them before
+running the file.
+
+An example will be easiest to understand:
 
 ```
 michael@d30748af6d3d:~$ cat turtle.hs
@@ -1389,20 +1397,23 @@ dependencies), but subsequent runs are able to reuse everything already built,
 and are therefore quite fast.
 
 The first line in the source file is the usual "shebang" to use stack as a
-script interpreter. The second line, which is required, is a Haskell comment
-providing additional options to stack (due to the common limitation of the
-"shebang" line only being allowed a single argument). In this case, the options
-tell stack to use the lts-3.2 resolver, automatically install GHC if it is not
-already installed, and ensure the turtle package is available.
+script interpreter. The second line, is a Haskell comment providing additional
+options to stack (due to the common limitation of the "shebang" line only being
+allowed a single argument). In this case, the options tell stack to use the
+lts-3.2 resolver, automatically install GHC if it is not already installed, and
+ensure the turtle package is available.
 
 If you're on Windows: you can run `stack turtle.hs` instead of `./turtle.hs`.
 The shebang line is not required in that case.
 
-The stack comment must specify a single valid stack command line, starting with
-`stack` as the command followed by the stack options to use for executing
-this file. The comment must always be on the line immediately following the
-shebang line when the shebang line is present otherwise it must be the first
-line in the file. The comment must always start in the first column of the line.
+### Specifying interpreter options
+
+The stack interpreter options comment must specify a single valid stack command
+line, starting with `stack` as the command followed by the stack options to use
+for executing this file. The comment must always be on the line immediately
+following the shebang line when the shebang line is present otherwise it must
+be the first line in the file. The comment must always start in the first
+column of the line.
 
 When many options are needed a block style comment may be more convenient to
 split the command on multiple lines for better readability. Here is an example

--- a/src/Data/Attoparsec/Args.hs
+++ b/src/Data/Attoparsec/Args.hs
@@ -1,78 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns #-}
-{- |  This module implements the following:
-
-    * Parsing of command line arguments for the stack command
-    * Parsing of additional arguments embedded in a comment when stack is
-      invoked as a script interpreter
-
-  ===Specifying arguments in script interpreter mode
-  @/stack/@ can execute a Haskell source file using @/runghc/@ and if required
-  it can also install and setup the compiler and any package dependencies
-  automatically.
-
-  For using a Haskell source file as an executable script on a Unix like OS,
-  the first line of the file must specify @stack@ as the interpreter using a
-  shebang directive e.g.
-
-  > #!/usr/bin/env stack
-
-  Additional arguments can be specified in a haskell comment following the
-  @#!@ line. The contents inside the comment must be a single valid stack
-  command line, starting with @stack@ as the command and followed by the
-  options to use for executing this file.
-
-  The comment must be on the line immediately following the @#!@ line. The
-  comment must start in the first column of the line. When using a block style
-  comment the command can be split on multiple lines.
-
-  Here is an example of a single line comment:
-
-  > #!/usr/bin/env stack
-  > -- stack --resolver lts-3.14 --install-ghc runghc --package random
-
-  Here is an example of a multi line block comment:
-
-@
-  #!\/usr\/bin\/env stack
-  {\- stack
-    --verbosity silent
-    --resolver lts-3.14
-    --install-ghc
-    runghc
-    --package random
-    --package system-argv0
-  -\}
-@
-
-  When the @#!@ line is not present, the file can still be executed
-  using @stack \<file name\>@ command if the file starts with a valid stack
-  interpreter comment. This can be used to execute the file on Windows for
-  example.
-
-  Nested block comments are not supported.
--}
+-- | Parsing of stack command line arguments
 
 module Data.Attoparsec.Args
     ( EscapingMode(..)
     , argsParser
-    , interpreterArgsParser -- for unit tests
     , parseArgs
-    , getInterpreterArgs
     ) where
 
 import           Control.Applicative
-import           Control.Monad.Catch (MonadThrow)
 import           Data.Attoparsec.Text ((<?>))
 import qualified Data.Attoparsec.Text as P
-import           Data.Conduit
-import           Data.Conduit.Attoparsec
-import qualified Data.Conduit.Binary as CB
-import           Data.Conduit.Text(decodeUtf8)
-import           Data.Char (isSpace)
-import           Data.Text (Text, pack)
-import           System.Directory (doesFileExist)
-import           System.IO (IOMode (ReadMode), withBinaryFile)
+import           Data.Text (Text)
 
 -- | Mode for parsing escape characters.
 data EscapingMode
@@ -98,51 +36,3 @@ argsParser mode = many (P.skipSpace *> (quoted <|> unquoted)) <*
     escaped = P.char '\\' *> P.anyChar
     nonquote = P.satisfy (/= '"')
     naked = P.satisfy (not . flip elem ("\" " :: String))
-
--- | Parser to extract the stack command line embedded inside a comment
--- after validating the placement and formatting rules for a valid
--- interpreter specification.
-interpreterArgsParser :: String -> P.Parser String
-interpreterArgsParser progName = P.option "" sheBangLine *> interpreterComment
-  where
-    sheBangLine =   P.string "#!"
-                 *> P.manyTill P.anyChar P.endOfLine
-
-    commentStart str =   P.string str
-                      *> P.skipSpace
-                      *> P.string (pack progName)
-
-    -- Treat newlines as spaces inside the block comment
-    anyCharNormalizeSpace = let normalizeSpace c = if isSpace c then ' ' else c
-                            in P.satisfyWith normalizeSpace $ const True
-
-    comment start end = commentStart start
-      *> ((end >> return "")
-          <|> (P.space *> P.manyTill anyCharNormalizeSpace end))
-
-    lineComment =  comment "--" (P.endOfLine <|> P.endOfInput)
-    blockComment = comment "{-" (P.string "-}" <?> "unterminated block comment")
-    interpreterComment = lineComment <|> blockComment
-
--- | Extract stack arguments from a correctly placed and correctly formatted
--- comment when it is being used as an interpreter
--- FIXME this is broken when options are specified before the filename
-getInterpreterArgs :: [String] -> String -> IO (Maybe [String])
-getInterpreterArgs (f:_) progName = do
-    isFile <- doesFileExist f
-    if isFile
-    then withBinaryFile f ReadMode parse
-    else return Nothing
-    where parse h =
-            CB.sourceHandle h
-            =$= decodeUtf8
-            $$ sinkInterpreterArgs progName
-getInterpreterArgs _ _ = return Nothing
-
-sinkInterpreterArgs :: MonadThrow m => String -> Sink Text m (Maybe [String])
-sinkInterpreterArgs progName = do
-    eArgs <- sinkParserEither (interpreterArgsParser progName)
-    case eArgs of
-        Right (P.parseOnly (argsParser Escaping) . pack -> Right args) ->
-            return $ Just args
-        _ -> return Nothing

--- a/src/Data/Attoparsec/Interpreter.hs
+++ b/src/Data/Attoparsec/Interpreter.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
+{- |  This module implements parsing of additional arguments embedded in a
+      comment when stack is invoked as a script interpreter
+
+  ===Specifying arguments in script interpreter mode
+  @/stack/@ can execute a Haskell source file using @/runghc/@ and if required
+  it can also install and setup the compiler and any package dependencies
+  automatically.
+
+  For using a Haskell source file as an executable script on a Unix like OS,
+  the first line of the file must specify @stack@ as the interpreter using a
+  shebang directive e.g.
+
+  > #!/usr/bin/env stack
+
+  Additional arguments can be specified in a haskell comment following the
+  @#!@ line. The contents inside the comment must be a single valid stack
+  command line, starting with @stack@ as the command and followed by the
+  options to use for executing this file.
+
+  The comment must be on the line immediately following the @#!@ line. The
+  comment must start in the first column of the line. When using a block style
+  comment the command can be split on multiple lines.
+
+  Here is an example of a single line comment:
+
+  > #!/usr/bin/env stack
+  > -- stack --resolver lts-3.14 --install-ghc runghc --package random
+
+  Here is an example of a multi line block comment:
+
+@
+  #!\/usr\/bin\/env stack
+  {\- stack
+    --verbosity silent
+    --resolver lts-3.14
+    --install-ghc
+    runghc
+    --package random
+    --package system-argv0
+  -\}
+@
+
+  When the @#!@ line is not present, the file can still be executed
+  using @stack \<file name\>@ command if the file starts with a valid stack
+  interpreter comment. This can be used to execute the file on Windows for
+  example.
+
+  Nested block comments are not supported.
+-}
+
+module Data.Attoparsec.Interpreter
+    ( interpreterArgsParser -- for unit tests
+    , getInterpreterArgs
+    ) where
+
+import           Control.Applicative
+import           Control.Monad.Catch (MonadThrow)
+import           Data.Attoparsec.Args
+import           Data.Attoparsec.Text ((<?>))
+import qualified Data.Attoparsec.Text as P
+import           Data.Conduit
+import           Data.Conduit.Attoparsec
+import qualified Data.Conduit.Binary as CB
+import           Data.Conduit.Text(decodeUtf8)
+import           Data.Char (isSpace)
+import           Data.Text (Text, pack)
+import           System.Directory (doesFileExist)
+import           System.IO (IOMode (ReadMode), withBinaryFile)
+
+-- | Parser to extract the stack command line embedded inside a comment
+-- after validating the placement and formatting rules for a valid
+-- interpreter specification.
+interpreterArgsParser :: String -> P.Parser String
+interpreterArgsParser progName = P.option "" sheBangLine *> interpreterComment
+  where
+    sheBangLine =   P.string "#!"
+                 *> P.manyTill P.anyChar P.endOfLine
+
+    commentStart str =   P.string str
+                      *> P.skipSpace
+                      *> P.string (pack progName)
+
+    -- Treat newlines as spaces inside the block comment
+    anyCharNormalizeSpace = let normalizeSpace c = if isSpace c then ' ' else c
+                            in P.satisfyWith normalizeSpace $ const True
+
+    comment start end = commentStart start
+      *> ((end >> return "")
+          <|> (P.space *> P.manyTill anyCharNormalizeSpace end))
+
+    lineComment =  comment "--" (P.endOfLine <|> P.endOfInput)
+    blockComment = comment "{-" (P.string "-}" <?> "unterminated block comment")
+    interpreterComment = lineComment <|> blockComment
+
+-- | Extract stack arguments from a correctly placed and correctly formatted
+-- comment when it is being used as an interpreter
+-- FIXME this is broken when options are specified before the filename
+getInterpreterArgs :: [String] -> String -> IO (Maybe [String])
+getInterpreterArgs (f:_) progName = do
+    isFile <- doesFileExist f
+    if isFile
+    then withBinaryFile f ReadMode parse
+    else return Nothing
+    where parse h =
+            CB.sourceHandle h
+            =$= decodeUtf8
+            $$ sinkInterpreterArgs progName
+getInterpreterArgs _ _ = return Nothing
+
+sinkInterpreterArgs :: MonadThrow m => String -> Sink Text m (Maybe [String])
+sinkInterpreterArgs progName = do
+    eArgs <- sinkParserEither (interpreterArgsParser progName)
+    case eArgs of
+        Right (P.parseOnly (argsParser Escaping) . pack -> Right args) ->
+            return $ Just args
+        _ -> return Nothing

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -21,7 +21,8 @@ import           Control.Monad.Reader (ask, asks, runReaderT)
 import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Control.Monad.Trans.Either (EitherT)
 import           Control.Monad.Trans.Writer (Writer)
-import           Data.Attoparsec.Args (getInterpreterArgs, parseArgs, EscapingMode (Escaping))
+import           Data.Attoparsec.Args (parseArgs, EscapingMode (Escaping))
+import           Data.Attoparsec.Interpreter (getInterpreterArgs)
 import qualified Data.ByteString.Lazy as L
 import           Data.IORef
 import           Data.List

--- a/src/test/Stack/ArgsSpec.hs
+++ b/src/test/Stack/ArgsSpec.hs
@@ -3,14 +3,14 @@
 module Stack.ArgsSpec where
 
 import Control.Applicative
-import Control.Exception.Base(assert)
+import Control.Exception.Base (assert)
 import Control.Monad
-import Options.Applicative.Args
-import Test.Hspec
-import Data.Text (pack)
-import Data.Attoparsec.Args(interpreterArgsParser)
-import Stack.Constants(stackProgName)
+import Data.Attoparsec.Interpreter (interpreterArgsParser)
 import qualified Data.Attoparsec.Text as P
+import Data.Text (pack)
+import Options.Applicative.Args
+import Stack.Constants (stackProgName)
+import Test.Hspec
 
 -- | Test spec.
 spec :: Spec

--- a/stack.cabal
+++ b/stack.cabal
@@ -113,6 +113,7 @@ library
                      System.Process.Run
                      Network.HTTP.Download.Verified
                      Data.Attoparsec.Args
+                     Data.Attoparsec.Interpreter
                      Data.Maybe.Extra
                      Path.IO
                      Path.Extra


### PR DESCRIPTION
Add better diagnostics to interpreter options parsing. More details in the commit messages.

Its best to review the commits spearately. The first commit just splits a file, no other change. The second one is most of the changes.

Closes #1516 