### PR TITLE
Various version bound/build-depends fixes

### DIFF
--- a/stack.cabal
+++ b/stack.cabal
@@ -196,7 +196,7 @@ library
                    , persistent-sqlite (>= 2.1.4 && < 2.5.0.1) || (> 2.5.0.1 && < 2.6)
                    , persistent-template >= 2.1.1 && < 2.6
                    , pretty >= 1.1.1.1
-                   , process >= 1.2.0.0 && < 1.5
+                   , process >= 1.2.1.0 && < 1.5
                    , regex-applicative-text >=0.1.0.1 && <0.2
                    , resourcet >= 1.1.4.1
                    , retry >= 0.6 && < 0.8

--- a/stack.cabal
+++ b/stack.cabal
@@ -49,6 +49,10 @@ flag static
   -- Not intended for general use. Simply makes it easier to
   -- build a fully static binary on Linux platforms that enable it.
 
+flag use-old-locale
+  default:     False
+  description: Use old-locale instead of time >= 1.5
+
 library
   hs-source-dirs:    src/
   ghc-options:       -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-identities
@@ -206,7 +210,6 @@ library
                    , temporary >= 1.2.0.3
                    , text >= 1.2.0.4
                    , text-binary
-                   , time >= 1.4.2 && < 1.7
                    , tls >= 1.3.8
                    , transformers >= 0.3.0.0 && < 0.6
                    , transformers-base >= 0.4.4
@@ -222,6 +225,13 @@ library
                    , zip-archive < 0.4
                    , hpack >= 0.14.0 && < 0.15
                    , store
+
+  if flag(use-old-locale)
+    build-depends:   old-locale
+                   , time >= 1.4.2 && < 1.5
+  else
+    build-depends:   time >= 1.5 && < 1.7
+
   if os(windows)
     cpp-options:     -DWINDOWS
     build-depends:   Win32

--- a/stack.cabal
+++ b/stack.cabal
@@ -219,7 +219,7 @@ library
                    , vector-binary-instances
                    , yaml >= 0.8.10.1
                    , zlib >= 0.5.4.2 && < 0.7
-                   , deepseq >= 1.4
+                   , deepseq >= 1.3 && < 1.5
                    , hastache
                    , project-template >= 0.2
                    , zip-archive < 0.4


### PR DESCRIPTION
Various version bound fixes, mainly to make stack compile with `lts-2.22`. Please consider the individual commits for details.