### PR TITLE
Nix: Select the correct GHC version in more cases.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,10 @@ Bug fixes:
   [Mailing list discussion](https://groups.google.com/d/msg/haskell-stack/iVGDG5OHYxs/FjUrR5JsDQAJ)
 - Gracefully handle invalid paths in error/warning messages
   [#1561](https://github.com/commercialhaskell/stack/issues/1561)
+- Nix: select the correct GHC version corresponding to the snapshot
+  even when an abstract resolver is passed via `--resolver` on the
+  command-line.
+  [#1641](https://github.com/commercialhaskell/stack/issues/1641)
 
 ## 1.0.0
 

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -234,7 +234,7 @@ configFromConfigMonoid configStackRoot configUserConfigPath mresolver mproject c
 
      configDocker <-
          dockerOptsFromMonoid (fmap fst mproject) configStackRoot mresolver configMonoidDockerOpts
-     configNix <- nixOptsFromMonoid (fmap fst mproject) mresolver configMonoidNixOpts os
+     configNix <- nixOptsFromMonoid configMonoidNixOpts os
 
      rawEnv <- liftIO getEnvironment
      pathsEnv <- augmentPathMap (map toFilePath configMonoidExtraPath)

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -698,7 +698,7 @@ setupCmd SetupCmdOpts{..} go@GlobalOpts{..} = do
           (lcProjectRoot lc)
           Nothing
           (runStackTGlobal manager (lcConfig lc) go $
-           Nix.reexecWithOptionalShell (lcProjectRoot lc) $
+           Nix.reexecWithOptionalShell (lcProjectRoot lc) globalResolver $
            runStackLoggingTGlobal manager go $ do
               (wantedCompiler, compilerCheck, mstack) <-
                   case scoCompilerVersion of
@@ -864,7 +864,7 @@ withBuildConfigExt go@GlobalOpts{..} mbefore inner mafter = do
                  (lcProjectRoot lc)
                  mbefore
                  (runStackTGlobal manager (lcConfig lc) go $
-                    Nix.reexecWithOptionalShell (lcProjectRoot lc) (inner'' lk0))
+                    Nix.reexecWithOptionalShell (lcProjectRoot lc) globalResolver (inner'' lk0))
                  mafter
                  (Just $ liftIO $
                       do lk' <- readIORef curLk
@@ -1007,6 +1007,7 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
                         menv <- liftIO $ configEnvOverride config plainEnvSettings
                         Nix.reexecWithOptionalShell
                             (lcProjectRoot lc)
+                            globalResolver
                             (runStackTGlobal manager (lcConfig lc) go $
                                 exec menv cmd args))
                     Nothing


### PR DESCRIPTION
Even when abstract resolver is provided.

Fixes #1641.