### PR TITLE
Switch from ‘edit-distance’ to ‘text-metrics’

### DIFF
--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -73,6 +73,7 @@ extra-deps:
 - annotated-wl-pprint-0.7.0
 - neat-interpolation-0.3.2
 - optparse-applicative-0.13.0.0
+- text-metrics-0.1.0
 flags:
   time-locale-compat:
     old-locale: false

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -17,3 +17,4 @@ extra-deps:
 - store-core-0.2.0.0
 - th-utilities-0.2.0.1
 - optparse-applicative-0.13.0.0
+- text-metrics-0.1.0

--- a/stack.cabal
+++ b/stack.cabal
@@ -173,7 +173,6 @@ library
                    , cryptohash >= 0.11.6
                    , cryptohash-conduit
                    , directory >= 1.2.1.0
-                   , edit-distance >= 0.2
                    , either
                    , enclosed-exceptions
                    , errors < 2.2
@@ -223,6 +222,7 @@ library
                    , temporary >= 1.2.0.3
                    , text >= 1.2.0.4
                    , text-binary
+                   , text-metrics >= 0.1 && < 0.2
                    , time >= 1.4.2 && < 1.7
                    , tls >= 1.3.8
                    , transformers >= 0.3.0.0 && < 0.6

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,6 +20,7 @@ extra-deps:
 - http-client-tls-0.3.0
 - http-conduit-2.2.0
 - optparse-applicative-0.13.0.0
+- text-metrics-0.1.0
 flags:
   stack:
     hide-dependency-versions: true


### PR DESCRIPTION
The `text-metrics` package is ×2.5 faster and it works on strict `Text` values rather than on `String`s, which eliminates the need in unpacking of all package names (which should also speed-up things).
