### PR TITLE
Removing nix enabled by default when nix: section is present

### DIFF
--- a/doc/nix_integration.md
+++ b/doc/nix_integration.md
@@ -104,9 +104,9 @@ With Nix enabled, `stack build` and `stack exec` will automatically
 launch themselves in a local build environment (using `nix-shell`
 behind the scenes).
 
-If `enable:` is set to `false`, you can still build in a nix-shell by
-passing the `--nix` flag to stack, for instance `stack --nix build`.
-Passing any `--nix*` option to the command line will do the same.
+If `enable:` is omitted or set to `false`, you can still build in a nix-shell by
+passing the `--nix` flag to stack, for instance `stack --nix build`.  Passing
+any `--nix*` option to the command line will do the same.
 
 **Known limitation on OS X:** currently, `stack --nix ghci` fails on
 OS X, due to a bug in GHCi when working with external shared
@@ -162,9 +162,10 @@ Here is a commented configuration file, showing the default values:
 ```yaml
 nix:
 
-  # true by default when the nix section is present. Set
-  # it to `false` to disable using Nix.
-  enable: true
+  # false by default. Must be present and set to `true` to enable Nix.
+  # You can set set it in your `$HOME/.stack/config.yaml` to enable
+  # Nix for all your projects without having to repeat it
+  # enable: true
 
   # true by default. Tells Nix whether to run in a pure shell or not.
   pure: true

--- a/src/Stack/Types/Nix.hs
+++ b/src/Stack/Types/Nix.hs
@@ -49,7 +49,7 @@ data NixOptsMonoid = NixOptsMonoid
 -- | Decode uninterpreted nix options from JSON/YAML.
 instance FromJSON (WithJSONWarnings NixOptsMonoid) where
   parseJSON = withObjectWarnings "NixOptsMonoid"
-    (\o -> do nixMonoidDefaultEnable <- pure True
+    (\o -> do nixMonoidDefaultEnable <- pure False
               nixMonoidEnable        <- o ..:? nixEnableArgName
               nixMonoidPureShell     <- o ..:? nixPureShellArgName
               nixMonoidPackages      <- o ..:? nixPackagesArgName


### PR DESCRIPTION
In order to solve https://github.com/commercialhaskell/stack/issues/1924, I propose to no longer enable nix by default when a nix: section is present in the configuration.

This allows package developers to propose a nix configuration (list of nix packages) for their packages without _forcing_ the use of nix. I.e. now, if the user has a `nix.enable` flag set to `false` in their `$HOME/.stack/config.yaml`, this setting will not be overriden by the presence of a nix package list.