### PR TITLE
Hide `nix-shell-file` from help text

### DIFF
--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -374,7 +374,8 @@ nixOptsParser hide0 = overrideActivation <$>
                                  hide)))
   <*> optional (option str (long "nix-shell-file" <>
                             metavar "FILEPATH" <>
-                            help "Nix file to be used to launch a nix-shell (for regular Nix users)"))
+                            help "Nix file to be used to launch a nix-shell (for regular Nix users)" <>
+                            hide))
   <*> (fmap (map T.pack)
        <$> optional (argsOption (long "nix-shell-options" <>
                                  metavar "OPTIONS" <>


### PR DESCRIPTION
#### Expected
```
$ stack image --help
Usage: stack image COMMAND [--help]
  Subcommands specific to imaging (EXPERIMENTAL)

Available options:
  --help                   Show this help text

Available commands:
  container                Build a Docker image for the project

Run 'stack --help' for global options that apply to all subcommands.
```

#### Actual:
```
$ stack image --help
Usage: stack image [--nix-shell-file FILEPATH] COMMAND
                   [--nix-shell-file FILEPATH] [--help]
  Subcommands specific to imaging (EXPERIMENTAL)

Available options:
  --nix-shell-file FILEPATH
                           Nix file to be used to launch a nix-shell (for
                           regular Nix users)
  --nix-shell-file FILEPATH
                           Nix file to be used to launch a nix-shell (for
                           regular Nix users)
  --help                   Show this help text

Available commands:
  container                Build a Docker image for the project

Run 'stack --help' for global options that apply to all subcommands.
```