### PR TITLE
Pretty printer + improved plan construction errors

### DIFF
--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -858,7 +859,7 @@ getShortestDepsPath (MonoidMap parentsMap) wanted name =
             [] -> findShortest (fuel - 1) $ M.fromListWith chooseBest $ concatMap extendPath recurses
             _ -> let (DepsPath _ _ path) = minimum (map snd targets) in path
       where
-        (targets, recurses) = partition (\(n, _) -> n `elem` wanted) (M.toList paths)
+        (targets, recurses) = partition (\(n, _) -> n `Set.member` wanted) (M.toList paths)
     chooseBest :: DepsPath -> DepsPath -> DepsPath
     chooseBest x y = if x > y then x else y
     -- Extend a path to all its parents.

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE LambdaCase            #-}
 -- | Perform a build
 module Stack.Build.Execute
     ( printPlan
@@ -1088,18 +1089,33 @@ singleBuild runInBase ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} in
                 writeBuildCache pkgDir $ lpNewBuildCache lp
             TTUpstream _ _ _ -> return ()
 
+        -- FIXME: only output these if they're in the build plan.
+
+        preBuildTime <- modTime <$> liftIO getCurrentTime
+        let postBuildCheck succeeded = do
+                warnings <- checkForUnlistedFiles taskType preBuildTime pkgDir
+                let hasUnlistedModule = any $ \case
+                        UnlistedModulesWarning{} -> True
+                        _ -> False
+                when (not (null warnings)) $ $logInfo ""
+                when (not succeeded && hasUnlistedModule warnings) $ do
+                    $logInfo "If the above build failed with a linker error or .so/DLL error, addressing these may help:"
+                mapM_ ($logWarn . ("Warning: " <>) . T.pack . show) warnings
+
         () <- announce ("build" <> annSuffix)
         config <- asks getConfig
         extraOpts <- extraBuildOptions eeBuildOpts
-        preBuildTime <- modTime <$> liftIO getCurrentTime
-        cabal (configHideTHLoading config) $ ("build" :) $ (++ extraOpts) $
+        (cabal (configHideTHLoading config) $ ("build" :) $ (++ extraOpts) $
             case (taskType, taskAllInOne, isFinalBuild) of
                 (_, True, True) -> fail "Invariant violated: cannot have an all-in-one build that also has a final build step."
                 (TTLocal lp, False, False) -> primaryComponentOptions lp
                 (TTLocal lp, False, True) -> finalComponentOptions lp
                 (TTLocal lp, True, False) -> primaryComponentOptions lp ++ finalComponentOptions lp
-                (TTUpstream{}, _, _) -> []
-        checkForUnlistedFiles taskType preBuildTime pkgDir
+                (TTUpstream{}, _, _) -> [])
+          `catch` \ex -> case ex of
+              CabalExitedUnsuccessfully{} -> postBuildCheck False >> throwM ex
+              _ -> throwM ex
+        postBuildCheck True
 
         when (doHaddock package) $ do
             announce "haddock"
@@ -1166,7 +1182,7 @@ singleBuild runInBase ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} in
             _ -> error "singleBuild: invariant violated: multiple results when describing installed package"
 
 -- | Check if any unlisted files have been found, and add them to the build cache.
-checkForUnlistedFiles :: M env m => TaskType -> ModTime -> Path Abs Dir -> m ()
+checkForUnlistedFiles :: M env m => TaskType -> ModTime -> Path Abs Dir -> m [PackageWarning]
 checkForUnlistedFiles (TTLocal lp) preBuildTime pkgDir = do
     (addBuildCache,warnings) <-
         addUnlistedToBuildCache
@@ -1174,11 +1190,11 @@ checkForUnlistedFiles (TTLocal lp) preBuildTime pkgDir = do
             (lpPackage lp)
             (lpCabalFile lp)
             (lpNewBuildCache lp)
-    mapM_ ($logWarn . ("Warning: " <>) . T.pack . show) warnings
     unless (null addBuildCache) $
         writeBuildCache pkgDir $
         Map.unions (lpNewBuildCache lp : addBuildCache)
-checkForUnlistedFiles (TTUpstream _ _ _) _ _ = return ()
+    return warnings
+checkForUnlistedFiles (TTUpstream _ _ _) _ _ = return []
 
 -- | Determine if all of the dependencies given are installed
 depsPresent :: InstalledMap -> Map PackageName VersionRange -> Bool

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -32,10 +32,8 @@ module Stack.Types.Build
     ,TaskType(..)
     ,TaskConfigOpts(..)
     ,ConfigCache(..)
-    ,ConstructPlanException(..)
     ,configureOpts
     ,isStackOpt
-    ,BadDependency(..)
     ,wantedLocalPackages
     ,FileCacheInfo (..)
     ,ConfigureOpts (..)
@@ -50,7 +48,7 @@ import qualified Data.ByteString as S
 import           Data.Char (isSpace)
 import           Data.Data
 import           Data.Hashable
-import           Data.List (dropWhileEnd, nub, intercalate)
+import           Data.List (dropWhileEnd, intercalate)
 import qualified Data.Map as Map
 import           Data.Map.Strict (Map)
 import           Data.Maybe
@@ -67,7 +65,7 @@ import           Data.Time.Calendar
 import           Data.Time.Clock
 import           Distribution.PackageDescription (TestSuiteInterface)
 import           Distribution.System (Arch)
-import           Distribution.Text (display)
+import qualified Distribution.Text as C
 import           GHC.Generics (Generic)
 import           Path (Path, Abs, File, Dir, mkRelDir, toFilePath, parseRelDir, (</>))
 import           Path.Extra (toFilePathNoTrailingSep)
@@ -104,9 +102,7 @@ data StackBuildException
     (Path Abs File) -- stack.yaml
   | TestSuiteFailure PackageIdentifier (Map Text (Maybe ExitCode)) (Maybe (Path Abs File)) S.ByteString
   | TestSuiteTypeUnsupported TestSuiteInterface
-  | ConstructPlanExceptions
-        [ConstructPlanException]
-        (Path Abs File) -- stack.yaml
+  | ConstructPlanFailed String
   | CabalExitedUnsuccessfully
         ExitCode
         PackageIdentifier
@@ -151,7 +147,7 @@ instance Show StackBuildException where
                         [ "Compiler version mismatched, found "
                         , compilerVersionString actual
                         , " ("
-                        , display arch
+                        , C.display arch
                         , ")"
                         , ", but expected "
                         ]
@@ -161,7 +157,7 @@ instance Show StackBuildException where
                     NewerMinor -> "minor version match or newer with "
                 , compilerVersionString expected
                 , " ("
-                , display earch
+                , C.display earch
                 , ghcVariantSuffix ghcVariant
                 , ") (based on "
                 , case mstack of
@@ -217,34 +213,6 @@ instance Show StackBuildException where
           doubleIndent = indent . indent
     show (TestSuiteTypeUnsupported interface) =
               ("Unsupported test suite type: " <> show interface)
-    show (ConstructPlanExceptions exceptions stackYaml) =
-        "While constructing the BuildPlan the following exceptions were encountered:" ++
-        appendExceptions exceptions' ++
-        if Map.null extras then "" else (unlines
-                $ ("\n\nRecommended action: try adding the following to your extra-deps in "
-                    ++ toFilePath stackYaml)
-                : map (\(name, version) -> concat
-                    [ "- "
-                    , packageNameString name
-                    , "-"
-                    , versionString version
-                    ]) (Map.toList extras)
-                    ++ ["", "You may also want to try the 'stack solver' command"]
-                )
-         where
-             exceptions' = removeDuplicates exceptions
-             appendExceptions = foldr (\e -> (++) ("\n\n--" ++ show e)) ""
-             removeDuplicates = nub
-             extras = Map.unions $ map getExtras exceptions'
-
-             getExtras (DependencyCycleDetected _) = Map.empty
-             getExtras (UnknownPackage _) = Map.empty
-             getExtras (DependencyPlanFailures _ m) =
-                Map.unions $ map go $ Map.toList m
-              where
-                go (name, (_range, Just version, NotInBuildPlan)) =
-                    Map.singleton name version
-                go _ = Map.empty
      -- Supressing duplicate output
     show (CabalExitedUnsuccessfully exitCode taskProvides' execName fullArgs logFiles bss) =
         let fullCmd = unwords
@@ -354,6 +322,7 @@ instance Show StackBuildException where
             , innerMsg
             , "\n"
             ]
+    show (ConstructPlanFailed msg) = msg
 
 missingExeError :: Bool -> String -> String
 missingExeError isSimpleBuildType msg =
@@ -371,82 +340,7 @@ missingExeError isSimpleBuildType msg =
 
 instance Exception StackBuildException
 
-data ConstructPlanException
-    = DependencyCycleDetected [PackageName]
-    | DependencyPlanFailures Package (Map PackageName (VersionRange, LatestApplicableVersion, BadDependency))
-    | UnknownPackage PackageName -- TODO perhaps this constructor will be removed, and BadDependency will handle it all
-    -- ^ Recommend adding to extra-deps, give a helpful version number?
-    deriving (Typeable, Eq)
-
--- | For display purposes only, Nothing if package not found
-type LatestApplicableVersion = Maybe Version
-
--- | Reason why a dependency was not used
-data BadDependency
-    = NotInBuildPlan
-    | Couldn'tResolveItsDependencies
-    | DependencyMismatch Version
-    deriving (Typeable, Eq)
-
-instance Show ConstructPlanException where
-  show e =
-    let details = case e of
-         (DependencyCycleDetected pNames) ->
-           "While checking call stack,\n" ++
-           "  dependency cycle detected in packages:" ++ indent (appendLines pNames)
-         (DependencyPlanFailures pkg (Map.toList -> pDeps)) ->
-           "Failure when adding dependencies:" ++ doubleIndent (appendDeps pDeps) ++ "\n" ++
-           "  needed for package " ++ packageIdentifierString (packageIdentifier pkg) ++
-           appendFlags (packageFlags pkg)
-         (UnknownPackage pName) ->
-             "While attempting to add dependency,\n" ++
-             "  Could not find package " ++ show pName  ++ " in known packages"
-    in indent details
-     where
-      appendLines = foldr (\pName-> (++) ("\n" ++ show pName)) ""
-      indent = dropWhileEnd isSpace . unlines . fmap (\line -> "  " ++ line) . lines
-      doubleIndent = indent . indent
-      appendFlags flags =
-          if Map.null flags
-              then ""
-              else " with flags:\n" ++
-                  (doubleIndent . intercalate "\n" . map showFlag . Map.toList) flags
-      showFlag (name, bool) = show name ++ ": " ++ show bool
-      appendDeps = foldr (\dep-> (++) ("\n" ++ showDep dep)) ""
-      showDep (name, (range, mlatestApplicable, badDep)) = concat
-        [ show name
-        , ": needed ("
-        , display range
-        , ")"
-        , ", "
-        , let latestApplicableStr =
-                case mlatestApplicable of
-                    Nothing -> ""
-                    Just la -> " (latest applicable is " ++ versionString la ++ ")"
-           in case badDep of
-                NotInBuildPlan -> "stack configuration has no specified version" ++ latestApplicableStr
-                Couldn'tResolveItsDependencies -> "couldn't resolve its dependencies"
-                DependencyMismatch version ->
-                    case mlatestApplicable of
-                        Just la
-                            | la == version ->
-                                versionString version ++
-                                " found (latest applicable version available)"
-                        _ -> versionString version ++ " found" ++ latestApplicableStr
-        ]
-         {- TODO Perhaps change the showDep function to look more like this:
-          dropQuotes = filter ((/=) '\"')
-         (VersionOutsideRange pName pIdentifier versionRange) ->
-             "Exception: Stack.Build.VersionOutsideRange\n" ++
-             "  While adding dependency for package " ++ show pName ++ ",\n" ++
-             "  " ++ dropQuotes (show pIdentifier) ++ " was found to be outside its allowed version range.\n" ++
-             "  Allowed version range is " ++ display versionRange ++ ",\n" ++
-             "  should you correct the version range for " ++ dropQuotes (show pIdentifier) ++ ", found in [extra-deps] in the project's stack.yaml?"
-             -}
-
-
 ----------------------------------------------
-
 
 -- | Package dependency oracle.
 newtype PkgDepsOracle =

--- a/src/Stack/Types/Internal.hs
+++ b/src/Stack/Types/Internal.hs
@@ -17,6 +17,7 @@ data Env config =
   Env {envConfig :: !config
       ,envLogLevel :: !LogLevel
       ,envTerminal :: !Bool
+      ,envAnsiTerminal :: !Bool
       ,envReExec :: !Bool
       ,envManager :: !Manager
       ,envSticky :: !Sticky
@@ -50,9 +51,11 @@ instance HasLogLevel LogLevel where
 
 class HasTerminal r where
   getTerminal :: r -> Bool
+  getAnsiTerminal :: r -> Bool
 
 instance HasTerminal (Env config) where
   getTerminal = envTerminal
+  getAnsiTerminal = envAnsiTerminal
 
 class HasReExec r where
   getReExec :: r -> Bool

--- a/src/Stack/Types/StackT.hs
+++ b/src/Stack/Types/StackT.hs
@@ -54,6 +54,7 @@ import           Stack.Types.Internal
 import           Stack.Types.Config (GlobalOpts (..))
 import           System.IO
 import           System.Log.FastLogger
+import           System.Console.ANSI (hSupportsANSI)
 
 #ifndef MIN_VERSION_time
 #define MIN_VERSION_time(x, y, z) 0
@@ -99,13 +100,14 @@ runStackTGlobal manager config GlobalOpts{..} =
 runStackT :: (MonadIO m)
           => Manager -> LogLevel -> config -> Bool -> Bool -> StackT config m a -> m a
 runStackT manager logLevel config terminal reExec m = do
+    ansiTerminal <- liftIO $ hSupportsANSI stderr
     canUseUnicode <- liftIO getCanUseUnicode
     withSticky
         terminal
         (\sticky ->
               runReaderT
                   (unStackT m)
-                  (Env config logLevel terminal reExec manager sticky canUseUnicode))
+                  (Env config logLevel terminal ansiTerminal reExec manager sticky canUseUnicode))
 
 -- | Taken from GHC: determine if we should use Unicode syntax
 getCanUseUnicode :: IO Bool
@@ -124,6 +126,7 @@ getCanUseUnicode = do
 data LoggingEnv = LoggingEnv
     { lenvLogLevel :: !LogLevel
     , lenvTerminal :: !Bool
+    , lenvAnsiTerminal :: !Bool
     , lenvReExec :: !Bool
     , lenvManager :: !Manager
     , lenvSticky :: !Sticky
@@ -163,6 +166,7 @@ instance HasHttpManager LoggingEnv where
 
 instance HasTerminal LoggingEnv where
     getTerminal = lenvTerminal
+    getAnsiTerminal = lenvAnsiTerminal
 
 instance HasReExec LoggingEnv where
     getReExec = lenvReExec
@@ -198,6 +202,7 @@ runStackLoggingTGlobal manager GlobalOpts{..} =
 runStackLoggingT :: MonadIO m
                  => Manager -> LogLevel -> Bool -> Bool -> StackLoggingT m a -> m a
 runStackLoggingT manager logLevel terminal reExec m = do
+    ansiTerminal <- liftIO $ hSupportsANSI stderr
     canUseUnicode <- liftIO getCanUseUnicode
     withSticky
         terminal
@@ -209,6 +214,7 @@ runStackLoggingT manager logLevel terminal reExec m = do
                   , lenvManager = manager
                   , lenvSticky = sticky
                   , lenvTerminal = terminal
+                  , lenvAnsiTerminal = ansiTerminal
                   , lenvReExec = reExec
                   , lenvSupportsUnicode = canUseUnicode
                   })

--- a/src/Text/PrettyPrint/Leijen/Extended.hs
+++ b/src/Text/PrettyPrint/Leijen/Extended.hs
@@ -136,6 +136,14 @@ import System.IO (Handle)
 import qualified Text.PrettyPrint.Annotated.Leijen as P
 import Text.PrettyPrint.Annotated.Leijen hiding ((<>), display)
 
+-- TODO: consider smashing together the code for wl-annotated-pprint and
+-- wl-pprint-text. The code here already handles doing the
+-- ansi-wl-pprint stuff (better!) atop wl-annotated-pprint. So the
+-- result would be a package unifying 3 different wl inspired packages.
+--
+-- Perhaps it can still have native string support, by adding a type
+-- parameter to Doc?
+
 instance Monoid (Doc a) where
     mappend = (P.<>)
     mempty = empty

--- a/src/Text/PrettyPrint/Leijen/Extended.hs
+++ b/src/Text/PrettyPrint/Leijen/Extended.hs
@@ -1,0 +1,370 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+-- | This module re-exports some of the interface for
+-- "Text.PrettyPrint.Annotated.Leijen" along with additional definitions
+-- useful for stack.
+--
+-- It defines a 'Monoid' instance for 'Doc'.
+module Text.PrettyPrint.Leijen.Extended
+  (
+  -- * Pretty-print typeclass
+  Display(..),
+
+  -- * Logging based on pretty-print typeclass
+  debug, info, warn, displayError,
+
+  -- * Ansi terminal Doc
+  --
+  -- See "System.Console.ANSI" for 'SGR' values to use beyond the colors
+  -- provided.
+  AnsiDoc, AnsiAnn(..), HasAnsiAnn(..),
+  hDisplayAnsi, displayAnsi, displayPlain,
+
+  -- ** Color combinators
+  black, red, green, yellow, blue, magenta, cyan, white,
+  dullblack, dullred, dullgreen, dullyellow, dullblue, dullmagenta, dullcyan, dullwhite,
+  onblack, onred, ongreen, onyellow, onblue, onmagenta, oncyan, onwhite,
+  ondullblack, ondullred, ondullgreen, ondullyellow, ondullblue, ondullmagenta, ondullcyan, ondullwhite,
+
+  -- * Selective re-exports from "Text.PrettyPrint.Annotated.Leijen"
+  --
+  -- Documentation of omissions up-to-date with @annotated-wl-pprint-0.7.0@
+
+  -- ** Documents, parametrized by their annotations
+  --
+  -- Omitted compared to original: @putDoc, hPutDoc@
+  Doc,
+
+  -- ** Basic combinators
+  --
+  -- Omitted compared to original: @empty, char, text, (<>)@
+  --
+  -- Instead of @text@ and @char@, use 'fromString'.
+  --
+  -- Instead of @empty@, use 'mempty'.
+  nest, line, linebreak, group, softline, softbreak,
+
+  -- ** Alignment
+  --
+  -- The combinators in this section can not be described by Wadler's
+  -- original combinators. They align their output relative to the
+  -- current output position - in contrast to @nest@ which always
+  -- aligns to the current nesting level. This deprives these
+  -- combinators from being \`optimal\'. In practice however they
+  -- prove to be very useful. The combinators in this section should
+  -- be used with care, since they are more expensive than the other
+  -- combinators. For example, @align@ shouldn't be used to pretty
+  -- print all top-level declarations of a language, but using @hang@
+  -- for let expressions is fine.
+  --
+  -- Omitted compared to original: @list, tupled, semiBraces@
+  align, hang, indent, encloseSep,
+
+  -- ** Operators
+  --
+  -- Omitted compared to original: @(<$>), (</>), (<$$>), (<//>)@
+  (<+>),
+
+  -- ** List combinators
+  hsep, vsep, fillSep, sep, hcat, vcat, fillCat, cat, punctuate,
+
+  -- ** Fillers
+  fill, fillBreak,
+
+  -- ** Bracketing combinators
+  enclose, squotes, dquotes, parens, angles, braces, brackets,
+
+  -- ** Character documents
+  -- Entirely omitted:
+  --
+  -- @
+  -- lparen, rparen, langle, rangle, lbrace, rbrace, lbracket, rbracket,
+  -- squote, dquote, semi, colon, comma, space, dot, backslash, equals,
+  -- pipe
+  -- @
+
+  -- ** Primitive type documents
+  -- Entirely omitted:
+  --
+  -- @
+  -- string, int, integer, float, double, rational, bool,
+  -- @
+
+  -- ** Semantic annotations
+  annotate, noAnnotate,
+
+  -- ** Rendering
+  -- Original entirely omitted:
+  -- @
+  -- SimpleDoc(..), renderPretty, renderCompact, displayDecorated, displayDecoratedA, display, displayS, displayIO,
+  -- SpanList(..), displaySpans
+  -- @
+
+  -- ** Undocumented
+  -- Entirely omitted:
+  -- @
+  -- column, nesting, width
+  -- @
+  ) where
+
+import Control.Monad.Logger
+import Control.Monad.Reader
+import Data.Either (partitionEithers)
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe)
+import Data.Monoid
+import Data.String
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Builder as LTB
+import Language.Haskell.TH
+import Path
+import Stack.Types.Internal
+import System.Console.ANSI (Color(..), ColorIntensity(..), ConsoleLayer(..), SGR(..), setSGRCode, hSupportsANSI)
+import System.IO (Handle)
+import qualified Text.PrettyPrint.Annotated.Leijen as P
+import Text.PrettyPrint.Annotated.Leijen hiding ((<>), display)
+
+instance Monoid (Doc a) where
+    mappend = (P.<>)
+    mempty = empty
+
+--------------------------------------------------------------------------------
+-- Pretty-Print class
+
+class Display a where
+    type Ann a
+    type Ann a = ()
+    display :: a -> Doc (Ann a)
+    default display :: Show a => a -> Doc (Ann a)
+    display = fromString . show
+
+instance Display (Path b t)
+
+instance Display (Doc a) where
+    type Ann (Doc a) = a
+    display = id
+
+displayPlain :: Display a => a -> T.Text
+displayPlain = LT.toStrict . displayAnsiSimple . renderDefault . fmap (\_ -> mempty) . display
+
+-- TODO: tweak these settings more?
+-- TODO: options for settings if this is released as a lib
+
+renderDefault :: Doc a -> SimpleDoc a
+renderDefault = renderPretty 1 120
+
+-- TODO: switch to using implicit callstacks once 7.8 support is dropped
+
+debug :: Q Exp
+debug = do
+    loc <- location
+    [e| monadLoggerLog loc "" LevelDebug <=< displayAnsiIfPossible |]
+
+info :: Q Exp
+info = do
+    loc <- location
+    [e| monadLoggerLog loc "" LevelInfo <=< displayAnsiIfPossible |]
+
+warn :: Q Exp
+warn = do
+    loc <- location
+    [e| monadLoggerLog loc "" LevelWarn <=< displayAnsiIfPossible |]
+
+displayError :: Q Exp
+displayError = do
+    loc <- location
+    [e| monadLoggerLog loc "" LevelError <=< displayAnsiIfPossible |]
+
+displayAnsiIfPossible
+    :: (HasTerminal env, MonadReader env m, Display a, HasAnsiAnn (Ann a))
+    => a -> m T.Text
+displayAnsiIfPossible x = do
+    useAnsi <- asks getAnsiTerminal
+    return $ if useAnsi then displayAnsi x else displayPlain x
+
+--------------------------------------------------------------------------------
+-- Ansi Doc
+
+type AnsiDoc = Doc AnsiAnn
+
+newtype AnsiAnn = AnsiAnn [SGR]
+    deriving (Eq, Ord, Show, Monoid)
+
+class HasAnsiAnn a where
+    getAnsiAnn :: a -> AnsiAnn
+    toAnsiDoc :: Doc a -> AnsiDoc
+    toAnsiDoc = fmap getAnsiAnn
+
+instance HasAnsiAnn AnsiAnn where
+    getAnsiAnn = id
+    toAnsiDoc = id
+
+instance HasAnsiAnn () where
+    getAnsiAnn _ = mempty
+
+displayAnsi :: (Display a, HasAnsiAnn (Ann a)) => a -> T.Text
+displayAnsi = LT.toStrict . displayAnsiSimple . renderDefault . toAnsiDoc . display
+
+hDisplayAnsi
+    :: (Display a, HasAnsiAnn (Ann a), MonadIO m, MonadReader env m)
+    => Handle -> a -> m ()
+hDisplayAnsi h x = liftIO $ do
+    useAnsi <- hSupportsANSI h
+    T.hPutStr h $ if useAnsi then displayAnsi x else displayPlain x
+
+displayAnsiSimple :: SimpleDoc AnsiAnn -> LT.Text
+displayAnsiSimple doc =
+     LTB.toLazyText $ flip runReader mempty $ displayDecoratedWrap go doc
+  where
+    go (AnsiAnn sgrs) inner = do
+        old <- ask
+        let sgrs' = mapMaybe (\sgr -> if sgr == Reset then Nothing else Just (getSGRTag sgr, sgr)) sgrs
+            new = if Reset `elem` sgrs
+                      then M.fromList sgrs'
+                      else foldl (\mp (tag, sgr) -> M.insert tag sgr mp) old sgrs'
+        (extra, contents) <- local (\_ -> new) inner
+        return (extra, transitionCodes old new <> contents <> transitionCodes new old)
+    transitionCodes old new =
+        case (null removals, null additions) of
+            (True, True) -> mempty
+            (True, False) -> fromString (setSGRCode additions)
+            (False, _) -> fromString (setSGRCode (Reset : M.elems new))
+      where
+        (removals, additions) = partitionEithers $ M.elems $
+            M.mergeWithKey
+               (\_ o n -> if o == n then Nothing else Just (Right n))
+               (fmap Left)
+               (fmap Right)
+               old
+               new
+
+displayDecoratedWrap
+    :: forall a m. Monad m
+    => (forall b. a -> m (b, LTB.Builder) -> m (b, LTB.Builder))
+    -> SimpleDoc a
+    -> m LTB.Builder
+displayDecoratedWrap f doc = do
+    (mafter, result) <- go doc
+    case mafter of
+      Just _ -> fail "Invariant violated by input to displayDecoratedWrap: no matching SAnnotStart for SAnnotStop."
+      Nothing -> return result
+  where
+    spaces n = LTB.fromText (T.replicate n " ")
+
+    go :: SimpleDoc a -> m (Maybe (SimpleDoc a), LTB.Builder)
+    go SEmpty = return (Nothing, mempty)
+    go (SChar c x) = liftM (fmap (LTB.singleton c <>)) (go x)
+    -- NOTE: Could actually use the length to guess at an initial
+    -- allocation.  Better yet would be to just use Text in pprint..
+    go (SText _l s x) = liftM (fmap (fromString s <>)) (go x)
+    go (SLine n x) = liftM (fmap ((LTB.singleton '\n' <>) . (spaces n <>))) (go x)
+    go (SAnnotStart ann x) = do
+        (mafter, contents) <- f ann (go x)
+        case mafter of
+            Just after -> liftM (fmap (contents <>)) (go after)
+            Nothing -> error "Invariant violated by input to displayDecoratedWrap: no matching SAnnotStop for SAnnotStart."
+    go (SAnnotStop x) = return (Just x, mempty)
+
+-- Foreground color combinators
+
+black, red, green, yellow, blue, magenta, cyan, white,
+    dullblack, dullred, dullgreen, dullyellow, dullblue, dullmagenta, dullcyan, dullwhite,
+    onblack, onred, ongreen, onyellow, onblue, onmagenta, oncyan, onwhite,
+    ondullblack, ondullred, ondullgreen, ondullyellow, ondullblue, ondullmagenta, ondullcyan, ondullwhite
+    :: Doc AnsiAnn -> Doc AnsiAnn
+(black, dullblack, onblack, ondullblack) = colorFunctions Black
+(red, dullred, onred, ondullred) = colorFunctions Red
+(green, dullgreen, ongreen, ondullgreen) = colorFunctions Green
+(yellow, dullyellow, onyellow, ondullyellow) = colorFunctions Yellow
+(blue, dullblue, onblue, ondullblue) = colorFunctions Blue
+(magenta, dullmagenta, onmagenta, ondullmagenta) = colorFunctions Magenta
+(cyan, dullcyan, oncyan, ondullcyan) = colorFunctions Cyan
+(white, dullwhite, onwhite, ondullwhite) = colorFunctions White
+
+type EndoAnsiDoc = Doc AnsiAnn -> Doc AnsiAnn
+
+colorFunctions :: Color -> (EndoAnsiDoc, EndoAnsiDoc, EndoAnsiDoc, EndoAnsiDoc)
+colorFunctions color =
+    ( ansiAnn [SetColor Foreground Vivid color]
+    , ansiAnn [SetColor Foreground Dull color]
+    , ansiAnn [SetColor Background Vivid color]
+    , ansiAnn [SetColor Background Dull color]
+    )
+
+ansiAnn :: [SGR] -> Doc AnsiAnn -> Doc AnsiAnn
+ansiAnn = annotate . AnsiAnn
+
+-- | Tags for each field of state in SGR (Select Graphics Rendition).
+--
+-- It's a bit of a hack that 'TagReset' is included.
+data SGRTag
+    = TagReset
+    | TagConsoleIntensity
+    | TagItalicized
+    | TagUnderlining
+    | TagBlinkSpeed
+    | TagVisible
+    | TagSwapForegroundBackground
+    | TagColorForeground
+    | TagColorBackground
+    deriving (Eq, Ord)
+
+getSGRTag :: SGR -> SGRTag
+getSGRTag Reset{}                       = TagReset
+getSGRTag SetConsoleIntensity{}         = TagConsoleIntensity
+getSGRTag SetItalicized{}               = TagItalicized
+getSGRTag SetUnderlining{}              = TagUnderlining
+getSGRTag SetBlinkSpeed{}               = TagBlinkSpeed
+getSGRTag SetVisible{}                  = TagVisible
+getSGRTag SetSwapForegroundBackground{} = TagSwapForegroundBackground
+getSGRTag (SetColor Foreground _ _)     = TagColorForeground
+getSGRTag (SetColor Background _ _)     = TagColorBackground
+
+-- Probably overkill. Doesn't work well due to variadic + monad poly
+
+{-
+class LogDisplay ann t where
+    logDisplay :: Loc -> LogSource -> LogLevel -> ([Doc ann] -> [Doc ann]) -> t
+
+instance (LogDisplay ann t, Display a, ann ~ Ann a) => LogDisplay ann (a -> t) where
+    logDisplay loc src lvl f x = logDisplay loc src lvl (f . (display x:))
+
+instance (MonadLogger m, MonadReader env m, HasTerminal env, HasAnsiAnn ann, a ~ ()) => LogDisplay ann (m a) where
+    logDisplay loc src lvl f = do
+        useAnsi <- asks getAnsiTerminal
+        let result = hsep (f [])
+            output = if useAnsi then displayAnsi result else displayPlain result
+        monadLoggerLog loc src lvl output
+
+debug :: Q Exp
+debug = do
+    loc <- location
+    [e| logDisplay loc "" LevelDebug id |]
+
+info :: Q Exp
+info = do
+    loc <- location
+    [e| logDisplay loc "" LevelInfo id |]
+
+warn :: Q Exp
+warn = do
+    loc <- location
+    [e| logDisplay loc "" LevelInfo id |]
+
+displayError :: Q Exp
+displayError = do
+    loc <- location
+    [e| logDisplay loc "" LevelInfo id |]
+-}

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -61,6 +61,7 @@ extra-deps:
 - th-utilities-0.1.1.0
 - th-orphans-0.13.1
 - base-orphans-0.5.4
+- annotated-wl-pprint-0.7.0
 flags:
   time-locale-compat:
     old-locale: false

--- a/stack.cabal
+++ b/stack.cabal
@@ -134,6 +134,7 @@ library
                      Stack.Types.Version
                      Stack.Upgrade
                      Stack.Upload
+                     Text.PrettyPrint.Leijen.Extended
                      System.Process.Log
                      System.Process.PagerEditor
                      System.Process.Read
@@ -222,6 +223,7 @@ library
                    , zip-archive
                    , hpack >= 0.14.0 && < 0.15
                    , store
+                   , annotated-wl-pprint
   if os(windows)
     cpp-options:     -DWINDOWS
     build-depends:   Win32


### PR DESCRIPTION
Sometimes when you select the wrong version of a package that a lot of things depend on, you can get gobs and gobs of output.  For example, setting `containers-0.3.0.0` breaks pretty much every package in the build plan and you get hundreds of lines of output: https://gist.github.com/mgsloan/2a93bc5282f38d9b337e9571dbc8611a

I've omitted info about which specific inter-package dependencies have failed.  Instead, it tells you the root problem with color-coded info

![2016-06-03-211018_472x97_scrot](https://cloud.githubusercontent.com/assets/22570/15797497/94520ede-29cf-11e6-98ce-52d4d94b0068.png)

The "needed due to" path gives the shortest path from a target to the package.  Hopefully it's clear that this is not necessarily the only path (in this case, just one of many)