### PR TITLE
Add a config option to override gcc path

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,9 @@ Other enhancements:
   custom `shell.nix` is used
   See [#2243](https://github.com/commercialhaskell/stack/issues/2243)
 
+* Add the ability to explictly specify a gcc executable.
+  [#593](https://github.com/commercialhaskell/stack/issues/593)
+
 Bug fixes:
 
 * Support most executable extensions on Windows

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -345,6 +345,14 @@ extra-lib-dirs:
 - /opt/foo/lib
 ```
 
+### with-ghc
+
+Specify a path to gcc explicitly, rather than relying on the normal path resolution.
+
+```yaml
+with-gcc: /usr/local/bin/gcc-5
+```
+
 ### compiler-check
 
 (Since 0.1.4)

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -232,6 +232,7 @@ configFromConfigMonoid configStackRoot configUserConfigPath mresolver mproject C
 
          configExtraIncludeDirs = configMonoidExtraIncludeDirs
          configExtraLibDirs = configMonoidExtraLibDirs
+         configOverrideGccPath = getFirst configMonoidOverrideGccPath
 
          -- Only place in the codebase where platform is hard-coded. In theory
          -- in the future, allow it to be configured.

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -281,7 +281,7 @@ configOptsParser hide0 =
            <> hide
             )))
     <*> optionalFirst (textOption
-             ( long "with-ghc"
+             ( long "with-gcc"
             <> metavar "PATH-TO-GCC"
             <> help "Use gcc found at PATH-TO-GCC"
             <> hide

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -203,7 +203,7 @@ cleanOptsParser = CleanShallow <$> packages <|> doFullClean
 -- | Command-line arguments parser for configuration.
 configOptsParser :: GlobalOptsContext -> Parser ConfigMonoid
 configOptsParser hide0 =
-    (\stackRoot workDir buildOpts dockerOpts nixOpts systemGHC installGHC arch os ghcVariant jobs includes libs skipGHCCheck skipMsys localBin modifyCodePage allowDifferentUser -> mempty
+    (\stackRoot workDir buildOpts dockerOpts nixOpts systemGHC installGHC arch os ghcVariant jobs includes libs overrideGccPath skipGHCCheck skipMsys localBin modifyCodePage allowDifferentUser -> mempty
         { configMonoidStackRoot = stackRoot
         , configMonoidWorkDir = workDir
         , configMonoidBuildOpts = buildOpts
@@ -218,6 +218,7 @@ configOptsParser hide0 =
         , configMonoidJobs = jobs
         , configMonoidExtraIncludeDirs = includes
         , configMonoidExtraLibDirs = libs
+        , configMonoidOverrideGccPath = overrideGccPath
         , configMonoidSkipMsys = skipMsys
         , configMonoidLocalBinPath = localBin
         , configMonoidModifyCodePage = modifyCodePage
@@ -279,6 +280,12 @@ configOptsParser hide0 =
            <> help "Extra directories to check for libraries"
            <> hide
             )))
+    <*> optionalFirst (textOption
+             ( long "with-ghc"
+            <> metavar "PATH-TO-GCC"
+            <> help "Use gcc found at PATH-TO-GCC"
+            <> hide
+             ))
     <*> firstBoolFlags
             "skip-ghc-check"
             "skipping the GHC version and architecture check"

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -629,6 +629,7 @@ configureOptsNoDir econfig bco deps isLocal package = concat
     , concatMap (\x -> ["--ghc-options", T.unpack x]) (packageGhcOptions package)
     , map (("--extra-include-dirs=" ++) . T.unpack) (Set.toList (configExtraIncludeDirs config))
     , map (("--extra-lib-dirs=" ++) . T.unpack) (Set.toList (configExtraLibDirs config))
+    , maybe [] (\customGcc -> ["--with-gcc=" ++ T.unpack customGcc]) (configOverrideGccPath config)
     , if whichCompiler (envConfigCompilerVersion econfig) == Ghcjs
         then ["--ghcjs"]
         else []

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -282,6 +282,8 @@ data Config =
          -- ^ Require a version of stack within this range.
          ,configJobs                :: !Int
          -- ^ How many concurrent jobs to run, defaults to number of capabilities
+         ,configOverrideGccPath     :: !(Maybe Text)
+         -- ^ Optional gcc override path
          ,configExtraIncludeDirs    :: !(Set Text)
          -- ^ --extra-include-dirs arguments
          ,configExtraLibDirs        :: !(Set Text)
@@ -840,6 +842,8 @@ data ConfigMonoid =
     -- ^ See: 'configExtraIncludeDirs'
     ,configMonoidExtraLibDirs        :: !(Set Text)
     -- ^ See: 'configExtraLibDirs'
+    , configMonoidOverrideGccPath    :: !(First Text)
+    -- ^ Allow users to override the path to gcc
     ,configMonoidConcurrentTests     :: !(First Bool)
     -- ^ See: 'configConcurrentTests'
     ,configMonoidLocalBinPath        :: !(First FilePath)
@@ -913,6 +917,7 @@ parseConfigMonoidJSON obj = do
     configMonoidJobs <- First <$> obj ..:? configMonoidJobsName
     configMonoidExtraIncludeDirs <- obj ..:?  configMonoidExtraIncludeDirsName ..!= Set.empty
     configMonoidExtraLibDirs <- obj ..:?  configMonoidExtraLibDirsName ..!= Set.empty
+    configMonoidOverrideGccPath <- First <$> obj ..:? configMonoidOverrideGccPathName
     configMonoidConcurrentTests <- First <$> obj ..:? configMonoidConcurrentTestsName
     configMonoidLocalBinPath <- First <$> obj ..:? configMonoidLocalBinPathName
     configMonoidImageOpts <- jsonSubWarnings (obj ..:?  configMonoidImageOptsName ..!= mempty)
@@ -1016,6 +1021,9 @@ configMonoidExtraIncludeDirsName = "extra-include-dirs"
 
 configMonoidExtraLibDirsName :: Text
 configMonoidExtraLibDirsName = "extra-lib-dirs"
+
+configMonoidOverrideGccPathName :: Text
+configMonoidOverrideGccPathName = "with-gcc"
 
 configMonoidConcurrentTestsName :: Text
 configMonoidConcurrentTestsName = "concurrent-tests"


### PR DESCRIPTION
This allows one to specify `with-gcc:` in stack.yaml.

Happy for any feedback - I just picked this up as it's marked with newcomer!

