### PR TITLE
Fix pattern overlap warning with GHC-7.8 and GHC-7.10

### DIFF
--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -293,12 +293,9 @@ generateUnionReport report reportDir tixFiles = do
 
 readTixOrLog :: (MonadLogger m, MonadIO m, MonadBaseControl IO m) => Path b File -> m (Maybe Tix)
 readTixOrLog path = do
-    mtix <- liftIO (readTix (toFilePath path)) `catch` \case
-        ErrorCall err -> do
-            $logError $ "Error while reading tix: " <> T.pack err
-            return Nothing
-        -- https://ghc.haskell.org/trac/ghc/ticket/8779
-        _ -> fail "Impossible case in readTixOrLog"
+    mtix <- liftIO (readTix (toFilePath path)) `catch` \errorCall -> do
+        $logError $ "Error while reading tix: " <> T.pack (show (errorCall :: ErrorCall))
+        return Nothing
     when (isNothing mtix) $
         $logError $ "Failed to read tix file " <> T.pack (toFilePath path)
     return mtix


### PR DESCRIPTION
`show (ErrorCall x) = x`, so the error message is as before.