### PR TITLE
Support .buildinfo files in stack ghci.

### DIFF
--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -18,6 +18,7 @@ module Stack.Package
   (readPackage
   ,readPackageBS
   ,readPackageDescriptionDir
+  ,readDotBuildinfo
   ,readPackageUnresolved
   ,readPackageUnresolvedBS
   ,resolvePackage
@@ -146,6 +147,17 @@ readPackageDescriptionDir config pkgDir = do
     cabalfp <- findOrGenerateCabalFile pkgDir
     gdesc   <- liftM snd (readPackageUnresolved cabalfp)
     return (gdesc, resolvePackageDescription config gdesc)
+
+-- | Read @<package>.buildinfo@ ancillary files produced by some Setup.hs hooks.
+-- The file includes Cabal file syntax to be merged into the package description
+-- derived from the package's .cabal file.
+--
+-- NOTE: not to be confused with BuildInfo, an Stack-internal datatype.
+readDotBuildinfo :: MonadIO m
+                 => Path Abs File
+                 -> m HookedBuildInfo
+readDotBuildinfo buildinfofp =
+    liftIO $ readHookedBuildInfo D.silent (toFilePath buildinfofp)
 
 -- | Print cabal file warnings.
 printCabalFileWarning


### PR DESCRIPTION
`Distribution.Simple` based `Setup.hs` sometimes create
`<package>.buildinfo` files as an artifact of the configure phase.
This is the case in particular when using the autoconf hooks. Since
this is an internal detail private to any given package's `Setup.hs`,
Stack shouldn't (and doesn't) need to care or be aware of this. But
`stack ghci` does, since in that use case we're not using Cabal to
build - we're taking care of the build ourselves. In particular,
ignoring the `<package.buildinfo` file can mean that a successful
build using `stack build` can't be replicated using `stack ghci`.

E.g. in the case of the `network` package, the set of C files to build
is decided at configure time, based on the current platform. So the
`c-files` stanza in the .cabal file is not complete. This in turn
means `stack ghci` isn't aware of all object files it has to link in,
leading to obscure link errors (see #1239).

See [1] for more on .buildinfo files.

Fixes #2239.

To test:

```
$ stack unpack network
$ cd network
$ stack ghci
```

Without this patch the above sequence of commands doesn't work.

[1]: https://www.haskell.org/cabal/users-guide/developing-packages.html#system-dependent-parameters