### PR TITLE
Adds hpack support for when initing projects.

### DIFF
--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -205,8 +205,8 @@ applyTemplate project template nonceParams dir templateText = do
                    throwM (InvalidTemplate template (show e)))
     when (M.null files) $
          throwM (InvalidTemplate template "Template does not contain any files")
-    unless (any (".cabal" `isSuffixOf`) . M.keys $ files) $
-         throwM (InvalidTemplate template "Template does not contain a .cabal\
+    unless (any (\x -> or [".cabal" `isSuffixOf` x, x == "package.yaml"]) . M.keys $ files) $
+         throwM (InvalidTemplate template "Template does not contain a .cabal or `package.yaml`\
                                           \ file")
     liftM
         M.fromList

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -21,6 +21,7 @@ module Stack.Package
   ,readPackageUnresolvedBS
   ,resolvePackage
   ,findOrGenerateCabalFile
+  ,hpack
   ,Package(..)
   ,GetPackageFiles(..)
   ,GetPackageOpts(..)


### PR DESCRIPTION
This allows stack templates to define only a `package.yaml` file instead of a
`.cabal` file.

Let me know if this needs a bit more finesse around how it generates the cabal files.  I.e. I could probably unify how it walks the dir path generating as it goes if a package file is found, instead of walking twice.