### PR TITLE
stack sdist: Fix timestamp in tarball

### DIFF
--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -108,7 +108,8 @@ getSDistTarball mpvpBounds pkgDir = do
         packFile fp
             | tweakCabal && isCabalFp fp = do
                 lbs <- getCabalLbs pvpBounds $ toFilePath cabalfp
-                return $ Tar.fileEntry (tarPath False fp) lbs
+                currTime <- liftIO getPOSIXTime -- Seconds from UNIX epoch
+                return $ (Tar.fileEntry (tarPath False fp) lbs) { Tar.entryTime = floor currTime }
             | otherwise = packWith packFileEntry False fp
         isCabalFp fp = toFilePath pkgDir FP.</> fp == toFilePath cabalfp
         tarName = pkgId FP.<.> "tar.gz"


### PR DESCRIPTION
Here tar (the tool) [warns on Travis](https://travis-ci.org/commercialhaskell/stack/jobs/145921846#L254) that a time stamp in a tarball generated by stack sdist is very odd:

> tar: stack.cabal: implausibly old time stamp 1970-01-01 00:00:00

The warning *is* harmless, but it might still puzzle users (e.g. http://raspberrypi.stackexchange.com/a/13152/4395 in other scenarios), so here's a 2-line fix.