### PR TITLE
Pretty-print YAML parse errors

### DIFF
--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -180,6 +180,7 @@ import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8, decodeUtf8)
 import           Data.Typeable
 import           Data.Yaml (ParseException)
+import qualified Data.Yaml as Yaml
 import           Distribution.System (Platform)
 import qualified Distribution.Text
 import           Distribution.Version (anyVersion)
@@ -1101,14 +1102,14 @@ instance Show ConfigException where
         [ "Could not parse '"
         , toFilePath configFile
         , "':\n"
-        , show exception
+        , Yaml.prettyPrintParseException exception
         , "\nSee http://docs.haskellstack.org/en/stable/yaml_configuration/."
         ]
     show (ParseCustomSnapshotException url exception) = concat
         [ "Could not parse '"
         , T.unpack url
         , "':\n"
-        , show exception
+        , Yaml.prettyPrintParseException exception
         -- FIXME: Link to docs about custom snapshots
         -- , "\nSee http://docs.haskellstack.org/en/stable/yaml_configuration/."
         ]


### PR DESCRIPTION
Follow-up to #2374. Unfortunately, the Yaml library's `prettyPrintParseException` doesn't do a great job for the example in #2374:

```
Could not parse '/home/sidharth/sidharthkapur1@gmail.com/workspace/stack-testing/2374/stack.yaml':
YAML parse exception at line 2, column 17,
:
mapping values are not allowed in this context

See http://docs.haskellstack.org/en/stable/yaml_configuration/.
```

The second line of the error contains only a `:` because `yamlContext` is empty in this case (see [code](https://hackage.haskell.org/package/yaml-0.8.18/docs/src/Data-Yaml-Internal.html#prettyPrintParseException)). It would be nice to send them a PR to clean this up. Regardless, I think this is an improvement.