### PR TITLE
Print dependencies version in --version

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,51 @@
-import Distribution.Simple
-main = defaultMain
+module Main (main) where
+
+import Data.List ( nub, sortBy )
+import Data.Ord ( comparing )
+import Data.Version ( showVersion )
+import Distribution.Package ( PackageName(PackageName), PackageId, InstalledPackageId, packageVersion, packageName )
+import Distribution.PackageDescription ( PackageDescription(), TestSuite(..), Executable(..) )
+import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )
+import Distribution.Simple.Utils ( rewriteFile, createDirectoryIfMissingVerbose )
+import Distribution.Simple.BuildPaths ( autogenModulesDir )
+import Distribution.Simple.Setup ( BuildFlags(buildVerbosity), fromFlag )
+import Distribution.Simple.LocalBuildInfo ( withLibLBI, withTestLBI, withExeLBI, LocalBuildInfo(), ComponentLocalBuildInfo(componentPackageDeps) )
+import Distribution.Verbosity ( Verbosity )
+import System.FilePath ( (</>) )
+
+main :: IO ()
+main = defaultMainWithHooks simpleUserHooks
+  { buildHook = \pkg lbi hooks flags -> do
+     generateBuildModule (fromFlag (buildVerbosity flags)) pkg lbi
+     buildHook simpleUserHooks pkg lbi hooks flags
+  }
+
+generateBuildModule :: Verbosity -> PackageDescription -> LocalBuildInfo -> IO ()
+generateBuildModule verbosity pkg lbi = do
+  let dir = autogenModulesDir lbi
+  createDirectoryIfMissingVerbose verbosity True dir
+  withLibLBI pkg lbi $ \_ libcfg -> do
+    withTestLBI pkg lbi $ \suite clbi ->
+      rewriteFile (dir </> "Build_" ++ testName suite ++ ".hs") $ unlines
+        [ "module Build_" ++ testName suite ++ " where"
+        , ""
+        , "autogen_dir :: String"
+        , "autogen_dir = " ++ show dir
+        , ""
+        , "deps :: [String]"
+        , "deps = " ++ (show $ formatdeps (testDeps libcfg clbi))
+        ]
+    withExeLBI pkg lbi $ \exe clbi ->
+      rewriteFile (dir </> "Build_" ++ exeName exe ++ ".hs") $ unlines
+        [ "module Build_" ++ exeName exe ++ " where"
+        , ""
+        , "deps :: [String]"
+        , "deps = " ++ (show $ formatdeps (testDeps libcfg clbi))
+        ]
+  where
+    formatdeps = map formatone . sortBy (comparing unPackageName') . map snd
+    formatone p = unPackageName' p ++ "-" ++ showVersion (packageVersion p)
+    unPackageName' p = case packageName p of PackageName n -> n
+
+testDeps :: ComponentLocalBuildInfo -> ComponentLocalBuildInfo -> [(InstalledPackageId, PackageId)]
+testDeps xs ys = nub $ componentPackageDeps xs ++ componentPackageDeps ys

--- a/src/Options/Applicative/Complicated.hs
+++ b/src/Options/Applicative/Complicated.hs
@@ -30,6 +30,8 @@ complicatedOptions
   -> Maybe String
   -- ^ version string
   -> String
+  -- ^ dependencies list
+  -> String
   -- ^ hpack numeric version, as string
   -> String
   -- ^ header
@@ -43,7 +45,7 @@ complicatedOptions
   -> EitherT b (Writer (Mod CommandFields (b,a))) ()
   -- ^ commands (use 'addCommand')
   -> IO (a,b)
-complicatedOptions numericVersion versionString numericHpackVersion h pd commonParser mOnFailure commandParser =
+complicatedOptions numericVersion versionString depsString numericHpackVersion h pd commonParser mOnFailure commandParser =
   do args <- getArgs
      (a,(b,c)) <- case execParserPure (prefs noBacktrack) parser args of
        Failure _ | null args -> withArgs ["--help"] (execParser parser)

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -11,6 +11,7 @@
 
 module Main (main) where
 
+import qualified Build_stack
 import           Control.Exception
 import qualified Control.Exception.Lifted as EL
 import           Control.Monad hiding (mapM, forM)
@@ -181,6 +182,7 @@ commandLineHandler
 commandLineHandler progName isInterpreter = complicatedOptions
   Meta.version
   (Just versionString')
+  ("Compiled with:\n" ++ unlines (map ("- " ++) Build_stack.deps))
   VERSION_hpack
   "stack - The Haskell Tool Stack"
   ""

--- a/stack.cabal
+++ b/stack.cabal
@@ -11,7 +11,7 @@ license-file:        LICENSE
 author:              Commercial Haskell SIG
 maintainer:          manny@fpcomplete.com
 category:            Development
-build-type:          Simple
+build-type:          Custom
 cabal-version:       >=1.10
 homepage:            http://haskellstack.org
 extra-source-files:  CONTRIBUTING.md


### PR DESCRIPTION
Addresses: https://github.com/commercialhaskell/stack/issues/2222

I have no idea how to differentiate between whether package is build with `stack` or `cabal`, and AFAICS you can screw dependencies with custom `stack.yaml` as well (not so easily though).

The output of `--version` is now quite long, but OTOH, dunno if it used much for anything else then issue reporting?

```
% stack exec stack -- --version
Version 1.1.3, Git revision fb3f1d23d82e633cbc8d07dcbaf1f14c8c358751 (dirty) (3700 commits) x86_64 hpack-0.14.0
Compiled with:
- Cabal-1.22.8.0
- aeson-0.11.2.0
- ansi-terminal-0.6.2.3
- async-2.1.0
- attoparsec-0.13.0.2
- base-4.8.2.0
- base-compat-0.9.1
- base16-bytestring-0.1.1.6
- base64-bytestring-1.0.0.1
- binary-0.7.5.0
- binary-tagged-0.1.4.0
- blaze-builder-0.4.0.2
- byteable-0.1.1
- bytestring-0.10.6.0
- conduit-1.2.6.6
- conduit-extra-1.1.13.1
- containers-0.5.6.2
- cryptohash-0.11.9
- cryptohash-conduit-0.1.1
- deepseq-1.4.1.1
- directory-1.2.2.0
- edit-distance-0.2.2.1
- either-4.4.1.1
- enclosed-exceptions-1.0.1.1
- errors-2.1.2
- exceptions-0.8.2.1
- extra-1.4.7
- fast-logger-2.4.6
- filelock-0.1.0.1
- filepath-1.4.0.0
- fsnotify-0.2.1
- generic-deriving-1.10.4.1
- gitrev-1.2.0
- hashable-1.2.4.0
- hastache-0.6.1
- hit-0.6.3
- hpack-0.14.0
- hpc-0.6.0.2
- http-client-0.4.28
- http-client-tls-0.2.4
- http-conduit-2.1.10.1
- http-types-0.9
- lifted-base-0.2.3.6
- microlens-0.4.4.0
- monad-control-1.0.1.0
- monad-logger-0.3.18
- monad-unlift-0.2.0
- mtl-2.2.1
- open-browser-0.2.1.0
- optparse-applicative-0.12.1.0
- optparse-simple-0.0.3
- path-0.5.7
- path-io-1.1.0
- persistent-2.2.4.1
- persistent-sqlite-2.2.1
- persistent-template-2.1.8.1
- pretty-1.1.2.0
- process-1.2.3.0
- project-template-0.2.0
- regex-applicative-text-0.1.0.1
- resourcet-1.1.7.4
- retry-0.7.2
- safe-0.3.9
- semigroups-0.18.1
- split-0.2.3.1
- stack-1.1.3
- stm-2.4.4.1
- store-0.1.0.1
- streaming-commons-0.1.15.5
- tar-0.5.0.3
- template-haskell-2.10.0.0
- temporary-1.2.0.4
- text-1.2.2.1
- text-binary-0.2.1
- time-1.5.0.1
- tls-1.3.8
- transformers-0.4.2.0
- transformers-base-0.4.4
- unix-2.7.1.0
- unix-compat-0.4.1.4
- unordered-containers-0.2.7.0
- vector-0.11.0.0
- vector-binary-instances-0.2.3.2
- yaml-0.8.17.1
- zip-archive-0.2.3.7
- zlib-0.6.1.1
```