### PR TITLE
[docs] Small fix in 'How to contribute' section.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -119,7 +119,7 @@ installed.
 3. Build `stack` using a pre-existing `stack` install with
    `stack setup && stack build`.
 4. Once `stack` finishes building, check the stack version with
-   `stack --version`. Make sure the version is the latest.
+   `stack exec stack -- --version`. Make sure the version is the latest.
 5. Look for issues tagged with
    [`newcomer` and `awaiting-pr` labels](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3Anewcomer+label%3A%22awaiting+pr%22).
 


### PR DESCRIPTION
Following steps from "How to contribute" section, I've noticed that `stack --version` doesn't launch newly-built stack executable and probably should be changed to `stack exec stack -- --version`.