### PR TITLE
Fix cabal warning about use of a deprecated profiling flag (Fixes #2350)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,8 @@ Other enhancements:
 
 Bug fixes:
 
+* Fix cabal warning about use of a deprecated cabal flag
+  [#2350](https://github.com/commercialhaskell/stack/issues/2350)
 * Support most executable extensions on Windows
   [#2225](https://github.com/commercialhaskell/stack/issues/2225)
 * Detect resolver change in `stack solver`

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -619,7 +619,7 @@ configureOptsNoDir econfig bco deps isLocal package = concat
     [ depOptions
     , ["--enable-library-profiling" | boptsLibProfile bopts || boptsExeProfile bopts]
     -- Cabal < 1.21.1 does not support --enable-profiling, use --enable-executable-profiling instead
-    , let profFlag = "--enable-" <> (if newerProfFlagCabal then "" else "executable-") <> "profiling"
+    , let profFlag = "--enable-" <> concat ["executable-" | newerCabal] <> "profiling"
       in [ profFlag | boptsExeProfile bopts && isLocal]
     , ["--enable-split-objs" | boptsSplitObjs bopts]
     , map (\(name,enabled) ->
@@ -645,9 +645,7 @@ configureOptsNoDir econfig bco deps isLocal package = concat
     -- earlier. Cabal also might do less work then.
     useExactConf = configAllowNewer config
 
-    cabalVersion = envConfigCabalVersion econfig
-    newerCabal = cabalVersion >= $(mkVersion "1.22")
-    newerProfFlagCabal = cabalVersion >= $(mkVersion "1.21.1")
+    newerCabal = envConfigCabalVersion econfig >= $(mkVersion "1.22")
 
     -- Unioning atop defaults is needed so that all flags are specified
     -- with --exact-configuration.

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -619,7 +619,7 @@ configureOptsNoDir econfig bco deps isLocal package = concat
     [ depOptions
     , ["--enable-library-profiling" | boptsLibProfile bopts || boptsExeProfile bopts]
     -- Cabal < 1.21.1 does not support --enable-profiling, use --enable-executable-profiling instead
-    , let profFlag = "--enable-" <> concat ["executable-" | newerCabal] <> "profiling"
+    , let profFlag = "--enable-" <> concat ["executable-" | not newerCabal] <> "profiling"
       in [ profFlag | boptsExeProfile bopts && isLocal]
     , ["--enable-split-objs" | boptsSplitObjs bopts]
     , map (\(name,enabled) ->

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -633,10 +633,8 @@ configureOptsNoDir econfig bco deps isLocal package = concat
     , map (("--extra-include-dirs=" ++) . T.unpack) (Set.toList (configExtraIncludeDirs config))
     , map (("--extra-lib-dirs=" ++) . T.unpack) (Set.toList (configExtraLibDirs config))
     , maybe [] (\customGcc -> ["--with-gcc=" ++ T.unpack customGcc]) (configOverrideGccPath config)
-    , if whichCompiler (envConfigCompilerVersion econfig) == Ghcjs
-        then ["--ghcjs"]
-        else []
-    , if useExactConf then ["--exact-configuration"] else []
+    , ["--ghcjs" | whichCompiler (envConfigCompilerVersion econfig) == Ghcjs]
+    , ["--exact-configuration" | useExactConf]
     ]
   where
     config = getConfig econfig


### PR DESCRIPTION
This fixes issue #2350. See the commit for details.
This PR also includes a minor refactoring commit which improves consistency.