### PR TITLE
Cabal file Git SHA

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,9 @@ Behavior changes:
 
 Other enhancements:
 
+* Grab Cabal files via Git SHA to avoid regressions from Hackage revisions
+  [#2070](https://github.com/commercialhaskell/stack/pull/2070)
+
 Bug fixes:
 
 ## 1.1.0

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -22,11 +22,12 @@ module Stack.Build
 
 import           Control.Exception (Exception)
 import           Control.Monad
-import           Control.Monad.Catch (MonadCatch, MonadMask)
+import           Control.Monad.Catch (MonadMask, MonadMask)
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import           Control.Monad.Reader (MonadReader, asks)
 import           Control.Monad.Trans.Resource
+import           Control.Monad.Trans.Unlift (MonadBaseUnlift)
 import           Data.Aeson (Value (Object, Array), (.=), object)
 import           Data.Function
 import qualified Data.HashMap.Strict as HM
@@ -68,7 +69,7 @@ import           System.Win32.Console (setConsoleCP, setConsoleOutputCP, getCons
 import qualified Control.Monad.Catch as Catch
 #endif
 
-type M env m = (MonadIO m,MonadReader env m,HasHttpManager env,HasBuildConfig env,MonadLogger m,MonadBaseControl IO m,MonadMask m,HasLogLevel env,HasEnvConfig env,HasTerminal env)
+type M env m = (MonadIO m,MonadReader env m,HasHttpManager env,HasBuildConfig env,MonadLogger m,MonadBaseUnlift IO m,MonadMask m,HasLogLevel env,HasEnvConfig env,HasTerminal env)
 
 -- | Build.
 --
@@ -267,8 +268,8 @@ mkBaseConfigOpts boptsCli = do
 withLoadPackage :: ( MonadIO m
                    , HasHttpManager env
                    , MonadReader env m
-                   , MonadBaseControl IO m
-                   , MonadCatch m
+                   , MonadBaseUnlift IO m
+                   , MonadMask m
                    , MonadLogger m
                    , HasEnvConfig env)
                 => EnvOverride

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -113,7 +113,7 @@ preFetch plan
     toIdent (name, task) =
         case taskType task of
             TTLocal _ -> Set.empty
-            TTUpstream package _ -> Set.singleton $ PackageIdentifier
+            TTUpstream package _ _ -> Set.singleton $ PackageIdentifier
                 name
                 (packageVersion package)
 
@@ -187,7 +187,7 @@ displayTask task = T.pack $ concat
         TTLocal lp -> concat
             [ toFilePath $ lpDir lp
             ]
-        TTUpstream _ _ -> "package index"
+        TTUpstream _ _ _ -> "package index"
     , if Set.null missing
         then ""
         else ", after: " ++ intercalate "," (map packageIdentifierString $ Set.toList missing)
@@ -665,7 +665,7 @@ getConfigCache ExecuteEnv {..} Task {..} installedMap enableTest enableBench = d
             , configCacheComponents =
                 case taskType of
                     TTLocal lp -> Set.map renderComponent $ lpComponents lp
-                    TTUpstream _ _ -> Set.empty
+                    TTUpstream _ _ _ -> Set.empty
             , configCacheHaddock =
                 shouldHaddockPackage eeBuildOpts eeWanted (packageIdentifierName taskProvides)
             }
@@ -764,7 +764,7 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
     wanted =
         case taskType of
             TTLocal lp -> lpWanted lp
-            TTUpstream _ _ -> False
+            TTUpstream _ _ _ -> False
 
     console = wanted
            && all (\(ActionId ident _) -> ident == taskProvides) (Set.toList acRemaining)
@@ -773,7 +773,7 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
     withPackage inner =
         case taskType of
             TTLocal lp -> inner (lpPackage lp) (lpCabalFile lp) (lpDir lp)
-            TTUpstream package _ -> do
+            TTUpstream package _ gitSHA1 -> do
                 mdist <- liftM Just distRelativeDir
                 m <- unpackPackageIdents eeEnvOverride eeTempDir mdist $ Set.singleton taskProvides
                 case Map.toList m of
@@ -1078,7 +1078,7 @@ singleBuild runInBase ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} in
             TTLocal lp -> do
                 when enableTests $ unsetTestSuccess pkgDir
                 writeBuildCache pkgDir $ lpNewBuildCache lp
-            TTUpstream _ _ -> return ()
+            TTUpstream _ _ _ -> return ()
 
         () <- announce ("build" <> annSuffix)
         config <- asks getConfig
@@ -1170,7 +1170,7 @@ checkForUnlistedFiles (TTLocal lp) preBuildTime pkgDir = do
     unless (null addBuildCache) $
         writeBuildCache pkgDir $
         Map.unions (lpNewBuildCache lp : addBuildCache)
-checkForUnlistedFiles (TTUpstream _ _) _ _ = return ()
+checkForUnlistedFiles (TTUpstream _ _ _) _ _ = return ()
 
 -- | Determine if all of the dependencies given are installed
 depsPresent :: InstalledMap -> Map PackageName VersionRange -> Bool

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -775,7 +775,8 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
             TTLocal lp -> inner (lpPackage lp) (lpCabalFile lp) (lpDir lp)
             TTUpstream package _ gitSHA1 -> do
                 mdist <- liftM Just distRelativeDir
-                m <- unpackPackageIdents eeEnvOverride eeTempDir mdist $ Set.singleton taskProvides
+                m <- unpackPackageIdents eeEnvOverride eeTempDir mdist
+                   $ Map.singleton taskProvides gitSHA1
                 case Map.toList m of
                     [(ident, dir)]
                         | ident == taskProvides -> do

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -116,8 +116,8 @@ loadSourceMap needTargets boptsCli = do
 
         -- Overwrite any flag settings with those from the config file
         extraDeps3 = Map.mapWithKey
-            (\n (v, f) -> PSUpstream v Local $
-                case ( Map.lookup (Just n) $ boptsCLIFlags boptsCli
+            (\n (v, f) -> PSUpstream v Local
+               (case ( Map.lookup (Just n) $ boptsCLIFlags boptsCli
                      , Map.lookup Nothing $ boptsCLIFlags boptsCli
                      , Map.lookup n $ bcFlags bconfig
                      ) of
@@ -132,6 +132,10 @@ loadSourceMap needTargets boptsCli = do
                         , fromMaybe Map.empty y
                         , fromMaybe Map.empty z
                         ])
+
+                 -- currently have no ability for extra-deps to specify their
+                 -- cabal file hashes
+                 Nothing)
             extraDeps2
 
     let sourceMap = Map.unions

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -23,7 +23,7 @@ import           Control.Applicative
 import           Control.Arrow ((&&&))
 import           Control.Exception (assert, catch)
 import           Control.Monad
-import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.Catch (MonadMask)
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import           Control.Monad.Reader (MonadReader, asks)
@@ -68,7 +68,7 @@ import qualified System.Directory as D
 import           System.IO (withBinaryFile, IOMode (ReadMode))
 import           System.IO.Error (isDoesNotExistError)
 
-loadSourceMap :: (MonadIO m, MonadCatch m, MonadReader env m, HasBuildConfig env, MonadBaseControl IO m, HasHttpManager env, MonadLogger m, HasEnvConfig env)
+loadSourceMap :: (MonadIO m, MonadMask m, MonadReader env m, HasBuildConfig env, MonadBaseControl IO m, HasHttpManager env, MonadLogger m, HasEnvConfig env)
               => NeedTargets
               -> BuildOptsCLI
               -> m ( Map PackageName SimpleTarget
@@ -140,14 +140,14 @@ loadSourceMap needTargets boptsCli = do
                  in (packageName p, PSLocal lp)
             , extraDeps3
             , flip fmap (mbpPackages mbp) $ \mpi ->
-                PSUpstream (mpiVersion mpi) Snap (mpiFlags mpi)
+                PSUpstream (mpiVersion mpi) Snap (mpiFlags mpi) (mpiGitSHA1 mpi)
             ] `Map.difference` Map.fromList (map (, ()) (HashSet.toList wiredInPackages))
 
     return (targets, mbp, locals, nonLocalTargets, sourceMap)
 
 -- | Use the build options and environment to parse targets.
 parseTargetsFromBuildOpts
-    :: (MonadIO m, MonadCatch m, MonadReader env m, HasBuildConfig env, MonadBaseControl IO m, HasHttpManager env, MonadLogger m, HasEnvConfig env)
+    :: (MonadIO m, MonadMask m, MonadReader env m, HasBuildConfig env, MonadBaseControl IO m, HasHttpManager env, MonadLogger m, HasEnvConfig env)
     => NeedTargets
     -> BuildOptsCLI
     -> m (MiniBuildPlan, M.Map PackageName Version, M.Map PackageName SimpleTarget)
@@ -275,7 +275,7 @@ splitComponents =
 -- based on the selected components
 loadLocalPackage
     :: forall m env.
-       (MonadReader env m, HasEnvConfig env, MonadCatch m, MonadLogger m, MonadIO m)
+       (MonadReader env m, HasEnvConfig env, MonadMask m, MonadLogger m, MonadIO m)
     => BuildOptsCLI
     -> Map PackageName SimpleTarget
     -> (PackageName, (LocalPackageView, GenericPackageDescription))
@@ -428,7 +428,7 @@ localFlags boptsflags bconfig name = Map.unions
 -- this was then superseded by
 -- https://github.com/commercialhaskell/stack/issues/651
 extendExtraDeps
-    :: (HasBuildConfig env, MonadIO m, MonadLogger m, MonadReader env m, HasHttpManager env, MonadBaseControl IO m, MonadCatch m)
+    :: (HasBuildConfig env, MonadIO m, MonadLogger m, MonadReader env m, HasHttpManager env, MonadBaseControl IO m, MonadMask m)
     => Map PackageName Version -- ^ original extra deps
     -> Map PackageName Version -- ^ package identifiers from the command line
     -> Set PackageName -- ^ all packages added on the command line
@@ -489,7 +489,7 @@ checkBuildCache oldCache files = liftIO $ do
 
 -- | Returns entries to add to the build cache for any newly found unlisted modules
 addUnlistedToBuildCache
-    :: (MonadIO m, MonadReader env m, MonadCatch m, MonadLogger m, HasEnvConfig env)
+    :: (MonadIO m, MonadReader env m, MonadMask m, MonadLogger m, HasEnvConfig env)
     => ModTime
     -> Package
     -> Path Abs File
@@ -516,7 +516,7 @@ addUnlistedToBuildCache preBuildTime pkg cabalFP buildCache = do
 
 -- | Gets list of Paths for files in a package
 getPackageFilesSimple
-    :: (MonadIO m, MonadReader env m, MonadCatch m, MonadLogger m, HasEnvConfig env)
+    :: (MonadIO m, MonadReader env m, MonadMask m, MonadLogger m, HasEnvConfig env)
     => Package -> Path Abs File -> m (Set (Path Abs File), [PackageWarning])
 getPackageFilesSimple pkg cabalFP = do
     (_,compFiles,cabalFiles,warnings) <-
@@ -565,7 +565,7 @@ checkComponentsBuildable lps =
         ]
 
 -- | Get 'PackageConfig' for package given its name.
-getPackageConfig :: (MonadIO m, MonadThrow m, MonadCatch m, MonadLogger m, MonadReader env m, HasEnvConfig env)
+getPackageConfig :: (MonadIO m, MonadThrow m, MonadMask m, MonadLogger m, MonadReader env m, HasEnvConfig env)
   => BuildOptsCLI
   -> PackageName
   -> m PackageConfig

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -214,7 +214,7 @@ data ResolveState = ResolveState
     , rsUsedBy    :: Map PackageName (Set PackageName)
     }
 
-toMiniBuildPlan :: (MonadIO m, MonadLogger m, MonadReader env m, HasHttpManager env, MonadThrow m, HasConfig env, MonadBaseControl IO m, MonadCatch m)
+toMiniBuildPlan :: (MonadIO m, MonadLogger m, MonadReader env m, HasHttpManager env, MonadMask m, HasConfig env, MonadBaseControl IO m)
                 => CompilerVersion -- ^ Compiler version
                 -> Map PackageName Version -- ^ cores
                 -> Map PackageName (Version, Map FlagName Bool, Maybe GitSHA1) -- ^ non-core packages
@@ -256,7 +256,7 @@ toMiniBuildPlan compilerVersion corePackages packages = do
         }
 
 -- | Add in the resolved dependencies from the package index
-addDeps :: (MonadIO m, MonadLogger m, MonadReader env m, HasHttpManager env, MonadThrow m, HasConfig env, MonadBaseControl IO m, MonadCatch m)
+addDeps :: (MonadIO m, MonadLogger m, MonadReader env m, HasHttpManager env, MonadMask m, HasConfig env, MonadBaseControl IO m)
         => Bool -- ^ allow missing
         -> CompilerVersion -- ^ Compiler version
         -> Map PackageName (Version, Map FlagName Bool, Maybe GitSHA1)
@@ -404,7 +404,7 @@ getToolMap mbp =
 
 -- | Load up a 'MiniBuildPlan', preferably from cache
 loadMiniBuildPlan
-    :: (MonadIO m, MonadThrow m, MonadLogger m, MonadReader env m, HasHttpManager env, HasConfig env, HasGHCVariant env, MonadBaseControl IO m, MonadCatch m)
+    :: (MonadIO m, MonadLogger m, MonadReader env m, HasHttpManager env, HasConfig env, HasGHCVariant env, MonadBaseControl IO m, MonadMask m)
     => SnapName
     -> m MiniBuildPlan
 loadMiniBuildPlan name = do
@@ -681,7 +681,7 @@ instance Show BuildPlanCheck where
 -- given snapshot. Returns how well the snapshot satisfies the dependencies of
 -- the packages.
 checkSnapBuildPlan
-    :: ( MonadIO m, MonadCatch m, MonadLogger m, MonadReader env m
+    :: ( MonadIO m, MonadMask m, MonadLogger m, MonadReader env m
        , HasHttpManager env, HasConfig env, HasGHCVariant env
        , MonadBaseControl IO m)
     => [GenericPackageDescription]
@@ -716,7 +716,7 @@ checkSnapBuildPlan gpds flags snap = do
 -- | Find a snapshot and set of flags that is compatible with and matches as
 -- best as possible with the given 'GenericPackageDescription's.
 selectBestSnapshot
-    :: ( MonadIO m, MonadCatch m, MonadLogger m, MonadReader env m
+    :: ( MonadIO m, MonadMask m, MonadLogger m, MonadReader env m
        , HasHttpManager env, HasConfig env, HasGHCVariant env
        , MonadBaseControl IO m)
     => [GenericPackageDescription]
@@ -880,7 +880,7 @@ shadowMiniBuildPlan (MiniBuildPlan cv pkgs0) shadowed =
                 Just False -> Right
                 Nothing -> assert False Right
 
-parseCustomMiniBuildPlan :: (MonadIO m, MonadCatch m, MonadLogger m, MonadReader env m, HasHttpManager env, HasConfig env, MonadBaseControl IO m)
+parseCustomMiniBuildPlan :: (MonadIO m, MonadMask m, MonadLogger m, MonadReader env m, HasHttpManager env, HasConfig env, MonadBaseControl IO m)
                          => Path Abs File -- ^ stack.yaml file location
                          -> T.Text -> m MiniBuildPlan
 parseCustomMiniBuildPlan stackYamlFP url0 = do

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -189,7 +189,7 @@ createDepLoader :: Applicative m
 createDepLoader sourceMap installed loadPackageDeps pkgName =
   case Map.lookup pkgName sourceMap of
     Just (PSLocal lp) -> pure ((packageAllDeps &&& (Just . packageVersion)) (lpPackage lp))
-    Just (PSUpstream version _ flags) -> loadPackageDeps pkgName version flags
+    Just (PSUpstream version _ flags _) -> loadPackageDeps pkgName version flags
     Nothing -> pure (Set.empty, fmap installedVersion (Map.lookup pkgName installed))
 
 -- | Resolve the direct (depth 0) external dependencies of the given local packages

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -16,7 +16,7 @@ import           Control.Monad.Catch (MonadCatch,MonadMask)
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger (MonadLogger)
 import           Control.Monad.Reader (MonadReader)
-import           Control.Monad.Trans.Control (MonadBaseControl)
+import           Control.Monad.Trans.Unlift (MonadBaseUnlift)
 import qualified Data.Foldable as F
 import qualified Data.HashSet as HashSet
 import           Data.Map (Map)
@@ -55,7 +55,7 @@ data DotOpts = DotOpts
 dot :: (HasEnvConfig env
        ,HasHttpManager env
        ,HasLogLevel env
-       ,MonadBaseControl IO m
+       ,MonadBaseUnlift IO m
        ,MonadCatch m
        ,MonadLogger m
        ,MonadIO m
@@ -81,7 +81,7 @@ createDependencyGraph :: (HasEnvConfig env
                          ,HasHttpManager env
                          ,HasLogLevel env
                          ,MonadLogger m
-                         ,MonadBaseControl IO m
+                         ,MonadBaseUnlift IO m
                          ,MonadCatch m
                          ,MonadIO m
                          ,MonadMask m
@@ -111,7 +111,7 @@ createDependencyGraph dotOpts = do
 listDependencies :: (HasEnvConfig env
                     ,HasHttpManager env
                     ,HasLogLevel env
-                    ,MonadBaseControl IO m
+                    ,MonadBaseUnlift IO m
                     ,MonadCatch m
                     ,MonadLogger m
                     ,MonadMask m

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -326,7 +326,7 @@ withCabalLoader menv inner = do
                  -> IO ByteString
         doLookup ident = do
             caches <- loadCaches
-            eres <- unlift $ lookupPackageIdentifierExact ident env cachesCurr
+            eres <- unlift $ lookupPackageIdentifierExact ident env caches
             case eres of
                 Just bs -> return bs
                 -- Update the cache and try again

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -60,7 +60,7 @@ import qualified Data.List.NonEmpty             as NE
 import           Data.Map                       (Map)
 import qualified Data.Map                       as Map
 import           Data.Maybe                     (maybeToList, catMaybes)
-import           Data.Monoid                    ((<>))
+import           Data.Monoid
 import           Data.Set                       (Set)
 import qualified Data.Set                       as Set
 import           Data.String                    (fromString)

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -23,7 +23,7 @@ import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import           Control.Monad.RWS.Strict
 import           Control.Monad.State.Strict
-import           Control.Monad.Trans.Resource
+import           Control.Monad.Trans.Unlift (MonadBaseUnlift)
 import qualified Data.ByteString.Char8 as S8
 import           Data.Either
 import           Data.Function
@@ -105,7 +105,7 @@ instance Show GhciException where
 -- given options and configure it with the load paths and extensions
 -- of those targets.
 ghci
-    :: (HasConfig r, HasBuildConfig r, HasHttpManager r, MonadMask m, HasLogLevel r, HasTerminal r, HasEnvConfig r, MonadReader r m, MonadIO m, MonadThrow m, MonadLogger m, MonadBaseControl IO m)
+    :: (HasConfig r, HasBuildConfig r, HasHttpManager r, MonadMask m, HasLogLevel r, HasTerminal r, HasEnvConfig r, MonadReader r m, MonadIO m, MonadLogger m, MonadBaseUnlift IO m)
     => GhciOpts -> m ()
 ghci opts@GhciOpts{..} = do
     bopts <- asks (configBuild . getConfig)
@@ -256,7 +256,7 @@ figureOutMainFile bopts mainIsTargets targets0 packages =
 -- | Create a list of infos for each target containing necessary
 -- information to load that package/components.
 ghciSetup
-    :: (HasConfig r, HasHttpManager r, HasBuildConfig r, MonadMask m, HasTerminal r, HasLogLevel r, HasEnvConfig r, MonadReader r m, MonadIO m, MonadThrow m, MonadLogger m, MonadBaseControl IO m)
+    :: (HasConfig r, HasHttpManager r, HasBuildConfig r, MonadMask m, HasTerminal r, HasLogLevel r, HasEnvConfig r, MonadReader r m, MonadIO m, MonadThrow m, MonadLogger m, MonadBaseUnlift IO m)
     => GhciOpts
     -> m (Map PackageName SimpleTarget, Maybe (Map PackageName SimpleTarget), [GhciPkgInfo])
 ghciSetup GhciOpts{..} = do

--- a/src/Stack/Ide.hs
+++ b/src/Stack/Ide.hs
@@ -15,7 +15,7 @@ import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import           Control.Monad.Reader
-import           Control.Monad.Trans.Control (MonadBaseControl)
+import           Control.Monad.Trans.Unlift (MonadBaseUnlift)
 import           Data.List
 import           Data.Maybe
 import           Data.Monoid
@@ -39,7 +39,7 @@ import           System.Process.Run
 -- given options and configure it with the load paths and extensions
 -- of those targets.
 ide
-    :: (HasConfig r, HasBuildConfig r, HasTerminal r, HasLogLevel r, MonadMask m, HasEnvConfig r, MonadReader r m, MonadIO m, MonadThrow m, MonadLogger m, MonadBaseControl IO m, HasHttpManager r)
+    :: (HasConfig r, HasBuildConfig r, HasTerminal r, HasLogLevel r, MonadMask m, HasEnvConfig r, MonadReader r m, MonadIO m, MonadLogger m, MonadBaseUnlift IO m, HasHttpManager r)
     => [Text] -- ^ Targets.
     -> [String] -- ^ GHC options.
     -> m ()

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -351,7 +351,7 @@ generateBuildInfoOpts sourceMap installedMap mcabalMacros cabalDir distDir omitP
         , let name = fromCabalPackageName cname
         , name `notElem` omitPkgs]
     -- Generates: -package=base -package=base16-bytestring-0.1.1.6 ...
-    sourceVersion (PSUpstream ver _ _) = ver
+    sourceVersion (PSUpstream ver _ _ _) = ver
     sourceVersion (PSLocal localPkg) = packageVersion (lpPackage localPkg)
     ghcOpts = concatMap snd . filter (isGhc . fst) . options
       where

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -144,7 +144,7 @@ getCabalLbs pvpBounds fp = do
         lookupVersion name =
           case Map.lookup name sourceMap of
               Just (PSLocal lp) -> Just $ packageVersion $ lpPackage lp
-              Just (PSUpstream version _ _) -> Just version
+              Just (PSUpstream version _ _ _) -> Just version
               Nothing ->
                   case Map.lookup name installedMap of
                       Just (_, installed) -> Just (installedVersion installed)

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -486,7 +486,7 @@ upgradeCabal :: (MonadIO m, MonadLogger m, MonadReader env m, HasHttpManager env
              -> m ()
 upgradeCabal menv wc = do
     let name = $(mkPackageName "Cabal")
-    rmap <- resolvePackages menv Set.empty (Set.singleton name)
+    rmap <- resolvePackages menv Map.empty (Set.singleton name)
     newest <-
         case Map.keys rmap of
             [] -> error "No Cabal library found in index, cannot upgrade"
@@ -510,7 +510,8 @@ upgradeCabal menv wc = do
                 , T.pack $ versionString installed
                 ]
             let ident = PackageIdentifier name newest
-            m <- unpackPackageIdents menv tmpdir Nothing (Set.singleton ident)
+            -- Nothing below: use the newest .cabal file revision
+            m <- unpackPackageIdents menv tmpdir Nothing (Map.singleton ident Nothing)
 
             compilerPath <- join $ findExecutable menv (compilerExeName wc)
             newestDir <- parseRelDir $ versionString newest

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -496,7 +496,7 @@ getResolverConstraints stackYaml resolver =
 -- If the package flags are passed as 'Nothing' then flags are chosen
 -- automatically.
 checkResolverSpec
-    :: ( MonadIO m, MonadCatch m, MonadLogger m, MonadReader env m
+    :: ( MonadIO m, MonadMask m, MonadLogger m, MonadReader env m
        , HasHttpManager env, HasConfig env, HasGHCVariant env
        , MonadBaseControl IO m)
     => [C.GenericPackageDescription]

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -71,6 +71,7 @@ import           GHC.Generics (Generic, from, to)
 import           Path (Path, Abs, File, Dir, mkRelDir, toFilePath, parseRelDir, (</>))
 import           Path.Extra (toFilePathNoTrailingSep)
 import           Prelude
+import           Stack.Types.BuildPlan (GitSHA1)
 import           Stack.Types.Compiler
 import           Stack.Types.Config
 import           Stack.Types.FlagName
@@ -519,14 +520,14 @@ instance Show TaskConfigOpts where
 -- | The type of a task, either building local code or something from the
 -- package index (upstream)
 data TaskType = TTLocal LocalPackage
-              | TTUpstream Package InstallLocation
+              | TTUpstream Package InstallLocation (Maybe GitSHA1)
     deriving Show
 
 taskLocation :: Task -> InstallLocation
 taskLocation task =
     case taskType task of
         TTLocal _ -> Local
-        TTUpstream _ loc -> loc
+        TTUpstream _ loc _ -> loc
 
 -- | A complete plan of what needs to be built and how to do it
 data Plan = Plan

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -37,6 +37,7 @@ import           Distribution.Text (display)
 import           GHC.Generics (Generic)
 import           Path as FL
 import           Prelude
+import           Stack.Types.BuildPlan (GitSHA1)
 import           Stack.Types.Compiler
 import           Stack.Types.Config
 import           Stack.Types.FlagName
@@ -219,17 +220,17 @@ type SourceMap = Map PackageName PackageSource
 -- | Where the package's source is located: local directory or package index
 data PackageSource
     = PSLocal LocalPackage
-    | PSUpstream Version InstallLocation (Map FlagName Bool)
+    | PSUpstream Version InstallLocation (Map FlagName Bool) (Maybe GitSHA1)
     -- ^ Upstream packages could be installed in either local or snapshot
     -- databases; this is what 'InstallLocation' specifies.
     deriving Show
 
 instance PackageInstallInfo PackageSource where
     piiVersion (PSLocal lp) = packageVersion $ lpPackage lp
-    piiVersion (PSUpstream v _ _) = v
+    piiVersion (PSUpstream v _ _ _) = v
 
     piiLocation (PSLocal _) = Local
-    piiLocation (PSUpstream _ loc _) = loc
+    piiLocation (PSUpstream _ loc _ _) = loc
 
 -- | Datatype which tells how which version of a package to install and where
 -- to install it into

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -15,7 +15,6 @@ import qualified Data.Map                    as Map
 import           Data.Maybe                  (isNothing)
 import           Data.Monoid                 ((<>))
 import qualified Data.Monoid
-import qualified Data.Set                    as Set
 import qualified Data.Text as T
 import           Lens.Micro                  (set)
 import           Network.HTTP.Client.Conduit (HasHttpManager)
@@ -83,7 +82,9 @@ upgrade gitRepo mresolver builtHash =
                 return Nothing
             Just version -> do
                 let ident = PackageIdentifier $(mkPackageName "stack") version
-                paths <- unpackPackageIdents menv tmp Nothing $ Set.singleton ident
+                paths <- unpackPackageIdents menv tmp Nothing
+                    -- accept latest cabal revision by not supplying a Git SHA
+                    $ Map.singleton ident Nothing
                 case Map.lookup ident paths of
                     Nothing -> error "Stack.Upgrade.upgrade: invariant violated, unpacked directory not found"
                     Just path -> return $ Just path

--- a/src/test/Stack/BuildPlanSpec.hs
+++ b/src/test/Stack/BuildPlanSpec.hs
@@ -87,6 +87,7 @@ spec = beforeAll setup $ afterAll teardown $ do
                 , mpiToolDeps = Set.empty
                 , mpiExes = Set.empty
                 , mpiHasLibrary = True
+                , mpiGitSHA1 = Nothing
                 }
             go x y = (pn x, mkMPI y)
             resourcet = go "resourcet" ""

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -46,3 +46,4 @@ extra-deps:
 - http-client-tls-0.2.4
 - connection-0.2.5
 - regex-applicative-text-0.1.0.1
+- monad-unlift-0.1.1.0

--- a/stack.cabal
+++ b/stack.cabal
@@ -168,6 +168,7 @@ library
                    , filepath >= 1.3.0.2
                    , fsnotify >= 0.2.1
                    , hashable >= 1.2.3.2
+                   , hit
                    , hpc
                    , http-client >= 0.4.17
                    , http-client-tls >= 0.2.2

--- a/stack.cabal
+++ b/stack.cabal
@@ -177,6 +177,7 @@ library
                    , microlens >= 0.3.0.0
                    , monad-control
                    , monad-logger >= 0.3.13.1
+                   , monad-unlift
                    , mtl >= 2.1.3.1
                    , open-browser >= 0.2.1
                    , optparse-applicative >= 0.11 && < 0.13


### PR DESCRIPTION
This patch turned out to be much larger than expected, and mostly for tedious reasons. I recommend reviewing one commit at a time, as two of these are very mechanical (changing constraints and adding fields to some data types).

I added support to stackage-curator recently to include hashes of .cabal files for newly generated snapshots. This patch will ensure that, when using Git as a package index and a snapshot with this hash information, we get the same version of the .cabal file as was used when generating the snapshot, avoiding the possibility of Hackage edits from corrupting the snapshot for end users.

I recommend holding off on merging this for a few days so it can be properly tested with upstream Stackage Nightly snapshots that actually have this .cabal hash information.