### PR TITLE
stack.cabal: add a 'debug' flag

### DIFF
--- a/stack.cabal
+++ b/stack.cabal
@@ -49,9 +49,17 @@ flag static
   -- Not intended for general use. Simply makes it easier to
   -- build a fully static binary on Linux platforms that enable it.
 
+flag debug
+  manual: True
+  default: False
+  description: Allow a faster development cycle for Stack itself.
+
 library
   hs-source-dirs:    src/
-  ghc-options:       -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  if flag(debug)
+    ghc-options:  -O0 -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  else
+    ghc-options:  -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   exposed-modules:   Control.Concurrent.Execute
                      Data.Aeson.Extended
                      Data.Attoparsec.Args
@@ -229,10 +237,13 @@ library
 executable stack
   hs-source-dirs: src/main
   main-is:        Main.hs
-  ghc-options:    -threaded -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  if flag(debug)
+    ghc-options:  -O0 -threaded -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  else
+    ghc-options:  -threaded -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   other-modules:  Paths_stack
   if flag(static)
-      ld-options: -static -pthread
+    ld-options: -static -pthread
 
   build-depends:  Cabal >= 1.18.1.5 && < 1.25
                 , base >=4.7 && < 5
@@ -277,7 +288,11 @@ test-suite stack-test
                 , Stack.ArgsSpec
                 , Stack.NixSpec
                 , Network.HTTP.Download.VerifiedSpec
-  ghc-options:    -threaded -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  if flag(debug)
+    ghc-options:  -O0 -threaded -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  else
+    ghc-options:  -threaded -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+
   build-depends:  Cabal >= 1.18.1.5 && < 1.25
                 , QuickCheck
                 , attoparsec < 0.14
@@ -305,7 +320,10 @@ test-suite stack-integration-test
   type:           exitcode-stdio-1.0
   hs-source-dirs: test/integration
   main-is:        IntegrationSpec.hs
-  ghc-options:    -threaded -rtsopts -with-rtsopts=-N -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  if flag(debug)
+    ghc-options:  -O0 -threaded -rtsopts -with-rtsopts=-N -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  else
+    ghc-options:  -threaded -rtsopts -with-rtsopts=-N -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
 
   if !flag(integration-tests)
     buildable: False


### PR DESCRIPTION
This change enables hacking on Stack with a shorter development cycle, using:

```
    stack build --flag stack:debug
```

It cuts down the full build of Stack on my setup from 3.3 minutes to 1 minute, and I get a functioning exe that is a bit slower (and I'm not doing optimization work most of time, so it's cool).