### PR TITLE
Added option to add nix dependencies as nix GC roots

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,8 @@ Other enhancements:
   See [#2243](https://github.com/commercialhaskell/stack/issues/2243)
 * Stack/Nix: Sets `LD_LIBRARY_PATH` so packages using C libs for Template Haskell can work
   (See _e.g._ [this HaskellR issue](https://github.com/tweag/HaskellR/issues/253))
-
+* Stack/nix: Dependencies can be added as nix GC roots, so they are not removed
+  when running `nix-collect-garbage`
 * Parse CLI arguments and configuration files into less permissive types,
   improving error messages for bad inputs.
   [#2267](https://github.com/commercialhaskell/stack/issues/2267)

--- a/doc/nix_integration.md
+++ b/doc/nix_integration.md
@@ -186,6 +186,14 @@ nix:
   # `[nixpkgs=/my/local/nixpkgs/clone]` that will be used to override
   # NIX_PATH.
   path: []
+  
+  # false by default. Whether to add your nix dependencies as nix garbage
+  # collection roots. This way, calling nix-collect-garbage will not remove
+  # those packages from the nix store, saving you some time when running
+  # stack build again with nix support activated.
+  # This creates a `nix-gc-symlinks` directory in the project `.stack-work`.
+  # To revert that, just delete this `nix-gc-symlinks` directory.
+  add-gc-roots: false
 ```
 
 ## Using a custom shell.nix file

--- a/src/Stack/Config/Nix.hs
+++ b/src/Stack/Config/Nix.hs
@@ -36,6 +36,7 @@ nixOptsFromMonoid NixOptsMonoid{..} os = do
         nixInitFile = getFirst nixMonoidInitFile
         nixShellOptions = fromFirst [] nixMonoidShellOptions
                           ++ prefixAll (T.pack "-I") (fromFirst [] nixMonoidPath)
+        nixAddGCRoots   = fromFirst False nixMonoidAddGCRoots
     when (not (null nixPackages) && isJust nixInitFile) $
        throwM NixCannotUseShellFileAndPackagesException
     return NixOpts{..}

--- a/src/Stack/Nix.hs
+++ b/src/Stack/Nix.hs
@@ -42,6 +42,7 @@ import           Stack.Types.Nix
 import           Stack.Types.Compiler
 import           Stack.Types.Internal
 import           System.Environment (lookupEnv,getArgs,getExecutablePath)
+import qualified System.FilePath  as F
 import           System.Process.Read (getEnvOverride)
 
 -- | If Nix is enabled, re-runs the currently running OS command in a Nix container.
@@ -87,6 +88,7 @@ runShellAndExit mprojectRoot getCompilerVersion getCmdArgs = do
          pkgs = pkgsInConfig ++ [ghc]
          pkgsStr = "[" <> T.intercalate " " pkgs <> "]"
          pureShell = nixPureShell (configNix config)
+         addGCRoots = nixAddGCRoots (configNix config)
          nixopts = case mshellFile of
            Just fp -> [toFilePath fp, "--arg", "ghc"
                       ,"with (import <nixpkgs> {}); " ++ T.unpack ghc]
@@ -109,8 +111,11 @@ runShellAndExit mprojectRoot getCompilerVersion getCmdArgs = do
                               ,"STACK_IN_NIX_EXTRA_ARGS = stackExtraArgs; "
                               ,"} \"\""]]
                     -- glibcLocales is necessary on Linux to avoid warnings about GHC being incapable to set the locale.
-         fullArgs = concat [if pureShell then ["--pure"] else [],
-                            map T.unpack (nixShellOptions (configNix config))
+         fullArgs = concat [if pureShell then ["--pure"] else []
+                           ,if addGCRoots then ["--indirect", "--add-root"
+                                               ,toFilePath (configWorkDir config)
+                                                F.</> "nix-gc-symlinks" F.</> "gc-root"] else []
+                           ,map T.unpack (nixShellOptions (configNix config))
                            ,nixopts
                            ,["--run", intercalate " " (cmnd:"$STACK_IN_NIX_EXTRA_ARGS":args)]
                            ]

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -484,6 +484,9 @@ nixOptsParser hide0 = overrideActivation <$>
                metavar "PATH_OPTIONS" <>
                help "Additional options to override NIX_PATH parts (notably 'nixpkgs')" <>
                hide))
+  <*> firstBoolFlags "nix-add-gc-roots"
+                     "addition of packages to the nix GC roots so nix-collect-garbage doesn't remove them"
+                     hide
   )
   where
     hide = hideMods hide0

--- a/src/Stack/Types/Nix.hs
+++ b/src/Stack/Types/Nix.hs
@@ -26,6 +26,8 @@ data NixOpts = NixOpts
     -- ^ The path of a file containing preconfiguration of the environment (e.g shell.nix)
   ,nixShellOptions :: ![Text]
     -- ^ Options to be given to the nix-shell command line
+  ,nixAddGCRoots :: !Bool
+    -- ^ Should we register gc roots so running nix-collect-garbage doesn't remove nix dependencies
   }
   deriving (Show)
 
@@ -46,6 +48,8 @@ data NixOptsMonoid = NixOptsMonoid
     -- ^ Options to be given to the nix-shell command line
   ,nixMonoidPath :: !(First [Text])
     -- ^ Override parts of NIX_PATH (notably 'nixpkgs')
+  ,nixMonoidAddGCRoots :: !(First Bool)
+    -- ^ Should we register gc roots so running nix-collect-garbage doesn't remove nix dependencies
   }
   deriving (Eq, Show, Generic)
 
@@ -59,6 +63,7 @@ instance FromJSON (WithJSONWarnings NixOptsMonoid) where
               nixMonoidInitFile      <- First <$> o ..:? nixInitFileArgName
               nixMonoidShellOptions  <- First <$> o ..:? nixShellOptsArgName
               nixMonoidPath          <- First <$> o ..:? nixPathArgName
+              nixMonoidAddGCRoots    <- First <$> o ..:? nixAddGCRootsArgName
               return NixOptsMonoid{..})
 
 -- | Left-biased combine Nix options
@@ -89,3 +94,7 @@ nixShellOptsArgName = "nix-shell-options"
 -- | NIX_PATH override argument name
 nixPathArgName :: Text
 nixPathArgName = "path"
+
+-- | Add GC roots arg name
+nixAddGCRootsArgName :: Text
+nixAddGCRootsArgName = "add-gc-roots"


### PR DESCRIPTION
This PR makes it easier to use stack nix with small disk spaces or low bandwidth internet.
Nix provides a command that removes all the packages that aren't registered as nix GC roots: nix-collect-garbage.
This PR gives you an option to tell stack to call nix-shell with the option to register the packages as GC roots. This way, you can run nix-collect-garbage to remove old packages you don't need anymore and nix will preserve your current depedencies, so you don't have to re-download them again.