### PR TITLE
Fix issue #2289, apply ghc-options to snapshot pkg

### DIFF
--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -147,8 +147,9 @@ loadSourceMap needTargets boptsCli = do
                 let p = lpPackage lp
                  in (packageName p, PSLocal lp)
             , extraDeps3
-            , flip fmap (mbpPackages mbp) $ \mpi ->
-                PSUpstream (mpiVersion mpi) Snap (mpiFlags mpi) (mpiGhcOptions mpi) (mpiGitSHA1 mpi)
+            , flip Map.mapWithKey (mbpPackages mbp) $ \n mpi ->
+                let configOpts = getGhcOptions bconfig boptsCli n False False
+                 in PSUpstream (mpiVersion mpi) Snap (mpiFlags mpi) (mpiGhcOptions mpi ++ configOpts) (mpiGitSHA1 mpi)
             ] `Map.difference` Map.fromList (map (, ()) (HashSet.toList wiredInPackages))
 
     return (targets, mbp, locals, nonLocalTargets, sourceMap)


### PR DESCRIPTION
Commit c891a24 created a regression, ghc-options were no longer applied to 
packages in the snapshot. The "mini build plan" for missing snapshot packages
did not check the configuration's "ghc-options" settings at all, so even
configurations with "apply-ghc-options: everything" would not apply those
options.

This commit, combined with a change to config.yaml, fixes these issues:

https://github.com/DanielG/ghc-mod/issues/762
https://github.com/gibiansky/IHaskell/issues/636

To fix those issues, `config.yaml` (usually located in `~/.stack`) should
contain:

```
apply-ghc-options: everything
ghc-options:
  "*": -opta-Wa,-mrelax-relocations=no
```

And for snapshots already installed, the following command will force stack
to rebuild them with those options:

```
stack exec -- ghc-pkg unregister $PACKAGENAME --force
```

*Not tested:* Alternatively, add the line `rebuild-ghc-options: true` to
`config.yaml`. This may cause undesirable behavior in forcing all ghc-options
changes to rebuild the snapshot.