### PR TITLE
Clone recursively

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,9 @@ Major changes:
 
 Other enhancements:
 
+* `git` packages with submodules are supported by passing the `--recursive`
+  flag to `git clone`.
+
 Bug fixes:
 
 ## 1.0.4

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -576,13 +576,14 @@ resolvePackageLocation menv projRoot (PLRemote url remotePackageType) = do
     unless exists $ do
         ignoringAbsence (removeDirRecur dirTmp)
 
-        let cloneAndExtract commandName resetCommand commit = do
+        let cloneAndExtract commandName cloneArgs resetCommand commit = do
                 ensureDir (parent dirTmp)
                 readInNull (parent dirTmp) commandName menv
-                    [ "clone"
-                    , T.unpack url
+                    ("clone" :
+                    cloneArgs ++
+                    [ T.unpack url
                     , toFilePathNoTrailingSep dirTmp
-                    ]
+                    ])
                     Nothing
                 readInNull dirTmp commandName menv
                     (resetCommand ++ [T.unpack commit])
@@ -615,8 +616,8 @@ resolvePackageLocation menv projRoot (PLRemote url remotePackageType) = do
 
                 tryTar `catchAllLog` tryZip `catchAllLog` err
 
-            RPTGit commit -> cloneAndExtract "git" ["reset", "--hard"] commit
-            RPTHg  commit -> cloneAndExtract "hg"  ["update", "-C"]    commit
+            RPTGit commit -> cloneAndExtract "git" ["--recursive"] ["reset", "--hard"] commit
+            RPTHg  commit -> cloneAndExtract "hg"  []              ["update", "-C"]    commit
 
         renameDir dirTmp dir
 


### PR DESCRIPTION
`git` packages using submodules may need to be cloned recursively.

- Allows us to pass arguments to the `clone` command on a case-by-case basis.
- Adds the `--recursive` option to `git clone`.
- `hg clone` will [already clone subrepos](https://www.mercurial-scm.org/wiki/Subrepository#Update).

I have not added a configuration option to control this, because it doesn’t seem particularly useful in the context of repos which are Haskell packages.

Fixes #1764.