### PR TITLE
stack.cabal: remove the redundant build-dependency on email-validate

### DIFF
--- a/stack.cabal
+++ b/stack.cabal
@@ -205,7 +205,6 @@ library
                    , word8
                    , hastache
                    , project-template >= 0.2
-                   , email-validate >=2.0
                    , uuid
   if os(windows)
     cpp-options:     -DWINDOWS


### PR DESCRIPTION
The build dependency on email-validate from bcf73ec0 seem to be redundant.