### PR TITLE
Ability to provide args to haddock command

### DIFF
--- a/src/Stack/Config/Build.hs
+++ b/src/Stack/Config/Build.hs
@@ -18,6 +18,7 @@ buildOptsFromMonoid BuildOptsMonoid{..} = BuildOpts
     , boptsHaddock = fromFirst
           (boptsHaddock defaultBuildOpts)
           buildMonoidHaddock
+    , boptsHaddockOpts = haddockOptsFromMonoid buildMonoidHaddockOpts
     , boptsOpenHaddocks = fromFirst
           (boptsOpenHaddocks defaultBuildOpts)
           buildMonoidOpenHaddocks
@@ -48,6 +49,12 @@ buildOptsFromMonoid BuildOptsMonoid{..} = BuildOpts
           (boptsSplitObjs defaultBuildOpts)
           buildMonoidSplitObjs
     }
+
+
+haddockOptsFromMonoid :: HaddockOptsMonoid -> HaddockOpts
+haddockOptsFromMonoid HaddockOptsMonoid{..} =
+    defaultHaddockOpts
+    {toHaddockArgs = toMonoidHaddockArgs}
 
 testOptsFromMonoid :: TestOptsMonoid -> TestOpts
 testOptsFromMonoid TestOptsMonoid{..} =

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -22,6 +22,7 @@ module Stack.Options
     ,ghciOptsParser
     ,solverOptsParser
     ,testOptsParser
+    ,haddockOptsParser
     ,hpcReportOptsParser
     ,pvpBoundsOption
     ,globalOptsFromMonoid
@@ -374,7 +375,8 @@ buildOptsMonoidParser hide0 =
                     \exception" <>
             hide)
     options =
-        BuildOptsMonoid <$> libProfiling <*> exeProfiling <*> haddock <*> openHaddocks <*>
+        BuildOptsMonoid <$> libProfiling <*> exeProfiling <*> haddock <*>
+        haddockOptsParser hide0 <*> openHaddocks <*>
         haddockDeps <*> copyBins <*> preFetch <*> keepGoing <*> forceDirty <*>
         tests <*> testOptsParser hide0 <*> benches <*> benchOptsParser hide0 <*> reconfigure <*>
         cabalVerbose <*> splitObjs
@@ -870,6 +872,18 @@ solverOptsParser = boolFlags False
     "update-config"
     "Automatically update stack.yaml with the solver's recommendations"
     idm
+
+-- | Parser for haddock arguments.
+haddockOptsParser :: Bool -> Parser HaddockOptsMonoid
+haddockOptsParser hide0 =
+  HaddockOptsMonoid <$> fmap (fromMaybe [])
+                             (optional
+                              (argsOption
+                               (long "haddock-arguments" <>
+                                metavar "HADDOCK_ARGS" <>
+                                help "Arguments passed to the haddock program" <>
+                                hide)))
+  where hide = hideMods hide0
 
 -- | Parser for test arguments.
 -- FIXME hide args


### PR DESCRIPTION
This is my first PR to this repository, I tried to follow the code usages.

Tell me if something is surprising.

This simply add the "--haddock-arguments" options which takes a string of arguments.
So you could for example use your own CSS:

~~~
stack haddock --haddock-arguments "--css $PWD/my.css"
~~~