### PR TITLE
Only call logWarn if there's anything to report

### DIFF
--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -531,7 +531,9 @@ fetchPackages' mdistDir toFetchAll = do
                 S.writeFile cabalFP $ tfCabal toFetch
 
                 atomically $ modifyTVar outputVar $ Map.insert ident destDir
-            $logWarn $ mconcat $ map (\(path, entryType) -> "Unexpected entry type " <> entryType <> " for entry " <> T.pack path) unexpectedEntries
+
+            F.forM_ unexpectedEntries $ \(path, entryType) ->
+                logWarnN $ "Unexpected entry type " <> entryType <> " for entry " <> T.pack path
 
 -- | Internal function used to unpack tarball.
 --

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -533,7 +533,7 @@ fetchPackages' mdistDir toFetchAll = do
                 atomically $ modifyTVar outputVar $ Map.insert ident destDir
 
             F.forM_ unexpectedEntries $ \(path, entryType) ->
-                logWarnN $ "Unexpected entry type " <> entryType <> " for entry " <> T.pack path
+                $logWarn $ "Unexpected entry type " <> entryType <> " for entry " <> T.pack path
 
 -- | Internal function used to unpack tarball.
 --


### PR DESCRIPTION
As reported in #2418, spurious newlines are being emitted. Doing a `git bisect` reduced it to a commit which introduced a `$logWarn` message which seemed responsible. This patch simply wraps the debug statements so that no call is made it the error report is the empty list.

(I leave aside the matter of whether this was a good way to do error reporting; I'm just trying to fix the output bug)

AfC