### PR TITLE
Change default keyserver URL to port 80 not 11371 (to prevent firewall issues in installation)

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -96,7 +96,7 @@ problems, see the linked FAQ entries:
 
  1. Get the FP Complete key:
 
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 575159689BEFB442
+        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442
 
  2. Add the appropriate source repository (if not sure, run ``lsb_release -a`` to find out your Ubuntu version):
 
@@ -130,7 +130,7 @@ problems, see the linked FAQ entries:
 
  1. Get the FP Complete key:
 
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 575159689BEFB442
+        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442
 
  2. Add the appropriate source repository:
 


### PR DESCRIPTION
The current installation instructions state that you need to run the following command:
`sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 575159689BEFB442`

This is fine if your firewall doesn't block it, but this isn't the case for many people (port 11371 is often blocked). The workaround for this is to use the following url for the key server instead:

`sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442`

This is the pull request changing this, as suggested here: https://github.com/commercialhaskell/stack/issues/1914

Martin Dehnel-Wild