### PR TITLE
Travis: Propagate failures in Cabal builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
    esac
 
 script:
- - case "$BUILD" in
+ - set -e; case "$BUILD" in
      stack)
        stack --no-terminal test --haddock --no-haddock-deps;;
      cabal)

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
 script:
  - set -e; case "$BUILD" in
      stack)
-       stack --no-terminal test --haddock --no-haddock-deps;;
+       stack --no-terminal test --haddock --no-haddock-deps --ghc-options="-Werror";;
      cabal)
        cabal configure --enable-tests --enable-benchmarks -v2 --ghc-options="-O0 -Werror";
        cabal build;

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -114,7 +114,7 @@ instance Store BuildCache
 instance NFData BuildCache
 
 -- | Try to read the dirtiness cache for the given package directory.
-tryGetBuildCache :: (MonadIO m, MonadReader env m, HasConfig env, MonadThrow m, MonadLogger m, HasEnvConfig env, MonadBaseControl IO m)
+tryGetBuildCache :: (MonadIO m, MonadReader env m, MonadThrow m, MonadLogger m, HasEnvConfig env, MonadBaseControl IO m)
                  => Path Abs Dir -> m (Maybe (Map FilePath FileCacheInfo))
 tryGetBuildCache = liftM (fmap buildCacheTimes) . tryGetCache buildCacheFile
 
@@ -174,7 +174,7 @@ deleteCaches dir = do
     ignoringAbsence (removeFile cfp)
 
 -- | Write to a cache.
-writeCache :: (Store a, NFData a, HasTypeHash a, Eq a, MonadIO m, MonadLogger m)
+writeCache :: (Store a, HasTypeHash a, Eq a, MonadIO m, MonadLogger m)
            => Path Abs Dir
            -> (Path Abs Dir -> m (Path Abs File))
            -> a
@@ -202,7 +202,7 @@ tryGetFlagCache gid = do
     fp <- flagCacheFile gid
     decodeFileMaybe fp
 
-writeFlagCache :: (MonadIO m, MonadReader env m, HasEnvConfig env, MonadThrow m, MonadLogger m, MonadBaseControl IO m)
+writeFlagCache :: (MonadIO m, MonadReader env m, HasEnvConfig env, MonadThrow m, MonadLogger m)
                => Installed
                -> ConfigCache
                -> m ()

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -124,7 +124,7 @@ instance HasEnvConfig Ctx where
     getEnvConfig = ctxEnvConfig
 
 constructPlan :: forall env m.
-                 (MonadCatch m, MonadReader env m, HasEnvConfig env, MonadIO m, MonadLoggerIO m, MonadBaseControl IO m, HasHttpManager env)
+                 (MonadCatch m, MonadReader env m, HasEnvConfig env, MonadLoggerIO m, MonadBaseControl IO m, HasHttpManager env)
               => MiniBuildPlan
               -> BaseConfigOpts
               -> [LocalPackage]

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -111,7 +111,7 @@ instance Show GhciException where
 -- given options and configure it with the load paths and extensions
 -- of those targets.
 ghci
-    :: (HasBuildConfig r, HasHttpManager r, MonadMask m, HasLogLevel r, HasTerminal r, HasEnvConfig r, MonadReader r m, MonadIO m, MonadLoggerIO m, MonadBaseUnlift IO m)
+    :: (HasBuildConfig r, HasHttpManager r, MonadMask m, HasLogLevel r, HasTerminal r, HasEnvConfig r, MonadReader r m, MonadLoggerIO m, MonadBaseUnlift IO m)
     => GhciOpts -> m ()
 ghci opts@GhciOpts{..} = do
     bopts <- asks (configBuild . getConfig)
@@ -276,7 +276,7 @@ figureOutMainFile bopts mainIsTargets targets0 packages =
 -- | Create a list of infos for each target containing necessary
 -- information to load that package/components.
 ghciSetup
-    :: (HasHttpManager r, HasBuildConfig r, MonadMask m, HasTerminal r, HasLogLevel r, HasEnvConfig r, MonadReader r m, MonadIO m, MonadLoggerIO m, MonadBaseUnlift IO m)
+    :: (HasHttpManager r, HasBuildConfig r, MonadMask m, HasTerminal r, HasLogLevel r, HasEnvConfig r, MonadReader r m, MonadLoggerIO m, MonadBaseUnlift IO m)
     => GhciOpts
     -> m (Map PackageName SimpleTarget, Maybe (Map PackageName SimpleTarget), [GhciPkgInfo])
 ghciSetup GhciOpts{..} = do

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -129,7 +129,7 @@ data TemplateFrom = LocalTemp | RemoteTemp
 -- | Download and read in a template's text content.
 loadTemplate
     :: forall m r.
-       (HasConfig r, HasHttpManager r, MonadReader r m, MonadIO m, MonadThrow m, MonadCatch m, MonadLogger m)
+       (HasConfig r, HasHttpManager r, MonadReader r m, MonadIO m, MonadCatch m, MonadLogger m)
     => TemplateName -> (TemplateFrom -> m ()) -> m Text
 loadTemplate name logIt = do
     templateDir <- asks (templatesDir . getConfig)

--- a/src/Stack/Types/StackT.hs
+++ b/src/Stack/Types/StackT.hs
@@ -227,7 +227,7 @@ stickyLoggerFunc loc src level msg = do
     liftIO $ func loc src level msg
 
 getStickyLoggerFunc
-    :: (HasSticky r, HasLogLevel r, HasSupportsUnicode r, ToLogStr msg, MonadReader r m, MonadIO m)
+    :: (HasSticky r, HasLogLevel r, HasSupportsUnicode r, ToLogStr msg, MonadReader r m)
     => m (Loc -> LogSource -> LogLevel -> msg -> IO ())
 getStickyLoggerFunc = do
     sticky <- asks getSticky

--- a/src/test/Network/HTTP/Download/VerifiedSpec.hs
+++ b/src/test/Network/HTTP/Download/VerifiedSpec.hs
@@ -2,7 +2,6 @@
 module Network.HTTP.Download.VerifiedSpec where
 
 import Crypto.Hash
-import Control.Monad (unless)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Logger (LoggingT, runStdoutLoggingT)
 import Control.Monad.Trans.Reader
@@ -12,7 +11,7 @@ import Network.HTTP.Client.Conduit
 import Network.HTTP.Download.Verified
 import Path
 import Path.IO
-import Test.Hspec hiding (shouldNotBe, shouldNotReturn)
+import Test.Hspec
 
 -- TODO: share across test files
 withTempDir' :: (Path Abs Dir -> IO a) -> IO a
@@ -77,15 +76,6 @@ setup = do
 
 teardown :: T -> IO ()
 teardown _ = return ()
-
-shouldNotBe :: (Show a, Eq a) => a -> a -> Expectation
-actual `shouldNotBe` expected =
-    unless (actual /= expected) (expectationFailure msg)
-  where
-    msg = "Value was exactly what it shouldn't be: " ++ show expected
-
-shouldNotReturn :: (Show a, Eq a) => IO a -> a -> Expectation
-action `shouldNotReturn` unexpected = action >>= (`shouldNotBe` unexpected)
 
 spec :: Spec
 spec = beforeAll setup $ afterAll teardown $ do

--- a/src/test/Stack/StoreSpec.hs
+++ b/src/test/Stack/StoreSpec.hs
@@ -45,7 +45,7 @@ instance Monad m => Serial m BS.ByteString where
 instance (Monad m, Serial m a, Ord a) => Serial m (Set a) where
     series = fmap setFromList series
 
-addMinAndMaxBounds :: forall a. (Bounded a, Eq a, Num a) => [a] -> [a]
+addMinAndMaxBounds :: forall a. (Bounded a, Eq a) => [a] -> [a]
 addMinAndMaxBounds xs =
     (if (minBound :: a) `notElem` xs then [minBound] else []) ++
     (if (maxBound :: a) `notElem` xs && (maxBound :: a) /= minBound then maxBound : xs else xs)

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -7,6 +7,11 @@ resolver: lts-2.22
 #     - base: "fpco/stack-base" # see ./etc/docker/stack-base/Dockerfile
 #       name: "fpco/stack-test"
 extra-deps:
+- hspec-2.2.3
+- hspec-core-2.2.3
+- hspec-discover-2.2.3
+- hspec-expectations-0.7.2
+- hspec-smallcheck-0.4.1
 - path-0.5.8
 - path-io-1.1.0
 - directory-1.2.2.0

--- a/stack.cabal
+++ b/stack.cabal
@@ -304,7 +304,7 @@ test-suite stack-test
                 , directory >= 1.2.1.0
                 , exceptions
                 , filepath
-                , hspec <2.3
+                , hspec >= 2.2 && <2.3
                 , http-conduit
                 , monad-logger
                 , path >= 0.5.7
@@ -341,7 +341,7 @@ test-suite stack-integration-test
                 , containers >= 0.5.5.1
                 , directory >= 1.2.1.0
                 , filepath >= 1.3.0.2
-                , hspec < 2.3
+                , hspec >= 2.2 && < 2.3
                 , process >= 1.2.0.0 && < 1.5
                 , resourcet
                 , temporary


### PR DESCRIPTION
Fix #2439. As mentioned there:

-  fix warnings from -Wredundant-constraints on GHC 8
-  fix the build script to propagate failures
-  add -Werror also to stack builds
