### PR TITLE
Added `--haddock-internal` command line argument (#2229)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,9 @@ Behavior changes:
 
 Other enhancements:
 
+* `stack haddock` now supports `--haddock-internal`. See
+  [#2229](https://github.com/commercialhaskell/stack/issues/2229)
+
 Bug fixes:
 
 ## 1.2.0

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -556,6 +556,7 @@ build:
   haddock-arguments: ""
   open-haddocks: false    # --open
   haddock-deps: false     # if unspecified, defaults to true if haddock is set
+  haddock-internal: false
 
   # These are inadvisable to use in your global configuration, as they make the
   # stack build CLI behave quite differently.

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1141,8 +1141,11 @@ singleBuild runInBase ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} in
                             ("Warning: haddock not generating hyperlinked sources because 'HsColour' not\n" <>
                              "found on PATH (use 'stack install hscolour' to install).")
                         return ["--hyperlink-source" | hscolourExists]
+            let internalDocs = if boptsHaddockInternal bopts
+                    then ["--internal"]
+                    else []
             cabal False (concat [["haddock", "--html", "--hoogle", "--html-location=../$pkg-$version/"]
-                                ,sourceFlag])
+                                ,sourceFlag, internalDocs])
 
         unless isFinalBuild $ withMVar eeInstallLock $ \() -> do
             announce "copy/register"

--- a/src/Stack/Config/Build.hs
+++ b/src/Stack/Config/Build.hs
@@ -23,6 +23,9 @@ buildOptsFromMonoid BuildOptsMonoid{..} = BuildOpts
           (boptsOpenHaddocks defaultBuildOpts)
           buildMonoidOpenHaddocks
     , boptsHaddockDeps = getFirst buildMonoidHaddockDeps
+    , boptsHaddockInternal = fromFirst
+          (boptsHaddockInternal defaultBuildOpts)
+          buildMonoidHaddockInternal
     , boptsInstallExes = fromFirst
           (boptsInstallExes defaultBuildOpts)
           buildMonoidInstallExes

--- a/src/Stack/Options.hs
+++ b/src/Stack/Options.hs
@@ -378,7 +378,7 @@ buildOptsMonoidParser hide0 =
     options =
         BuildOptsMonoid <$> libProfiling <*> exeProfiling <*> haddock <*>
         haddockOptsParser hide0 <*> openHaddocks <*>
-        haddockDeps <*> copyBins <*> preFetch <*> keepGoing <*> forceDirty <*>
+        haddockDeps <*> haddockInternal <*> copyBins <*> preFetch <*> keepGoing <*> forceDirty <*>
         tests <*> testOptsParser hide0 <*> benches <*> benchOptsParser hide0 <*> reconfigure <*>
         cabalVerbose <*> splitObjs
     libProfiling =
@@ -403,6 +403,11 @@ buildOptsMonoidParser hide0 =
             hide
     haddockDeps =
         firstBoolFlags "haddock-deps" "building Haddocks for dependencies" hide
+    haddockInternal =
+        firstBoolFlags
+            "haddock-internal"
+            "building Haddocks for internal modules (like cabal haddock --internal)"
+            hide
     copyBins =
         firstBoolFlags
             "copy-bins"

--- a/src/Stack/Types/Config/Build.hs
+++ b/src/Stack/Types/Config/Build.hs
@@ -52,6 +52,8 @@ data BuildOpts =
             -- ^ Open haddocks in the browser?
             ,boptsHaddockDeps :: !(Maybe Bool)
             -- ^ Build haddocks for dependencies?
+            ,boptsHaddockInternal :: !Bool
+            -- ^ Build haddocks for all symbols and packages, like @cabal haddock --internal@
             ,boptsInstallExes :: !Bool
             -- ^ Install executables to user path after building?
             ,boptsPreFetch :: !Bool
@@ -90,6 +92,7 @@ defaultBuildOpts = BuildOpts
     , boptsHaddockOpts = defaultHaddockOpts
     , boptsOpenHaddocks = False
     , boptsHaddockDeps = Nothing
+    , boptsHaddockInternal = False
     , boptsInstallExes = False
     , boptsPreFetch = False
     , boptsKeepGoing = Nothing
@@ -146,6 +149,7 @@ data BuildOptsMonoid = BuildOptsMonoid
     , buildMonoidHaddockOpts :: !HaddockOptsMonoid
     , buildMonoidOpenHaddocks :: !(First Bool)
     , buildMonoidHaddockDeps :: !(First Bool)
+    , buildMonoidHaddockInternal :: !(First Bool)
     , buildMonoidInstallExes :: !(First Bool)
     , buildMonoidPreFetch :: !(First Bool)
     , buildMonoidKeepGoing :: !(First Bool)
@@ -167,6 +171,7 @@ instance FromJSON (WithJSONWarnings BuildOptsMonoid) where
               buildMonoidHaddockOpts <- jsonSubWarnings (o ..:? buildMonoidHaddockOptsArgName ..!= mempty)
               buildMonoidOpenHaddocks <- First <$> o ..:? buildMonoidOpenHaddocksArgName
               buildMonoidHaddockDeps <- First <$> o ..:? buildMonoidHaddockDepsArgName
+              buildMonoidHaddockInternal <- First <$> o ..:? buildMonoidHaddockInternalArgName
               buildMonoidInstallExes <- First <$> o ..:? buildMonoidInstallExesArgName
               buildMonoidPreFetch <- First <$> o ..:? buildMonoidPreFetchArgName
               buildMonoidKeepGoing <- First <$> o ..:? buildMonoidKeepGoingArgName
@@ -197,6 +202,9 @@ buildMonoidOpenHaddocksArgName = "open-haddocks"
 
 buildMonoidHaddockDepsArgName :: Text
 buildMonoidHaddockDepsArgName = "haddock-deps"
+
+buildMonoidHaddockInternalArgName :: Text
+buildMonoidHaddockInternalArgName = "haddock-internal"
 
 buildMonoidInstallExesArgName :: Text
 buildMonoidInstallExesArgName = "copy-bins"


### PR DESCRIPTION
This is a boolean argument which causes haddocks to be generated in the
same manner as `cabal haddock --internal`, implemented by simply passing
`--internal` to the `cabal haddock` invocation used to build the docs.

It defaults to False.