### PR TITLE
Remove aberrant double spaces in generated text

### DIFF
--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -191,7 +191,7 @@ processLoadResult mdb _ (reason, lh) = do
         , packageNameText (fst (lhPair lh))
         ] ++
         maybe [] (\db -> [", from ", T.pack (show db), ","]) mdb ++
-        [ " due to "
+        [ " due to"
         , case reason of
             Allowed -> " the impossible?!?!"
             NeedsProfiling -> " it needing profiling."


### PR DESCRIPTION
Annoying double space in generated (verbose?) text.

For example: 
```
[debug] Ignoring package Cabal due to  wanting version 1.22.5.0 instead of 1.22.4.0
```
Note the double space in "to  wanting".