### PR TITLE
Fix typos

### DIFF
--- a/doc/docker_integration.md
+++ b/doc/docker_integration.md
@@ -4,7 +4,7 @@ Docker integration
 `stack` has support for automatically performing builds inside a Docker
 container, using volume mounts and user ID switching to make it mostly seamless.
 FP Complete provides images for use with stack that include GHC, tools, and
-optionally have all of the Stackage LTS packages pre-installed in in the global
+optionally have all of the Stackage LTS packages pre-installed in the global
 package database.
 
 The primary purpose for using stack/docker this way is for teams to ensure all
@@ -72,10 +72,10 @@ in the last seven days marked for removal.  You can add or remove the `R` in
 the left-most column to flag or unflag an image/container for removal.  When
 you save the file and quit the text editor, those images marked for removal
 will be deleted from your system.  If you wish to abort the cleanup, delete
-all all the lines from your editor.
+all the lines from your editor.
 
 If you use Docker for purposes other than stack, you may have other images on
-your system as well.  These will also appear in in a separate section, but they
+your system as well.  These will also appear in a separate section, but they
 will not be marked for removal by default.
 
 Run `stack docker cleanup --help` to see additional options to customize its
@@ -320,7 +320,7 @@ Stackage snapshots.  In addition, `~/.stack` is volume-mounted from the host.
 
 ### Network
 
-stack containers use use the host's network stack within the container
+stack containers use the host's network stack within the container
 by default, meaning a process running in the container can connect to
 services running on the host, and a server process run within the container
 can be accessed from the host without needing to explicitly publish its port.


### PR DESCRIPTION
Remove extra `in` (2 instances)
Remove extra `all`
Remove extra `use`