### PR TITLE
Detect extra-deps missing from indices

### DIFF
--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -439,7 +439,10 @@ extendExtraDeps :: (MonadThrow m, MonadReader env m, HasBuildConfig env)
                 -> Map PackageName Version -- ^ latest versions in indices
                 -> m (Map PackageName Version) -- ^ new extradeps
 extendExtraDeps extraDeps0 cliExtraDeps unknowns latestVersion
-    | null errs = return $ Map.unions $ extraDeps1 : unknowns'
+    | not (Map.null missing) =
+        throwM $ UnknownPackageIdentifiers (toPkgIdents missing) ""
+    | null errs =
+        return $ Map.unions $ extraDeps1 : unknowns'
     | otherwise = do
         bconfig <- asks getBuildConfig
         throwM $ UnknownTargets
@@ -447,7 +450,12 @@ extendExtraDeps extraDeps0 cliExtraDeps unknowns latestVersion
             Map.empty -- TODO check the cliExtraDeps for presence in index
             (bcStackYaml bconfig)
   where
-    extraDeps1 = Map.union extraDeps0 cliExtraDeps
+    (missing, extraDeps1) =
+        Map.partitionWithKey missingFromIndex $ Map.union extraDeps0 cliExtraDeps
+
+    missingFromIndex name _ = isNothing $ Map.lookup name latestVersion
+
+    toPkgIdents = Set.fromList . map fromTuple . Map.toList
 
     (errs, unknowns') = partitionEithers $ map addUnknown $ Set.toList unknowns
     addUnknown pn =

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -86,8 +86,6 @@ data FetchException
     | Couldn'tReadPackageTarball FilePath SomeException
     | UnpackDirectoryAlreadyExists (Set FilePath)
     | CouldNotParsePackageSelectors [String]
-    | UnknownPackageNames (Set PackageName)
-    | UnknownPackageIdentifiers (Set PackageIdentifier) String
     deriving Typeable
 instance Exception FetchException
 
@@ -110,13 +108,6 @@ instance Show FetchException where
     show (CouldNotParsePackageSelectors strs) =
         "The following package selectors are not valid package names or identifiers: " ++
         intercalate ", " strs
-    show (UnknownPackageNames names) =
-        "The following packages were not found in your indices: " ++
-        intercalate ", " (map packageNameString $ Set.toList names)
-    show (UnknownPackageIdentifiers idents suggestions) =
-        "The following package identifiers were not found in your indices: " ++
-        intercalate ", " (map packageIdentifierString $ Set.toList idents) ++
-        (if null suggestions then "" else "\n" ++ suggestions)
 
 -- | Fetch packages into the cache without unpacking
 fetchPackages :: (MonadIO m, MonadBaseControl IO m, MonadReader env m, HasHttpManager env, HasConfig env, MonadThrow m, MonadLogger m, MonadCatch m)

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -50,6 +50,8 @@ data PackageException
   | PackageNoCabalFileFound (Path Abs Dir)
   | PackageMultipleCabalFilesFound (Path Abs Dir) [Path Abs File]
   | MismatchedCabalName (Path Abs File) PackageName
+  | UnknownPackageNames (Set PackageName)
+  | UnknownPackageIdentifiers (Set PackageIdentifier) String
   deriving Typeable
 instance Exception PackageException
 instance Show PackageException where
@@ -77,6 +79,13 @@ instance Show PackageException where
         , ".cabal\n"
         , "For more information, see: https://github.com/commercialhaskell/stack/issues/317"
         ]
+    show (UnknownPackageNames names) =
+        "The following packages were not found in your indices: " ++
+        intercalate ", " (map packageNameString $ Set.toList names)
+    show (UnknownPackageIdentifiers idents suggestions) =
+        "The following package identifiers were not found in your indices: " ++
+        intercalate ", " (map packageIdentifierString $ Set.toList idents) ++
+        (if null suggestions then "" else "\n" ++ suggestions)
 
 -- | Some package info.
 data Package =


### PR DESCRIPTION
Stack used to silently accept `extra-deps` from config or cli that were missing from indices.
It now errors out when they are not found 
(will add package suggestions for typos in another PR)

fixes #1521