### PR TITLE
Add stack hoogle command (#55)

### DIFF
--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -386,6 +386,7 @@ data SpecialExecCmd
     = ExecCmd String
     | ExecGhc
     | ExecRunGhc
+    | ExecHoogle
     deriving (Show, Eq)
 
 data ExecOptsExtra

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -305,6 +305,10 @@ commandLineHandler progName isInterpreter = complicatedOptions
                     "Run ghc"
                     execCmd
                     (execOptsParser $ Just ExecGhc)
+        addCommand' "hoogle"
+                    "Search the local packages with Hoogle"
+                    execCmd
+                    (execOptsParser $ Just ExecHoogle)
         addCommand' "ghci"
                     "Run ghci in the context of package(s) (experimental)"
                     ghciCmd
@@ -999,11 +1003,13 @@ execCmd :: ExecOpts -> GlobalOpts -> IO ()
 execCmd ExecOpts {..} go@GlobalOpts{..} =
     case eoExtra of
         ExecOptsPlain -> do
+            (manager,lc) <- liftIO $ loadConfigWithOpts go
             (cmd, args) <- case (eoCmd, eoArgs) of
                  (ExecCmd cmd, args) -> return (cmd, args)
                  (ExecGhc, args) -> return ("ghc", args)
                  (ExecRunGhc, args) -> return ("runghc", args)
-            (manager,lc) <- liftIO $ loadConfigWithOpts go
+                 (ExecHoogle, args) ->
+                     return ("hoogle", makeHoogleArgs (lcConfig lc) args)
             withUserFileLock go (configStackRoot $ lcConfig lc) $ \lk ->
               runStackTGlobal manager (lcConfig lc) go $
                 Docker.reexecWithOptionalContainer
@@ -1018,7 +1024,7 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
                             globalResolver
                             globalCompiler
                             (runStackTGlobal manager (lcConfig lc) go $
-                                exec menv cmd args))
+                                execWithProperSetup (lcConfig lc) menv cmd args))
                     Nothing
                     Nothing -- Unlocked already above.
         ExecOptsEmbellished {..} ->
@@ -1026,6 +1032,8 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
                config <- asks getConfig
                (cmd, args) <- case (eoCmd, eoArgs) of
                    (ExecCmd cmd, args) -> return (cmd, args)
+                   (ExecHoogle, args) ->
+                       return ("hoogle", makeHoogleArgs config args)
                    (ExecGhc, args) -> execCompiler "" args
                     -- NOTE: this won't currently work for GHCJS, because it doesn't have
                     -- a runghcjs binary. It probably will someday, though.
@@ -1037,12 +1045,38 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
                        }
                munlockFile lk -- Unlock before transferring control away.
                menv <- liftIO $ configEnvOverride config eoEnvSettings
-               exec menv cmd args
+               execWithProperSetup config menv cmd args
   where
+    execWithProperSetup config menv cmd args =
+        do case eoCmd of
+             ExecHoogle ->
+                 unless (isHoogleGenerateCommand args)
+                        (ensureHoogleDatabase menv config)
+             _ -> return ()
+           exec menv cmd args
     execCompiler cmdPrefix args = do
         wc <- getWhichCompiler
         let cmd = cmdPrefix ++ compilerExeName wc
         return (cmd, args)
+    isHoogleGenerateCommand args =
+        take 1 (filter (not . isPrefixOf "-") args) == ["generate"]
+    ensureHoogleDatabase menv config =
+        do exists <- doesFileExist (hoogleDatabaseFile config)
+           if exists
+              then return ()
+              else do $logWarn "Hoogle database doesn't exist."
+                      $logInfo "Running: stack hoogle -- generate --local"
+                      $logInfo "You can re-run this command later to update the database."
+                      exec menv "hoogle" (makeHoogleArgs config ["generate","--local"])
+    makeHoogleArgs config args =
+        args ++ [hoogleDatabaseFlag config]
+        -- We add it at the end because putting it before the command
+        -- causes it to be misinterpreted, whereas this works in all
+        -- cases. Don't fiddle with this.
+    hoogleDatabaseFlag config =
+        "--database=" ++ toFilePath (hoogleDatabaseFile config)
+    hoogleDatabaseFile config =
+        configWorkDir config </> $(mkRelFile "hoogle")
 
 -- | Evaluate some haskell code inline.
 evalCmd :: EvalOpts -> GlobalOpts -> IO ()


### PR DESCRIPTION
Pinging interested parties: @ndmitchell @borsboom @mgsloan @snoyberg 

## The feature

This is a regular `exec` interface to Hoogle, but it adds a `--database` argument. This saves me from judging a new interface to Hoogle. The basic use-case is self-explanatory:

``` haskell
$ stack hoogle Conduit
module Data.Conduit
type Conduit i m o = ConduitM i o m ()
module Data.CSV.Conduit
[...]
```

To generate a database, one runs:

    $ stack hoogle -- generate --local

If you run `stack hoogle foo` without a database file present, it will automatically run `stack hoogle --generate --local`:

```
$ stack hoogle Conduit
Hoogle database doesn't exist.
Running: stack hoogle -- generate --local
You can re-run this command later to update the database.
Starting generate
Reading ghc-pkg... 0.11s
[1/142] Cabal... 0.42s
[2/142] Glob... 0.01s
[...]
```

## Details & issues

The database argument is set to `$PROJECT_ROOT/.stack-work/hoogle` as suggested by @ndmitchell in https://github.com/commercialhaskell/stack/issues/55#issuecomment-155186311.

The issue is that this support is available in Hoogle 5, which is not released yet. The workaround for users is to run:

    $ git clone git@github.com:ndmitchell/hoogle.git
    $ cd hoogle
    $ stack install

With `hoogle` version 5 in the `~/.local/bin`, the above feature works.