### PR TITLE
Travis: download stack for cabal builds

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -15,15 +15,18 @@ fetch_stack_linux() {
   curl -sL https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack';
 }
 
+# We need stack to generate cabal files with precise bounds, even for cabal
+# builds.
+mkdir -p ~/.local/bin;
+if [ `uname` = "Darwin" ]; then
+  travis_retry fetch_stack_osx
+else
+  travis_retry fetch_stack_linux
+fi
+
 case "$BUILD" in
   stack)
-    mkdir -p ~/.local/bin;
-    if [ `uname` = "Darwin" ]; then
-      travis_retry fetch_stack_osx
-    else
-      travis_retry fetch_stack_linux
-    fi;
-
+    # However, we only need stack to download GHC for stack builds.
     travis_retry stack --no-terminal setup;
     ;;
   cabal)

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ install:
        rm -f $(stack --compiler=ghc-$GHCVER path --dist-dir)/stack-*.tar.gz &&
        stack --compiler=ghc-$GHCVER sdist --pvp-bounds=both &&
        tar xf $(stack --compiler=ghc-$GHCVER path --dist-dir)/stack-*.tar.gz --wildcards --strip-components=1 '*/stack.cabal' &&
-       cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0;;
+       cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1;;
    esac
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ cache:
 
 matrix:
   include:
-    - env: BUILD=cabal CABALVER=1.18 GHCVER=7.8.4 STACK_YAML=stack-7.8.yaml
+    - env: BUILD=cabal CABALVER=1.22 GHCVER=7.8.4 STACK_YAML=stack-7.8.yaml
       compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.8.4], sources: [hvr-ghc]}}
 
     - env: BUILD=cabal CABALVER=1.22 GHCVER=7.10.1
       compiler: ": #GHC 7.10.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 
 matrix:
   include:
-    - env: BUILD=cabal CABALVER=1.18 GHCVER=7.8.4
+    - env: BUILD=cabal CABALVER=1.18 GHCVER=7.8.4 STACK_YAML=stack-7.8.yaml
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
 
@@ -78,9 +78,9 @@ install:
      cabal)
        cabal --version;
        travis_retry cabal update;
-       rm -f $(stack path --dist-dir)/stack-*.tar.gz;
-       stack sdist --pvp-bounds=both;
-       tar xf $(stack path --dist-dir)/stack-*.tar.gz --wildcards --strip-components=1 '*/stack.cabal';
+       rm -f $(stack --compiler=ghc-$GHCVER path --dist-dir)/stack-*.tar.gz;
+       stack --compiler=ghc-$GHCVER sdist --pvp-bounds=both;
+       tar xf $(stack --compiler=ghc-$GHCVER path --dist-dir)/stack-*.tar.gz --wildcards --strip-components=1 '*/stack.cabal';
        cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0;;
    esac
 
@@ -96,8 +96,8 @@ script:
        cabal sdist;
        cabal copy;
        cd test/integration;
-       true stack setup;
-       true stack test;
+       true stack setup --compiler=ghc-$GHCVER;
+       true stack test --compiler=ghc-$GHCVER;
        cd ../..;
        SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
        (cd dist && cabal install --force-reinstalls "$SRC_TGZ");;

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ cache:
 
 matrix:
   include:
-    - env: BUILD=cabal CABALVER=1.22 GHCVER=7.8.4 STACK_YAML=stack-7.8.yaml
+    - env: BUILD=cabal CABALVER=1.24 GHCVER=7.8.4 STACK_YAML=stack-7.8.yaml
       compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.8.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.8.4], sources: [hvr-ghc]}}
 
     - env: BUILD=cabal CABALVER=1.22 GHCVER=7.10.1
       compiler: ": #GHC 7.10.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,9 +78,9 @@ install:
      cabal)
        cabal --version;
        travis_retry cabal update;
-       rm -f $(stack --compiler=ghc-$GHCVER path --dist-dir)/stack-*.tar.gz;
-       stack --compiler=ghc-$GHCVER sdist --pvp-bounds=both;
-       tar xf $(stack --compiler=ghc-$GHCVER path --dist-dir)/stack-*.tar.gz --wildcards --strip-components=1 '*/stack.cabal';
+       rm -f $(stack --compiler=ghc-$GHCVER path --dist-dir)/stack-*.tar.gz &&
+       stack --compiler=ghc-$GHCVER sdist --pvp-bounds=both &&
+       tar xf $(stack --compiler=ghc-$GHCVER path --dist-dir)/stack-*.tar.gz --wildcards --strip-components=1 '*/stack.cabal' &&
        cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0;;
    esac
 


### PR DESCRIPTION
Fix #2390:
- download stack before using it;
- error out if the uses of stack fails;
- pass enough options to stack to make it work without requiring `stack setup` (specifically, pick correct stack file and GHC version).

This still does not ensure a successful build from scratch on GHC-7.8.4, but it still fixes a clear bug.