### PR TITLE
Use new Data.Store.Version to address #2296

### DIFF
--- a/src/Data/Store/VersionTagged.hs
+++ b/src/Data/Store/VersionTagged.hs
@@ -4,12 +4,14 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ViewPatterns #-}
 -- | Tag a Store instance with structural version info to ensure we're
 -- reading a compatible format.
 module Data.Store.VersionTagged
-    ( taggedDecodeOrLoad
-    , taggedEncodeFile
-    , decodeFileMaybe
+    ( versionedEncodeFile
+    , versionedDecodeOrLoad
+    , versionedDecodeFile
+    , storeVersionConfig
     ) where
 
 import Control.Applicative
@@ -18,60 +20,88 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Logger
 import Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Data.ByteString as BS
+import Data.Data (Data)
+import qualified Data.Map as M
 import Data.Monoid ((<>))
+import qualified Data.Set as S
 import Data.Store
-import Data.Store.TypeHash
+import Data.Store.Version
 import qualified Data.Text as T
+import Language.Haskell.TH
 import Path
 import Path.IO (ensureDir)
 import Prelude
 
--- | Write to the given file, with a binary-tagged tag.
-taggedEncodeFile :: (Store a, HasTypeHash a, MonadIO m, MonadLogger m, Eq a)
-                 => Path Abs File
-                 -> a
-                 -> m ()
-taggedEncodeFile fp x = do
+versionedEncodeFile :: Data a => VersionConfig a -> Q Exp
+versionedEncodeFile vc = [e| \fp x -> storeEncodeFile fp ($(wrapVersion vc) x) |]
+
+versionedDecodeOrLoad :: Data a => VersionConfig a -> Q Exp
+versionedDecodeOrLoad vc = [| versionedDecodeOrLoadImpl $(wrapVersion vc) $(checkVersion vc) |]
+
+versionedDecodeFile :: Data a => VersionConfig a -> Q Exp
+versionedDecodeFile vc = [e| versionedDecodeFileImpl $(checkVersion vc) |]
+
+-- | Write to the given file.
+storeEncodeFile :: (Store a, MonadIO m, MonadLogger m, Eq a)
+                => Path Abs File
+                -> a
+                -> m ()
+storeEncodeFile fp x = do
     let fpt = T.pack (toFilePath fp)
     $logDebug $ "Encoding " <> fpt
     ensureDir (parent fp)
-    let encoded = encode (Tagged x)
-    assert (decodeEx encoded == Tagged x) $ liftIO $ BS.writeFile (toFilePath fp) encoded
+    let encoded = encode x
+    assert (decodeEx encoded == x) $ liftIO $ BS.writeFile (toFilePath fp) encoded
     $logDebug $ "Finished writing " <> fpt
 
 -- | Read from the given file. If the read fails, run the given action and
 -- write that back to the file. Always starts the file off with the
 -- version tag.
-taggedDecodeOrLoad :: (Store a, HasTypeHash a, Eq a, MonadIO m, MonadLogger m, MonadBaseControl IO m)
-                   => Path Abs File
-                   -> m a
-                   -> m a
-taggedDecodeOrLoad fp mx = do
+versionedDecodeOrLoadImpl :: (Store a, Eq a, MonadIO m, MonadLogger m, MonadBaseControl IO m)
+                          => (a -> WithVersion a)
+                          -> (WithVersion a -> Either VersionCheckException a)
+                          -> Path Abs File
+                          -> m a
+                          -> m a
+versionedDecodeOrLoadImpl wrap check fp mx = do
     let fpt = T.pack (toFilePath fp)
     $logDebug $ "Trying to decode " <> fpt
-    mres <- decodeFileMaybe fp
+    mres <- versionedDecodeFileImpl check fp
     case mres of
-        Nothing -> do
-            $logDebug $ "Failure decoding " <> fpt
-            x <- mx
-            taggedEncodeFile fp x
-            return x
         Just x -> do
             $logDebug $ "Success decoding " <> fpt
             return x
+        _ -> do
+            $logDebug $ "Failure decoding " <> fpt
+            x <- mx
+            storeEncodeFile fp (wrap x)
+            return x
 
-decodeFileMaybe :: (Store a, HasTypeHash a, MonadIO m, MonadLogger m, MonadBaseControl IO m)
-                => Path loc File
-                -> m (Maybe a)
-decodeFileMaybe fp = do
+versionedDecodeFileImpl :: (Store a, MonadIO m, MonadLogger m, MonadBaseControl IO m)
+                        => (WithVersion a -> Either VersionCheckException a)
+                        -> Path loc File
+                        -> m (Maybe a)
+versionedDecodeFileImpl check fp = do
     mbs <- liftIO (Just <$> BS.readFile (toFilePath fp)) `catch` \(err :: IOException) -> do
         $logDebug ("Exception ignored when attempting to load " <> T.pack (toFilePath fp) <> ": " <> T.pack (show err))
         return Nothing
     case mbs of
         Nothing -> return Nothing
         Just bs ->
-            liftIO (do (Tagged res) <- decodeIO bs
-                       return (Just res)) `catch` \(err :: PeekException) -> do
+            liftIO (do decoded <- decodeIO bs
+                       return $ case check decoded of
+                           Right res -> Just res
+                           _ -> Nothing) `catch` \(err :: PeekException) -> do
                  let fpt = T.pack (toFilePath fp)
                  $logDebug ("Error while decoding " <> fpt <> ": " <> T.pack (show err) <> " (this might not be an error, when switching between stack versions)")
                  return Nothing
+
+storeVersionConfig :: String -> String -> VersionConfig a
+storeVersionConfig name hash = (namedVersionConfig name hash)
+    { vcIgnore = S.fromList
+        [ "Data.Vector.Unboxed.Base.Vector GHC.Types.Word"
+        , "Data.ByteString.Internal.ByteString"
+        ]
+    , vcRenames = M.fromList
+        [ ( "Data.Maybe.Maybe", "GHC.Base.Maybe") ]
+    }

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -54,23 +54,21 @@ import           Data.Maybe (fromMaybe, mapMaybe)
 import           Data.Monoid ((<>))
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Store (Store)
 import qualified Data.Store as Store
-import           Data.Store.TypeHash (HasTypeHash, mkManyHasTypeHash)
 import           Data.Store.VersionTagged
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Traversable (forM)
-import           GHC.Generics (Generic)
 import           Path
 import           Path.IO
 import           Stack.Constants
-import           Stack.Types.GhcPkgId
-import           Stack.Types.PackageIdentifier
-import           Stack.Types.Version
-import           Stack.Types.Config
 import           Stack.Types.Build
 import           Stack.Types.Compiler
+import           Stack.Types.Config
+import           Stack.Types.GhcPkgId
+import           Stack.Types.Package
+import           Stack.Types.PackageIdentifier
+import           Stack.Types.Version
 import qualified System.FilePath as FilePath
 
 -- | Directory containing files to mark an executable as installed
@@ -108,64 +106,47 @@ markExeNotInstalled loc ident = do
     ident' <- parseRelFile $ packageIdentifierString ident
     ignoringAbsence (removeFile $ dir </> ident')
 
--- | Stored on disk to know whether the flags have changed or any
--- files have changed.
-data BuildCache = BuildCache
-    { buildCacheTimes :: !(Map FilePath FileCacheInfo)
-      -- ^ Modification times of files.
-    }
-    deriving (Generic, Eq, Show)
-instance Store BuildCache
-instance NFData BuildCache
-
 -- | Try to read the dirtiness cache for the given package directory.
 tryGetBuildCache :: (MonadIO m, MonadReader env m, MonadThrow m, MonadLogger m, HasEnvConfig env, MonadBaseControl IO m)
                  => Path Abs Dir -> m (Maybe (Map FilePath FileCacheInfo))
-tryGetBuildCache = liftM (fmap buildCacheTimes) . tryGetCache buildCacheFile
+tryGetBuildCache dir = liftM (fmap buildCacheTimes) . $(versionedDecodeFile buildCacheVC) =<< buildCacheFile dir
 
 -- | Try to read the dirtiness cache for the given package directory.
 tryGetConfigCache :: (MonadIO m, MonadReader env m, MonadThrow m, HasEnvConfig env, MonadBaseControl IO m, MonadLogger m)
                   => Path Abs Dir -> m (Maybe ConfigCache)
-tryGetConfigCache = tryGetCache configCacheFile
+tryGetConfigCache dir = $(versionedDecodeFile configCacheVC) =<< configCacheFile dir
 
 -- | Try to read the mod time of the cabal file from the last build
 tryGetCabalMod :: (MonadIO m, MonadReader env m, MonadThrow m, HasEnvConfig env, MonadBaseControl IO m, MonadLogger m)
                => Path Abs Dir -> m (Maybe ModTime)
-tryGetCabalMod = tryGetCache configCabalMod
-
--- | Try to load a cache.
-tryGetCache :: (MonadIO m, Store a, HasTypeHash a, MonadBaseControl IO m, MonadLogger m)
-            => (Path Abs Dir -> m (Path Abs File))
-            -> Path Abs Dir
-            -> m (Maybe a)
-tryGetCache get' dir = do
-    fp <- get' dir
-    decodeFileMaybe fp
+tryGetCabalMod dir = $(versionedDecodeFile modTimeVC) =<< configCabalMod dir
 
 -- | Write the dirtiness cache for this package's files.
 writeBuildCache :: (MonadIO m, MonadReader env m, MonadThrow m, HasEnvConfig env, MonadLogger m)
                 => Path Abs Dir -> Map FilePath FileCacheInfo -> m ()
-writeBuildCache dir times =
-    writeCache
-        dir
-        buildCacheFile
-        BuildCache
-         { buildCacheTimes = times
-         }
+writeBuildCache dir times = do
+    fp <- buildCacheFile dir
+    $(versionedEncodeFile buildCacheVC) fp BuildCache
+        { buildCacheTimes = times
+        }
 
 -- | Write the dirtiness cache for this package's configuration.
 writeConfigCache :: (MonadIO m, MonadReader env m, MonadThrow m, HasEnvConfig env, MonadLogger m)
                 => Path Abs Dir
                 -> ConfigCache
                 -> m ()
-writeConfigCache dir = writeCache dir configCacheFile
+writeConfigCache dir x = do
+    fp <- configCacheFile dir
+    $(versionedEncodeFile configCacheVC) fp x
 
 -- | See 'tryGetCabalMod'
 writeCabalMod :: (MonadIO m, MonadReader env m, MonadThrow m, HasEnvConfig env, MonadLogger m)
               => Path Abs Dir
               -> ModTime
               -> m ()
-writeCabalMod dir = writeCache dir configCabalMod
+writeCabalMod dir x = do
+    fp <- configCabalMod dir
+    $(versionedEncodeFile modTimeVC) fp x
 
 -- | Delete the caches for the project.
 deleteCaches :: (MonadIO m, MonadReader env m, MonadCatch m, HasEnvConfig env)
@@ -177,16 +158,6 @@ deleteCaches dir = do
     -}
     cfp <- configCacheFile dir
     ignoringAbsence (removeFile cfp)
-
--- | Write to a cache.
-writeCache :: (Store a, HasTypeHash a, Eq a, MonadIO m, MonadLogger m)
-           => Path Abs Dir
-           -> (Path Abs Dir -> m (Path Abs File))
-           -> a
-           -> m ()
-writeCache dir get' content = do
-    fp <- get' dir
-    taggedEncodeFile fp content
 
 flagCacheFile :: (MonadIO m, MonadThrow m, MonadReader env m, HasEnvConfig env)
               => Installed
@@ -205,7 +176,7 @@ tryGetFlagCache :: (MonadIO m, MonadThrow m, MonadReader env m, HasEnvConfig env
                 -> m (Maybe ConfigCache)
 tryGetFlagCache gid = do
     fp <- flagCacheFile gid
-    decodeFileMaybe fp
+    $(versionedDecodeFile configCacheVC) fp
 
 writeFlagCache :: (MonadIO m, MonadReader env m, HasEnvConfig env, MonadThrow m, MonadLogger m)
                => Installed
@@ -214,27 +185,23 @@ writeFlagCache :: (MonadIO m, MonadReader env m, HasEnvConfig env, MonadThrow m,
 writeFlagCache gid cache = do
     file <- flagCacheFile gid
     ensureDir (parent file)
-    taggedEncodeFile file cache
+    $(versionedEncodeFile configCacheVC) file cache
 
 -- | Mark a test suite as having succeeded
 setTestSuccess :: (MonadIO m, MonadThrow m, MonadReader env m, HasEnvConfig env, MonadLogger m)
                => Path Abs Dir
                -> m ()
-setTestSuccess dir =
-    writeCache
-        dir
-        testSuccessFile
-        True
+setTestSuccess dir = do
+    fp <- testSuccessFile dir
+    $(versionedEncodeFile testSuccessVC) fp True
 
 -- | Mark a test suite as not having succeeded
 unsetTestSuccess :: (MonadIO m, MonadThrow m, MonadReader env m, HasEnvConfig env, MonadLogger m)
                  => Path Abs Dir
                  -> m ()
-unsetTestSuccess dir =
-    writeCache
-        dir
-        testSuccessFile
-        False
+unsetTestSuccess dir = do
+    fp <- testSuccessFile dir
+    $(versionedEncodeFile testSuccessVC) fp False
 
 -- | Check if the test suite already passed
 checkTestSuccess :: (MonadIO m, MonadThrow m, MonadReader env m, HasEnvConfig env, MonadBaseControl IO m, MonadLogger m)
@@ -243,7 +210,7 @@ checkTestSuccess :: (MonadIO m, MonadThrow m, MonadReader env m, HasEnvConfig en
 checkTestSuccess dir =
     liftM
         (fromMaybe False)
-        (tryGetCache testSuccessFile dir)
+        ($(versionedDecodeFile testSuccessVC) =<< testSuccessFile dir)
 
 --------------------------------------
 -- Precompiled Cache
@@ -325,7 +292,7 @@ writePrecompiledCache baseConfigOpts pkgident copts depIDs mghcPkgId exes = do
         name <- parseRelFile $ T.unpack exe
         relPath <- stackRootRelative $ bcoSnapInstallRoot baseConfigOpts </> bindirSuffix </> name
         return $ toFilePath $ relPath
-    taggedEncodeFile file PrecompiledCache
+    $(versionedEncodeFile precompiledCacheVC) file PrecompiledCache
         { pcLibrary = mlibpath
         , pcExes = exes'
         }
@@ -350,7 +317,7 @@ readPrecompiledCache pkgident copts depIDs = do
                   }
 
     (file, getOldFile) <- precompiledCacheFile pkgident copts depIDs
-    mres <- decodeFileMaybe file
+    mres <- $(versionedDecodeFile precompiledCacheVC) file
     case mres of
         Just res -> return (Just $ toAbsPC res)
         Nothing -> do
@@ -359,7 +326,7 @@ readPrecompiledCache pkgident copts depIDs = do
             mpc <- fmap (fmap toAbsPC) $ binaryDecodeFileOrFailDeep oldFile
             -- Write out file in new format. Keep old file around for
             -- the benefit of older stack versions.
-            forM_ mpc (taggedEncodeFile file)
+            forM_ mpc ($(versionedEncodeFile precompiledCacheVC) file)
             return mpc
 
 -- | Ensure that there are no lurking exceptions deep inside the parsed
@@ -375,10 +342,3 @@ binaryDecodeFileOrFailDeep fp = liftIO $ fmap (either (\_ -> Nothing) id) $ tryA
         Right x -> return (Just x)
 
 type BinarySchema a = (Binary a, NFData a, HasStructuralInfo a, HasSemanticVersion a)
-
-$(mkManyHasTypeHash
-    [ [t| BuildCache |]
-    -- TODO: put this orphan elsewhere? Not sure if we want tons of
-    -- instances of HasTypeHash or not.
-    , [t| Bool |]
-    ])

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -13,40 +13,41 @@ module Stack.Build.Installed
 
 import           Control.Applicative
 import           Control.Monad
-import           Control.Monad.Catch          (MonadMask)
+import           Control.Monad.Catch (MonadMask)
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
-import           Control.Monad.Reader         (MonadReader, asks)
+import           Control.Monad.Reader (MonadReader, asks)
 import           Control.Monad.Trans.Resource
 import           Data.Conduit
-import qualified Data.Conduit.List            as CL
+import qualified Data.Conduit.List as CL
+import qualified Data.Foldable as F
 import           Data.Function
-import qualified Data.Foldable                as F
-import qualified Data.HashSet                 as HashSet
+import qualified Data.HashSet as HashSet
 import           Data.List
-import           Data.Map.Strict              (Map)
-import qualified Data.Map.Strict              as M
-import qualified Data.Map.Strict              as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import qualified Data.Map.Strict as Map
 import           Data.Maybe
-import           Data.Maybe.Extra             (mapMaybeM)
+import           Data.Maybe.Extra (mapMaybeM)
 import           Data.Monoid
-import qualified Data.Text                    as T
-import           Network.HTTP.Client.Conduit  (HasHttpManager)
+import qualified Data.Text as T
+import           Network.HTTP.Client.Conduit (HasHttpManager)
 import           Path
-import           Prelude                      hiding (FilePath, writeFile)
+import           Prelude hiding (FilePath, writeFile)
 import           Stack.Build.Cache
-import           Stack.Types.Build
-import           Stack.Types.Version
 import           Stack.Constants
 import           Stack.GhcPkg
 import           Stack.PackageDump
+import           Stack.Types.Build
+import           Stack.Types.Compiler
+import           Stack.Types.Config
 import           Stack.Types.GhcPkgId
+import           Stack.Types.Internal
+import           Stack.Types.Package
+import           Stack.Types.PackageDump
 import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageName
-import           Stack.Types.Config
-import           Stack.Types.Package
-import           Stack.Types.Compiler
-import           Stack.Types.Internal
+import           Stack.Types.Version
 
 type M env m = (MonadIO m,MonadReader env m,HasHttpManager env,HasEnvConfig env,MonadLogger m,MonadBaseControl IO m,MonadMask m,HasLogLevel env)
 

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -45,7 +45,7 @@ import           Control.Monad.State.Strict      (State, execState, get, modify,
 import           Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Crypto.Hash.SHA256 as SHA256
 import           Data.Aeson.Extended (WithJSONWarnings(..), logJSONWarnings)
-import           Data.Store.VersionTagged (taggedDecodeOrLoad, decodeFileMaybe, taggedEncodeFile)
+import           Data.Store.VersionTagged
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Base64.URL as B64URL
 import qualified Data.ByteString.Char8 as S8
@@ -452,7 +452,7 @@ loadMiniBuildPlan
     -> m MiniBuildPlan
 loadMiniBuildPlan name = do
     path <- configMiniBuildPlanCache name
-    taggedDecodeOrLoad path $ liftM buildPlanFixes $ do
+    $(versionedDecodeOrLoad miniBuildPlanVC) path $ liftM buildPlanFixes $ do
         bp <- loadBuildPlan name
         toMiniBuildPlan
             (siCompilerVersion $ bpSystemInfo bp)
@@ -979,7 +979,7 @@ parseCustomMiniBuildPlan mconfigPath0 url0 = do
                    -- cases.
                    binaryPath <- getBinaryPath hash
                    alreadyCached <- doesFileExist binaryPath
-                   unless alreadyCached $ taggedEncodeFile binaryPath mbp
+                   unless alreadyCached $ $(versionedEncodeFile miniBuildPlanVC) binaryPath mbp
                    return (mbp, hash)
   where
     downloadCustom url req = do
@@ -991,7 +991,7 @@ parseCustomMiniBuildPlan mconfigPath0 url0 = do
         yamlBS <- liftIO $ S.readFile $ toFilePath cacheFP
         let yamlHash = doHash yamlBS
         binaryPath <- getBinaryPath yamlHash
-        liftM (, yamlHash) $ taggedDecodeOrLoad binaryPath $ do
+        liftM (, yamlHash) $ $(versionedDecodeOrLoad miniBuildPlanVC) binaryPath $ do
             (cs, mresolver) <- decodeYaml yamlBS
             parentMbp <- case (csCompilerVersion cs, mresolver) of
                 (Nothing, Nothing) -> throwM (NeitherCompilerOrResolverSpecified url)
@@ -1028,7 +1028,7 @@ parseCustomMiniBuildPlan mconfigPath0 url0 = do
                                 exists <- doesFileExist binaryPath
                                 if exists
                                     then do
-                                        eres <- decodeFileMaybe binaryPath
+                                        eres <- $(versionedDecodeFile miniBuildPlanVC) binaryPath
                                         case eres of
                                             Just mbp -> return mbp
                                             -- Invalid format cache file, remove.

--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DataKinds #-}
 module Stack.PackageDump
     ( Line
     , eachSection
@@ -15,9 +14,6 @@ module Stack.PackageDump
     , conduitDumpPackage
     , ghcPkgDump
     , ghcPkgDescribe
-    , InstalledCache
-    , InstalledCacheInner (..)
-    , InstalledCacheEntry (..)
     , newInstalledCache
     , loadInstalledCache
     , saveInstalledCache
@@ -37,7 +33,6 @@ import           Control.Monad.Logger (MonadLogger)
 import           Control.Monad.Trans.Control
 import           Data.Attoparsec.Args
 import           Data.Attoparsec.Text as P
-import           Data.Store.VersionTagged
 import           Data.Conduit
 import qualified Data.Conduit.List as CL
 import qualified Data.Conduit.Text as CT
@@ -48,37 +43,22 @@ import qualified Data.Map as Map
 import           Data.Maybe (catMaybes, listToMaybe)
 import           Data.Maybe.Extra (mapMaybeM)
 import qualified Data.Set as Set
-import           Data.Store (Store)
-import           Data.Store.TypeHash (mkManyHasTypeHash)
+import           Data.Store.VersionTagged
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Typeable (Typeable)
-import           GHC.Generics (Generic)
 import           Path
 import           Path.Extra (toFilePathNoTrailingSep)
-import           Path.IO (ensureDir)
 import           Prelude -- Fix AMP warning
 import           Stack.GhcPkg
+import           Stack.Types.Compiler
 import           Stack.Types.GhcPkgId
+import           Stack.Types.PackageDump
 import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageName
 import           Stack.Types.Version
-import           Stack.Types.Compiler
 import           System.Directory (getDirectoryContents, doesFileExist)
 import           System.Process.Read
-
--- | Cached information on whether package have profiling libraries and haddocks.
-newtype InstalledCache = InstalledCache (IORef InstalledCacheInner)
-newtype InstalledCacheInner = InstalledCacheInner (Map GhcPkgId InstalledCacheEntry)
-    deriving (Store, Generic, Eq, Show)
-
--- | Cached information on whether a package has profiling libraries and haddocks.
-data InstalledCacheEntry = InstalledCacheEntry
-    { installedCacheProfiling :: !Bool
-    , installedCacheHaddock :: !Bool
-    , installedCacheIdent :: !PackageIdentifier }
-    deriving (Eq, Generic, Show)
-instance Store InstalledCacheEntry
 
 -- | Call ghc-pkg dump with appropriate flags and stream to the given @Sink@, for a single database
 ghcPkgDump
@@ -135,14 +115,13 @@ newInstalledCache = liftIO $ InstalledCache <$> newIORef (InstalledCacheInner Ma
 loadInstalledCache :: (MonadLogger m, MonadIO m, MonadBaseControl IO m)
                    => Path Abs File -> m InstalledCache
 loadInstalledCache path = do
-    m <- taggedDecodeOrLoad path (return $ InstalledCacheInner Map.empty)
+    m <- $(versionedDecodeOrLoad installedCacheVC) path (return $ InstalledCacheInner Map.empty)
     liftIO $ InstalledCache <$> newIORef m
 
 -- | Save a @InstalledCache@ to disk
 saveInstalledCache :: (MonadLogger m, MonadIO m) => Path Abs File -> InstalledCache -> m ()
-saveInstalledCache path (InstalledCache ref) = do
-    ensureDir (parent path)
-    liftIO (readIORef ref) >>= taggedEncodeFile path
+saveInstalledCache path (InstalledCache ref) =
+    liftIO (readIORef ref) >>= $(versionedEncodeFile installedCacheVC) path
 
 -- | Prune a list of possible packages down to those whose dependencies are met.
 --
@@ -453,5 +432,3 @@ takeWhileC f =
     go x
         | f x = yield x >> loop
         | otherwise = leftover x
-
-$(mkManyHasTypeHash [ [t| InstalledCacheInner |] ])

--- a/src/Stack/PackageIndex.hs
+++ b/src/Stack/PackageIndex.hs
@@ -80,6 +80,7 @@ import           System.Process.Read         (EnvOverride,
                                               tryProcessStdout)
 import           System.Process.Run          (Cmd(..), callProcessInheritStderrStdout)
 import           Data.Streaming.Process      (ProcessExitedUnsuccessfully(..))
+import           Data.Store.Version
 
 -- | Populate the package index caches and return them.
 populateCache
@@ -416,7 +417,11 @@ getPackageCaches = do
         Nothing -> do
             result <- liftM mconcat $ forM (configPackageIndices config) $ \index -> do
                 fp <- configPackageIndexCache (indexName index)
-                PackageCacheMap pis' <- taggedDecodeOrLoad fp $ liftM PackageCacheMap $ populateCache menv index
+                PackageCacheMap pis' <-
+                    $(versionedDecodeOrLoad (storeVersionConfig "pkg-v1" "aHzcZ6_w3rL6NtEJUqEfh6fcjAc="
+                                             :: VersionConfig PackageCacheMap))
+                    fp
+                    (liftM PackageCacheMap (populateCache menv index))
                 return (fmap (index,) pis')
             liftIO $ writeIORef (configPackageCaches config) (Just result)
             return result

--- a/src/Stack/Types/Compiler.hs
+++ b/src/Stack/Types/Compiler.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 
@@ -6,6 +7,7 @@ module Stack.Types.Compiler where
 
 import           Control.DeepSeq
 import           Data.Aeson
+import           Data.Data
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Monoid ((<>))
@@ -33,7 +35,7 @@ data CompilerVersion
     | GhcjsVersion
         {-# UNPACK #-} !Version -- GHCJS version
         {-# UNPACK #-} !Version -- GHC version
-    deriving (Generic, Show, Eq, Ord)
+    deriving (Generic, Show, Eq, Ord, Data, Typeable)
 instance Store CompilerVersion
 instance NFData CompilerVersion
 instance ToJSON CompilerVersion where

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -26,7 +26,8 @@ import           Data.Monoid
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Store (Store)
-import           Data.Store.TypeHash (mkManyHasTypeHash)
+import           Data.Store.Version (VersionConfig)
+import           Data.Store.VersionTagged (storeVersionConfig)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8, decodeUtf8)
@@ -350,13 +351,19 @@ data FileCacheInfo = FileCacheInfo
     , fciSize :: !Word64
     , fciHash :: !S.ByteString
     }
-    deriving (Generic, Show, Eq)
+    deriving (Generic, Show, Eq, Data, Typeable)
 instance Store FileCacheInfo
 instance NFData FileCacheInfo
 
 -- | Used for storage and comparison.
 newtype ModTime = ModTime (Integer,Rational)
-  deriving (Ord,Show,Generic,Eq,NFData,Store)
+  deriving (Ord, Show, Generic, Eq, NFData, Store, Data, Typeable)
+
+modTimeVC :: VersionConfig ModTime
+modTimeVC = storeVersionConfig "mod-time-v1" "UBECpUI0JvM_SBOnRNdaiF9_yOU="
+
+testSuccessVC :: VersionConfig Bool
+testSuccessVC = storeVersionConfig "test-v1" "jC_GB0SGtbpRQbDlm7oQJP7thu8="
 
 -- | A descriptor from a .cabal file indicating one of the following:
 --
@@ -427,5 +434,3 @@ installedPackageIdentifier (Executable pid) = pid
 -- | Get the installed Version.
 installedVersion :: Installed -> Version
 installedVersion = packageIdentifierVersion . installedPackageIdentifier
-
-$(mkManyHasTypeHash [ [t| ModTime |] ])

--- a/src/Stack/Types/PackageDump.hs
+++ b/src/Stack/Types/PackageDump.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Stack.Types.PackageDump
+    ( InstalledCache(..)
+    , InstalledCacheInner(..)
+    , InstalledCacheEntry(..)
+    , installedCacheVC
+    ) where
+
+import Data.Data
+import Data.IORef
+import Data.Map (Map)
+import Data.Store
+import Data.Store.Version
+import Data.Store.VersionTagged
+import GHC.Generics (Generic)
+import Stack.Types.GhcPkgId
+import Stack.Types.PackageIdentifier
+
+-- | Cached information on whether package have profiling libraries and haddocks.
+newtype InstalledCache = InstalledCache (IORef InstalledCacheInner)
+newtype InstalledCacheInner = InstalledCacheInner (Map GhcPkgId InstalledCacheEntry)
+    deriving (Store, Generic, Eq, Show, Data, Typeable)
+
+-- | Cached information on whether a package has profiling libraries and haddocks.
+data InstalledCacheEntry = InstalledCacheEntry
+    { installedCacheProfiling :: !Bool
+    , installedCacheHaddock :: !Bool
+    , installedCacheIdent :: !PackageIdentifier }
+    deriving (Eq, Generic, Show, Data, Typeable)
+instance Store InstalledCacheEntry
+
+installedCacheVC :: VersionConfig InstalledCacheInner
+installedCacheVC = storeVersionConfig "installed-v1" "5yL7Ngpy4YKWDDCTUI6zAJ9UySI="

--- a/src/Stack/Types/PackageIndex.hs
+++ b/src/Stack/Types/PackageIndex.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 module Stack.Types.PackageIndex
     ( PackageDownload (..)
@@ -21,11 +22,11 @@ import           Control.Monad (mzero)
 import           Data.Aeson.Extended
 import           Data.ByteString (ByteString)
 import           Data.Hashable (Hashable)
+import           Data.Data (Data, Typeable)
 import           Data.Int (Int64)
 import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Store (Store)
-import           Data.Store.TypeHash (mkManyHasTypeHash)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8, decodeUtf8)
@@ -41,20 +42,20 @@ data PackageCache = PackageCache
     -- ^ size in bytes of the .cabal file
     , pcDownload :: !(Maybe PackageDownload)
     }
-    deriving (Generic, Eq, Show)
+    deriving (Generic, Eq, Show, Data, Typeable)
 
 instance Store PackageCache
 instance NFData PackageCache
 
 newtype PackageCacheMap = PackageCacheMap (Map PackageIdentifier PackageCache)
-    deriving (Generic, Store, NFData, Eq, Show)
+    deriving (Generic, Store, NFData, Eq, Show, Data, Typeable)
 
 data PackageDownload = PackageDownload
     { pdSHA512 :: !ByteString
     , pdUrl    :: !ByteString
     , pdSize   :: !Word64
     }
-    deriving (Show, Generic, Eq)
+    deriving (Show, Generic, Eq, Data, Typeable)
 instance Store PackageDownload
 instance NFData PackageDownload
 instance FromJSON PackageDownload where
@@ -72,9 +73,6 @@ instance FromJSON PackageDownload where
             , pdUrl = encodeUtf8 url
             , pdSize = size
             }
-
-$(mkManyHasTypeHash [ [t| PackageCacheMap |] ])
-
 
 -- | Unique name for a package index
 newtype IndexName = IndexName { unIndexName :: ByteString }

--- a/src/test/Stack/StoreSpec.hs
+++ b/src/test/Stack/StoreSpec.hs
@@ -21,11 +21,10 @@ import           Data.Word
 import           Language.Haskell.TH
 import           Language.Haskell.TH.ReifyMany
 import           Prelude
-import           Stack.Build.Cache (BuildCache(..))
-import           Stack.PackageDump
-import           Stack.Types.BuildPlan
-import           Stack.Types.PackageIndex
 import           Stack.Types.Build
+import           Stack.Types.BuildPlan
+import           Stack.Types.PackageDump
+import           Stack.Types.PackageIndex
 import           Test.Hspec
 import           Test.SmallCheck.Series
 

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -60,10 +60,11 @@ extra-deps:
 - http-api-data-0.2.2
 - time-locale-compat-0.1.1.1
 - persistent-2.5
-- store-0.1.0.1
+- store-0.2.1.0
+- store-core-0.2.0.0
 - th-reify-many-0.1.6
 - th-lift-instances-0.1.7
-- th-utilities-0.1.1.0
+- th-utilities-0.2.0.1
 - th-orphans-0.13.1
 - base-orphans-0.5.4
 - tar-0.5.0.3

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -13,3 +13,6 @@ extra-deps:
 - http-conduit-2.2.0
 - http-client-tls-0.3.0
 - unicode-transforms-0.1.0.1
+- store-0.2.1.0
+- store-core-0.2.0.0
+- th-utilities-0.2.0.1

--- a/stack.cabal
+++ b/stack.cabal
@@ -129,6 +129,7 @@ library
                      Stack.Types.Internal
                      Stack.Types.Nix
                      Stack.Types.Package
+                     Stack.Types.PackageDump
                      Stack.Types.PackageIdentifier
                      Stack.Types.PackageIndex
                      Stack.Types.PackageName

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,8 +13,9 @@ nix:
     - zlib
 extra-deps:
 - th-lift-instances-0.1.7
-- th-utilities-0.1.1.0
-- store-0.1.0.1
+- th-utilities-0.2.0.1
+- store-0.2.1.0
+- store-core-0.2.0.0
 - th-orphans-0.13.1
 - http-client-0.5.0
 - http-client-tls-0.3.0


### PR DESCRIPTION
Not quite ready yet, still pending review and release of the changes to store.

Also, the type hashes change when moving to 7.8 due to a type changing location:

```diff
--- /home/mgsloan/fpco/stack/.stack-work/store-versioned/aHzcZ6_w3rL6NtEJUqEfh6fcjAc=	2016-08-02 02:54:02.680394461 -0700
+++ /home/mgsloan/fpco/stack/.stack-work/store-versioned/QQs6brImltateKQyGnt1TgdkoVM=	2016-08-02 02:59:26.306286816 -0700
@@ -13,6 +13,13 @@
     slot 0 :: [(Stack.Types.PackageIdentifier.PackageIdentifier,Stack.Types.PackageIndex.PackageCache)]
   }
 
+data-type Data.Maybe.Maybe Stack.Types.PackageIndex.PackageDownload
+  = Nothing {
+  }
+  | Just {
+    slot 0 :: Stack.Types.PackageIndex.PackageDownload
+  }
+
 data-type Data.Text.Internal.Text
   = pack {
     slot 0 :: [GHC.Types.Char]
@@ -20,13 +27,6 @@
 
 data-type Data.Vector.Unboxed.Base.Vector GHC.Types.Word ignored
 
-data-type GHC.Base.Maybe Stack.Types.PackageIndex.PackageDownload
-  = Nothing {
-  }
-  | Just {
-    slot 0 :: Stack.Types.PackageIndex.PackageDownload
-  }
-
 data-type GHC.Int.Int64 has IntRep
 
 data-type GHC.Types.Char has CharRep
@@ -43,7 +43,7 @@
   = PackageCache {
     pcOffset :: GHC.Int.Int64
     pcSize :: GHC.Int.Int64
-    pcDownload :: GHC.Base.Maybe Stack.Types.PackageIndex.PackageDownload
+    pcDownload :: Data.Maybe.Maybe Stack.Types.PackageIndex.PackageDownload
   }
 
 data-type Stack.Types.PackageIndex.PackageCacheMap
```