### PR TITLE
Improve file and directory resolution

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -63,7 +63,7 @@ import           Distribution.System            (OS (Windows),
 import           Language.Haskell.TH as TH (location)
 import           Network.HTTP.Client.Conduit (HasHttpManager)
 import           Path
-import           Path.Extra (toFilePathNoTrailingSep)
+import           Path.Extra (toFilePathNoTrailingSep, rejectMissingFile)
 import           Path.IO hiding (findExecutable, makeAbsolute)
 import           Prelude hiding (FilePath, writeFile, any)
 import           Stack.Build.Cache
@@ -367,6 +367,7 @@ executePlan menv bopts baseConfigOpts locals globalPackages snapshotPackages loc
                         Snap -> snapBin
                         Local -> localBin
             mfp <- forgivingAbsence (resolveFile bindir $ T.unpack name ++ ext)
+              >>= rejectMissingFile
             case mfp of
                 Nothing -> do
                     $logWarn $ T.concat

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -33,6 +33,7 @@ import qualified Data.Set               as Set
 import           Data.Text              (Text)
 import qualified Data.Text              as T
 import           Path
+import           Path.Extra (rejectMissingDir)
 import           Path.IO
 import           Prelude -- Fix redundant import warnings
 import           Stack.Types
@@ -115,6 +116,7 @@ parseRawTargetDirs root locals t =
         Just rt -> return $ Right [(ri, rt)]
         Nothing -> do
             mdir <- forgivingAbsence (resolveDir root (T.unpack t))
+              >>= rejectMissingDir
             case mdir of
                 Nothing -> return $ Left $ "Directory not found: " `T.append` t
                 Just dir ->

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -1176,7 +1176,7 @@ resolveFileOrWarn :: (MonadCatch m,MonadIO m,MonadLogger m,MonadReader (Path Abs
                   => FilePath.FilePath
                   -> m (Maybe (Path Abs File))
 resolveFileOrWarn = resolveOrWarn "File" f
-  where f p x = forgivingAbsence (resolveFile p x)
+  where f p x = forgivingAbsence (resolveFile p x) >>= rejectMissingFile
 
 -- | Resolve the directory, if it can't be resolved, warn for the user
 -- (purely to be helpful).
@@ -1184,7 +1184,7 @@ resolveDirOrWarn :: (MonadCatch m,MonadIO m,MonadLogger m,MonadReader (Path Abs 
                  => FilePath.FilePath
                  -> m (Maybe (Path Abs Dir))
 resolveDirOrWarn = resolveOrWarn "Directory" f
-  where f p x = forgivingAbsence (resolveDir p x)
+  where f p x = forgivingAbsence (resolveDir p x) >>= rejectMissingDir
 
 -- | Extract the @PackageIdentifier@ given an exploded haskell package
 -- path.


### PR DESCRIPTION
Previously the idiom `forgivingAbsence (relsoveFile …)` alone was used, which relied on `canonicalizePath` throwing `isDoesNotExistError` when path does not exist. As it turns out, this behavior is actually not intentional and unreliable, see

https://github.com/haskell/directory/issues/44

This was “fixed” in version 1.2.3.0 of `directory` package (now it never throws). To make it work with all versions, we need to use the following idiom:

```haskell
forgivingAbsence (resolveFile …) >>= rejectMissingFile
```

This commit fixes all cases where new directory versions might cause problems.
