### PR TITLE
[DOCUMENTATION] Request to emphasize `stack list-dependencies` in user guide

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -457,9 +457,6 @@ library
                      , containers
 ```
 
-Often it's a good idea to specify exact versions of dependencies, but we didn't do that here: stack was able to
-find versions that are compatible with our project.
-
 After adding these two dependencies, we can again run `stack build` to have them installed:
 
 ```
@@ -486,9 +483,6 @@ helloworld 0.1.0.0
 integer-gmp 1.0.0.0
 text 1.2.2.1
 ```
-
-As our project grows in size, it may prove useful to have a comprehensive list of the packages and versions we are relying on.
-
 
 ### extra-deps
 

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -441,6 +441,55 @@ locally installed. Once that was done, we moved on to building our local package
 (helloworld). At no point did we need to ask stack to build dependencies — it
 does so automatically.
 
+### Listing Dependencies
+
+Let's have stack add a few more dependencies to our project. First, we'll include two new packages in the
+`build-depends` section for our library in our `helloworld.cabal`:
+
+```
+library
+  hs-source-dirs:      src
+  exposed-modules:     Lib
+  build-depends:       base >= 4.7 && < 5
+                     , text
+                     -- a couple more dependencies...
+                     , filepath
+                     , containers
+```
+
+Often it's a good idea to specify exact versions of dependencies, but we didn't do that here: stack was able to
+find versions that are compatible with our project.
+
+After adding these two dependencies, we can again run `stack build` to have them installed:
+
+```
+michael@d30748af6d3d:~/helloworld$ stack build
+helloworld-0.1.0.0: unregistering (dependencies changed)
+helloworld-0.1.0.0: configure
+Configuring helloworld-0.1.0.0...
+...
+```
+
+Finally, to find out which versions of these libraries stack installed, we can ask stack to `list-dependencies`:
+
+```
+michael@d30748af6d3d:~/helloworld$ stack list-dependencies
+array 0.5.1.0
+base 4.8.2.0
+binary 0.7.5.0
+bytestring 0.10.6.0
+containers 0.5.6.2
+deepseq 1.4.1.1
+filepath 1.4.0.0
+ghc-prim 0.4.0.0
+helloworld 0.1.0.0
+integer-gmp 1.0.0.0
+text 1.2.2.1
+```
+
+As our project grows in size, it may prove useful to have a comprehensive list of the packages and versions we are relying on.
+
+
 ### extra-deps
 
 Let's try a more off-the-beaten-track package: the joke


### PR DESCRIPTION
Hello,

I find that I'm often installing stuff and then later on I want to find out exactly which versions I installed (especially switching between projects created at different points in time). To do this, I rely on the command `stack list-dependencies`, but I always forget the command and have to look it up: is it `list-dependencies` or `show-dependencies`? Hyphen or no hyphen? Isn't it something simpler than `list-dependencies` (in the Python world, I'd use `pip freeze` or `conda env export`.)

To answer my question, there's the power-user section at the [bottom of the user guide](https://docs.haskellstack.org/en/stable/GUIDE/#power-user-commands) and it usually takes me a few minutes to find the command because it's buried there.

Anyway, it occurred to me that other people might also be wondering how to do this and highlighting this command might help them out and make it easier to remember. I also tend to think of this as a core function, not necessarily something only "power users" may want to use, but I may be generalizing broadly based only on my experience.