### PR TITLE
Allow --omit-packages even without --solver

### DIFF
--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1169,6 +1169,7 @@ instance Show ConfigException where
         , "' does not have all the packages to match your requirements.\n"
         , unlines $ fmap ("    " <>) (lines errDesc)
         , "\nHowever, you can try '--solver' to use external packages."
+        , "\nUse '--omit-packages' if you want to create a config anyway."
         ]
     show (NoSuchDirectory dir) = concat
         ["No directory could be located matching the supplied path: "


### PR DESCRIPTION
Sometimes you already know that dependencies will not be met and want to create
a config anyway which you will fix later. In that case we can skip using
--solver and directly use --omit-packages to create a config with packages
commented out in the config.