### PR TITLE
PAT-590 incorrect docker image content

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -1210,7 +1210,7 @@ imgDockerCmd (rebuild,images) go@GlobalOpts{..} = do
                          (const (return ()))
                          lk
                          defaultBuildOptsCLI
-                 Image.stageContainerImageArtifacts mProjectRoot)
+                 Image.stageContainerImageArtifacts mProjectRoot images)
         (Just $ Image.createContainerImageFromStage mProjectRoot images)
 
 -- | Load the configuration with a manager. Convenience function used


### PR DESCRIPTION
Fixes a bug where the user executes

`stack image container --image image9`

where the stack.yaml has multiple docker image definitions.  The code
was staging all of them but then creating an image by selecting the base
image (correct) along with the contents of folder "0" (incorrect)

Solution is to only stage the image(s) that we want to build (using the
same image name fitering that we have in our function to build the
image(s).

Haskell does not protect you from logic fails :D