### PR TITLE
Fix version mismatch in Travis-CI doc

### DIFF
--- a/doc/travis_ci.md
+++ b/doc/travis_ci.md
@@ -66,7 +66,7 @@ explain the second option. With single GHC the situation is simple:
 
 ```yaml
 before_install:
-  - export PATH=/opt/ghc/7.8.4/bin:$PATH
+  - export PATH=/opt/ghc/7.10.2/bin:$PATH
 
 addons:
   apt:


### PR DESCRIPTION
The installed version did not match with what was added to PATH,
effectively ignoring installed GHC.