### PR TITLE
Nix-shell no longer called with a GHC from an LTS mirror

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,9 @@ Other enhancements:
 
 * Add the ability to explictly specify a gcc executable.
   [#593](https://github.com/commercialhaskell/stack/issues/593)
+* Nix: No longer uses LTS mirroring in nixpkgs. Gives to nix-shell a derivation
+  like `haskell.compiler.ghc801`
+  See [#2259](https://github.com/commercialhaskell/stack/issues/2259)
 
 Bug fixes:
 

--- a/doc/nix_integration.md
+++ b/doc/nix_integration.md
@@ -40,37 +40,36 @@ a version of GHC matching the configured resolver. Enabling Nix
 support means packages will always be built using a GHC available
 inside the shell, rather than your globally installed one if any.
 
-Note that in this mode `stack` can use only those resolvers that have
-already been mirrored into the Nix package repository. The
-[Nixpkgs master branch](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/haskell-modules)
-usually picks up new resolvers such as Stackage nightlies and LTS
-versions within two or three days. Then it takes another two or three
+Note that in this mode `stack` can use only GHC versions than have
+already been mirrored into the Nix package repository.
+The [Nixpkgs master branch](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/haskell-modules)
+usually picks up new versions quickly, but it takes two or three
 days before those updates arrive in the `unstable` channel. Release
 channels, like `nixos-15.09`, receive those updates only
 occasionally -- say, every two or three months --, so you should not
-expect them to have the latest resolvers available. Fresh Nix installs
+expect them to have the latest compiler available. Fresh NixOS installs
 use a release version by default.
 
-To know for sure whether a given resolver as available on your system,
+To know for sure whether a given compiler is available on your system,
 you can use the command
 
 ```sh
-$ nix-env -f "<nixpkgs>" -qaP -A haskell.packages.lts-3_13.ghc
-haskell.packages.lts-3_13.ghc  ghc-7.10.2
+$ nix-env -f "<nixpkgs>" -qaP -A haskell.compiler.ghc801
+haskell.compiler.ghc801  ghc-8.0.1
 ```
 
 to check whether it's available. If Nix doesn't know that resolver
 yet, then you'll see the following error message instead:
 
 ```sh
-$ nix-env -f "<nixpkgs>" -qaP -A haskell.packages.lts-3_99.ghc
-error: attribute ‘lts-3_99’ in selection path ‘haskell.packages.lts-3_99.ghc’ not found
+$ nix-env -f "<nixpkgs>" -qaP -A haskell.compiler.ghc999
+error: attribute ‘ghc999’ in selection path ‘haskell.compiler.ghc999’ not found
 ```
 
-You can list all known Haskell package sets in Nix with the following:
+You can list all known Haskell compilers in Nix with the following:
 
 ```sh
-$ nix-instantiate --eval -E "with import <nixpkgs> {}; lib.attrNames haskell.packages"
+$ nix-instantiate --eval -E "with import <nixpkgs> {}; lib.attrNames haskell.compiler"
 ```
 
 Alternatively, install `nix-repl`, a convenient tool to explore
@@ -86,7 +85,7 @@ autocomplete:
 
 ```sh
 nix-repl> :l <nixpkgs>
-nix-repl> haskell.packages.lts-<Tab>
+nix-repl> haskell.compiler.ghc<Tab>
 ```
 
 You can type and evaluate any nix expression in the nix-repl, such as

--- a/src/Stack/Config/Nix.hs
+++ b/src/Stack/Config/Nix.hs
@@ -57,7 +57,7 @@ nixCompiler compilerVersion =
                                              (fixMinor (versionText v)))
   in case compilerVersion of
        GhcVersion v -> nixCompilerFromVersion v
-       _ -> T.pack "ghc"
+       _ -> error "Only GHC is supported by now by stack --nix"
 
 -- Exceptions thown specifically by Stack.Nix
 data StackNixException

--- a/src/Stack/Config/Nix.hs
+++ b/src/Stack/Config/Nix.hs
@@ -7,8 +7,7 @@ module Stack.Config.Nix
        ,StackNixException(..)
        ) where
 
-import Control.Applicative
-import Control.Monad (join, when)
+import Control.Monad (when)
 import Data.Maybe
 import Data.Monoid.Extra
 import qualified Data.Text as T
@@ -41,13 +40,9 @@ nixOptsFromMonoid NixOptsMonoid{..} os = do
   where prefixAll p (x:xs) = p : x : prefixAll p xs
         prefixAll _ _      = []
 
-nixCompiler :: Config -> Maybe Resolver -> Maybe CompilerVersion -> T.Text
-nixCompiler config resolverOverride compilerOverride =
-  let mproject = fst <$> configMaybeProject config
-      mresolver = resolverOverride <|> fmap projectResolver mproject
-      mcompiler = compilerOverride <|> join (fmap projectCompiler mproject)
-
-      -- These are the latest minor versions for each respective major version available in nixpkgs
+nixCompiler :: CompilerVersion -> T.Text
+nixCompiler compilerVersion =
+  let -- These are the latest minor versions for each respective major version available in nixpkgs
       fixMinor "8.0" = "8.0.1"
       fixMinor "7.10" = "7.10.3"
       fixMinor "7.8" = "7.8.4"
@@ -57,12 +52,11 @@ nixCompiler config resolverOverride compilerOverride =
       fixMinor "6.12" = "6.12.3"
       fixMinor "6.10" = "6.10.4"
       fixMinor v = v
-      nixCompilerFromVersion v = T.append (T.pack "haskell.compiler.ghc") (T.filter (/= '.') (fixMinor (versionText v)))
-  in case (mresolver, mcompiler)  of
-       (_, Just (GhcVersion v)) -> nixCompilerFromVersion v
-       (Just (ResolverCompiler (GhcVersion v)), _) -> nixCompilerFromVersion v
-       (Just (ResolverSnapshot (LTS x y)), _) ->
-         T.pack ("haskell.packages.lts-" ++ show x ++ "_" ++ show y ++ ".ghc")
+      nixCompilerFromVersion v = T.append (T.pack "haskell.compiler.ghc")
+                                          (T.filter (/= '.')
+                                             (fixMinor (versionText v)))
+  in case compilerVersion of
+       GhcVersion v -> nixCompilerFromVersion v
        _ -> T.pack "ghc"
 
 -- Exceptions thown specifically by Stack.Nix

--- a/src/Stack/Nix.hs
+++ b/src/Stack/Nix.hs
@@ -33,7 +33,6 @@ import           Path
 import           Path.IO
 import qualified Paths_stack as Meta
 import           Prelude hiding (mapM) -- Fix redundant import warnings
-import           Stack.Config (makeConcreteResolver)
 import           Stack.Config.Nix (nixCompiler)
 import           Stack.Constants (stackProgName,platformVariantEnvVar)
 import           Stack.Docker (reExecArgName)

--- a/src/Stack/Nix.hs
+++ b/src/Stack/Nix.hs
@@ -48,16 +48,15 @@ import           System.Process.Read (getEnvOverride)
 reexecWithOptionalShell
     :: M env m
     => Maybe (Path Abs Dir)
-    -> Maybe AbstractResolver
-    -> Maybe CompilerVersion
+    -> CompilerVersion
     -> IO ()
     -> m ()
-reexecWithOptionalShell mprojectRoot maresolver mcompiler inner =
+reexecWithOptionalShell mprojectRoot compilerVersion inner =
   do config <- asks getConfig
      inShell <- getInShell
      isReExec <- asks getReExec
      if nixEnable (configNix config) && not inShell && not isReExec
-       then runShellAndExit mprojectRoot maresolver mcompiler getCmdArgs
+       then runShellAndExit mprojectRoot compilerVersion getCmdArgs
        else liftIO inner
   where
     getCmdArgs = do
@@ -71,20 +70,18 @@ reexecWithOptionalShell mprojectRoot maresolver mcompiler inner =
 runShellAndExit
     :: M env m
     => Maybe (Path Abs Dir)
-    -> Maybe AbstractResolver
-    -> Maybe CompilerVersion
+    -> CompilerVersion
     -> m (String, [String])
     -> m ()
-runShellAndExit mprojectRoot maresolver mcompiler getCmdArgs = do
+runShellAndExit mprojectRoot compilerVersion getCmdArgs = do
      config <- asks getConfig
-     mresolver <- mapM makeConcreteResolver maresolver
      envOverride <- getEnvOverride (configPlatform config)
      (cmnd,args) <- fmap (escape *** map escape) getCmdArgs
      mshellFile <-
          traverse (resolveFile (fromMaybeProjectRoot mprojectRoot)) $
          nixInitFile (configNix config)
      let pkgsInConfig = nixPackages (configNix config)
-         ghc = nixCompiler config mresolver mcompiler
+         ghc = nixCompiler compilerVersion
          pkgs = pkgsInConfig ++ [ghc]
          libsAndIncludes =
            map (\p -> ("${" <> p <> "}/lib", "${" <> p <> "}/include ")) pkgs

--- a/src/test/Stack/NixSpec.hs
+++ b/src/test/Stack/NixSpec.hs
@@ -12,8 +12,10 @@ import Prelude -- to remove the warning about Data.Monoid being redundant on GHC
 import Stack.Config
 import Stack.Config.Nix
 import Stack.Types.Config
+import Stack.Types.Compiler
 import Stack.Types.Nix
 import Stack.Types.StackT
+import Stack.Types.Version
 import System.Directory
 import System.Environment
 import System.IO.Temp (withSystemTempDirectory)
@@ -57,8 +59,10 @@ spec = beforeAll setup $ afterAll teardown $ do
       writeFile (toFilePath stackDotYaml) sampleConfig
       lc <- loadConfig' manager
       (nixEnable $ configNix $ lcConfig lc) `shouldBe` True
-    it "sees that the only package asked for is glpk and adds GHC from nixpkgs mirror of LTS resolver" $ \T{..} -> inTempDir $ do
-      writeFile (toFilePath stackDotYaml) sampleConfig
-      lc <- loadConfig' manager
-      (nixPackages $ configNix $ lcConfig lc) `shouldBe` ["glpk"]
-      nixCompiler (lcConfig lc) Nothing Nothing `shouldBe` "haskell.packages.lts-2_10.ghc"
+    it "sees that the only package asked for is glpk and asks for the correct GHC derivation" $
+      \T{..} -> inTempDir $ do
+        writeFile (toFilePath stackDotYaml) sampleConfig
+        lc <- loadConfig' manager
+        (nixPackages $ configNix $ lcConfig lc) `shouldBe` ["glpk"]
+        v <- parseVersion "7.10.3"
+        nixCompiler (GhcVersion v) `shouldBe` "haskell.compiler.ghc7103"


### PR DESCRIPTION
As explained in https://github.com/commercialhaskell/stack/issues/2259
we will soon no longer be able to give to nix-shell indentifiers like `haskell.packages.lts-5_14.ghc`
since LTS mirroring will be removed from the Nixpkgs.
This PR proposes to retrieve the wanted GHC version before creating the nix shell, which will now
always be called with derivations like `haskell.compiler.ghc7103`.
Until the lts mirroring is removed from Nix, this also provides the advantage that now you don't have to pay attention to which LTS you use into your `stack.yaml`