### PR TITLE
Fix permission error when haddock files are copied within stack --nix

### DIFF
--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -228,7 +228,7 @@ generateHaddockIndex descr envOverride wc dumpPackages docRelFP destDir = do
             ignoringAbsence (removeDirRecur destHtmlAbsDir)
             ensureDir destHtmlAbsDir
             onException
-                (copyDirRecur (parent srcInterfaceAbsFile) destHtmlAbsDir)
+                (copyDirRecur' (parent srcInterfaceAbsFile) destHtmlAbsDir)
                 (ignoringAbsence (removeDirRecur destHtmlAbsDir))
         destHtmlAbsDir = parent destInterfaceAbsFile
 

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -1,7 +1,7 @@
 resolver: lts-2.22
 extra-deps:
 - path-0.5.3
-- path-io-1.0.0
+- path-io-1.1.0
 - directory-1.2.2.0
 - Win32-notify-0.3.0.1
 - hfsevents-0.1.5

--- a/stack.cabal
+++ b/stack.cabal
@@ -177,7 +177,7 @@ library
                    , mtl >= 2.1.3.1
                    , optparse-applicative >= 0.11 && < 0.13
                    , path >= 0.5.1
-                   , path-io >= 1.0.0 && < 2.0.0
+                   , path-io >= 1.1.0 && < 2.0.0
                    , persistent >= 2.1.2
                    , persistent-sqlite >= 2.1.4
                    , persistent-template >= 2.1.1
@@ -240,7 +240,7 @@ executable stack
                 , mtl >= 2.1.3.1
                 , optparse-applicative >= 0.11.0.2 && < 0.13
                 , path
-                , path-io >= 0.3.1
+                , path-io >= 1.1.0
                 , stack
                 , text >= 1.2.0.4
                 , transformers
@@ -282,7 +282,7 @@ test-suite stack-test
                 , http-conduit
                 , monad-logger
                 , path
-                , path-io >= 0.3.1
+                , path-io >= 1.1.0
                 , resourcet
                 , retry >= 0.6 && < 0.8
                 , stack

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,5 +10,5 @@ nix:
   packages:
     - zlib
 extra-deps:
-- path-io-1.0.0
+- path-io-1.1.0
 - hpack-0.10.0


### PR DESCRIPTION
In order to fix https://github.com/commercialhaskell/stack/issues/1832 , as @mrkkrp suggested we switch to `path-io-1.1.0`
Can people test it to be sure no other permission problems appear?