### PR TITLE
note in install_and_upgrade regarding #1515

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -70,9 +70,13 @@ If you have a popular [brew](http://brew.sh/) tool installed, you can just do:
 brew install haskell-stack
 ```
 
-Note: the Homebrew formula and bottles lag slightly behind new Stack releases,
+Note: 
+* the Homebrew formula and bottles lag slightly behind new Stack releases,
 but tend to be updated within a day or two.
-
+* at later stage, running `stack setup` might fail with `configure: error: cannot run C compiled programs.` in which case you should run:
+```
+$ xcode-select --install
+```
 Normally, Homebrew will install from a pre-built binary (aka "pour from a
 bottle"), but if `brew` starts trying to build everything from source (which
 will take hours), see


### PR DESCRIPTION
Small note prompting to run `xcode-select --install` if C compiler is not found while calling `stack setup`