### PR TITLE
All test suites run even when only one is requested

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1179,7 +1179,9 @@ singleTest runInBase topts testsToRun ac ee task installedMap = do
             hpcDir <- hpcDirFromDir pkgDir
             when needHpc (createTree hpcDir)
 
-            errs <- liftM Map.unions $ forM (Map.toList (packageTests package)) $ \(testName, suiteInterface) -> do
+            let suitesToRun = Map.toList $ packageTests package
+
+            errs <- liftM Map.unions $ forM suitesToRun $ \(testName, suiteInterface) -> do
                 let stestName = T.unpack testName
                 (testName', isTestTypeLib) <-
                     case suiteInterface of

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1179,7 +1179,12 @@ singleTest runInBase topts testsToRun ac ee task installedMap = do
             hpcDir <- hpcDirFromDir pkgDir
             when needHpc (createTree hpcDir)
 
-            let suitesToRun = Map.toList $ packageTests package
+            let suitesToRun
+                  = [ testSuitePair
+                    | testSuitePair <- Map.toList $ packageTests package
+                    , let testName = fst testSuitePair
+                    , testName `elem` testsToRun
+                    ]
 
             errs <- liftM Map.unions $ forM suitesToRun $ \(testName, suiteInterface) -> do
                 let stestName = T.unpack testName


### PR DESCRIPTION
In a previous version of `stack`, running

    stack test my-project:test:test-suite-1

would only run `test-suite-1`. The behaviour now seems to be to run all test suites.

Furthermore, running

    stack clean
    stack test my-project:test:test-suite-1

only seems to _build_ the given test suite but then attempts to run them all, and obviously the rest of them fail with `executable not found`.

