### PR TITLE
mount $HOME in the container

### DIFF
--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -320,6 +320,7 @@ runContainerAndExit getCmdArgs
           ,"-e","HOME=" ++ toFilePathNoTrailingSep sandboxHomeDir
           ,"-e","PATH=" ++ T.unpack newPathEnv
           ,"-e","PWD=" ++ toFilePathNoTrailingSep pwd
+          ,"-v",toFilePathNoTrailingSep homeDir ++ ":" ++ toFilePathNoTrailingSep homeDir
           ,"-v",toFilePathNoTrailingSep stackRoot ++ ":" ++ toFilePathNoTrailingSep stackRoot
           ,"-v",toFilePathNoTrailingSep projectRoot ++ ":" ++ toFilePathNoTrailingSep projectRoot
           ,"-v",toFilePathNoTrailingSep sandboxHomeDir ++ ":" ++ toFilePathNoTrailingSep sandboxHomeDir


### PR DESCRIPTION
This patch is for docker projects and specifically to assist tools (e.g.
Emacs) that read/write files in $HOME for dev work (flycheck & friends)

resolves #1949