### PR TITLE
Remove deprecated valid-wanted field

### DIFF
--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -226,7 +226,7 @@ getLocalPackageViews :: (MonadThrow m, MonadIO m, MonadReader env m, HasEnvConfi
                      => m (Map PackageName (LocalPackageView, GenericPackageDescription))
 getLocalPackageViews = do
     econfig <- asks getEnvConfig
-    locals <- forM (Map.toList $ envConfigPackages econfig) $ \(dir, validWanted) -> do
+    locals <- forM (Map.toList $ envConfigPackages econfig) $ \(dir, treatLikeExtraDep) -> do
         cabalfp <- findOrGenerateCabalFile dir
         (warnings,gpkg) <- readPackageUnresolved cabalfp
         mapM_ (printCabalFileWarning cabalfp) warnings
@@ -237,7 +237,7 @@ getLocalPackageViews = do
                 { lpvVersion = fromCabalVersion $ pkgVersion cabalID
                 , lpvRoot = dir
                 , lpvCabalFP = cabalfp
-                , lpvExtraDep = not validWanted
+                , lpvExtraDep = treatLikeExtraDep
                 , lpvComponents = getNamedComponents gpkg
                 }
         return (name, (lpv, gpkg))

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -101,7 +101,7 @@ data LocalPackageView = LocalPackageView
     , lpvRoot       :: !(Path Abs Dir)
     , lpvCabalFP    :: !(Path Abs File)
     , lpvComponents :: !(Set NamedComponent)
-    , lpvExtraDep   :: !Bool
+    , lpvExtraDep   :: !TreatLikeExtraDep
     }
 
 -- | Same as @parseRawTarget@, but also takes directories into account.

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -532,17 +532,14 @@ resolvePackageEntry
     => EnvOverride
     -> Path Abs Dir -- ^ project root
     -> PackageEntry
-    -> m [(Path Abs Dir, Bool)]
+    -> m [(Path Abs Dir, TreatLikeExtraDep)]
 resolvePackageEntry menv projRoot pe = do
     entryRoot <- resolvePackageLocation menv projRoot (peLocation pe)
     paths <-
         case peSubdirs pe of
             [] -> return [entryRoot]
             subs -> mapM (resolveDir entryRoot) subs
-    case peValidWanted pe of
-        Nothing -> return ()
-        Just _ -> $logWarn "Warning: you are using the deprecated valid-wanted field. You should instead use extra-dep. See: http://docs.haskellstack.org/en/stable/yaml_configuration/#packages"
-    return $ map (, not $ peExtraDep pe) paths
+    return $ map (, peExtraDep pe) paths
 
 -- | Resolve a PackageLocation into a path, downloading and cloning as
 -- necessary.

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -298,15 +298,15 @@ ghciSetup GhciOpts{..} = do
         sourceMap
     directlyWanted <-
         forMaybeM (M.toList (envConfigPackages econfig)) $
-        \(dir,validWanted) ->
+        \(dir,treatLikeExtraDep) ->
              do cabalfp <- findOrGenerateCabalFile dir
                 name <- parsePackageNameFromFilePath cabalfp
-                if validWanted
-                    then case M.lookup name targets of
+                if treatLikeExtraDep
+                    then return Nothing
+                    else case M.lookup name targets of
                              Just simpleTargets ->
                                  return (Just (name, (cabalfp, simpleTargets)))
                              Nothing -> return Nothing
-                    else return Nothing
     let extraLoadDeps = getExtraLoadDeps ghciLoadLocalDeps sourceMap directlyWanted
     wanted <-
         if (ghciSkipIntermediate && not ghciLoadLocalDeps) || null extraLoadDeps

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -129,8 +129,7 @@ initProject currDir initOpts mresolver = do
 
         pkgs = map toPkg $ Map.elems (fmap (parent . fst) rbundle)
         toPkg dir = PackageEntry
-            { peValidWanted = Nothing
-            , peExtraDepMaybe = Nothing
+            { peExtraDep = False
             , peLocation = PLFilePath $ makeRelDir dir
             , peSubdirs = []
             }


### PR DESCRIPTION
The field has been deprecated since [v0.1.1.0](https://github.com/commercialhaskell/stack/releases/tag/v0.1.1.0).

I've also removed all references to "validWanted" and introduced a type alias `TreatLikeExtraDep` to make it easier to interpret the `Bool` that is being passed around.