### PR TITLE
Add static flag to the stack executable

### DIFF
--- a/stack.cabal
+++ b/stack.cabal
@@ -41,6 +41,13 @@ flag disable-git-info
   -- should otherwise be avoided
   -- see: https://github.com/commercialhaskell/stack/issues/1425
 
+flag static
+  manual: True
+  default: False
+  description: Pass -static/-pthread to ghc when linking the stack binary.
+  -- Not intended for general use. Simply makes it easier to
+  -- build a fully static binary on Linux platforms that enable it.
+
 library
   hs-source-dirs:    src/
   ghc-options:       -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
@@ -218,6 +225,8 @@ executable stack
   main-is:        Main.hs
   ghc-options:    -threaded -rtsopts -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   other-modules:  Paths_stack
+  if flag(static)
+      ld-options: -static -pthread
 
   build-depends:  base >=4.7 && < 5
                 , bytestring >= 0.10.4.0


### PR DESCRIPTION
Add an optional flag, that is off by default to allow the stack binary to be created as a fully static executable.

This is primarily to enable fully static binaries on Alpine Linux which uses musl libc and is designed for static linking. The resultant binaries can run on almost any linux however, depending on libc used. (don't do this with glibc distributions unless you like weird behavior)

Example:
```
/tmp/stack-1.0.0 # cabal install -fstatic
Resolving dependencies...
In order, the following will be installed:
stack-1.0.0 (latest: 9.9.9) +static (reinstall) (changes: gitrev-1.1.0 added, optparse-simple-0.0.3 added)
Warning: Note that reinstalls are always dangerous. Continuing anyway...
Notice: installing into a sandbox located at /tmp/stack-1.0.0/.cabal-sandbox
Configuring stack-1.0.0...
Building stack-1.0.0...
Installed stack-1.0.0
/tmp/stack-1.0.0 # file ./.cabal-sandbox/bin/stack
./.cabal-sandbox/bin/stack: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
/tmp/stack-1.0.0 # rm ./.cabal-sandbox/bin/stack
/tmp/stack-1.0.0 # cabal install
Resolving dependencies...
In order, the following will be installed:
stack-1.0.0 (latest: 9.9.9) (reinstall) (changes: gitrev-1.1.0 added, optparse-simple-0.0.3 added)
Warning: Note that reinstalls are always dangerous. Continuing anyway...
Notice: installing into a sandbox located at /tmp/stack-1.0.0/.cabal-sandbox
Configuring stack-1.0.0...
Building stack-1.0.0...
Installed stack-1.0.0
/tmp/stack-1.0.0 # file ./.cabal-sandbox/bin/stack
./.cabal-sandbox/bin/stack: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-x86_64.so.1, stripped
/tmp/stack-1.0.0 # ldd ./.cabal-sandbox/bin/stack
        /lib/ld-musl-x86_64.so.1 (0x55a845acf000)
        libz.so.1 => /lib/libz.so.1 (0x7f02ce69f000)
        libgmp.so.10 => /usr/lib/libgmp.so.10 (0x7f02ce43b000)
        libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x55a845acf000)
```