### PR TITLE
always use --with-fingerprint

### DIFF
--- a/src/Stack/Sig/GPG.hs
+++ b/src/Stack/Sig/GPG.hs
@@ -62,7 +62,8 @@ gpgVerify
     :: (MonadIO m, MonadThrow m)
     => Signature -> Path Abs File -> m Fingerprint
 gpgVerify (Signature signature) path = do
-    (hIn,hOut,hErr,process) <- gpg ["--verify", "-", toFilePath path]
+    (hIn,hOut,hErr,process) <-
+        gpg ["--verify", "--with-fingerprint", "-", toFilePath path]
     (_in,out,err,code) <-
         liftIO
             ((,,,) <$>


### PR DESCRIPTION
Otherwise we are assuming the user has set up their gpg.conf like
everyone else [bad assumption]