### PR TITLE
Clarified the role of the `- '.'` line.

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -42,7 +42,7 @@ packages:
 extra-deps: []
 ```
 
-The above example specifies that the `proprietary-dep` package is found in the project's `third-party` folder, that the `conduit` package is found in the project's `github-version-of` folder, and that the `diagrams` package is found in the project's `patched` folder. This autodetects changes and reinstalls the package.
+The above example specifies that it should include any packages at the root directory (`'.'`), that the `proprietary-dep` package is found in the project's `third-party` folder, that the `conduit` package is found in the project's `github-version-of` folder, and that the `diagrams` package is found in the project's `patched` folder. This autodetects changes and reinstalls the package.
 
 To install packages directly from a Git repository, use e.g.:
 
@@ -53,6 +53,8 @@ packages:
     git: https://github.com/githubuser/reponame.git
     commit: somecommitID
 ```
+
+Note that the `- '.'` line has been omitted, so the root directory will not be searched for packages.
 
 #### What is the meaning of the arguments given to stack build, test, etc?
 


### PR DESCRIPTION
As mentioned in #1862 (specifically [this comment](https://github.com/commercialhaskell/stack/issues/1862#issuecomment-191173247)).

* Role of the `- '.'` line has been clarified
* A note has been added to the git-only example to reinforce this.