### PR TITLE
Require hpack >= 0.10.0

### DIFF
--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -24,5 +24,5 @@ extra-deps:
 - process-1.2.1.0
 - time-1.5.0.1
 - base-compat-0.9.0
-- hpack-0.9.1
+- hpack-0.10.0
 - microlens-0.4.1.0

--- a/stack.cabal
+++ b/stack.cabal
@@ -209,7 +209,7 @@ library
                    , project-template >= 0.2
                    , uuid
                    , zip-archive
-                   , hpack >= 0.9.1
+                   , hpack >= 0.10.0
   if os(windows)
     cpp-options:     -DWINDOWS
     build-depends:   Win32

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,4 +11,4 @@ nix:
     - zlib
 extra-deps:
 - path-io-1.0.0
-- hpack-0.9.1
+- hpack-0.10.0


### PR DESCRIPTION
 - fix an issue with file globs on Windows
 - add support for conditionals