### PR TITLE
Warn on missing extra-dep for external packages.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,9 @@ Behavior changes:
 
 * Switch the "Run from outside project" messages to debug-level, to
   avoid spamming users in the normal case of non-project usage
+* If a remote package is specified (such as a Git repo) without an explicit
+  `extra-dep` setting, a warning is given to the user to provide one
+  explicitly.
 
 Other enhancements:
 

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -532,7 +532,27 @@ resolvePackageEntry menv projRoot pe = do
         case peSubdirs pe of
             [] -> return [entryRoot]
             subs -> mapM (resolveDir entryRoot) subs
-    return $ map (, peExtraDep pe) paths
+    extraDep <-
+        case peExtraDepMaybe pe of
+            Just e -> return e
+            Nothing ->
+                case peLocation pe of
+                    PLFilePath _ ->
+                        -- we don't give a warning on missing explicit
+                        -- value here, user intent is almost always
+                        -- the default for a local directory
+                        return False
+                    PLRemote url _ -> do
+                        $logWarn $ mconcat
+                            [ "No extra-dep setting found for package at URL:\n\n"
+                            , url
+                            , "\n\n"
+                            , "This is usually a mistake, external packages "
+                            , "should typically\nbe treated as extra-deps to avoid "
+                            , "spurious test case failures."
+                            ]
+                        return False
+    return $ map (, extraDep) paths
 
 -- | Resolve a PackageLocation into a path, downloading and cloning as
 -- necessary.

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -141,7 +141,7 @@ initProject whichCmd currDir initOpts mresolver = do
 
         pkgs = map toPkg $ Map.elems (fmap (parent . fst) rbundle)
         toPkg dir = PackageEntry
-            { peExtraDep = False
+            { peExtraDepMaybe = Nothing
             , peLocation = PLFilePath $ makeRelDir dir
             , peSubdirs = []
             }


### PR DESCRIPTION
Motivation: the vast majority of the time, an external package should be
treated as an external dependency, in that we don't want to run test
suites. I regularly see user confusion on this topic. It was probably a
mistake on my part to make the default be extra-dep: false for external
packages.

Changing the default would be a breaking change, so instead, this change
will give the user a warning when they use an external package - such as
from a Git repo - without an explicit extra-dep setting. If the user
really wants the current default behavior, they can add `extra-dep:
false` to silence the warning. I expect in most cases users will end up
adding `extra-dep: true` and avoid a stumbling block.