### PR TITLE
Add an issue template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,43 +2,7 @@
 
 ## Bug Reports
 
-Before reporting a bug, please ensure that you are using the latest release (currently stack-1.1.2).  See the [upgrade instructions](http://docs.haskellstack.org/en/stable/install_and_upgrade/#upgrade) to upgrade.
-
-When reporting a bug, please write in the following format:
-
-> [Any general summary/comments if desired]
-
-> **Steps to reproduce:**
-
-> 1. _Remove directory *blah*._
-> 2. _Run command `stack blah`._
-> 3. _Edit file blah._
-> 3. _Run command `stack blah`._
-
-> **Expected:**
-
-> _What I expected to see and happen._
-
-> **Actual:**
-
-> _What actually happened._
->
-> Here is the `stack --version` output:
->
-> ```
-> $ stack --version
-> Version 0.0.2, Git revision 6a86ee32e5b869a877151f74064572225e1a0398
-> ```
-> Here is the command I ran **with `--verbose`**:
->
-> ```
-> $ stack <your command here> <args> --verbose
-> <output>
-> ```
-
-With `--verbose` mode we can see what the tool is doing and when. Without this output it is much more difficult to surmise what's going on with your issue. If the above output is larger than a page, paste it in a private [Gist](https://gist.github.com/) instead.
-
-Include any `.yaml` configuration if relevant.
+Please [open an issue](https://github.com/commercialhaskell/stack/issues/new) and use the provided template to include all necessary details.
 
 The more detailed your report, the faster it can be resolved and will ensure it is resolved in the right way. Once your bug has been resolved, the responsible will tag the issue as _Needs confirmation_ and assign the issue back to you. Once you have tested and confirmed that the issue is resolved, close the issue. If you are not a member of the project, you will be asked for confirmation and we will close it.
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,8 @@
+Do you have a question regarding stack's usage that isn't covered by [the docs](http://haskellstack.org)?
+In that case please ask your question on [Stack Overflow](http://stackoverflow.com) and use [the haskell-stack tag](http://stackoverflow.com/questions/tagged/haskell-stack).
+This way your question will be more easily discoverable by other people with the same question.
+
+
 If you're reporting a bug please follow the steps below:
 
 Make sure that you are using the latest release (currently stack-1.1.2).

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -45,3 +45,10 @@ $ stack <your command here> <args> --verbose
 $ stack --version
 Version 0.0.2, Git revision 6a86ee32e5b869a877151f74064572225e1a0398
 ```
+
+### Method of installation
+
+* Official binary, downloaded from stackage.org or fpcomplete's package repository
+* Via cabal-install
+* An unofficial package repository (please specify which)
+* Other (please specify)

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,42 @@
+If you're reporting a bug please follow the steps below:
+
+Make sure that you are using the latest release (currently stack-1.1.2).
+See the [upgrade instructions](http://docs.haskellstack.org/en/stable/install_and_upgrade/#upgrade) to upgrade.
+
+Please use the following schema for your bug report:
+
+### General summary/comments (optional)
+
+### Steps to reproduce
+
+For example:
+
+1. Remove directory *blah*.
+2. Run command `stack blah`.
+3. Edit file blah.
+4. Run command `stack blah`.
+
+Include any `.yaml` configuration if relevant.
+
+### Expected
+
+What you expected to see and happen.
+
+### Actual
+
+What actually happened.
+
+If you suspect that a stack command misbehaved, please include the output of that command in `--verbose` mode.
+If the output is larger than a page please paste the output in a [Gist](https://gist.github.com/).
+
+```
+$ stack <your command here> <args> --verbose
+<output>
+```
+
+### Stack version
+
+```
+$ stack --version
+Version 0.0.2, Git revision 6a86ee32e5b869a877151f74064572225e1a0398
+```

--- a/doc/MAINTAINER_GUIDE.md
+++ b/doc/MAINTAINER_GUIDE.md
@@ -37,6 +37,7 @@
           with new version
         * Look for any links to "latest" documentation, replace with version tag
         * Ensure all documentation pages listed in `mkdocs.yaml`
+    * Update the ISSUE_TEMPLATE.md to point at the new version.
     * Check that any new Linux distribution versions added to
       `etc/scripts/release.hs` and `etc/scripts/vagrant-releases.sh`
         * [Ubuntu](https://wiki.ubuntu.com/Releases)


### PR DESCRIPTION
This template will be shown in the text field when opening a new issue. You can give it a try at https://github.com/sjakobi/stack/issues/new.

The main expected advantage is that we'd receive fewer bug reports for outdated stack versions and that fewer bug reports would require questions for clarification.

I'm slightly worried that the template might come off as unfriendly or might make bug reports overly onerous and thus discourage bug reports. If you have any ideas on how to reduce such an effect, please comment!