### PR TITLE
Add zsh completion function

### DIFF
--- a/doc/_completion_helpers
+++ b/doc/_completion_helpers
@@ -1,0 +1,239 @@
+#autoload
+
+# Filename: _completion_helpers
+# Description: Extra utility functions to help create zsh completion functions
+# Author: Joe Bloggs <vapniks@yahoo.com>
+# Copyleft (Ↄ) 2015, Joe Bloggs, all rites reversed.
+# Created: 2015-12-19 19:00:00
+#           By: Joe Bloggs
+# URL: https://github.com/vapniks/zsh-completions
+
+## License:
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.
+# If not, see <http://www.gnu.org/licenses/>.
+
+# To use the following functions add a call to "_completion_helpers" in your completion script,
+# in order to load this file first.
+
+# This function joins together groups of consecutive lines. The first line in each group is identified by having 
+# less initial whitespace that subsequent lines in the group (i.e. it is indented less).
+# This is useful for preprocessing the output from a command called with its --help argument.
+# The function reads input from a pipe and takes the following three arguments:
+# 1) A separator to place between joined lines.
+# 2) A regular expression matching the initial line of each group. All lines subsequent to the initial line will
+#    be appended to it (after removing leading & trailing whitespace) until the next initial line of a group.
+#    Alternatively this argument can be the maximum number of leading whitespace chars for the initial line.
+#    Any lines with more than this many leading whitespace chars will be appended to previous lines.
+# 3) An optional regular expression matching the line before the beginning of the section of output to be processed.
+#    If this is set to the empty string then processing will start from the beginning of the output.
+# 4) An optional regular expression matching the line after the end of the section of output to be processed
+#    (if this arg is omitted then all output upto the last line will be processed).
+function _join_lines() {
+    awk -v SEP="$1" -v ARG2="$2" -v START="$3" -v END2="$4" 'BEGIN {if(START==""){f=1}{f=0};
+         if(ARG2 ~ "^[0-9]+"){LINE1 = "^[[:space:]]{,"ARG2"}[^[:space:]]"}else{LINE1 = ARG2}}
+         ($0 ~ END2 && f>0 && END2!="") {exit}
+         ($0 ~ START && f<1) {f=1; if(length(START)!=0){next}}
+         ($0 ~ LINE1 && f>0) {if(f<2){f=2; printf("%s",$0)}else{printf("\n%s",$0)}; next}
+         (f>1) {gsub(/^[[:space:]]+|[[:space:]]+$/,"",$0); printf("%s%s",SEP, $0); next}
+         END {print ""}'
+}
+
+# This function can be used to extract parts of lines into arrays. This is useful for extracting
+# completion information about commands by using the --help option.
+# It takes a variable number of arguments: a regexp (first arg), and the names of any number 
+# array variables (other args).
+# For each line of input piped into the function it will try and match the regexp on the line
+# and save each parenthesised subexpression into one of the arrays (first subexpression into
+# the first array, second subexpression into the second array, etc.)
+# For each line that doesn't match the regexp empty elements will be added to the arrays.
+# If a line matches but a subexpressions doesn't then whatever is stored in the corresponding
+# element of $match (see zsh documentation) will be used instead.
+function _extract_parts() {
+    OLDIFS=$IFS;IFS=;
+    while read -r inputtxt; do
+	local i=2 rx="${*[1]}" matched="no"
+	if [[ "$inputtxt" =~ "$rx" ]]; then
+	    matched="yes"
+	fi
+	while [[ "$i" -le "$#" ]]; do
+	    local arr="${*[$i]}"
+	    if [[ -n "$arr" ]]; then
+		if [[ "$matched" =~ "yes" ]]; then
+		    eval "$arr+=\$match[$i-1]"
+		else
+		    eval "$arr+=''"
+		fi
+	    fi
+	    let i=i+1
+	done
+    done
+    IFS=$OLDIFS
+}
+
+# Given three arrays of strings, apply _regex_words to triples formed by taking corresponding elements
+# from the arrays. The result will be stored in the $reply array, and can be viewed with: echo "${reply[@]}"
+# See documentation of _regex_words for more info.
+# This command takes 5 arguments:
+# 1) A tag name for the resulting call to _regex_words
+# 2) A description for the call to _regex_words
+# 3) The name of an array var containing completion words (each used in first part of a _regex_words spec)
+# 4) The name of an array var containing descriptions (each used in second part of a _regex_words spec)
+# 5) Optionally: the name of an array var containing further completions (each used in third part of a _regex_words spec)
+# 6) Optionally: the name of an array var in which to store the results from _regex_words
+#    (otherwise they can be found in ${reply[@]})
+function _arrays_to_regex_words() {
+    local opts="${*[3]}" descs="${*[4]}" args="${*[5]}" 
+    local -a regexwords 
+    local i=1 desc
+    while [[ "$i" -le "${(@P)#opts}" ]]; do
+	desc="${${${${${(@P)descs}[$i]//:/-}//\[/(}//]/)}//\'/}"
+	regexwords+="${${(@P)opts}[$i]}:$desc:${${(@P)args}[$i]}"
+	let i=i+1
+    done
+    _regex_words "$1" "$2" "${regexwords[@]}"
+    if [[ -n "${*[6]}" ]]; then
+	set -A "${*[6]}" "${reply[@]}"
+    fi
+}
+
+# This function can be used for substituting values in an indexed array (1st arg) according to rules defined in another
+# associative array (2nd arg)
+# Any elements of the indexed array that match a key of the associative array will be replaced with the corresponding value
+# of the associative array.
+# This can be used for replacing option argument names (extracted from command help info) with corresponding definitions
+# for _regex_words (also using _arrays_to_regex_words).
+function _replace_vals_in_array() {
+    local vals="$1" arg2="$2"
+    typeset -A repls
+    set -A repls "${(kvP@)arg2}"
+    local i=1 newval val repl
+    while [[ "$i" -le "${(P)#vals}" ]]; do
+	val="${${(@P)vals}[i]}"
+	repl="${repls[$val]}"
+	if [[ -n "$repl" ]]; then
+	   typeset -g "$vals""[$i]"="$repl"
+	fi
+	let i=i+1
+    done
+}
+
+# This function makes multiple substitutions in the input string and outputs the result.
+# It takes a single argument: the name of an associative array whose keys are the strings
+# to be replaced and whose values are the replacements.
+_multi_substitute () {
+    local instring="$(cat)"
+    local key val
+    typeset -A repls
+    set -A repls "${(kvP@)1}"
+    for key in "${(k@)repls}"
+    do
+	val="${repls[$key]}" 
+	instring="${instring//$key/$val}" 
+    done
+    print "$instring"
+}
+
+# This function creates an associative array from a pair of indexed arrays of keys and values.
+# It takes the following arguments:
+# 1) a name for the resulting associative array
+# 2) the name of an indexed array of keys
+# 3) the name of an indexed array of values (with order corresponding to the keys array)
+# If there are fewer keys than values then any excess values will be omitted from the results.
+# If there are more keys than values then the extra keys will not be assigned values
+function _create_assoc_array() {
+    typeset -g -A "$1"
+    local i=1 key val
+    local keys="$2" vals="$3"
+    while [[ "$i" -le "${(P@)#keys}" ]]; do
+	key="${${(P@)keys}[$i]}"
+	val="${${(P@)vals}[$i]}"
+	typeset -g "$1""[$key]"="$val"
+	let i=i+1
+    done
+}
+
+# This function tests whether its only argument is a shell option or not.
+function _is_option() {
+    [[ -n "$1" ]] \
+	&& ( (setopt | grep "^$1\$" >/dev/null) \
+		 || (unsetopt | grep "^$1\$" >/dev/null) )
+}
+
+# This function saves current shell option values to an associative array.
+# The first argument can be the name of a variable to save the option to,
+# or an option name.
+# All other arguments are names of options to save. If the first argument
+# is an option name then it save with the other option name arguments into
+# the SAVED_SHELL_OPTIONS variable instead.
+# The options can be restored using the _restore_options function.
+function _save_options() {
+    local savename
+    if _is_option "$1"; then
+	savename=SAVED_SHELL_OPTIONS
+    else
+	savename="$1"
+	shift
+    fi
+    local -a opts states 
+    opts=("$@")
+    local i=1
+    while [[ "$i" -le "${#opts}" ]]; do
+	if ( setopt | grep "^$opts[i]\$" > /dev/null ); then
+	    states[i]=on
+	elif ( unsetopt | grep "^$opts[i]\$" > /dev/null ); then
+	    states[i]=off
+	else
+	    echo "Invalid option $opts[i] !"
+	fi
+	let i=i+1
+    done
+    _create_assoc_array "$savename" opts states
+}
+
+# This function is used for restoring options previously saved with _save_options
+# The first argument can be the name of a variable containing the saved options,
+# or an option name. All other arguments are the names of options to restore.
+# If no option names are supplied then all saved options will be restored.
+# If the first argument is an option name, then it will be restored with the other
+# option name arguments from the SAVED_SHELL_OPTIONS variable instead.
+# If there are no arguments then all options in SAVED_SHELL_OPTIONS will be restored.
+function _restore_options () {
+    local savename
+    if _is_option "$1"; then
+	savename=SAVED_SHELL_OPTIONS
+    else
+	savename="$1"
+	shift
+    fi
+    typeset -A savedoptions
+    set -A savedoptions "${(kvP@)savename}"
+    local -a opts
+    opts=("$@")
+    local opt state 
+    for opt in "${(k@)savedoptions}"; do
+	if [[ "${#opts}" -eq 0 || "${opts[(r)$opt]}" == "$opt" ]]; then
+            state="${savedoptions[$opt]}" 
+            if [[ "$state" =~ "on" ]]; then
+		setopt "$opt"
+            elif [[ "$state" =~ "off" ]]; then
+		unsetopt "$opt"
+            fi
+	fi
+    done
+}
+
+# Local Variables:"
+# mode:sh"
+# End:"

--- a/doc/_stack
+++ b/doc/_stack
@@ -1,0 +1,217 @@
+#compdef stack
+
+# Load completion helper functions
+_completion_helpers
+
+# Extract command names and descriptions from stack help text (supplied as input).
+# Takes 2 args: the name of an array in which to store the command names,
+#               and the name of an array in which to store the command descriptions
+function _stack_get_commands() {
+    # extract command help lines, and join split description lines together
+    _join_lines " " 25 "^Available commands:" "^[^[:space:]]" |\
+	_extract_parts "^[[:space:]]*([^[:space:]]+)[[:space:]]+([^[:space:]].*)" "$1" "$2"
+}
+
+# Extract option names and descriptions from stack help text (supplied as input).
+# Takes 2 args: the name of an array in which to store the option names,
+#               and the name of an array in which to store the option descriptions
+function _stack_get_options() {
+    # extract option help lines, and join split description lines together
+    _join_lines " " 25 "^Available options:" "^[^[:space:]]" |\
+	# remove excessive whitespace (e.g. between option arg and description)
+	sed -r 's/[[:space:]]{3,}/   /g' |\
+	# extract option and description (keep option arg with description)
+	_extract_parts "^[[:space:]]*(?:[^[:space:],]+,)?(--[a-z-\*]+)[[:space:]]+([^[:space:]].*)" "$1" "$2"
+}
+
+# Extract usage string from stack help text (supplied as input), and transform the text
+# into a skeleton for arguments to _regex_arguments. 
+# Takes 1 optional argument: the subcommand being completed (none if completing main command)
+function _stack_get_optargs_skeleton() {
+    # First remove initial title line if present
+    sed -r '{s/^stack - .*//;s/^[[:space:]]*$//}' |\
+	# Extract usage string, and join into a single line
+	_join_lines " " 10 "" "^[[:space:]]{,9}([^U[:space:]]|U[^s]|Us[^a])" |\
+	# Remove preliminary text (make sure there's an initial space in result)
+	sed -r "s/Usage: stack ([a-z -]+)?([^a-z -])/ \2/" |\
+	# Remove any dots (e.g. in [SELECTOR...])
+	tr -d . |\
+	# Put brackets around whole set of options (by matching on 1st and last square parentheses)
+	sed -r "{s/\[/( [/;s/\]([^]]*)$/] ) '#' \1/}" |\
+	# put | between items
+	sed -r "s/([])]) ([[(])/\1 | \2/g" |\
+	# sometimes (stack sig sign sdist --help) we have an unbracketed item in the middle
+	sed -r "s/([])]) ([^]|[]+) ([[(])/\1 | \2 | \3/g" |\
+	# remove short options (just use long ones)
+	sed -r "s/\[([^[:space:]]+\|)?(--[^][:space:]]*)( [^]]+)?\]/[\2\3]/g" |\
+	#sed -r "s/\[([A-Z][^] \t]+)\]/\1/g"
+	# put single quotes and spaces around (,) & |
+	sed -r "s/([\|\(\)])/ '\1' /g" |\
+	# remove non-option bracketed stuff
+	sed -r "s/\[([A-Z_-]+)\]/\1/g" |\
+	# finally, put options and option args in form usable by _regex_arguments
+	sed -r "s/\[(--[^][:space:]]*)( [^]]+)?\]/\/$'\1\\\0'\/ ':options:$1 options:((\1\:\"description\"))'\2 /g" 
+}
+
+# This function creates the final arguments for _regex_arguments
+# Arguments:
+# 1) the name of an associative array containing option argument names and their replacements,
+# rest) full command line of command to be completed without any options, e.g. stack sig sign sdist
+function _stack_regex_arguments() {
+    # store stack help output in $helpstr
+    local optargs=$1
+    shift
+    local helpstr
+    helpstr=$("${@}" --help)
+    # save current state of rematchpcre shell option, and set it
+    local -A SAVED_SHELL_OPTIONS
+    _save_options rematchpcre
+    setopt rematchpcre
+    # get lists of commands, options, and descriptions of those things
+    local -a cmds cmd_descs opts opt_descs
+    print "$helpstr" | _stack_get_commands cmds cmd_descs
+    print "$helpstr" | _stack_get_options opts opt_descs
+    # get basic skeleton for arguments list to _regex_arguments
+    local regexopt="$(print $helpstr | _stack_get_optargs_skeleton $@)"
+    # insert option arg completions
+    local -A opt_args
+    set -A opt_args "${(kvP@)optargs}"
+    regexopt=$(print "$regexopt" | _multi_substitute opt_args)
+    # insert option descriptions into $regexopt
+    local opt_desc i=1
+    while [[ "$i" -le "${#opts}" ]]; do
+	opt_desc="${(qL)${opt_descs[i]//\"/\\\"}//[\`\']/}"
+	regexopt="${regexopt//\(\($opts[i]\:\"description\"\)\)/((${opts[i]//\*/}\:\"$opt_desc\"))}"
+	let i=i+1
+    done
+    # special treatment for "-- ARGS" (it's not listed under "Available options")
+    regexopt="${regexopt//\(\(--\:\"description\"\)\)/((--:\"ARGS (e.g. stack ghc -- X.hs -o x)\"))}"
+    # Create completions for commands
+    local cmd cmd_desc cmd_opts regexcmd i=1 
+    # make sure we have some commands
+    if [[ ( "$cmds" =~ "[[:alpha:]]+" ) ]]; then
+	regexcmd=" '(' "
+	while [[ ( "$i" -le "${#cmds}" ) ]]; do
+	    cmd="${cmds[$i]}"
+	    cmd_desc="${(q)${${cmd_descs[$i]//\"/\\\"}//[\`\']/}}"
+	    regexcmd+=" /\$'$cmd\0'/ ':cmds:commands:(($cmd:\\\"$cmd_desc\\\"))' "
+	    # recursively create completion functions for subcommands
+	    # (named by concatenating commands with _, e.g: _stack_sig_sign_sdist)
+	    regexcmd+=" /\$'[^\0]##\0'/ ':opt:$cmd options:{ _create_stack_completion_function $optargs ${@} $cmd; _${${^^@}// /_}_$cmd }' '#' "
+	    if [[ "$i" -lt "${#cmds}" ]]; then
+		regexcmd+=" '|' "
+	    fi
+	    let i=i+1
+	done
+	regexcmd+=" ')' "
+    fi
+    # Put all completions together
+    local regexall="${regexopt//COMMAND/} ${regexcmd}"
+    _restore_options rematchpcre
+    # output the _regex_arguments arguments
+    print "$regexall"
+}
+
+# Unless it already exists, create the completion function for stack or one of its subcommands.
+# Arguments:
+# 1) the name of an associative array containing option argument names and their replacements,
+# rest) full command line of command to be completed without any options, e.g. stack sig sign sdist
+_create_stack_completion_function() {
+    local optargs=$1
+    shift
+    local func regex
+    func="_${${^^@}// /_}"
+    regex="/$'${${^^@}// /\\0*}\\0'/"
+    if ! whence -w $func >/dev/null; then
+	eval "_regex_arguments $func $regex $(_stack_regex_arguments $optargs $@)"
+    fi
+}
+
+# Anonymous function for main code
+function() {
+    # arguments to _regex_arguments for completing files and directories
+    local matchany matchinteger matchquoted 
+    matchany="/$'[^\0]##\0'/"
+    matchinteger="/$'[0-9]##\0'/"
+    # the following regexp matches backslashed quotes only. I can't get it to match non-backslashed quotes.
+    matchquoted="/$'\"[^\"]##\"\0'/"
+    local -a files dirs
+    files=("$matchany" ':file:file:_files')
+    dirs=("$matchany" ':dir:directory:_dirs')
+    # following line commented out because it is too slow
+    #local templatesdir="$(stack path --global-stack-root 2>/dev/null)/templates"
+    # replace following path with path to templates directory if different    
+    local templatesdir="$HOME/.stack/templates/"
+    typeset -gA STACKOPTARGS
+    # Need to have spaces surrounding each key and value in following assoc array.
+    STACKOPTARGS=(
+	" ARCH " " /$'[a-z0-9-_]##\0'/ ':arch:system architecture:(i386 x86_64 ppc sparc)' "
+	# Following 2 entries correspond with  "ARGS (e.g. stack ghc -- X.hs -o x)"
+	" ARGS " " $matchany ':args:args for command:' "
+	# Remove this stuff
+	" '(' eg stack ghc -- Xhs -o x ')' " ""
+	" ARG " " $matchany ':arg:arg:' "
+	" BENCH_ARGS " " $matchany ':args:arguments:' "
+	" CMD " " $matchquoted ':cmd:command to run after build:' "
+	" CMD ARGS " " $matchquoted ':cmd:command to run after build:' "
+	" CODE " " $matchquoted ':code:code:' "
+	" COMPILER " " /$'ghc[^\0]#\0'/ ':compiler:compiler:' "
+	" CREATED-DAYS-AGO " " $matchinteger ':number:number:' "
+	" DEPTH " " $matchinteger ':number:number:' "
+	" DIR " " $matchany ':directory:directory:_dirs' "		
+	" FIELD VALUE " " '(' $matchany ':field:field:' $matchany ':value:value:' ')' "
+	" GHC " " $matchany ':file:ghc:_files' "
+	" GHC_VERSION " " /$'[0-9.]##\0'/ ':version:version:' "
+	" IGNORED " ""
+	" JOBS " " $matchinteger ':number:number of concurrent jobs to run:' "
+	" KEY:VALUE " " $matchany ':keyval:template parameter:' "
+	" LAST-USED-DAYS-AGO " " $matchinteger ':number:number:' "
+	" OPTION " " $matchany ':options:options:' "
+	" OS " " /$'[a-z]##\0'/ ':os:operating system:(linux windows osx freebsd solaris)' "
+	" PACKAGE " " $matchany ':name:package name:' "
+	" PACKAGE:-FLAG " " $matchany ':flag:package flag:' "
+	" PACKAGES " " $matchany ':name:package name:' "
+	" PACKAGE_NAME " " $matchany ':name:package name:' "
+	" PATH " " $matchany ':file:file:_files' "
+	" PVP-BOUNDS " " $matchany ':bounds:pvp version bounds:(none lower upper both)' "
+	" RESOLVER " " $matchany ':resolver:resolver:' "
+	" SELECTOR " " $matchany ':selector:selector:' "
+	" SEP " " $matchany ':separator:separator:' "
+	" STACK-YAML " " /$'[^\0]##.yaml\0'/ ':file:file:_files' "
+	" TARBALL/DIR " " $matchany ':name:package name:_files' "
+	# TODO: a completer for targets would be nice	
+	" TARGET " " /$'[a-zA-Z][^\0]##\0'/ ':target:package or package component:' "
+	" TEMPLATE_NAME " " $matchany ':name:template name:_path_files -W \"$templatesdir\" -g \"*.hsfiles(-.:r)\"' "
+	" TEST_ARGS " " $matchany ':args:arguments:' "
+	" URL " " $matchany ':url:url:' "
+	" VARIANT " " $matchany ':variant:ghc variant:' "
+	" VERBOSITY " " /$'(silent|error|warn|info|debug)\0'/ ':verbosity:verbosity:(silent error warn info debug)' "
+	" WORK-DIR " " $matchany ':directory:directory:_dirs' "
+    )
+    # remove any existing _stack functions
+    local -a stack_cmds 
+    stack --help | _stack_get_commands stack_cmds 
+    local cmd
+    # remove all preexisting stack completion functions
+    for cmd in "${stack_cmds[@]}"; do
+	for func in "${(k@)functions[(I)_stack_$cmd*]}"; do
+	    if whence -w $func >/dev/null; then
+		unfunction $func
+	    fi
+	done
+    done
+    if whence -w _stack >/dev/null; then
+	unfunction _stack
+    fi
+    # Create main stack completion function
+    _create_stack_completion_function STACKOPTARGS stack
+    # Set tag-order so that options are completed separately from arguments
+    zstyle ":completion:${curcontext}:" tag-order '! options'
+
+    # Execute the completion function
+    _stack "$@"
+}
+
+# Local Variables:"
+# mode:sh"
+# End:"

--- a/doc/shell_autocompletion.md
+++ b/doc/shell_autocompletion.md
@@ -16,20 +16,6 @@ You can also add it to your `.bashrc` file if you want.
 
 ## for ZSH users
 
-documentation says:
-> Zsh can handle bash completions functions. The latest development version of zsh has a function bashcompinit, that when run will allow zsh to read bash completion specifications and functions. This is documented in the zshcompsys man page. To use it all **you need to do is run bashcompinit at any time after compinit**. It will define complete and compgen functions corresponding to the bash builtins.
+Copy the `_stack` and `_completion_helpers` files into a directory on your `$fpath`, e.g. ~/.oh-my-zsh/custom/completions/.
 
-You must so:
-  1. launch compinint
-  2. launch bashcompinit
-  3. eval stack bash completion script
 
-```shell
-autoload -U +X compinit && compinit
-autoload -U +X bashcompinit && bashcompinit
-eval "$(stack --bash-completion-script stack)"
-```
-
-:information_source: If you already have quite a large zshrc, or if you use oh-my-zsh, **compinit** will probably already be loaded. If you have a blank zsh config, all of the 3 lines above are necessary.
-
-:gem: tip: instead of running those 3 lines from your shell every time you want to use stack, you can add those 3 lines in your $HOME/.zshrc file


### PR DESCRIPTION
The files _completion_helpers and _stack provide much better completion
than the bash completer. They provide command and options descriptions, and
completion of subcommands and option arguments.
The completion function is dynamically generated based on --help output
for stack and it's subcommands, so that it should always be up to date
as long as the help output keeps the same format.