### PR TITLE
[rfc] only unpack package versions within preferred-versions #1391

### DIFF
--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -510,7 +510,7 @@ loadBuildConfig mproject config mresolver mcompiler = do
 
     extraPackageDBs <- mapM resolveDir' (projectExtraPackageDBs project)
 
-    packageCaches <- runReaderT (getMinimalEnvOverride >>= getPackageCaches) miniConfig
+    packageCaches <- runReaderT (fst <$> (getMinimalEnvOverride >>= getPackageCaches)) miniConfig
 
     return BuildConfig
         { bcConfig = config

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -293,7 +293,7 @@ resolvePackagesAllowMissing menv idents0 names0 = do
 
     toTuple' (PackageIdentifier name version) = (name, [version])
 
-    groupByPackageName = fmap Set.fromList . Map.fromListWith mappend . map toTuple' . Map.keys
+    groupByPackageName = fmap Set.fromList . Map.fromListWith (<>) . map toTuple' . Map.keys
 
     toVersionRange (_, PreferredVersionsCache raw) = fromMaybe anyVersion $ parse raw
       where parse = simpleParse . T.unpack . T.dropWhile (/= ' ')

--- a/src/Stack/PackageIndex.hs
+++ b/src/Stack/PackageIndex.hs
@@ -22,6 +22,7 @@ module Stack.PackageIndex
     ) where
 
 import qualified Codec.Archive.Tar as Tar
+import           Control.Applicative
 import           Control.Exception (Exception)
 import           Control.Exception.Enclosed (tryIO)
 import           Control.Monad (unless, when, liftM)

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -72,6 +72,7 @@ module Stack.Types.Config
   ,configPackageIndexGz
   ,configPackageIndexRoot
   ,configPackageTarball
+  ,configPreferredVersionsCache
   ,indexNameText
   ,IndexLocation(..)
   -- ** Project & ProjectAndConfigMonoid
@@ -1222,6 +1223,10 @@ configPackageIndexRoot (IndexName name) = do
 -- | Location of the 00-index.cache file
 configPackageIndexCache :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> m (Path Abs File)
 configPackageIndexCache = liftM (</> $(mkRelFile "00-index.cache")) . configPackageIndexRoot
+
+-- | Location of the preferred-versions.cache file
+configPreferredVersionsCache :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> m (Path Abs File)
+configPreferredVersionsCache = liftM (</> $(mkRelFile "preferred-versions.cache")) . configPackageIndexRoot
 
 -- | Location of the 00-index.tar file
 configPackageIndex :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> m (Path Abs File)

--- a/src/Stack/Types/PackageIndex.hs
+++ b/src/Stack/Types/PackageIndex.hs
@@ -6,6 +6,8 @@ module Stack.Types.PackageIndex
     ( PackageDownload (..)
     , PackageCache (..)
     , PackageCacheMap (..)
+    , PreferredVersionsCache (..)
+    , PreferredVersionsCacheMap (..)
     ) where
 
 import           Control.Monad (mzero)
@@ -21,6 +23,20 @@ import           Data.Text.Encoding (encodeUtf8)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           Stack.Types.PackageIdentifier
+import           Stack.Types.PackageName
+
+data PreferredVersionsCache = PreferredVersionsCache Text
+    deriving (Show, Generic)
+
+instance Binary PreferredVersionsCache
+instance NFData PreferredVersionsCache
+instance HasStructuralInfo PreferredVersionsCache
+
+newtype PreferredVersionsCacheMap = PreferredVersionsCacheMap (Map PackageName PreferredVersionsCache)
+    deriving (Generic, Binary, NFData)
+instance HasStructuralInfo PreferredVersionsCacheMap
+instance HasSemanticVersion PreferredVersionsCacheMap
+
 
 data PackageCache = PackageCache
     { pcOffset :: !Int64

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -65,17 +65,8 @@ upgrade gitRepo mresolver builtHash =
                 return $ Just $ tmp </> $(mkRelDir "stack")
       Nothing -> do
         updateAllIndices menv
-        -- TODO(luigy) use same logic as in Stack.Fetch
-        (caches,_pv) <- getPackageCaches menv
-        let latest = Map.fromListWith max
-                   $ map toTuple
-                   $ Map.keys
-                   -- Mistaken upload to Hackage, just ignore it
-                   $ Map.delete (PackageIdentifier
-                        $(mkPackageName "stack")
-                        $(mkVersion "9.9.9"))
+        latest <- getLatestApplicablePackageCache menv
 
-                     caches
         case Map.lookup $(mkPackageName "stack") latest of
             Nothing -> error "No stack found in package indices"
             Just version | version <= fromCabalVersion Paths.version -> do

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -65,11 +65,11 @@ upgrade gitRepo mresolver builtHash =
                 return $ Just $ tmp </> $(mkRelDir "stack")
       Nothing -> do
         updateAllIndices menv
-        caches <- getPackageCaches menv
+        -- TODO(luigy) use same logic as in Stack.Fetch
+        (caches,_pv) <- getPackageCaches menv
         let latest = Map.fromListWith max
                    $ map toTuple
                    $ Map.keys
-
                    -- Mistaken upload to Hackage, just ignore it
                    $ Map.delete (PackageIdentifier
                         $(mkPackageName "stack")

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -260,7 +260,10 @@ commandLineHandler progName isInterpreter = complicatedOptions
         addCommand' "unpack"
                     "Unpack one or more packages locally"
                     unpackCmd
-                    (some $ strArgument $ metavar "PACKAGE")
+                    ((,) <$> switch
+                              ( long "latest"
+                             <> help "fetch latest version from hackage")
+                         <*> some (strArgument $ metavar "PACKAGE"))
         addCommand' "update"
                     "Update the package index"
                     updateCmd
@@ -900,10 +903,10 @@ uninstallCmd _ go = withConfigAndLock go $ do
     $logError "For the default executable destination, please run 'stack path --local-bin-path'"
 
 -- | Unpack packages to the filesystem
-unpackCmd :: [String] -> GlobalOpts -> IO ()
-unpackCmd names go = withConfigAndLock go $ do
+unpackCmd :: (Bool,[String]) -> GlobalOpts -> IO ()
+unpackCmd (useLatest, names) go = withBuildConfig go $ do
     menv <- getMinimalEnvOverride
-    Stack.Fetch.unpackPackages menv "." names
+    Stack.Fetch.unpackPackages menv "." names useLatest
 
 -- | Update the package index
 updateCmd :: () -> GlobalOpts -> IO ()

--- a/test/integration/tests/1391-unpack-within-preferred-version/Main.hs
+++ b/test/integration/tests/1391-unpack-within-preferred-version/Main.hs
@@ -1,0 +1,30 @@
+import Control.Monad (when)
+import StackTest
+import System.Exit
+
+
+main :: IO ()
+main = do
+    -- get version from snapshot
+    stack ["--resolver=lts-4.0", "unpack", "stack"]
+    doesExist "stack-1.0.0"
+
+    -- check latest download querying hackage
+    -- stack ["unpack", "--latest", "stack"]
+    -- let latestCmd = unwords
+    --         ["curl -H 'Accept: application/json'"
+    --          ,"http://hackage.haskell.org/package/stack/preferred"
+    --          ,"| sed -n  's/.*\"normal-version\":\\[\\([0-9,\"\\.]*\\)\\].*/\\1/p'"
+    --          ,"| tr ',' '\n' | tr -d '\"'"
+    --          ,"| sort"
+    --          ,"| tail -1"
+    --         ]
+    -- ec <- run' "bash" ["-c", "ls stack-$("++ latestCmd ++")"]
+    -- when (ec /= ExitSuccess) $ fail "didn't match latest on hackage."
+
+    -- download deprecated version when asked explicitly
+    stack ["unpack", "stack-9.9.9"]
+    doesExist "stack-9.9.9"
+
+    -- should fail when a package does not exist
+    stackErr ["unpack", "i-dont-exists-0"]


### PR DESCRIPTION
first pass at #1391

* fetches version present in snapshot otherwise falls back to hackage
* caches `preferred-versions` from index
* only versions within `preferred-versions` are fetched unless explicitly asked by package identifier
* added --latest flag to fetch latest version from hackage regardless of resolver

TODO:

- [ ] Don't copy `loadBuildPlan` from `Stack.BuildPlan` into `Stack.Fetch`
- [x] Update `Stack.Upgrade` to only consider non-deprecated versions.

New behavior:

```sh
λ cat stack.yaml
resolver: lts-5.4

λ stack unpack stack
Unpacked stack-1.0.2 to /Users/luigy/stack-1.0.2/

λ stack --resolver lts-3.0 unpack stack
Unpacked stack-0.1.3.0 to /Users/luigy/stack-0.1.3.0/

λ stack unpack --latest stack
Unpacked stack-1.0.4.1 to /Users/luigy/stack-1.0.4.1/

λ stack unpack stack-9.9.9
Unpacked stack-9.9.9 to /Users/luigy/stack-9.9.9/
```