### PR TITLE
improve 'stack new'

### DIFF
--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -204,6 +204,7 @@ configFromConfigMonoid configStackRoot configUserConfigPath mresolver mproject c
          configRebuildGhcOptions = fromMaybe False configMonoidRebuildGhcOptions
          configApplyGhcOptions = fromMaybe AGOLocals configMonoidApplyGhcOptions
          configAllowNewer = fromMaybe False configMonoidAllowNewer
+         configDefaultTemplate = configMonoidDefaultTemplate
 
      return Config {..}
 

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -150,7 +150,6 @@ loadTemplate name logIt = do
         $logDebug ("Opening local template: \"" <> T.pack (toFilePath path)
                                                 <> "\"")
         exists <- fileExists path
-        unless exists ($logDebug "Template file doesn't exist")
         if exists
             then liftIO (T.readFile (toFilePath path))
             else throwM (FailedToLoadTemplate name (toFilePath path))

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -16,6 +16,7 @@ module Stack.New
     , listTemplates)
     where
 
+import           Control.Applicative
 import           Control.Monad
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
@@ -47,6 +48,7 @@ import           Network.HTTP.Download
 import           Network.HTTP.Types.Status
 import           Path
 import           Path.IO
+import           Prelude
 import           Stack.Constants
 import           Stack.Types
 import           Stack.Types.TemplateName
@@ -72,7 +74,7 @@ data NewOpts = NewOpts
 
 -- | Create a new project with the given options.
 new
-    :: (HasConfig r, MonadReader r m, MonadLogger m, MonadCatch m, MonadThrow m, MonadIO m, HasHttpManager r)
+    :: (HasConfig r, MonadReader r m, MonadLogger m, MonadCatch m, MonadThrow m, MonadIO m, HasHttpManager r, Functor m, Applicative m)
     => NewOpts -> m (Path Abs Dir)
 new opts = do
     pwd <- getWorkingDir
@@ -121,7 +123,7 @@ data TemplateFrom = LocalTemp | RemoteTemp
 -- | Download and read in a template's text content.
 loadTemplate
     :: forall m r.
-       (HasConfig r, HasHttpManager r, MonadReader r m, MonadIO m, MonadThrow m, MonadCatch m, MonadLogger m)
+       (HasConfig r, HasHttpManager r, MonadReader r m, MonadIO m, MonadThrow m, MonadCatch m, MonadLogger m, Functor m, Applicative m)
     => TemplateName -> (TemplateFrom -> m ()) -> m Text
 loadTemplate name logIt = do
     templateDir <- templatesDir <$> asks getConfig

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -804,7 +804,7 @@ newOptsParser = (,) <$> newOpts <*> initOptsParser
              help "Do not create a subdirectory for the project") <*>
         templateNameArgument
             (metavar "TEMPLATE_NAME" <>
-             help "Name of a template or a local template in a subdirectory,\
+             help "Name of a template or a local template in a file,\
                   \ for example: foo or foo.hsfiles" <>
              value defaultTemplateName) <*>
         fmap

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -802,12 +802,11 @@ newOptsParser = (,) <$> newOpts <*> initOptsParser
         switch
             (long "bare" <>
              help "Do not create a subdirectory for the project") <*>
-        templateNameArgument
+        optional (templateNameArgument
             (metavar "TEMPLATE_NAME" <>
              help "Name of a template or a local template in a file or a URL.\
                   \ For example: foo or foo.hsfiles or ~/foo or\
-                  \ https://example.com/foo.hsfiles" <>
-             value defaultTemplateName) <*>
+                  \ https://example.com/foo.hsfiles")) <*>
         fmap
             M.fromList
             (many

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -804,8 +804,9 @@ newOptsParser = (,) <$> newOpts <*> initOptsParser
              help "Do not create a subdirectory for the project") <*>
         templateNameArgument
             (metavar "TEMPLATE_NAME" <>
-             help "Name of a template or a local template in a file,\
-                  \ for example: foo or foo.hsfiles" <>
+             help "Name of a template or a local template in a file or a URL.\
+                  \ For example: foo or foo.hsfiles or ~/foo or\
+                  \ https://example.com/foo.hsfiles" <>
              value defaultTemplateName) <*>
         fmap
             M.fromList

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -167,6 +167,7 @@ import           Stack.Types.Image
 import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageIndex
 import           Stack.Types.PackageName
+import           Stack.Types.TemplateName
 import           Stack.Types.Version
 import           System.PosixCompat.Types (UserID, GroupID)
 import           System.Process.Read (EnvOverride)
@@ -273,6 +274,9 @@ data Config =
          ,configAllowNewer          :: !Bool
          -- ^ Ignore version ranges in .cabal files. Funny naming chosen to
          -- match cabal.
+         ,configDefaultTemplate     :: !(Maybe TemplateName)
+         -- ^ The default template to use when none is specified.
+         -- (If Nothing, the default default is used.)
          }
 
 -- | Which packages to ghc-options on the command line apply to?
@@ -793,6 +797,9 @@ data ConfigMonoid =
     -- ^ See 'configApplyGhcOptions'
     ,configMonoidAllowNewer          :: !(Maybe Bool)
     -- ^ See 'configMonoidAllowNewer'
+    ,configMonoidDefaultTemplate     :: !(Maybe TemplateName)
+    -- ^ The default template to use when none is specified.
+    -- (If Nothing, the default default is used.)
     }
   deriving Show
 
@@ -831,6 +838,7 @@ instance Monoid ConfigMonoid where
     , configMonoidRebuildGhcOptions = Nothing
     , configMonoidApplyGhcOptions = Nothing
     , configMonoidAllowNewer = Nothing
+    , configMonoidDefaultTemplate = Nothing
     }
   mappend l r = ConfigMonoid
     { configMonoidWorkDir = configMonoidWorkDir l <|> configMonoidWorkDir r
@@ -867,6 +875,7 @@ instance Monoid ConfigMonoid where
     , configMonoidRebuildGhcOptions = configMonoidRebuildGhcOptions l <|> configMonoidRebuildGhcOptions r
     , configMonoidApplyGhcOptions = configMonoidApplyGhcOptions l <|> configMonoidApplyGhcOptions r
     , configMonoidAllowNewer = configMonoidAllowNewer l <|> configMonoidAllowNewer r
+    , configMonoidDefaultTemplate = configMonoidDefaultTemplate l <|> configMonoidDefaultTemplate r
     }
 
 instance FromJSON (ConfigMonoid, [JSONWarning]) where
@@ -930,6 +939,7 @@ parseConfigMonoidJSON obj = do
     configMonoidRebuildGhcOptions <- obj ..:? configMonoidRebuildGhcOptionsName
     configMonoidApplyGhcOptions <- obj ..:? configMonoidApplyGhcOptionsName
     configMonoidAllowNewer <- obj ..:? configMonoidAllowNewerName
+    configMonoidDefaultTemplate <- obj ..:? configMonoidDefaultTemplateName
 
     return ConfigMonoid {..}
   where
@@ -1054,6 +1064,9 @@ configMonoidApplyGhcOptionsName = "apply-ghc-options"
 
 configMonoidAllowNewerName :: Text
 configMonoidAllowNewerName = "allow-newer"
+
+configMonoidDefaultTemplateName :: Text
+configMonoidDefaultTemplateName = "default-template"
 
 data ConfigException
   = ParseConfigFileException (Path Abs File) ParseException

--- a/src/Stack/Types/TemplateName.hs
+++ b/src/Stack/Types/TemplateName.hs
@@ -69,7 +69,8 @@ parseTemplateNameFromString fname =
         , TemplateName prefix        . AbsPath <$> parseAbsFile hsf
         , TemplateName prefix        . RelPath <$> parseRelFile hsf
         ]
-    expected = "Expected a template filename like: foo or foo.hsfiles"
+    expected = "Expected a template like: foo or foo.hsfiles or\
+               \ https://example.com/foo.hsfiles"
 
 -- | Make a template name.
 mkTemplateName :: String -> Q Exp

--- a/src/Stack/Types/TemplateName.hs
+++ b/src/Stack/Types/TemplateName.hs
@@ -8,6 +8,7 @@
 module Stack.Types.TemplateName where
 
 import           Control.Error.Safe (justErr)
+import           Data.Aeson.Extended (FromJSON, withText, parseJSON)
 import           Data.Foldable (asum)
 import           Data.Monoid
 import           Data.Text (Text)
@@ -30,6 +31,10 @@ data TemplatePath = AbsPath (Path Abs File)
                   | UrlPath String
                   -- ^ a full URL
   deriving (Eq, Ord, Show)
+
+instance FromJSON TemplateName where
+    parseJSON = withText "TemplateName" $
+        either fail return . parseTemplateNameFromString . T.unpack
 
 -- | An argument which accepts a template name of the format
 -- @foo.hsfiles@ or @foo@, ultimately normalized to @foo@.

--- a/src/Stack/Types/TemplateName.hs
+++ b/src/Stack/Types/TemplateName.hs
@@ -7,17 +7,29 @@
 
 module Stack.Types.TemplateName where
 
+import           Control.Error.Safe (justErr)
+import           Data.Foldable (asum)
 import           Data.Monoid
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Language.Haskell.TH
+import           Network.HTTP.Client (parseUrl)
 import qualified Options.Applicative as O
 import           Path
 import           Path.Internal
 
 -- | A template name.
-data TemplateName = TemplateName !Text !(Either (Path Abs File) (Path Rel File))
+data TemplateName = TemplateName !Text !TemplatePath
   deriving (Ord,Eq,Show)
+
+data TemplatePath = AbsPath (Path Abs File)
+                  -- ^ an absolute path on the filesystem
+                  | RelPath (Path Rel File)
+                  -- ^ a relative path on the filesystem, or relative to
+                  -- the template repository
+                  | UrlPath String
+                  -- ^ a full URL
+  deriving (Eq, Ord, Show)
 
 -- | An argument which accepts a template name of the format
 -- @foo.hsfiles@ or @foo@, ultimately normalized to @foo@.
@@ -46,16 +58,17 @@ templateParamArgument =
 parseTemplateNameFromString :: String -> Either String TemplateName
 parseTemplateNameFromString fname =
     case T.stripSuffix ".hsfiles" (T.pack fname) of
-        Nothing -> parseValidFile (T.pack fname) (fname <> ".hsfiles")
-        Just prefix -> parseValidFile prefix fname
+        Nothing -> parseValidFile (T.pack fname) (fname <> ".hsfiles") fname
+        Just prefix -> parseValidFile prefix fname fname
   where
-    parseValidFile prefix str =
-        case parseRelFile str of
-            Nothing ->
-                case parseAbsFile str of
-                    Nothing -> Left expected
-                    Just fp -> return (TemplateName prefix (Left fp))
-            Just fp -> return (TemplateName prefix (Right fp))
+    parseValidFile prefix hsf orig = justErr expected
+                                           $ asum (validParses prefix hsf orig)
+    validParses prefix hsf orig =
+        -- NOTE: order is important
+        [ TemplateName (T.pack orig) . UrlPath <$> (parseUrl orig *> Just orig)
+        , TemplateName prefix        . AbsPath <$> parseAbsFile hsf
+        , TemplateName prefix        . RelPath <$> parseRelFile hsf
+        ]
     expected = "Expected a template filename like: foo or foo.hsfiles"
 
 -- | Make a template name.
@@ -67,13 +80,14 @@ mkTemplateName s =
             [|TemplateName (T.pack prefix) $(pn)|]
             where pn =
                       case p of
-                          Left (Path fp) -> [|Left (Path fp)|]
-                          Right (Path fp) -> [|Right (Path fp)|]
+                          AbsPath (Path fp) -> [|AbsPath (Path fp)|]
+                          RelPath (Path fp) -> [|RelPath (Path fp)|]
+                          UrlPath fp -> [|UrlPath fp|]
 
 -- | Get a text representation of the template name.
 templateName :: TemplateName -> Text
 templateName (TemplateName prefix _) = prefix
 
 -- | Get the path of the template.
-templatePath :: TemplateName -> Either (Path Abs File) (Path Rel File)
+templatePath :: TemplateName -> TemplatePath
 templatePath (TemplateName _ fp) = fp

--- a/src/Stack/Types/TemplateName.hs
+++ b/src/Stack/Types/TemplateName.hs
@@ -8,6 +8,7 @@
 module Stack.Types.TemplateName where
 
 import           Control.Error.Safe (justErr)
+import           Control.Applicative
 import           Data.Aeson.Extended (FromJSON, withText, parseJSON)
 import           Data.Foldable (asum)
 import           Data.Monoid
@@ -18,6 +19,7 @@ import           Network.HTTP.Client (parseUrl)
 import qualified Options.Applicative as O
 import           Path
 import           Path.Internal
+import           Prelude
 
 -- | A template name.
 data TemplateName = TemplateName !Text !TemplatePath

--- a/stack.cabal
+++ b/stack.cabal
@@ -151,6 +151,7 @@ library
                    , edit-distance >= 0.2
                    , either
                    , enclosed-exceptions
+                   , errors
                    , exceptions >= 0.8.0.2
                    , extra
                    , fast-logger >= 2.3.1


### PR DESCRIPTION
- You can now specify an explicit URL to download the template from
- I've improved the logging/output so that it doesn't say it's "Downloading" a local file
- You can specify a default-template in ~/.stack/config.yaml, which is nice if you have a favorite

I considered adding the ability to configure the template repository location, but I'm thinking I might leave that for a separate PR later if it sounds interesting to anyone. I think it'd be a decent feature, but it's a little complicated by the existence of the `stack templates` command, which I haven't really worked out how to deal with.

I'm working on some tests to exercise this functionality and make sure, but it basically seems to work fine to me.