### PR TITLE
Fix #1810: Unicode-normalized pkg name comparison

### DIFF
--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -76,8 +76,7 @@ import qualified System.Directory            as D
 import qualified System.FilePath             as FP
 import           System.Process.Read
 
-import qualified Data.Text.Normalize         as T ( normalize )
-import           Data.Unicode.Types          ( NormalizationMode(NFC) )
+import qualified Data.Text.Normalize         as T ( normalize , NormalizationMode(NFC) )
 
 data ConstraintType = Constraint | Preference deriving (Eq)
 type ConstraintSpec = Map PackageName (Version, Map FlagName Bool)
@@ -562,10 +561,9 @@ cabalPackagesCheck cabalfps noPkgMsg dupErrMsg = do
     -- Just the latter check is enough to cover both the cases
 
     let packages  = zip cabalfps gpds
-        -- XXX taken from https://github.com/ppelleti/normalization-insensitive, see #1810
-        unicodeNormalize = T.unpack . T.normalize NFC . T.pack
+        normalizeString = T.unpack . T.normalize T.NFC . T.pack
         getNameMismatchPkg (fp, gpd)
-            | (unicodeNormalize . show . gpdPackageName) gpd /= (unicodeNormalize . FP.takeBaseName . toFilePath) fp
+            | (normalizeString . show . gpdPackageName) gpd /= (normalizeString . FP.takeBaseName . toFilePath) fp
                 = Just fp
             | otherwise = Nothing
         nameMismatchPkgs = mapMaybe getNameMismatchPkg packages

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -62,6 +62,7 @@ extra-deps:
 - th-orphans-0.13.1
 - base-orphans-0.5.4
 - tar-0.5.0.3
+- unicode-transforms-0.1.0.1
 flags:
   time-locale-compat:
     old-locale: false

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -12,3 +12,4 @@ extra-deps:
 - http-client-0.5.0
 - http-conduit-2.2.0
 - http-client-tls-0.3.0
+- unicode-transforms-0.1.0.1

--- a/stack.cabal
+++ b/stack.cabal
@@ -216,6 +216,7 @@ library
                    , tls >= 1.3.8
                    , transformers >= 0.3.0.0 && < 0.6
                    , transformers-base >= 0.4.4
+                   , unicode-transforms >= 0.1 && <0.2
                    , unix-compat
                    , unordered-containers >= 0.2.5.1
                    , vector >= 0.10.12.3 && < 0.12

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,3 +20,4 @@ extra-deps:
 - http-client-tls-0.3.0
 - http-conduit-2.2.0
 - path-0.5.8
+- unicode-transforms-0.1.0.1

--- a/test/integration/lib/StackTest.hs
+++ b/test/integration/lib/StackTest.hs
@@ -122,9 +122,6 @@ exeExt = if isWindows then ".exe" else ""
 -- | Is the OS Windows?
 isWindows = os == "mingw32"
 
--- | Is the OS Mac OS X?
-isMacOSX = os == "darwin"
-
 -- | To avoid problems with GHC version mismatch when a new LTS major
 -- version is released, pass this argument to @stack@ when running in
 -- a global context.  The LTS major version here should match that of

--- a/test/integration/tests/1336-1337-new-package-names/Main.hs
+++ b/test/integration/tests/1336-1337-new-package-names/Main.hs
@@ -1,5 +1,4 @@
 import StackTest
-import Control.Monad
 import System.Directory
 import System.FilePath
 
@@ -18,7 +17,7 @@ main =
             stackErr ["new", "44444444444444"]
             stackErr ["new", "abc-1"]
             stackErr ["new", "444-ば日本-4本"]
-            unless isMacOSX $ stack ["new", "ば日本-4本"]
+            stack ["new", "ば日本-4本"]
             stack ["new", "אבהץש"]
             stack ["new", "ΔΘΩϬ"]
             doesExist "./ΔΘΩϬ/stack.yaml"


### PR DESCRIPTION
(Untested yet).
Potential quick fix to the most urgent part #1810, based on @harendra-kumar's pure Haskell normalization library. A more proper and systematic fix, replacing `text` with a normalizing version, remains for future work.

Includes one line from normalization-insensitive, pending https://github.com/ppelleti/normalization-insensitive#2—maybe I should add @ppelleti's copyright or is this line too trivial?