### PR TITLE
Resolve #2084: Rewrite solver output parseLine using regexp

### DIFF
--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -9,7 +10,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE CPP #-}
 
 -- | Dealing with Cabal.
 
@@ -37,21 +37,19 @@ module Stack.Package
   ,cabalFilePackageId)
   where
 
-#if __GLASGOW_HASKELL__ < 710
-import           Control.Applicative (Applicative, (<$>), (<*>))
-#endif
+import Prelude ()
+import Prelude.Compat
 
 import           Control.Arrow ((&&&))
 import           Control.Exception hiding (try,catch)
-import           Control.Monad
+import           Control.Monad (liftM, liftM2, (<=<), when, forM)
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger (MonadLogger,logWarn)
-import           Control.Monad.Reader
+import           Control.Monad.Reader (MonadReader,runReaderT,ask,asks)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as C8
-import           Data.Function
-import           Data.List
+import           Data.List.Compat
 import           Data.List.Extra (nubOrd)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
@@ -85,7 +83,6 @@ import           Path as FL
 import           Path.Extra
 import           Path.Find
 import           Path.IO hiding (findFiles)
-import           Prelude
 import           Safe (headDef, tailSafe)
 import           Stack.Build.Installed
 import           Stack.Constants

--- a/src/Stack/Sig/GPG.hs
+++ b/src/Stack/Sig/GPG.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 
 {-|
@@ -15,9 +13,8 @@ Portability : POSIX
 
 module Stack.Sig.GPG (gpgSign, gpgVerify) where
 
-#if __GLASGOW_HASKELL__ < 710
-import           Control.Applicative ((<$>), (<*>))
-#endif
+import Prelude ()
+import Prelude.Compat
 
 import           Control.Monad.Catch (MonadThrow, throwM)
 import           Control.Monad.IO.Class (MonadIO, liftIO)

--- a/src/Stack/Sig/Sign.hs
+++ b/src/Stack/Sig/Sign.hs
@@ -16,9 +16,8 @@ Portability : POSIX
 
 module Stack.Sig.Sign (sign, signPackage, signTarBytes) where
 
-#if __GLASGOW_HASKELL__ < 710
-import           Control.Applicative (Applicative(..))
-#endif
+import Prelude ()
+import Prelude.Compat
 
 import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Compression.GZip as GZip

--- a/src/Stack/Types/Sig.hs
+++ b/src/Stack/Types/Sig.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -16,9 +15,8 @@ Portability : POSIX
 module Stack.Types.Sig
        (Signature(..), Fingerprint, mkFingerprint, SigException(..)) where
 
-#if __GLASGOW_HASKELL__ < 710
-import           Control.Applicative ((<$>))
-#endif
+import Prelude ()
+import Prelude.Compat
 
 import           Control.Exception (Exception)
 import           Data.Aeson (Value(..), ToJSON(..), FromJSON(..))

--- a/src/test/Stack/SolverSpec.hs
+++ b/src/test/Stack/SolverSpec.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+-- | Test suite for "Stack.Solver"
+module Stack.SolverSpec where
+
+import           Data.Text (unpack)
+import           Stack.Types
+import           Test.Hspec
+import qualified Data.Map as Map
+
+import Stack.Solver
+
+spec :: Spec
+spec =
+  describe "Stack.Solver" $ do
+    successfulExample 
+      "text-1.2.1.1 (latest: 1.2.2.0) -integer-simple (via: parsec-3.1.9) (new package)"
+      $(mkPackageName "text")
+      $(mkVersion "1.2.1.1")
+      [ ($(mkFlagName "integer-simple"), False)
+      ]
+    successfulExample 
+      "hspec-snap-1.0.0.0 *test (via: servant-snap-0.5) (new package)"
+      $(mkPackageName "hspec-snap")
+      $(mkVersion "1.0.0.0")
+      []
+    successfulExample
+      "time-locale-compat-0.1.1.1 -old-locale (via: http-api-data-0.2.2) (new package)"
+      $(mkPackageName "time-locale-compat")
+      $(mkVersion "0.1.1.1")
+      [ ($(mkFlagName "old-locale"), False)
+      ]
+    successfulExample
+      "flowdock-rest-0.2.0.0 -aeson-compat *test (via: haxl-fxtra-0.0.0.0) (new package)"
+      $(mkPackageName "flowdock-rest")
+      $(mkVersion "0.2.0.0")
+      [ ($(mkFlagName "aeson-compat"), False)
+      ]
+  where
+    successfulExample input pkgName pkgVersion flags =
+      it ("parses " ++ unpack input) $ 
+        parseCabalOutputLine input `shouldBe` Right (pkgName, (pkgVersion, Map.fromList flags))

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -45,3 +45,4 @@ extra-deps:
 - x509-system-1.6.3
 - http-client-tls-0.2.4
 - connection-0.2.5
+- regex-applicative-text-0.1.0.1

--- a/stack.cabal
+++ b/stack.cabal
@@ -143,6 +143,7 @@ library
                    , async >= 2.0.2 && < 2.2
                    , attoparsec >= 0.12.1.5 && < 0.14
                    , base >= 4.7 && <5
+                   , base-compat >=0.6 && <0.10
                    , base16-bytestring
                    , base64-bytestring
                    , binary >= 0.7
@@ -187,6 +188,7 @@ library
                    , pretty >= 1.1.1.1
                    , process >= 1.2.0.0
                    , resourcet >= 1.1.4.1
+                   , regex-applicative-text >=0.1.0.1 && <0.2
                    , retry >= 0.6 && < 0.8
                    , safe >= 0.3
                    , semigroups >= 0.5 && < 0.19


### PR DESCRIPTION
Also `text-1.2.1.1 (latest: 1.2.2.0) -integer-simple (via: parsec-3.1.9) (new package)` was parsed without flags before