### PR TITLE
v1.0.4.2 hotfix for release

### DIFF
--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -272,8 +272,7 @@ projectDockerSandboxDir :: (MonadReader env m, HasConfig env)
   => Path Abs Dir      -- ^ Project root
   -> m (Path Abs Dir)  -- ^ Docker sandbox
 projectDockerSandboxDir projectRoot = do
-  workDir <- getWorkDir
-  return $ projectRoot </> workDir </> $(mkRelDir "docker/")
+  return $ projectRoot </> $(mkRelDir ".stack-docker/")
 
 -- | Image staging dir from project root.
 imageStagingDir :: (MonadReader env m, HasConfig env, MonadThrow m)

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -320,6 +320,7 @@ runContainerAndExit getCmdArgs
           ,"-e","HOME=" ++ toFilePathNoTrailingSep sandboxHomeDir
           ,"-e","PATH=" ++ T.unpack newPathEnv
           ,"-e","PWD=" ++ toFilePathNoTrailingSep pwd
+          ,"-v",toFilePathNoTrailingSep homeDir ++ ":" ++ toFilePathNoTrailingSep homeDir
           ,"-v",toFilePathNoTrailingSep stackRoot ++ ":" ++ toFilePathNoTrailingSep stackRoot
           ,"-v",toFilePathNoTrailingSep projectRoot ++ ":" ++ toFilePathNoTrailingSep projectRoot
           ,"-v",toFilePathNoTrailingSep sandboxHomeDir ++ ":" ++ toFilePathNoTrailingSep sandboxHomeDir


### PR DESCRIPTION
This resolves #2000 by mounting the docker sandbox dir in a different place so that `stack clean --full` doesn't try to clobber it and everything underneath it.  Stack has some of these folders mounted even and it fails when stack tries to delete them out from underneath itself.