### PR TITLE
Issue 1800: Show bundled hpack version in --version

### DIFF
--- a/src/Options/Applicative/Complicated.hs
+++ b/src/Options/Applicative/Complicated.hs
@@ -30,6 +30,8 @@ complicatedOptions
   -> Maybe String
   -- ^ version string
   -> String
+  -- ^ hpack numeric version, as string
+  -> String
   -- ^ header
   -> String
   -- ^ program description
@@ -41,7 +43,7 @@ complicatedOptions
   -> EitherT b (Writer (Mod CommandFields (b,a))) ()
   -- ^ commands (use 'addCommand')
   -> IO (a,b)
-complicatedOptions numericVersion versionString h pd commonParser mOnFailure commandParser =
+complicatedOptions numericVersion versionString numericHpackVersion h pd commonParser mOnFailure commandParser =
   do args <- getArgs
      (a,(b,c)) <- case execParserPure (prefs noBacktrack) parser args of
        Failure _ | null args -> withArgs ["--help"] (execParser parser)
@@ -54,7 +56,7 @@ complicatedOptions numericVersion versionString h pd commonParser mOnFailure com
         versionOptions =
           case versionString of
             Nothing -> versionOption (showVersion numericVersion)
-            Just s -> versionOption s <*> numericVersionOption
+            Just s -> versionOption s <*> numericVersionOption <*> numericHpackVersionOption
         versionOption s =
           infoOption
             s
@@ -65,6 +67,11 @@ complicatedOptions numericVersion versionString h pd commonParser mOnFailure com
             (showVersion numericVersion)
             (long "numeric-version" <>
              help "Show only version number")
+        numericHpackVersionOption =
+          infoOption
+            numericHpackVersion
+            (long "hpack-numeric-version" <>
+             help "Show only hpack's version number")
 
 -- | Add a command to the options dispatcher.
 addCommand :: String   -- ^ command string

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -116,10 +116,14 @@ versionString' = concat $ concat
     , [" (" ++ commitCount ++ " commits)" | commitCount /= ("1"::String) &&
                                           commitCount /= ("UNKNOWN" :: String)]
     , [" ", display buildArch]
+    , [" hpack-", VERSION_hpack]
     ]
     where commitCount = $gitCommitCount
 #else
-versionString' = showVersion Meta.version ++ ' ' : display buildArch
+versionString' =
+    showVersion Meta.version
+    ++ ' ' : display buildArch
+    ++ " hpack" ++ VERSION_hpack
 #endif
 
 main :: IO ()
@@ -177,6 +181,7 @@ commandLineHandler
 commandLineHandler progName isInterpreter = complicatedOptions
   Meta.version
   (Just versionString')
+  VERSION_hpack
   "stack - The Haskell Tool Stack"
   ""
   (globalOpts OuterGlobalOpts)

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,6 @@ nix:
   packages:
     - zlib
 extra-deps:
-- path-io-1.1.0
-- hpack-0.10.0
+- hpack-0.12.0
 - path-0.5.7
+- path-io-1.1.0


### PR DESCRIPTION
```
% stack exec -- stack --version
Version 1.0.5, Git revision c2159137c1cdff5bb4e6c68c58967038e26a0a5b (dirty) (3450 commits) x86_64 hpack-0.12.0

% stack exec -- stack --hpack-numeric-version
0.12.0

```