### PR TITLE
Added pointers for creating your own .deb packages

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -140,6 +140,10 @@ Yosemite and Mavericks as well, and may also work on older versions (YMMV).
 
         sudo apt-get update && sudo apt-get install stack -y
 
+### Building your own package
+
+Stack needs itself (the stack command) to build. You can download a stack binary following the instructions for the [generic Linux option](#linux), then look into the etc/scripts/vagrant-distros.sh script (basically, you need to use stack to compile release.hs, then execute that binary with specific parameters). The preferred method is to install the FP Complete repo, if you try this route you are on your own.
+
 ## CentOS / Red Hat / Amazon Linux
 
 *note*: for 32-bit, use the [generic Linux option](#linux)


### PR DESCRIPTION
Some pointers of where to look to create your own .deb file.

At the time of this writing the following instructions get the job done:

You will need to have fpm installed, though. As root:

apt-get install ruby-dev libffi-dev make build-essential rubygems
gem install fpm  --version '< 1.4.0'

(assuming a binary version of stack is in the path and the current directory is the root of the git version)

cd etc/scripts
stack --install-ghc-build
RELEASE_SCRIPT=`stack exec which stack-release-script`
cd ../..
RELEASE_SCRIPT --upload-label='Linux 64-bit, standard' --allow-dirty build-debian-8

the .deb file will be located under the _release folder.

(I didn't add these instructions to the documentation itself as it will get hopelessly out of date very quickly, but feel free to do so if you think there'll be value on it.)