### PR TITLE
Support OpenBSD's tar where possible, require GNU tar for xz support (#2283)

### DIFF
--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -813,11 +813,11 @@ installGHCPosix version _ archiveFile archiveType destDir = do
     menv0 <- getMinimalEnvOverride
     menv <- mkEnvOverride platform (removeHaskellEnvVars (unEnvOverride menv0))
     $logDebug $ "menv = " <> T.pack (show (unEnvOverride menv))
-    zipTool' <-
+    (zipTool', compOpt) <-
         case archiveType of
-            TarXz -> return "xz"
-            TarBz2 -> return "bzip2"
-            TarGz -> return "gzip"
+            TarXz -> return ("xz", 'J')
+            TarBz2 -> return ("bzip2", 'j')
+            TarGz -> return ("gzip", 'z')
             SevenZ -> error "Don't know how to deal with .7z files on non-Windows"
     -- Slight hack: OpenBSD's tar doesn't support xz.
     -- https://github.com/commercialhaskell/stack/issues/2283#issuecomment-237980986
@@ -842,7 +842,7 @@ installGHCPosix version _ archiveFile archiveType destDir = do
 
         $logSticky $ T.concat ["Unpacking GHC into ", T.pack . toFilePath $ root, " ..."]
         $logDebug $ "Unpacking " <> T.pack (toFilePath archiveFile)
-        readInNull root tarTool menv ["xf", toFilePath archiveFile] Nothing
+        readInNull root tarTool menv [compOpt : "xf", toFilePath archiveFile] Nothing
 
         $logSticky "Configuring GHC ..."
         readInNull dir (toFilePath $ dir </> $(mkRelFile "configure"))

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -819,10 +819,16 @@ installGHCPosix version _ archiveFile archiveType destDir = do
             TarBz2 -> return "bzip2"
             TarGz -> return "gzip"
             SevenZ -> error "Don't know how to deal with .7z files on non-Windows"
+    -- Slight hack: OpenBSD's tar doesn't support xz.
+    -- https://github.com/commercialhaskell/stack/issues/2283#issuecomment-237980986
+    let tarDep =
+          case (platform, archiveType) of
+            (Platform _ Cabal.OpenBSD, TarXz) -> checkDependency "gtar"
+            _ -> checkDependency "tar"
     (zipTool, makeTool, tarTool) <- checkDependencies $ (,,)
         <$> checkDependency zipTool'
         <*> (checkDependency "gmake" <|> checkDependency "make")
-        <*> checkDependency "tar"
+        <*> tarDep
 
     $logDebug $ "ziptool: " <> T.pack zipTool
     $logDebug $ "make: " <> T.pack makeTool


### PR DESCRIPTION
This PR improves the support for OpenBSD's tar as discussed in #2283. For `.tar.xz` archives that are unsupported there, it will error out and require installing `gtar`. For other archives it will specify `z` and `j` options (on all platforms), hence supporting OpenBSD tar directly (and I assume staying compatible with other ones).

The first commit is already tested by @bonds on OpenBSD, I tested both on OS X, and checked  manpages for GNU tar and FreeBSD tar, so this should work there too.

Relevant UNIX man pages:
[OpenBSD tar](http://man.openbsd.org/tar.1)
[FreeBSD tar](http://www.freebsd.org/cgi/man.cgi?query=tar&apropos=0&sektion=0&manpath=FreeBSD+10.3-RELEASE+and+Ports&arch=default&format=html).