### PR TITLE
listInstalled: move side-effects away

### DIFF
--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -636,6 +636,7 @@ downloadAndInstallTool :: (MonadIO m, MonadMask m, MonadLogger m, MonadReader en
                        -> (SetupInfo -> Path Abs File -> ArchiveType -> Path Abs Dir -> m ())
                        -> m Tool
 downloadAndInstallTool programsDir si downloadInfo tool installer = do
+    ensureDir programsDir
     (file, at) <- downloadFromInfo programsDir downloadInfo tool
     dir <- installDir programsDir tool
     unmarkInstalled programsDir tool
@@ -749,6 +750,7 @@ downloadFromInfo programsDir downloadInfo tool = do
             _ -> error $ "Unknown extension for url: " ++ T.unpack url
     relfile <- parseRelFile $ toolString tool ++ extension
     let path = programsDir </> relfile
+    ensureDir programsDir
     chattyDownload (T.pack (toolString tool)) downloadInfo path
     return (path, at)
   where
@@ -1168,6 +1170,7 @@ setup7z :: (MonadReader env m, HasHttpManager env, HasConfig env, MonadThrow m, 
         -> m (Path Abs Dir -> Path Abs File -> n ())
 setup7z si = do
     dir <- asks $ configLocalPrograms . getConfig
+    ensureDir dir
     let exe = dir </> $(mkRelFile "7z.exe")
         dll = dir </> $(mkRelFile "7z.dll")
     case (siSevenzDll si, siSevenzExe si) of

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE LambdaCase #-}
+
 module Stack.Setup.Installed
     ( getCompilerVersion
     , markInstalled
@@ -78,9 +80,10 @@ listInstalled :: (MonadIO m, MonadThrow m)
               => Path Abs Dir
               -> m [Tool]
 listInstalled programsPath = do
-    ensureDir programsPath
-    (_, files) <- listDir programsPath
-    return $ mapMaybe toTool files
+    doesDirExist programsPath >>= \case
+        False -> return []
+        True -> do (_, files) <- listDir programsPath
+                   return $ mapMaybe toTool files
   where
     toTool fp = do
         x <- T.stripSuffix ".installed" $ T.pack $ toFilePath $ filename fp


### PR DESCRIPTION
It's odd to create an empty directory just to list it, from a function that merely lists the installed programs. Better to have that directory created at the same place we may be writing to it.