### PR TITLE
Nix: Adding LD_LIBRARY_PATH to shell (Template Haskell issues)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@ Other enhancements:
 * Stack/Nix: Passes the right ghc derivation as an argument to the `shell.nix` when a
   custom `shell.nix` is used
   See [#2243](https://github.com/commercialhaskell/stack/issues/2243)
+* Stack/Nix: Sets `LD_LIBRARY_PATH` so packages using C libs for Template Haskell can work
+  (See _e.g._ [this HaskellR issue](https://github.com/tweag/HaskellR/issues/253))
 
 Bug fixes:
 


### PR DESCRIPTION
GHCi and therefore template haskell need LD_LIBRARY_PATH when in a nix shell.
This makes stack (when using a list of nix packages instead of a shell file) behave more like `haskell.lib.buildStackProject` in nixpkgs.
See for instance https://github.com/tweag/HaskellR/issues/253