### PR TITLE
Include the current working directory in process failure exceptions

### DIFF
--- a/src/System/Process/Read.hs
+++ b/src/System/Process/Read.hs
@@ -192,10 +192,11 @@ data ReadProcessException
     | ExecutableNotFoundAt FilePath
     deriving Typeable
 instance Show ReadProcessException where
-    show (ReadProcessException cp ec out err) = concat
+    show (ReadProcessException cp ec out err) = concat $
         [ "Running "
-        , showSpec $ cmdspec cp
-        , " exited with "
+        , showSpec $ cmdspec cp] ++
+        maybe [] (\x -> [" in directory ", x]) (cwd cp) ++
+        [ " exited with "
         , show ec
         , "\n"
         , toStr out


### PR DESCRIPTION
This makes reproducing bugs much easier. Now I see:

   Running C:\Program Files (x86)\Git\cmd\git.exe fetch --tags --depth=1 in directory C:\Users\ndmit_000\AppData\Roaming\stack\indices\Hackage\git-update\all-cabal-hashes\ exited with ExitFailure 128

Before I just saw a git, but the directory it was in took ages to find.