### PR TITLE
mounts the host's TMPDIR as /tmp in the container

### DIFF
--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -65,7 +65,7 @@ import           Stack.Docker.GlobalDB
 import           Stack.Types
 import           Stack.Types.Internal
 import           Stack.Setup (ensureDockerStackExe)
-import           System.Directory (canonicalizePath,getHomeDirectory)
+import           System.Directory (canonicalizePath,getHomeDirectory,getTemporaryDirectory)
 import           System.Environment (getEnv,getEnvironment,getProgName,getArgs,getExecutablePath)
 import           System.Exit (exitSuccess, exitWith)
 import qualified System.FilePath as FP
@@ -309,6 +309,7 @@ runContainerAndExit getCmdArgs
      liftIO
        (do updateDockerImageLastUsed config iiId (toFilePath projectRoot)
            mapM_ (ensureDir) [sandboxHomeDir, stackRoot])
+     tmp <- parseAbsDir =<< liftIO getTemporaryDirectory
      containerID <- (trim . decodeUtf8) <$> readDockerProcess
        envOverride
        (concat
@@ -320,6 +321,7 @@ runContainerAndExit getCmdArgs
           ,"-e","HOME=" ++ toFilePathNoTrailingSep sandboxHomeDir
           ,"-e","PATH=" ++ T.unpack newPathEnv
           ,"-e","PWD=" ++ toFilePathNoTrailingSep pwd
+          ,"-v",toFilePathNoTrailingSep tmp ++ ":/tmp"
           ,"-v",toFilePathNoTrailingSep stackRoot ++ ":" ++ toFilePathNoTrailingSep stackRoot
           ,"-v",toFilePathNoTrailingSep projectRoot ++ ":" ++ toFilePathNoTrailingSep projectRoot
           ,"-v",toFilePathNoTrailingSep sandboxHomeDir ++ ":" ++ toFilePathNoTrailingSep sandboxHomeDir


### PR DESCRIPTION
This is for development tools like Emacs flycheck. Some tools expect to
be able to write temp files into /tmp and then run `stack ....` to
process them. Except, without this patch & using docker, the /tmp dir 
files are gone.

resolves #1949