### PR TITLE
Stack init and solver overhaul

### DIFF
--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -695,8 +695,9 @@ selectBestSnapshot gpds snaps = do
           | (Map.size e1) <= (Map.size e2) = (s1, e1)
           | otherwise = (s2, e2)
 
-        reportResult (BuildPlanCheckOk _) snap =
+        reportResult (BuildPlanCheckOk _) snap = do
             $logInfo $ "* Selected " <> renderSnapName snap
+            $logInfo ""
 
         reportResult (BuildPlanCheckPartial _ errs) snap = do
             $logWarn $ "* Partially matches " <> renderSnapName snap
@@ -705,9 +706,9 @@ selectBestSnapshot gpds snaps = do
         reportResult (BuildPlanCheckFail compiler errs) snap = do
             $logWarn $ "* Rejected "
                        <> renderSnapName snap
-                       <> " due to conflicting compiler ("
+                       <> " due to conflict of compiler ("
                        <> compilerVersionText compiler
-                       <> ") requirements"
+                       <> ") packages"
             displayDepErrors errs
 
 displayDepErrors :: MonadLogger m => DepErrors -> m ()

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -21,7 +21,7 @@ import qualified Data.Yaml as Yaml
 import           Network.HTTP.Client.Conduit (HasHttpManager)
 import           Path
 import           Stack.BuildPlan
-import           Stack.Init
+import           Stack.Config (makeConcreteResolver)
 import           Stack.Types
 
 data ConfigCmdSet = ConfigCmdSetResolver AbstractResolver

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -69,8 +69,16 @@ initProject currDir initOpts = do
     let noPkgMsg =  "In order to init, you should have an existing .cabal \
                     \file. Please try \"stack new\" instead."
 
+        dupPkgFooter = "You have the following options:\n"
+            <> "- Use '--ignore-subdirs' command line switch to ignore "
+            <> "packages in subdirectories. You can init subdirectories as "
+            <> "independent projects.\n"
+            <> "- Put selected packages in the stack config file "
+            <> "and then use 'stack solver' command to automatically resolve "
+            <> "dependencies and update the config file."
+
     cabalfps <- findCabalFiles (includeSubDirs initOpts) currDir
-    gpds <- cabalPackagesCheck cabalfps noPkgMsg
+    gpds <- cabalPackagesCheck cabalfps noPkgMsg dupPkgFooter
 
     (r, flags, extraDeps) <-
         getDefaultResolver dest (map parent cabalfps) gpds initOpts

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -207,10 +207,10 @@ getDefaultResolver stackYaml cabalfps gpds initOpts = do
     case result of
         BuildPlanCheckFail _ _ -> throwM $ ResolverMismatch resolver
         BuildPlanCheckOk flags -> return (resolver, flags, Map.empty)
-        BuildPlanCheckPartial _ _
+        BuildPlanCheckPartial flags _
             | needSolver resolver initOpts ->
                 solveResolverSpec stackYaml (map parent cabalfps)
-                                  (resolver, Map.empty, Map.empty)
+                                  (resolver, flags, Map.empty)
             | otherwise -> throwM $ ResolverPartial resolver
     where
       -- TODO support selecting best across regular and custom snapshots

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -46,6 +46,7 @@ import           Stack.Types
 import           Stack.Types.Internal            ( HasTerminal, HasReExec
                                                  , HasLogLevel)
 import           System.Directory                (getDirectoryContents)
+import           System.FilePath                 (dropTrailingPathSeparator)
 import           Stack.Config                    ( getSnapshots
                                                  , makeConcreteResolver)
 
@@ -55,7 +56,8 @@ findCabalFiles recurse dir =
   where
     isCabal path = ".cabal" `isSuffixOf` toFilePath path
 
-    isIgnored path = toFilePath (dirname path) `Set.member` ignoredDirs
+    isIgnored path = dropTrailingPathSeparator (toFilePath (dirname path))
+                     `Set.member` ignoredDirs
 
 -- | Special directories that we don't want to traverse for .cabal files
 ignoredDirs :: Set FilePath

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -85,7 +85,8 @@ initProject currDir initOpts = do
     let p = Project
             { projectPackages = pkgs
             , projectExtraDeps = extraDeps
-            , projectFlags = flags
+            -- TODO do not write flags with default values
+            , projectFlags = Map.filter (not . Map.null) flags
             , projectResolver = r
             , projectCompiler = Nothing
             , projectExtraPackageDBs = []
@@ -211,9 +212,7 @@ getDefaultResolver stackYaml cabalDirs gpds initOpts = do
                                          (res, srcConstraints, Map.empty)
           case mresolver of
               Just (src, ext) -> do
-                  let flags  = fmap snd (Map.union src ext)
-                      flags' = Map.filter (not . Map.null) flags
-                  return (res, flags', fmap fst ext)
+                  return (res, fmap snd (Map.union src ext), fmap fst ext)
               Nothing
                   | forceOverwrite initOpts -> do
                       $logWarn "\nSolver could not arrive at a workable build \

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -85,8 +85,7 @@ initProject currDir initOpts = do
     let p = Project
             { projectPackages = pkgs
             , projectExtraDeps = extraDeps
-            -- TODO do not write flags with default values
-            , projectFlags = Map.filter (not . Map.null) flags
+            , projectFlags = removeSrcPkgDefaultFlags gpds flags
             , projectResolver = r
             , projectCompiler = Nothing
             , projectExtraPackageDBs = []

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -199,11 +199,11 @@ getDefaultResolver stackYaml cabalDirs gpds initOpts = do
     result   <- checkResolverSpec gpds Nothing resolver
 
     case result of
-        BuildPlanCheckFail _ _ -> throwM $ ResolverMismatch resolver
         BuildPlanCheckOk flags -> return (resolver, flags, Map.empty)
         BuildPlanCheckPartial flags _
             | needSolver resolver initOpts -> solve (resolver, flags)
             | otherwise -> throwM $ ResolverPartial resolver
+        BuildPlanCheckFail _ _ _ -> throwM $ ResolverMismatch resolver
 
     where
       solve (res, f) = do

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -204,20 +204,16 @@ getDefaultResolver stackYaml cabalDirs gpds initOpts = do
             | otherwise -> throwM $ ResolverPartial resolver
     where
       -- TODO support selecting best across regular and custom snapshots
-      getResolver (MethodSnapshot snapPref) = selectSnapResolver snapPref
+      getResolver (MethodSnapshot snapPref)  = selectSnapResolver snapPref
       getResolver (MethodResolver aresolver) = makeConcreteResolver aresolver
 
       selectSnapResolver snapPref =
           getSnapshots'
           >>= maybe (throwM NoMatchingSnapshot)
-                  (getRecommendedSnapshots snapPref)
+                    (getRecommendedSnapshots snapPref)
           >>= selectBestSnapshot gpds
           >>= maybe (throwM NoMatchingSnapshot)
-                    (\s -> do
-                      $logInfo ("Selected snapshot '"
-                                <> (renderSnapName s)
-                                <> "'.")
-                      return $ ResolverSnapshot s)
+                    (return . ResolverSnapshot)
 
       needSolver _ (InitOpts {useSolver = True}) = True
       needSolver (ResolverCompiler _)  _ = True

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -199,7 +199,7 @@ getDefaultResolver stackYaml cabalDirs gpds initOpts = do
         BuildPlanCheckOk flags -> return (resolver, flags, Map.empty)
         BuildPlanCheckPartial flags _
             | needSolver resolver initOpts ->
-                solveResolverSpec stackYaml cabalDirs
+                solveResolverSpec stackYaml cabalDirs (gpdPackages gpds)
                                   (resolver, flags, Map.empty)
             | otherwise -> throwM $ ResolverPartial resolver
     where

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -783,8 +783,8 @@ ghcVariantParser hide =
 -- | Parser for @solverCmd@
 solverOptsParser :: Parser Bool
 solverOptsParser = boolFlags False
-    "modify-stack-yaml"
-    "Automatically modify stack.yaml with the solver's recommendations"
+    "update-config"
+    "Automatically update stack.yaml with the solver's recommendations"
     idm
 
 -- | Parser for test arguments.

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -694,7 +694,7 @@ initOptsParser =
     resolver = option readAbstractResolver
         (long "resolver" <>
          metavar "RESOLVER" <>
-         help "Use the given resolver, even if not all dependencies are met")
+         help "Use the specified resolver")
 
 -- | Parser for a logging level.
 logLevelOptsParser :: Bool -> Maybe LogLevel -> Parser (Maybe LogLevel)

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -670,20 +670,17 @@ globalOptsFromMonoid defaultTerminal GlobalOptsMonoid{..} = GlobalOpts
 
 initOptsParser :: Parser InitOpts
 initOptsParser =
-    InitOpts <$> method <*> overwrite <*> fmap not ignoreSubDirs
+    InitOpts <$> method <*> solver <*> overwrite <*> fmap not ignoreSubDirs
   where
     ignoreSubDirs = switch (long "ignore-subdirs" <>
                            help "Do not search for .cabal files in sub directories")
     overwrite = switch (long "force" <>
                        help "Force overwriting of an existing stack.yaml if it exists")
-    method = solver
-         <|> (MethodResolver <$> resolver)
-         <|> (MethodSnapshot <$> snapPref)
+    solver = switch (long "solver" <>
+             help "Use a dependency solver to determine extra dependencies")
 
-    solver =
-        flag' MethodSolver
-            (long "solver" <>
-             help "Use a dependency solver to determine dependencies")
+    method = (MethodResolver <$> resolver)
+         <|> (MethodSnapshot <$> snapPref)
 
     snapPref =
         flag' PrefLTS

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -675,7 +675,8 @@ initOptsParser =
     ignoreSubDirs = switch (long "ignore-subdirs" <>
                            help "Do not search for .cabal files in sub directories")
     overwrite = switch (long "force" <>
-                       help "Force overwriting of an existing stack.yaml if it exists")
+                       help "Force overwriting an existing stack.yaml or \
+                            \creating a stack.yaml with incomplete config.")
     solver = switch (long "solver" <>
              help "Use a dependency solver to determine extra dependencies")
 

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -16,8 +16,10 @@ module Stack.Setup
   ( setupEnv
   , ensureCompiler
   , ensureDockerStackExe
+  , getSystemCompiler
   , SetupOpts (..)
   , defaultStackSetupYaml
+  , removeHaskellEnvVars
   ) where
 
 import           Control.Applicative

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -152,7 +152,7 @@ data ExtraDirs = ExtraDirs
     { edBins :: ![FilePath]
     , edInclude :: ![FilePath]
     , edLib :: ![FilePath]
-    }
+    } deriving (Show)
 instance Monoid ExtraDirs where
     mempty = ExtraDirs [] [] []
     mappend (ExtraDirs a b c) (ExtraDirs x y z) = ExtraDirs

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -181,14 +181,16 @@ getCabalConfig dir constraintType constraints = do
             , ":http://0.0.0.0/fake-url"
             ]
 
-    goConstraint (name, version) = T.concat
-        [ (if constraintType == Constraint
-           then "constraint: "
-           else "preference: ")
-        , T.pack $ packageNameString name
-        , "=="
-        , T.pack $ versionString version
-        ]
+    goConstraint (name, version) =
+        assert (not . null . versionString $ version) $
+            T.concat
+              [ (if constraintType == Constraint
+                 then "constraint: "
+                 else "preference: ")
+              , T.pack $ packageNameString name
+              , "=="
+              , T.pack $ versionString version
+              ]
 
 setupCompiler
     :: ( MonadBaseControl IO m, MonadIO m, MonadLogger m, MonadMask m
@@ -273,10 +275,6 @@ solveResolverSpec stackYaml cabalDirs srcPackages
     $logInfo $ "Using resolver: " <> resolverName resolver
     (compilerVer, snapPackages) <- getResolverMiniPlan resolver
     menv <- setupCabalEnv compilerVer
-
-    let assertVer v = assert ((not . null . versionString) v) $ return ()
-    mapM_ assertVer snapPackages
-    mapM_ assertVer extraPackages
 
     -- Note - The order in Map.union below is important.
     -- We prefer extraPackages over the snapshot packages.

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -483,12 +483,13 @@ solveExtraDeps modStackYaml = do
         printFlags goneFlags "* Flags to be deleted"
         printDeps  goneDeps  "* Dependencies to be deleted"
 
+        -- TODO backup the old config file
         if modStackYaml then do
             writeStackYaml stackYaml resolver extraDeps flags
             $logInfo $ "Updated " <> T.pack relStackYaml
         else do
             $logInfo $ "To automatically update " <> T.pack relStackYaml
-                       <> ", rerun with '--modify-stack-yaml'"
+                       <> ", rerun with '--update-config'"
      else
         $logInfo $ "No changes needed to " <> T.pack relStackYaml
 

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -467,8 +467,9 @@ reportMissingCabalFiles cabalfps includeSubdirs = do
     allCabalfps <- findCabalFiles (includeSubdirs) =<< getWorkingDir
 
     relpaths <- mapM makeRel (allCabalfps \\ cabalfps)
-    $logWarn $ "The following packages are missing from the config:"
-    $logWarn $ T.pack (formatGroup relpaths)
+    when (not (null relpaths)) $ do
+        $logWarn $ "The following packages are missing from the config:"
+        $logWarn $ T.pack (formatGroup relpaths)
 
 -- | Solver can be thought of as a counterpart of init. init creates a
 -- stack.yaml whereas solver verifies or fixes an existing one. It can verify
@@ -535,7 +536,7 @@ solveExtraDeps modStackYaml = do
         Just x -> return x
 
     let
-        flags    = Map.filter (not . Map.null) (fmap snd (Map.union srcs edeps))
+        flags = removeSrcPkgDefaultFlags gpds (fmap snd (Map.union srcs edeps))
         versions = fmap fst edeps
 
         vDiff v v' = if v == v' then Nothing else Just v

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -497,12 +497,12 @@ solveExtraDeps modStackYaml = do
 
     resolverResult <- checkResolverSpec gpds (Just oldSrcFlags) resolver
     resultSpecs <- case resolverResult of
-        BuildPlanCheckFail _ _ -> throwM $ ResolverMismatch resolver
         BuildPlanCheckOk flags ->
             return $ Just ((mergeConstraints oldSrcs flags), Map.empty)
         BuildPlanCheckPartial _ _ ->
             solveResolverSpec stackYaml cabalDirs
                               (resolver, srcConstraints, extraConstraints)
+        BuildPlanCheckFail _ _ _ -> throwM $ ResolverMismatch resolver
 
     (srcs, edeps) <- case resultSpecs of
         Nothing -> throwM (SolverGiveUp Nothing)

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -121,8 +121,6 @@ data StackBuildException
   | TargetParseException [Text]
   | DuplicateLocalPackageNames [(PackageName, [Path Abs Dir])]
   | SolverMissingCabalInstall
-  | SolverMissingGHC
-  | SolverNoCabalFiles
   | SomeTargetsNotBuildable [(PackageName, NamedComponent)]
   deriving Typeable
 
@@ -325,14 +323,6 @@ instance Show StackBuildException where
     show SolverMissingCabalInstall = unlines
         [ "Solver requires that cabal be on your PATH"
         , "Try running 'stack install cabal-install'"
-        ]
-    show SolverMissingGHC = unlines
-        [ "Solver requires that GHC be on your PATH"
-        , "Try running 'stack setup'"
-        ]
-    show SolverNoCabalFiles = unlines
-        [ "No cabal files provided.  Maybe this is due to not having a stack.yaml file?"
-        , "Try running 'stack init' to create a stack.yaml"
         ]
     show (SomeTargetsNotBuildable xs) =
         "The following components have 'buildable: False' set in the cabal configuration, and so cannot be targets:\n    " ++

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -70,6 +70,7 @@ import           GHC.Generics
 import           Path (Path, Abs, File, Dir, mkRelDir, toFilePath, parseRelDir, (</>))
 import           Path.Extra (toFilePathNoTrailingSep)
 import           Prelude
+import           Stack.Constants (stackDotYaml)
 import           Stack.Types.FlagName
 import           Stack.Types.GhcPkgId
 import           Stack.Types.Compiler
@@ -120,6 +121,7 @@ data StackBuildException
   | InvalidFlagSpecification (Set UnusedFlags)
   | TargetParseException [Text]
   | DuplicateLocalPackageNames [(PackageName, [Path Abs Dir])]
+  | SolverGiveUp (Maybe String)
   | SolverMissingCabalInstall
   | SomeTargetsNotBuildable [(PackageName, NamedComponent)]
   deriving Typeable
@@ -320,6 +322,19 @@ instance Show StackBuildException where
             : (packageNameString name ++ " used in:")
             : map goDir dirs
         goDir dir = "- " ++ toFilePath dir
+    show (SolverGiveUp footer) = concat
+        [ "\nSolver could not resolve package dependencies. "
+        , "You can:\n"
+        , "- Use 'stack update' to update the package index and try again.\n"
+        , "- Add some extra dependencies in " <> toFilePath stackDotYaml
+        , " and then use 'stack solver' to figure out the rest.\n"
+        , "- Add any missed local or remote source package required to "
+        , "build your package.\n"
+        , "- Remove any unnecessary packages which may be causing dependency "
+        , "issues.\n"
+        , "- Use '--ignore-subdirs' to ignore packages in subdirectories.\n"
+        , maybe "" (("\n" <>) . id) footer
+        ]
     show SolverMissingCabalInstall = unlines
         [ "Solver requires that cabal be on your PATH"
         , "Try running 'stack install cabal-install'"

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -70,7 +70,6 @@ import           GHC.Generics
 import           Path (Path, Abs, File, Dir, mkRelDir, toFilePath, parseRelDir, (</>))
 import           Path.Extra (toFilePathNoTrailingSep)
 import           Prelude
-import           Stack.Constants (stackDotYaml)
 import           Stack.Types.FlagName
 import           Stack.Types.GhcPkgId
 import           Stack.Types.Compiler
@@ -121,7 +120,7 @@ data StackBuildException
   | InvalidFlagSpecification (Set UnusedFlags)
   | TargetParseException [Text]
   | DuplicateLocalPackageNames [(PackageName, [Path Abs Dir])]
-  | SolverGiveUp (Maybe String)
+  | SolverGiveUp String
   | SolverMissingCabalInstall
   | SomeTargetsNotBuildable [(PackageName, NamedComponent)]
   deriving Typeable
@@ -322,18 +321,10 @@ instance Show StackBuildException where
             : (packageNameString name ++ " used in:")
             : map goDir dirs
         goDir dir = "- " ++ toFilePath dir
-    show (SolverGiveUp footer) = concat
-        [ "\nSolver could not resolve package dependencies. "
-        , "You can:\n"
-        , "- Use 'stack update' to update the package index and try again.\n"
-        , "- Add some extra dependencies in " <> toFilePath stackDotYaml
-        , " and then use 'stack solver' to figure out the rest.\n"
-        , "- Add any missed local or remote source package required to "
-        , "build your package.\n"
-        , "- Remove any unnecessary packages which may be causing dependency "
-        , "issues.\n"
-        , "- Use '--ignore-subdirs' to ignore packages in subdirectories.\n"
-        , maybe "" (("\n" <>) . id) footer
+    show (SolverGiveUp msg) = concat
+        [ "\nSolver could not resolve package dependencies.\n"
+        , "You can try the following:\n"
+        , msg
         ]
     show SolverMissingCabalInstall = unlines
         [ "Solver requires that cabal be on your PATH"

--- a/src/System/Process/Read.hs
+++ b/src/System/Process/Read.hs
@@ -198,7 +198,7 @@ instance Show ReadProcessException where
         maybe [] (\x -> [" in directory ", x]) (cwd cp) ++
         [ " exited with "
         , show ec
-        , "\n"
+        , "\n\n"
         , toStr out
         , "\n"
         , toStr err


### PR DESCRIPTION
These commits are part of a series of commits to enhance the `stack init` and `solver` functionality. The goal is to be able to automatically init any project which has a working cabal file. Similarly the `stack solver` command should be able to verify and fix the configuration in an optimal manner. Also, to provide a better user experience by providing informative error messages and next steps at every failure. In other words, init should just work and be smooth and painless and always work unless the package is really broken.

See also #1529 and #1533.

The commit messages have more details about the problems and fixes. I will be adding more commits to the branch very soon. I am pushing these out for an early review. The changes are logically self contained, add incremental functionality and should not break any existing functionality.

**Please review individual commits in order and see the commit messages for an overview of each commit.**