### PR TITLE
#863 extensible snapshots

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,12 +6,19 @@ Release notes:
 
 Major changes:
 
+* Extensible custom snapshots implemented. These allow you to define snapshots
+which extend other snapshots. See
+[#863](https://github.com/commercialhaskell/stack/issues/863). Local file custom
+snapshots can now be safely updated without changing their name.  Remote custom
+snapshots should still be treated as immutable.
+
 Behavior changes:
 
 Other enhancements:
 
 * Grab Cabal files via Git SHA to avoid regressions from Hackage revisions
   [#2070](https://github.com/commercialhaskell/stack/pull/2070)
+* Custom snapshots now support `ghc-options`.
 
 Bug fixes:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,9 @@ Other enhancements:
 
 Bug fixes:
 
+* Now ignore project config when doing `stack init` or `stack new`. See
+  [#2110](https://github.com/commercialhaskell/stack/issues/2110).
+
 ## 1.1.0
 
 Release notes:

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -102,7 +102,7 @@ type M = RWST
 data Ctx = Ctx
     { mbp            :: !MiniBuildPlan
     , baseConfigOpts :: !BaseConfigOpts
-    , loadPackage    :: !(PackageName -> Version -> Map FlagName Bool -> IO Package)
+    , loadPackage    :: !(PackageName -> Version -> Map FlagName Bool -> [Text] -> IO Package)
     , combinedMap    :: !CombinedMap
     , toolToPackages :: !(Cabal.Dependency -> Map PackageName VersionRange)
     , ctxEnvConfig   :: !EnvConfig
@@ -129,7 +129,7 @@ constructPlan :: forall env m.
               -> [LocalPackage]
               -> Set PackageName -- ^ additional packages that must be built
               -> [DumpPackage () ()] -- ^ locally registered
-              -> (PackageName -> Version -> Map FlagName Bool -> IO Package) -- ^ load upstream package
+              -> (PackageName -> Version -> Map FlagName Bool -> [Text] -> IO Package) -- ^ load upstream package
               -> SourceMap
               -> InstalledMap
               -> m Plan
@@ -205,7 +205,7 @@ mkUnregisterLocal tasks dirtyReason locallyRegistered sourceMap =
         case M.lookup name tasks of
             Nothing ->
                 case M.lookup name sourceMap of
-                    Just (PSUpstream _ Snap _ _) -> Map.singleton gid
+                    Just (PSUpstream _ Snap _ _ _) -> Map.singleton gid
                         ( ident
                         , Just "Switching to snapshot installed package"
                         )
@@ -234,7 +234,6 @@ addFinal lp package isAllInOne = do
                             (getEnvConfig ctx)
                             (baseConfigOpts ctx)
                             allDeps
-                            True -- wanted
                             True -- local
                             Local
                             package
@@ -279,14 +278,16 @@ tellExecutables :: PackageName -> PackageSource -> M ()
 tellExecutables _ (PSLocal lp)
     | lpWanted lp = tellExecutablesPackage Local $ lpPackage lp
     | otherwise = return ()
-tellExecutables name (PSUpstream version loc flags _) =
+-- Ignores ghcOptions because they don't matter for enumerating
+-- executables.
+tellExecutables name (PSUpstream version loc flags _ghcOptions _gitSha) =
     tellExecutablesUpstream name version loc flags
 
 tellExecutablesUpstream :: PackageName -> Version -> InstallLocation -> Map FlagName Bool -> M ()
 tellExecutablesUpstream name version loc flags = do
     ctx <- ask
     when (name `Set.member` extraToBuild ctx) $ do
-        p <- liftIO $ loadPackage ctx name version flags
+        p <- liftIO $ loadPackage ctx name version flags []
         tellExecutablesPackage loc p
 
 tellExecutablesPackage :: InstallLocation -> Package -> M ()
@@ -319,8 +320,8 @@ installPackage :: Bool -- ^ is this being used by a dependency?
 installPackage treatAsDep name ps minstalled = do
     ctx <- ask
     case ps of
-        PSUpstream version _ flags _ -> do
-            package <- liftIO $ loadPackage ctx name version flags
+        PSUpstream version _ flags ghcOptions _ -> do
+            package <- liftIO $ loadPackage ctx name version flags ghcOptions
             resolveDepsAndInstall False treatAsDep ps package minstalled
         PSLocal lp ->
             case lpTestBench lp of
@@ -403,7 +404,6 @@ installPackageGivenDeps isAllInOne ps package minstalled (missing, present, minL
                         (getEnvConfig ctx)
                         (baseConfigOpts ctx)
                         allDeps
-                        (psWanted ps)
                         (psLocal ps)
                         -- An assertion to check for a recurrence of
                         -- https://github.com/commercialhaskell/stack/issues/345
@@ -413,7 +413,7 @@ installPackageGivenDeps isAllInOne ps package minstalled (missing, present, minL
             , taskType =
                 case ps of
                     PSLocal lp -> TTLocal lp
-                    PSUpstream _ loc _ sha -> TTUpstream package (loc <> minLoc) sha
+                    PSUpstream _ loc _ _ sha -> TTUpstream package (loc <> minLoc) sha
             , taskAllInOne = isAllInOne
             }
 
@@ -503,7 +503,6 @@ checkDirtiness ps installed package present wanted = do
             (getEnvConfig ctx)
             (baseConfigOpts ctx)
             present
-            (psWanted ps)
             (psLocal ps)
             (piiLocation ps) -- should be Local always
             package
@@ -598,10 +597,6 @@ psForceDirty (PSUpstream {}) = False
 psDirty :: PackageSource -> Maybe (Set FilePath)
 psDirty (PSLocal lp) = lpDirtyFiles lp
 psDirty (PSUpstream {}) = Nothing -- files never change in an upstream package
-
-psWanted :: PackageSource -> Bool
-psWanted (PSLocal lp) = lpWanted lp
-psWanted (PSUpstream {}) = False
 
 psLocal :: PackageSource -> Bool
 psLocal (PSLocal _) = True

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -213,7 +213,7 @@ parseTargetsFromBuildOpts needTargets boptscli = do
                     }
             ResolverCustom _ url -> do
                 stackYamlFP <- asks $ bcStackYaml . getBuildConfig
-                parseCustomMiniBuildPlan stackYamlFP url
+                parseCustomMiniBuildPlan (Just stackYamlFP) url
     rawLocals <- getLocalPackageViews
     workingDir <- getCurrentDir
 

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -91,7 +91,6 @@ loadSourceMap needTargets boptsCli = do
     locals <- mapM (loadLocalPackage boptsCli targets) $ Map.toList rawLocals
     checkFlagsUsed boptsCli locals extraDeps0 (mbpPackages mbp0)
     checkComponentsBuildable locals
-    warnAllowNewer mbp0
 
     let
         -- loadLocals returns PackageName (foo) and PackageIdentifier (bar-1.2.3) targets separately;
@@ -205,7 +204,6 @@ parseTargetsFromBuildOpts needTargets boptscli = do
                 return MiniBuildPlan
                     { mbpCompilerVersion = version
                     , mbpPackages = Map.empty
-                    , mbpAllowNewer = False
                     }
             _ -> return (bcWantedMiniBuildPlan bconfig)
     rawLocals <- getLocalPackageViews
@@ -590,21 +588,6 @@ checkComponentsBuildable lps =
         | lp <- lps
         , c <- Set.toList (lpUnbuildable lp)
         ]
-
-warnAllowNewer :: (MonadThrow m, MonadLogger m, MonadReader env m, HasConfig env)
-               => MiniBuildPlan -> m ()
-warnAllowNewer mpb = do
-    -- TODO: Perhaps we should just have the snapshot setting imply
-    -- allow-newer? I just didn't want to make 'configAllowNewer'
-    -- non-authoritative about whether allow-newer is enabled.
-    allowNewer <- asks (configAllowNewer . getConfig)
-    when (mbpAllowNewer mpb && not allowNewer) $ do
-        $logWarn $ T.unlines
-            [ ""
-            , "WARNING: The snapshot specifies that allow-newer needs to be used."
-            , "You should probably add 'allow-newer: true' to suppress this warning."
-            , ""
-            ]
 
 getDefaultPackageConfig :: (MonadIO m, MonadThrow m, MonadCatch m, MonadLogger m, MonadReader env m, HasEnvConfig env)
   => m PackageConfig

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -58,8 +58,7 @@ import           Path.IO
 import           Prelude
 import           Stack.Build.Cache
 import           Stack.Build.Target
-import           Stack.BuildPlan (loadMiniBuildPlan, shadowMiniBuildPlan,
-                                  parseCustomMiniBuildPlan)
+import           Stack.BuildPlan (shadowMiniBuildPlan)
 import           Stack.Constants (wiredInPackages)
 import           Stack.Package
 import           Stack.PackageIndex (getPackageVersions)
@@ -198,9 +197,6 @@ parseTargetsFromBuildOpts needTargets boptscli = do
     bconfig <- asks getBuildConfig
     mbp0 <-
         case bcResolver bconfig of
-            ResolverSnapshot snapName -> do
-                $logDebug $ "Checking resolver: " <> renderSnapName snapName
-                loadMiniBuildPlan snapName
             ResolverCompiler _ -> do
                 -- We ignore the resolver version, as it might be
                 -- GhcMajorVersion, and we want the exact version
@@ -211,9 +207,7 @@ parseTargetsFromBuildOpts needTargets boptscli = do
                     , mbpPackages = Map.empty
                     , mbpAllowNewer = False
                     }
-            ResolverCustom _ url -> do
-                stackYamlFP <- asks $ bcStackYaml . getBuildConfig
-                parseCustomMiniBuildPlan (Just stackYamlFP) url
+            _ -> return (bcWantedMiniBuildPlan bconfig)
     rawLocals <- getLocalPackageViews
     workingDir <- getCurrentDir
 

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -512,8 +512,11 @@ loadBuildConfig mproject config mresolver mcompiler = do
             , projectCompiler = mcompiler <|> projectCompiler project'
             }
 
-    (mbp, loadedResolver) <- flip runReaderT miniConfig $
+    (mbp0, loadedResolver) <- flip runReaderT miniConfig $
         loadResolver (Just stackYamlFP) (projectResolver project)
+    let mbp = case projectCompiler project of
+            Just compiler -> mbp0 { mbpCompilerVersion = compiler }
+            Nothing -> mbp0
 
     extraPackageDBs <- mapM resolveDir' (projectExtraPackageDBs project)
 

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -298,7 +298,7 @@ configFromConfigMonoid configStackRoot configUserConfigPath mresolver mproject c
 
      let configTemplateParams = configMonoidTemplateParameters
          configScmInit = getFirst configMonoidScmInit
-         configGhcOptions = getCliOptionMap configMonoidGhcOptions
+         configGhcOptions = configMonoidGhcOptions
          configSetupInfoLocations = configMonoidSetupInfoLocations
          configPvpBounds = fromFirst PvpBoundsNone configMonoidPvpBounds
          configModifyCodePage = fromFirst True configMonoidModifyCodePage

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -520,7 +520,7 @@ loadBuildConfig mproject config mresolver mcompiler = do
                     mbp <- runReaderT (loadMiniBuildPlan snapName) miniConfig
                     return $ mbpCompilerVersion mbp
                 ResolverCustom _name url -> do
-                    mbp <- runReaderT (parseCustomMiniBuildPlan stackYamlFP url) miniConfig
+                    mbp <- runReaderT (parseCustomMiniBuildPlan (Just stackYamlFP) url) miniConfig
                     return $ mbpCompilerVersion mbp
                 ResolverCompiler wantedCompiler -> return wantedCompiler
 

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -45,6 +45,7 @@ cfgCmdSet (ConfigCmdSetResolver newResolver) = do
     (projectYamlConfig :: Yaml.Object) <-
         liftIO (Yaml.decodeFileEither stackYamlFp) >>=
         either throwM return
+    -- TODO: custom snapshot support?
     newResolverText <- fmap resolverName (makeConcreteResolver newResolver)
     -- We checking here that the snapshot actually exists
     snap <- parseSnapName newResolverText

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -124,7 +124,7 @@ ghci opts@GhciOpts{..} = do
             getUserOptions Nothing ++
             concatMap (getUserOptions . Just . ghciPkgName) pkgs
         getUserOptions mpkg =
-            map T.unpack (M.findWithDefault [] mpkg (configGhcOptions config))
+            map T.unpack (M.findWithDefault [] mpkg (unGhcOptions (configGhcOptions config)))
         badForGhci x =
             isPrefixOf "-O" x || elem x (words "-debug -threaded -ticky -static -Werror")
     unless (null omittedOpts) $
@@ -260,7 +260,7 @@ ghciSetup
     => GhciOpts
     -> m (Map PackageName SimpleTarget, Maybe (Map PackageName SimpleTarget), [GhciPkgInfo])
 ghciSetup GhciOpts{..} = do
-    (_,_,targets) <- parseTargetsFromBuildOpts AllowNoTargets ghciBuildOptsCLI 
+    (_,_,targets) <- parseTargetsFromBuildOpts AllowNoTargets ghciBuildOptsCLI
     mainIsTargets <-
         case ghciMainIs of
             Nothing -> return Nothing
@@ -357,7 +357,8 @@ makeGhciPkgInfo boptsCli sourceMap installedMap locals addPkgs name cabalfp targ
             PackageConfig
             { packageConfigEnableTests = True
             , packageConfigEnableBenchmarks = True
-            , packageConfigFlags = localFlags (boptsCLIFlags boptsCli) bconfig name
+            , packageConfigFlags = getLocalFlags bconfig boptsCli name
+            , packageConfigGhcOptions = getGhcOptions bconfig boptsCli name True True
             , packageConfigCompilerVersion = envConfigCompilerVersion econfig
             , packageConfigPlatform = configPlatform (getConfig bconfig)
             }

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -118,7 +118,7 @@ initProject currDir initOpts mresolver = do
             { projectUserMsg = if userMsg == "" then Nothing else Just userMsg
             , projectPackages = pkgs
             , projectExtraDeps = extraDeps
-            , projectFlags = removeSrcPkgDefaultFlags gpds flags
+            , projectFlags = PackageFlags (removeSrcPkgDefaultFlags gpds flags)
             , projectResolver = r
             , projectCompiler = Nothing
             , projectExtraPackageDBs = []

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -51,7 +51,7 @@ import           Prelude -- Fix redundant import warnings
 import           Stack.Build (mkBaseConfigOpts)
 import           Stack.Build.Execute
 import           Stack.Build.Installed
-import           Stack.Build.Source (loadSourceMap, getPackageConfig)
+import           Stack.Build.Source (loadSourceMap, getDefaultPackageConfig)
 import           Stack.Build.Target
 import           Stack.Constants
 import           Stack.Package
@@ -144,7 +144,7 @@ getCabalLbs pvpBounds fp = do
         lookupVersion name =
           case Map.lookup name sourceMap of
               Just (PSLocal lp) -> Just $ packageVersion $ lpPackage lp
-              Just (PSUpstream version _ _ _) -> Just version
+              Just (PSUpstream version _ _ _ _) -> Just version
               Nothing ->
                   case Map.lookup name installedMap of
                       Just (_, installed) -> Just (installedVersion installed)
@@ -175,8 +175,7 @@ gtraverseT f =
 readLocalPackage :: M env m => Path Abs Dir -> m LocalPackage
 readLocalPackage pkgDir = do
     cabalfp <- findOrGenerateCabalFile pkgDir
-    name    <- parsePackageNameFromFilePath cabalfp
-    config  <- getPackageConfig defaultBuildOptsCLI name
+    config  <- getDefaultPackageConfig
     (warnings,package) <- readPackage config cabalfp
     mapM_ (printCabalFileWarning cabalfp) warnings
     return LocalPackage
@@ -271,7 +270,7 @@ checkSDistTarball tarball = withTempTarGzContents tarball $ \pkgDir' -> do
     --               ^ drop ".tar"     ^ drop ".gz"
     cabalfp <- findOrGenerateCabalFile pkgDir
     name    <- parsePackageNameFromFilePath cabalfp
-    config  <- getPackageConfig defaultBuildOptsCLI name
+    config  <- getDefaultPackageConfig
     (gdesc, pkgDesc) <- readPackageDescriptionDir config pkgDir
     $logInfo $
         "Checking package '" <> packageNameText name <> "' for common mistakes"

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -1016,8 +1016,8 @@ loadGhcjsEnvConfig stackYaml binPath = runInnerStackLoggingT $ do
             { configMonoidInstallGHC = First (Just True)
             , configMonoidLocalBinPath = First (Just (toFilePath binPath))
             })
-        (Just stackYaml)
         Nothing
+        (Just stackYaml)
     bconfig <- lcLoadBuildConfig lc Nothing
     runInnerStackT bconfig $ setupEnv Nothing
 

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -660,7 +660,7 @@ solveExtraDeps modStackYaml = do
     (bundle, _) <- cabalPackagesCheck cabalfps noPkgMsg (Just dupPkgFooter)
 
     let gpds              = Map.elems $ fmap snd bundle
-        oldFlags          = bcFlags bconfig
+        oldFlags          = unPackageFlags (bcFlags bconfig)
         oldExtraVersions  = bcExtraDeps bconfig
         resolver          = bcResolver bconfig
         oldSrcs           = gpdPackages gpds

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -481,7 +481,7 @@ getResolverConstraints stackYaml resolver =
         ResolverCustom _ url -> do
             -- FIXME instead of passing the stackYaml dir we should maintain
             -- the file URL in the custom resolver always relative to stackYaml.
-            mbp <- parseCustomMiniBuildPlan stackYaml url
+            mbp <- parseCustomMiniBuildPlan (Just stackYaml) url
             return (mbpCompilerVersion mbp, mbpConstraints mbp)
         ResolverCompiler compiler ->
             return (compiler, Map.empty)

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -473,21 +473,12 @@ getResolverConstraints
     -> Resolver
     -> m (CompilerVersion,
           Map PackageName (Version, Map FlagName Bool))
-getResolverConstraints stackYaml resolver =
-    case resolver of
-        ResolverSnapshot snapName -> do
-            mbp <- loadMiniBuildPlan snapName
-            return (mbpCompilerVersion mbp, mbpConstraints mbp)
-        ResolverCustom _ url -> do
-            -- FIXME instead of passing the stackYaml dir we should maintain
-            -- the file URL in the custom resolver always relative to stackYaml.
-            mbp <- parseCustomMiniBuildPlan (Just stackYaml) url
-            return (mbpCompilerVersion mbp, mbpConstraints mbp)
-        ResolverCompiler compiler ->
-            return (compiler, Map.empty)
-    where
-      mpiConstraints mpi = (mpiVersion mpi, mpiFlags mpi)
-      mbpConstraints mbp = fmap mpiConstraints (mbpPackages mbp)
+getResolverConstraints stackYaml resolver = do
+    (mbp, _loadedResolver) <- loadResolver (Just stackYaml) resolver
+    return (mbpCompilerVersion mbp, mbpConstraints mbp)
+  where
+    mpiConstraints mpi = (mpiVersion mpi, mpiFlags mpi)
+    mbpConstraints mbp = fmap mpiConstraints (mbpPackages mbp)
 
 -- | Given a bundle of user packages, flag constraints on those packages and a
 -- resolver, determine if the resolver fully, partially or fails to satisfy the
@@ -670,13 +661,14 @@ solveExtraDeps modStackYaml = do
         srcConstraints    = mergeConstraints oldSrcs oldSrcFlags
         extraConstraints  = mergeConstraints oldExtraVersions oldExtraFlags
 
-    resolverResult <- checkResolverSpec gpds (Just oldSrcFlags) resolver
+    let resolver' = toResolverNotLoaded resolver
+    resolverResult <- checkResolverSpec gpds (Just oldSrcFlags) resolver'
     resultSpecs <- case resolverResult of
         BuildPlanCheckOk flags ->
             return $ Just ((mergeConstraints oldSrcs flags), Map.empty)
         BuildPlanCheckPartial {} -> do
             eres <- solveResolverSpec stackYaml cabalDirs
-                              (resolver, srcConstraints, extraConstraints)
+                              (resolver', srcConstraints, extraConstraints)
             -- TODO Solver should also use the init code to ignore incompatible
             -- packages
             return $ either (const Nothing) Just eres

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -424,7 +424,6 @@ instance FromJSON a => FromJSON (Map ExeName a) where
 data MiniBuildPlan = MiniBuildPlan
     { mbpCompilerVersion :: !CompilerVersion
     , mbpPackages :: !(Map PackageName MiniPackageInfo)
-    , mbpAllowNewer :: !Bool
     }
     deriving (Generic, Show, Eq)
 instance Binary MiniBuildPlan

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -424,6 +424,7 @@ instance FromJSON a => FromJSON (Map ExeName a) where
 data MiniBuildPlan = MiniBuildPlan
     { mbpCompilerVersion :: !CompilerVersion
     , mbpPackages :: !(Map PackageName MiniPackageInfo)
+    , mbpAllowNewer :: !Bool
     }
     deriving (Generic, Show, Eq)
 instance Binary MiniBuildPlan
@@ -435,6 +436,7 @@ instance HasSemanticVersion MiniBuildPlan
 data MiniPackageInfo = MiniPackageInfo
     { mpiVersion :: !Version
     , mpiFlags :: !(Map FlagName Bool)
+    , mpiGhcOptions :: ![Text]
     , mpiPackageDeps :: !(Set PackageName)
     , mpiToolDeps :: !(Set Text)
     -- ^ Due to ambiguity in Cabal, it is unclear whether this refers to the

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -25,6 +25,8 @@ module Stack.Types.BuildPlan
     , GitSHA1 (..)
     , renderSnapName
     , parseSnapName
+    , SnapshotHash (..)
+    , trimmedSnapshotHash
     ) where
 
 import           Control.Applicative
@@ -36,6 +38,7 @@ import           Data.Aeson                      (FromJSON (..), ToJSON (..),
                                                   (.!=), (.:), (.:?), (.=))
 import           Data.Binary.VersionTagged
 import           Data.ByteString                 (ByteString)
+import qualified Data.ByteString                 as BS
 import           Data.Hashable                   (Hashable)
 import qualified Data.HashMap.Strict             as HashMap
 import           Data.IntMap                     (IntMap)
@@ -458,3 +461,9 @@ instance NFData MiniPackageInfo
 
 newtype GitSHA1 = GitSHA1 ByteString
     deriving (Generic, Show, Eq, NFData, HasStructuralInfo, Binary)
+
+newtype SnapshotHash = SnapshotHash { unShapshotHash :: ByteString }
+    deriving (Generic, Show, Eq)
+
+trimmedSnapshotHash :: SnapshotHash -> ByteString
+trimmedSnapshotHash = BS.take 12 . unShapshotHash

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -184,7 +184,7 @@ import           Generics.Deriving.Monoid (memptydefault, mappenddefault)
 import           Network.HTTP.Client (parseUrl)
 import           Path
 import qualified Paths_stack as Meta
-import           Stack.Types.BuildPlan (MiniBuildPlan(..), SnapName, renderSnapName, parseSnapName)
+import           Stack.Types.BuildPlan (MiniBuildPlan(..), SnapName, renderSnapName, parseSnapName, SnapshotHash (..), trimmedSnapshotHash)
 import           Stack.Types.Urls
 import           Stack.Types.Compiler
 import           Stack.Types.Docker
@@ -679,7 +679,7 @@ data ResolverThat's (l :: IsLoaded) where
     -- | Like 'ResolverCustom', but after loading the build-plan, so we
     -- have a hash. This is necessary in order to identify the location
     -- files are stored for the resolver.
-    ResolverCustomLoaded :: !Text -> !Text -> !Text -> ResolverThat's 'Loaded
+    ResolverCustomLoaded :: !Text -> !Text -> !SnapshotHash -> ResolverThat's 'Loaded
 
 deriving instance Show (ResolverThat's k)
 
@@ -709,7 +709,7 @@ instance FromJSON (WithJSONWarnings (ResolverThat's 'NotLoaded)) where
 resolverDirName :: LoadedResolver -> Text
 resolverDirName (ResolverSnapshot name) = renderSnapName name
 resolverDirName (ResolverCompiler v) = compilerVersionText v
-resolverDirName (ResolverCustomLoaded name _ hash) = "custom-" <> name <> "-" <> hash
+resolverDirName (ResolverCustomLoaded name _ hash) = "custom-" <> name <> "-" <> decodeUtf8 (trimmedSnapshotHash hash)
 
 -- | Convert a Resolver into its @Text@ representation for human
 -- presentation.
@@ -719,7 +719,7 @@ resolverName (ResolverCompiler v) = compilerVersionText v
 resolverName (ResolverCustom name _) = "custom-" <> name
 resolverName (ResolverCustomLoaded name _ _) = "custom-" <> name
 
-customResolverHash :: LoadedResolver-> Maybe Text
+customResolverHash :: LoadedResolver-> Maybe SnapshotHash
 customResolverHash (ResolverCustomLoaded _ _ hash) = Just hash
 customResolverHash _ = Nothing
 

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -661,22 +661,25 @@ data IsLoaded = Loaded | NotLoaded
 type LoadedResolver = ResolverThat's 'Loaded
 type Resolver = ResolverThat's 'NotLoaded
 
+-- TODO: once GHC 8.0 is the lowest version we support, make these into
+-- actual haddock comments...
+
 -- | How we resolve which dependencies to install given a set of packages.
 data ResolverThat's (l :: IsLoaded) where
-    -- | Use an official snapshot from the Stackage project, either an LTS
-    -- Haskell or Stackage Nightly
+    -- Use an official snapshot from the Stackage project, either an LTS
+    -- Haskell or Stackage Nightly.
     ResolverSnapshot :: !SnapName -> ResolverThat's l
-    -- | Require a specific compiler version, but otherwise provide no
+    -- Require a specific compiler version, but otherwise provide no
     -- build plan. Intended for use cases where end user wishes to
     -- specify all upstream dependencies manually, such as using a
     -- dependency solver.
     ResolverCompiler :: !CompilerVersion -> ResolverThat's l
-    -- | A custom resolver based on the given name and URL. When a URL is
+    -- A custom resolver based on the given name and URL. When a URL is
     -- provided, it file is to be completely immutable. Filepaths are
     -- always loaded. This constructor is used before the build-plan has
     -- been loaded, as we do not yet know the custom snapshot's hash.
     ResolverCustom :: !Text -> !Text -> ResolverThat's 'NotLoaded
-    -- | Like 'ResolverCustom', but after loading the build-plan, so we
+    -- Like 'ResolverCustom', but after loading the build-plan, so we
     -- have a hash. This is necessary in order to identify the location
     -- files are stored for the resolver.
     ResolverCustomLoaded :: !Text -> !Text -> !SnapshotHash -> ResolverThat's 'Loaded

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1708,7 +1708,6 @@ data CustomSnapshot = CustomSnapshot
     , csDropPackages :: !(Set PackageName)
     , csFlags :: !PackageFlags
     , csGhcOptions :: !GhcOptions
-    , csAllowNewer :: !(Maybe Bool)
     }
 
 instance FromJSON (WithJSONWarnings (CustomSnapshot, Maybe Resolver)) where
@@ -1718,8 +1717,7 @@ instance FromJSON (WithJSONWarnings (CustomSnapshot, Maybe Resolver)) where
             <*> o ..:? "packages" ..!= mempty
             <*> o ..:? "drop-packages" ..!= mempty
             <*> o ..:? "flags" ..!= mempty
-            <*> o ..:? configMonoidGhcOptionsName ..!= mempty
-            <*> o ..:? configMonoidAllowNewerName)
+            <*> o ..:? configMonoidGhcOptionsName ..!= mempty)
         <*> jsonSubWarningsT (o ..:? "resolver")
 
 newtype GhcOptions = GhcOptions

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -88,6 +88,7 @@ data Package =
           ,packageDeps :: !(Map PackageName VersionRange) -- ^ Packages that the package depends on.
           ,packageTools :: ![Dependency]                  -- ^ A build tool name.
           ,packageAllDeps :: !(Set PackageName)           -- ^ Original dependencies (not sieved).
+          ,packageGhcOptions :: ![Text]                   -- ^ Ghc options used on package.
           ,packageFlags :: !(Map FlagName Bool)           -- ^ Flags used on package.
           ,packageDefaultFlags :: !(Map FlagName Bool)    -- ^ Defaults for unspecified flags.
           ,packageHasLibrary :: !Bool                     -- ^ does the package have a buildable library stanza?
@@ -201,7 +202,8 @@ instance Show PackageWarning where
 data PackageConfig =
   PackageConfig {packageConfigEnableTests :: !Bool                -- ^ Are tests enabled?
                 ,packageConfigEnableBenchmarks :: !Bool           -- ^ Are benchmarks enabled?
-                ,packageConfigFlags :: !(Map FlagName Bool)       -- ^ Package config flags.
+                ,packageConfigFlags :: !(Map FlagName Bool)       -- ^ Configured flags.
+                ,packageConfigGhcOptions :: ![Text]               -- ^ Configured ghc options.
                 ,packageConfigCompilerVersion :: !CompilerVersion -- ^ GHC version
                 ,packageConfigPlatform :: !Platform               -- ^ host platform
                 }
@@ -220,17 +222,17 @@ type SourceMap = Map PackageName PackageSource
 -- | Where the package's source is located: local directory or package index
 data PackageSource
     = PSLocal LocalPackage
-    | PSUpstream Version InstallLocation (Map FlagName Bool) (Maybe GitSHA1)
+    | PSUpstream Version InstallLocation (Map FlagName Bool) [Text] (Maybe GitSHA1)
     -- ^ Upstream packages could be installed in either local or snapshot
     -- databases; this is what 'InstallLocation' specifies.
     deriving Show
 
 instance PackageInstallInfo PackageSource where
     piiVersion (PSLocal lp) = packageVersion $ lpPackage lp
-    piiVersion (PSUpstream v _ _ _) = v
+    piiVersion (PSUpstream v _ _ _ _) = v
 
     piiLocation (PSLocal _) = Local
-    piiLocation (PSUpstream _ loc _ _) = loc
+    piiLocation (PSUpstream _ loc _ _ _) = loc
 
 -- | Datatype which tells how which version of a package to install and where
 -- to install it into

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -96,8 +96,8 @@ upgrade gitRepo mresolver builtHash =
                 (configConfigMonoid config <> Data.Monoid.mempty
                     { configMonoidInstallGHC = First (Just True)
                     })
-                (Just $ dir </> $(mkRelFile "stack.yaml"))
                 mresolver
+                (Just $ dir </> $(mkRelFile "stack.yaml"))
             lcLoadBuildConfig lc Nothing
         envConfig1 <- runInnerStackT bconfig $ setupEnv $ Just $
             "Try rerunning with --install-ghc to install the correct GHC into " <>

--- a/src/test/Network/HTTP/Download/VerifiedSpec.hs
+++ b/src/test/Network/HTTP/Download/VerifiedSpec.hs
@@ -3,6 +3,8 @@ module Network.HTTP.Download.VerifiedSpec where
 
 import Crypto.Hash
 import Control.Monad (unless)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Logger (LoggingT, runStdoutLoggingT)
 import Control.Monad.Trans.Reader
 import Control.Retry (limitRetries)
 import Data.Maybe
@@ -65,8 +67,8 @@ data T = T
   { manager :: Manager
   }
 
-runWith :: Manager -> ReaderT Manager m r -> m r
-runWith = flip runReaderT
+runWith :: MonadIO m => Manager -> ReaderT Manager (LoggingT m) r -> m r
+runWith manager = runStdoutLoggingT . flip runReaderT manager
 
 setup :: IO T
 setup = do

--- a/src/test/Stack/BuildPlanSpec.hs
+++ b/src/test/Stack/BuildPlanSpec.hs
@@ -83,6 +83,7 @@ spec = beforeAll setup $ afterAll teardown $ do
             mkMPI deps = MiniPackageInfo
                 { mpiVersion = version
                 , mpiFlags = Map.empty
+                , mpiGhcOptions = []
                 , mpiPackageDeps = Set.fromList $ map pn $ words deps
                 , mpiToolDeps = Set.empty
                 , mpiExes = Set.empty
@@ -99,6 +100,7 @@ spec = beforeAll setup $ afterAll teardown $ do
             mkMBP pkgs = MiniBuildPlan
                 { mbpCompilerVersion = GhcVersion version
                 , mbpPackages = Map.fromList pkgs
+                , mbpAllowNewer = False
                 }
             mbpAll = mkMBP [resourcet, conduit, conduitExtra, text, attoparsec, aeson]
             test name input shadowed output extra =

--- a/src/test/Stack/BuildPlanSpec.hs
+++ b/src/test/Stack/BuildPlanSpec.hs
@@ -100,7 +100,6 @@ spec = beforeAll setup $ afterAll teardown $ do
             mkMBP pkgs = MiniBuildPlan
                 { mbpCompilerVersion = GhcVersion version
                 , mbpPackages = Map.fromList pkgs
-                , mbpAllowNewer = False
                 }
             mbpAll = mkMBP [resourcet, conduit, conduitExtra, text, attoparsec, aeson]
             test name input shadowed output extra =

--- a/test/integration/tests/1265-extensible-snapshots/Main.hs
+++ b/test/integration/tests/1265-extensible-snapshots/Main.hs
@@ -1,0 +1,4 @@
+import StackTest
+
+main :: IO ()
+main = stack ["build", "SHA"]

--- a/test/integration/tests/1265-extensible-snapshots/Main.hs
+++ b/test/integration/tests/1265-extensible-snapshots/Main.hs
@@ -1,4 +1,8 @@
 import StackTest
 
 main :: IO ()
-main = stack ["build", "SHA"]
+main = do
+    stack ["build", "async"]
+    stackErr ["build", "zlib-bindings"]
+    stack ["build", "--stack-yaml", "stack-modify-lts.yaml", "async"]
+    stackErr ["build", "--stack-yaml", "stack-modify-lts.yaml", "zlib-bindings"]

--- a/test/integration/tests/1265-extensible-snapshots/files/snapshot-2.yaml
+++ b/test/integration/tests/1265-extensible-snapshots/files/snapshot-2.yaml
@@ -1,0 +1,9 @@
+resolver: ghc-7.10
+packages:
+- stm-2.4.4.1
+- async-2.1.0
+- zlib-0.6.1.1
+# FIXME: test these here
+flags: {}
+ghc-options: {}
+allow-newer: true

--- a/test/integration/tests/1265-extensible-snapshots/files/snapshot-2.yaml
+++ b/test/integration/tests/1265-extensible-snapshots/files/snapshot-2.yaml
@@ -6,4 +6,3 @@ packages:
 # FIXME: test these here
 flags: {}
 ghc-options: {}
-allow-newer: true

--- a/test/integration/tests/1265-extensible-snapshots/files/snapshot-modify-lts.yaml
+++ b/test/integration/tests/1265-extensible-snapshots/files/snapshot-modify-lts.yaml
@@ -1,0 +1,3 @@
+resolver: lts-5.11
+drop-packages:
+- zlib

--- a/test/integration/tests/1265-extensible-snapshots/files/snapshot.yaml
+++ b/test/integration/tests/1265-extensible-snapshots/files/snapshot.yaml
@@ -1,15 +1,7 @@
-compiler: ghc-7.10
+resolver:
+    name: test-snapshot-2
+    location: snapshot-2.yaml
 packages:
-# Just the first thing I found via github search that conditionally adds exports
-# based on flags.
-#
-# TODO: check that the decoder interface is present (and that this flag matters)
-- SHA-1.6.4
-- binary-0.8.0.0
-flags:
-    SHA:
-        DecoderInterface: true
-# FIXME: test this better
-ghc-options:
-    SHA: "-Wall"
-allow-newer: true
+- microlens-0.4.3.0
+drop-packages:
+- zlib

--- a/test/integration/tests/1265-extensible-snapshots/files/snapshot.yaml
+++ b/test/integration/tests/1265-extensible-snapshots/files/snapshot.yaml
@@ -1,0 +1,15 @@
+compiler: ghc-7.10
+packages:
+# Just the first thing I found via github search that conditionally adds exports
+# based on flags.
+#
+# TODO: check that the decoder interface is present (and that this flag matters)
+- SHA-1.6.4
+- binary-0.8.0.0
+flags:
+    SHA:
+        DecoderInterface: true
+# FIXME: test this better
+ghc-options:
+    SHA: "-Wall"
+allow-newer: true

--- a/test/integration/tests/1265-extensible-snapshots/files/stack-modify-lts.yaml
+++ b/test/integration/tests/1265-extensible-snapshots/files/stack-modify-lts.yaml
@@ -1,0 +1,4 @@
+resolver:
+    name: snapshot-modify-lts
+    location: snapshot-modify-lts.yaml
+packages: []

--- a/test/integration/tests/1265-extensible-snapshots/files/stack.yaml
+++ b/test/integration/tests/1265-extensible-snapshots/files/stack.yaml
@@ -1,0 +1,5 @@
+resolver:
+    name: test-snapshot
+    location: snapshot.yaml
+packages: []
+allow-newer: true


### PR DESCRIPTION
* Extensible custom snapshots implemented - see #863. These allow you to define snapshots which extend other snapshots. Local file custom snapshots can now be safely updated without changing their name.  Remote custom snapshots should still be treated as immutable.

* Custom snapshots now support `ghc-options`.

* Consolidates logic for ghc-options and flags (now mostly in `Stack.Build.Source`)

@borsboom Want to review this?  I think it's pretty solid, but it could be valuable to get a review, particularly the changes in `Stack.BuildPlan` and `Stack.Types.Config`.