### PR TITLE
Change 'stack ghc' to provide package context

### DIFF
--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -13,7 +13,6 @@ module Stack.Ghci
     , GhciPkgInfo(..)
     , GhciException(..)
     , ghciSetup
-    , ghciSetup'
     , ghci
     ) where
 
@@ -101,14 +100,6 @@ instance Show GhciException where
         [ "Not attempting to start ghci due to these duplicate modules."
         , "Use --no-load to try to start it anyway, without loading any modules (but these are still likely to cause errors)"
         ]
-
-ghciSetup' :: (MonadIO f, HasHttpManager r, MonadReader r f, MonadBaseControl IO f, MonadMask f, MonadLogger f, HasEnvConfig r, HasTerminal r, HasLogLevel r) => GhciOpts -> f [String]
-ghciSetup' opts = genOpts . extract <$> ghciSetup opts
-  where
-    extract (_, _, x) = x
-    genOpts :: [GhciPkgInfo] -> [String]
-    genOpts pkgs = nubOrd (concatMap (concatMap (oneWordOpts . snd) . ghciPkgOpts) pkgs)
-    oneWordOpts bio = bioOneWordOpts bio ++ bioPackageFlags bio
 
 -- | Launch a GHCi session for the given local package targets with the
 -- given options and configure it with the load paths and extensions

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -13,6 +13,7 @@ module Stack.Ghci
     , GhciPkgInfo(..)
     , GhciException(..)
     , ghciSetup
+    , ghciSetup'
     , ghci
     ) where
 
@@ -100,6 +101,14 @@ instance Show GhciException where
         [ "Not attempting to start ghci due to these duplicate modules."
         , "Use --no-load to try to start it anyway, without loading any modules (but these are still likely to cause errors)"
         ]
+
+ghciSetup' :: (MonadIO f, HasHttpManager r, MonadReader r f, MonadBaseControl IO f, MonadMask f, MonadLogger f, HasEnvConfig r, HasTerminal r, HasLogLevel r) => GhciOpts -> f [String]
+ghciSetup' opts = genOpts . extract <$> ghciSetup opts
+  where
+    extract (_, _, x) = x
+    genOpts :: [GhciPkgInfo] -> [String]
+    genOpts pkgs = nubOrd (concatMap (concatMap (oneWordOpts . snd) . ghciPkgOpts) pkgs)
+    oneWordOpts bio = bioOneWordOpts bio ++ bioPackageFlags bio
 
 -- | Launch a GHCi session for the given local package targets with the
 -- given options and configure it with the load paths and extensions

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -621,6 +621,10 @@ execOptsExtraParser = eoPlainParser <|>
                       ExecOptsEmbellished
                          <$> eoEnvSettingsParser
                          <*> eoPackagesParser
+                         <*> boolFlags False
+                                 "add-ghci-packages"
+                                 "prefix the executed command line with the same -package (etc.) args that would be used for GHCI"
+                                 idm
   where
     eoEnvSettingsParser :: Parser EnvSettings
     eoEnvSettingsParser = EnvSettings

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -383,6 +383,7 @@ data ExecOptsExtra
     | ExecOptsEmbellished
         { eoEnvSettings :: !EnvSettings
         , eoPackages :: ![String]
+        , eoGhciPackages :: !Bool
         }
     deriving (Show)
 

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -304,10 +304,6 @@ commandLineHandler progName isInterpreter = complicatedOptions
                     "Run ghc"
                     execCmd
                     (execOptsParser $ Just ExecGhc)
-        addCommand' "ghcCmd"
-                    "Run ghc with package context"
-                    ghcCmd
-                    (execOptsParser $ Just ExecGhc)
         addCommand' "ghci"
                     "Run ghci in the context of package(s) (experimental)"
                     ghciCmd
@@ -1060,17 +1056,6 @@ ghciCmd ghciOpts go@GlobalOpts{..} =
   withBuildConfigAndLock go $ \lk -> do
     munlockFile lk -- Don't hold the lock while in the GHCI.
     ghci ghciOpts
-
--- | Run GHC in the context of a project.
-ghcCmd :: ExecOpts -> GlobalOpts -> IO ()
-ghcCmd execOpts go@GlobalOpts { .. } =
-  withBuildConfig go $ do
-    pkgOpts <- ghciSetup' ghciOpts
-    let e = execOpts { eoArgs = ("-i" : "-hide-all-packages" : pkgOpts) ++ eoArgs execOpts }
-    liftIO $ execCmd e go
-  where
-    ghciOpts :: GhciOpts
-    ghciOpts = GhciOpts False [] Nothing False [] Nothing False False False defaultBuildOpts
 
 -- | Run ide-backend in the context of a project.
 ideCmd :: ([Text], [String]) -> GlobalOpts -> IO ()

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -23,6 +23,7 @@ import           Data.Attoparsec.Interpreter (getInterpreterArgs)
 import qualified Data.ByteString.Lazy as L
 import           Data.IORef
 import           Data.List
+import           Data.List.Extra (nubOrd)
 import qualified Data.Map as Map
 import qualified Data.Map.Strict as M
 import           Data.Maybe
@@ -1028,7 +1029,7 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
 
                if eoCmd == ExecGhc || eoGhciPackages
                then do
-                   pkgOpts <- ghciSetup' ghciOpts
+                   pkgOpts <- genOpts . extract <$> ghciSetup ghciOpts
                    exec menv cmd $ ("-i" : "-hide-all-packages" : pkgOpts) ++ args
                else
                    exec menv cmd args
@@ -1039,6 +1040,11 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
         return (cmd, args)
     ghciOpts :: GhciOpts
     ghciOpts = GhciOpts True [] Nothing False [] Nothing False False False defaultBuildOpts
+    extract (_, _, x) = x
+    genOpts :: [GhciPkgInfo] -> [String]
+    genOpts pkgs = nubOrd (concatMap (concatMap (oneWordOpts . snd) . ghciPkgOpts) pkgs)
+    oneWordOpts bio = bioOneWordOpts bio ++ bioPackageFlags bio
+
 
 -- | Evaluate some haskell code inline.
 evalCmd :: EvalOpts -> GlobalOpts -> IO ()

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -1029,12 +1029,20 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
                        }
                munlockFile lk -- Unlock before transferring control away.
                menv <- liftIO $ configEnvOverride config eoEnvSettings
-               exec menv cmd args
+
+               if eoCmd == ExecGhc || eoGhciPackages
+               then do
+                   pkgOpts <- ghciSetup' ghciOpts
+                   exec menv cmd $ ("-i" : "-hide-all-packages" : pkgOpts) ++ args
+               else
+                   exec menv cmd args
   where
     execCompiler cmdPrefix args = do
         wc <- getWhichCompiler
         let cmd = cmdPrefix ++ compilerExeName wc
         return (cmd, args)
+    ghciOpts :: GhciOpts
+    ghciOpts = GhciOpts True [] Nothing False [] Nothing False False False defaultBuildOpts
 
 -- | Evaluate some haskell code inline.
 evalCmd :: EvalOpts -> GlobalOpts -> IO ()

--- a/stack.cabal
+++ b/stack.cabal
@@ -257,6 +257,7 @@ executable stack
                 , conduit
                 , transformers
                 , http-client
+                , extra
   default-language:    Haskell2010
   if os(windows)
     build-depends:   Win32


### PR DESCRIPTION
This patch is necessary for me to use `flycheck` (which calls `stack ghc` internally) on a project that uses `cryptonite` with a package database that contains `cryptohash`.

Without it, I get flycheck errors like this:

```
    Ambiguous module name ‘Crypto.Hash’:
      it was found in multiple packages:
      cryptonite-0.10@crypt_9z0j8QI27Av2VIWw0mEkTO cryptohash-0.11.6@crypt_3Cwvwq9ssRY1dmVI1qI6C2
```

Related: https://github.com/flycheck/flycheck-haskell/issues/52