### PR TITLE
setupEnv: Run some processes concurrently

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,8 @@ Other enhancements:
 * Nix: No longer uses LTS mirroring in nixpkgs. Gives to nix-shell a derivation
   like `haskell.compiler.ghc801`
   See [#2259](https://github.com/commercialhaskell/stack/issues/2259)
+* Perform some subprocesses during setup concurrently, slightly speeding up most
+  commands. [#2346](https://github.com/commercialhaskell/stack/pull/2346)
 
 Bug fixes:
 

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -23,6 +23,7 @@ module Stack.Setup
   ) where
 
 import           Control.Applicative
+import           Control.Concurrent.Async.Lifted (Concurrently(..))
 import           Control.Exception.Enclosed (catchIO, tryAny)
 import           Control.Monad (liftM, when, join, void, unless)
 import           Control.Monad.Catch
@@ -214,10 +215,13 @@ setupEnv mResolveMissingGHC = do
     menv0 <- getMinimalEnvOverride
     env <- removeHaskellEnvVars
              <$> augmentPathMap (maybe [] edBins mghcBin) (unEnvOverride menv0)
-
     menv <- mkEnvOverride platform env
-    compilerVer <- getCompilerVersion menv wc
-    cabalVer <- getCabalPkgVer menv wc
+
+    (compilerVer, cabalVer, globaldb) <- runConcurrently $ (,,)
+        <$> Concurrently (getCompilerVersion menv wc)
+        <*> Concurrently (getCabalPkgVer menv wc)
+        <*> Concurrently (getGlobalDB menv wc)
+
     $logDebug "Resolving package entries"
     packages <- mapM
         (resolvePackageEntry menv (bcRoot bconfig))
@@ -240,7 +244,6 @@ setupEnv mResolveMissingGHC = do
     createDatabase menv wc deps
     localdb <- runReaderT packageDatabaseLocal envConfig0
     createDatabase menv wc localdb
-    globaldb <- getGlobalDB menv wc
     extras <- runReaderT packageDatabaseExtra envConfig0
     let mkGPP locals = mkGhcPackagePath locals localdb deps extras globaldb
 

--- a/stack.cabal
+++ b/stack.cabal
@@ -181,6 +181,7 @@ library
                    , http-client-tls >= 0.3.0
                    , http-conduit >= 2.2.0
                    , http-types >= 0.8.6 && < 0.10
+                   , lifted-async
                        -- https://github.com/basvandijk/lifted-base/issues/31
                    , lifted-base < 0.2.3.7 || > 0.2.3.7
                    , microlens >= 0.3.0.0


### PR DESCRIPTION
This should make most commands slightly faster.
On my machine, `stack path` takes ~20% less time than before, a no-op
`stack build` in a single-package project ~15%.