### PR TITLE
Interpreter: Provide a way to hide implicit packages

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -545,7 +545,8 @@ interpreterHandler args f = do
       progName <- getProgName
       iargs <- getInterpreterArgs path
       let parseCmdLine = commandLineHandler progName True
-      let cmdArgs = stackArgs ++ iargs ++ "--" : path : fileArgs
+          separator = if "--" `elem` iargs then [] else ["--"]
+          cmdArgs = stackArgs ++ iargs ++ separator ++ path : fileArgs
        -- TODO show the command in verbose mode
        -- hPutStrLn stderr $ unwords $
        --   ["Running", "[" ++ progName, unwords cmdArgs ++ "]"]
@@ -745,7 +746,9 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
                    (ExecGhc, args) -> execCompiler "" args
                     -- NOTE: this won't currently work for GHCJS, because it doesn't have
                     -- a runghcjs binary. It probably will someday, though.
-                   (ExecRunGhc, args) -> execCompiler "" ("-e" : "Main.main" : args)
+                   (ExecRunGhc, args) ->
+                        let opts = concatMap (\x -> ["-package", x]) eoPackages
+                        in execCompiler "" (opts ++ ("-e" : "Main.main" : args))
                let targets = concatMap words eoPackages
                unless (null targets) $
                    Stack.Build.build (const $ return ()) lk defaultBuildOptsCLI


### PR DESCRIPTION
Always pass all the explicitly specified packages in the script to ghc command
line. Also allow ghc options to be specified from the interpreter command. This
will give user the flixibility to, for example, use '-hide-all-packages' ghc
option. Like this:

{- stack runghc
    --package base
    --package exceptions
    --package transformers
    --package containers
    --package getopt-generics
    --package filepath
    --package path
    --package path-io
    --package process
    --package unix-compat
    --
    -hide-all-packages
-}

fixes #1208