### PR TITLE
Allow git/hg revisions containing slashes

### DIFF
--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -593,7 +593,7 @@ resolvePackageLocation menv projRoot (PLRemote url remotePackageType) = do
                     ])
                     Nothing
                 readInNull dirTmp commandName menv
-                    (resetCommand ++ [T.unpack commit])
+                    (resetCommand ++ [T.unpack commit, "--"])
                     (Just $ "Please ensure that commit " <> commit <>
                       " exists within " <> url)
 


### PR DESCRIPTION
Fixes the problem:
```
packages:
  - location:
      git: http://gerrit.example.com/myrepo
      commit: refs/changes/14/1814/2
```
```
$ stack test
Running /usr/bin/git reset --hard refs/changes/14/1814/2 in directory /home/cblp/dev/example/.stack-work/downloaded/cd48acc46c3d9ad4e0b5362b27617c4cb3d379e93b5d73338191b1a3ded81633.tmp/ exited with ExitFailure 128


fatal: ambiguous argument 'refs/changes/14/1814/2': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

Please ensure that commit refs/changes/14/1814/2 exists within http://gerrit.example.com/myrepo
```