### PR TITLE
Let extra-source-files mark a package as dirty (#1891, #2040).

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -90,6 +90,9 @@ Bug fixes:
   checked for dirtiness. See
   [#1982](https://github.com/commercialhaskell/stack/issues/1982)
 * Signing: always use `--with-fingerprints`
+  [#2110](https://github.com/commercialhaskell/stack/issues/2110).
+* Now consider a package to be dirty when an extra-source-file is changed.
+  See [#2040](https://github.com/commercialhaskell/stack/issues/2040).
 
 ## 1.1.0
 

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -558,7 +558,9 @@ packageDescModulesAndFiles pkg = do
             (mapM
                  (asModuleAndFileMap benchComponent benchmarkFiles)
                  (benchmarks pkg))
-    (dfiles) <- resolveGlobFiles (map (dataDir pkg FilePath.</>) (dataFiles pkg))
+    (dfiles) <- resolveGlobFiles
+                    (extraSrcFiles pkg
+                        ++ map (dataDir pkg FilePath.</>) (dataFiles pkg))
     let modules = libraryMods <> executableMods <> testMods <> benchModules
         files =
             libDotCabalFiles <> exeDotCabalFiles <> testDotCabalFiles <>


### PR DESCRIPTION
This is necessary for packages that use a custom Setup.hs
(`build-type: Custom`).  Previously, stack wouldn't rebuild the package
if the only changes were to the `extra-source-files`.

Stack was already marking the package as dirty if `data-files` changed;
this just hooks `extra-source-files` into the same mechanism.