### PR TITLE
Add --license option to list-dependencies

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ Other enhancements:
   16.10) and adjusts the GHC `configure` options accordingly.
   [#2542](https://github.com/commercialhaskell/stack/issues/2542)
 * Upload to Hackage with HTTP digest instead of HTTP basic.
+* Make `stack list-dependencies` understand all of the `stack dot` options too.
+* Add the ability for `stack list-dependencies` to list dependency licenses by
+  passing the `--license` flag.
 
 Bug fixes:
 

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -13,7 +13,7 @@ module Stack.Dot (dot
 import           Control.Applicative
 import           Control.Arrow ((&&&))
 import           Control.Monad (liftM, void)
-import           Control.Monad.Catch (MonadCatch,MonadMask)
+import           Control.Monad.Catch (MonadMask)
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger (MonadLogger)
 import           Control.Monad.Reader (MonadReader)
@@ -72,7 +72,6 @@ dot :: (HasEnvConfig env
        ,HasHttpManager env
        ,HasLogLevel env
        ,MonadBaseUnlift IO m
-       ,MonadCatch m
        ,MonadLogger m
        ,MonadIO m
        ,MonadMask m

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -128,7 +128,7 @@ listDependencies sep = do
   resultGraph <- createDependencyGraph dotOpts
   void (Map.traverseWithKey go (snd <$> resultGraph))
     where go name v = liftIO (Text.putStrLn $
-                                Text.pack (packageNameString name) <>
+                                packageNameText name <>
                                 sep <>
                                 maybe "<unknown>" (Text.pack . show) v)
 
@@ -250,7 +250,7 @@ printEdge from to = liftIO $ Text.putStrLn (Text.concat [ nodeName from, " -> ",
 
 -- | Convert a package name to a graph node name.
 nodeName :: PackageName -> Text
-nodeName name = "\"" <> Text.pack (packageNameString name) <> "\""
+nodeName name = "\"" <> packageNameText name <> "\""
 
 -- | Print a node with no dependencies
 printLeaf :: MonadIO m => PackageName -> m ()

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -63,6 +63,8 @@ data ListDepsOpts = ListDepsOpts
     -- ^ The normal dot options.
     , listDepsSep :: Text
     -- ^ Separator between the package name and details.
+    , listDepsLicense :: Bool
+    -- ^ Print dependency licenses instead of versions.
     }
 
 -- | Visualize the project's dependencies as a graphviz graph
@@ -160,10 +162,12 @@ listDependencies opts = do
   (_, resultGraph) <- createPrunedDependencyGraph dotOpts
   void (Map.traverseWithKey go (snd <$> resultGraph))
     where go name payload =
-            liftIO (Text.putStrLn $
-                    packageNameText name <>
-                    (listDepsSep opts) <>
-                    maybe "<unknown>" (Text.pack . show) (fst payload))
+            let payloadText =
+                    if listDepsLicense opts
+                      then maybe "<unknown>" (Text.pack . show) (snd payload)
+                      else maybe "<unknown>" (Text.pack . show) (fst payload)
+                line = packageNameText name <> (listDepsSep opts) <> payloadText
+            in  liftIO $ Text.putStrLn $ line
 
 -- | @pruneGraph dontPrune toPrune graph@ prunes all packages in
 -- @graph@ with a name in @toPrune@ and removes resulting orphans

--- a/src/Stack/Options/DockerParser.hs
+++ b/src/Stack/Options/DockerParser.hs
@@ -2,9 +2,7 @@ module Stack.Options.DockerParser where
 
 import           Data.Char
 import           Data.List                         (intercalate)
-import           Data.List.Split                   (splitOn)
 import           Data.Monoid.Extra
-import qualified Data.Set                          as Set
 import qualified Data.Text                         as T
 import           Distribution.Version              (anyVersion)
 import           Options.Applicative
@@ -13,7 +11,6 @@ import           Options.Applicative.Builder.Extra
 import           Stack.Constants
 import           Stack.Docker
 import qualified Stack.Docker                      as Docker
-import           Stack.Dot
 import           Stack.Options.Utils
 import           Stack.Types.Version
 import           Stack.Types.Docker
@@ -144,35 +141,3 @@ dockerCleanupOptsParser =
                          Nothing -> " (default)")) <|>
           pure def'
         toDescr = map (\c -> if c == '-' then ' ' else c)
-
--- | Parser for arguments to `stack dot`
-dotOptsParser :: Parser DotOpts
-dotOptsParser = DotOpts
-            <$> includeExternal
-            <*> includeBase
-            <*> depthLimit
-            <*> fmap (maybe Set.empty Set.fromList . fmap splitNames) prunedPkgs
-  where includeExternal = boolFlags False
-                                    "external"
-                                    "inclusion of external dependencies"
-                                    idm
-        includeBase = boolFlags True
-                                "include-base"
-                                "inclusion of dependencies on base"
-                                idm
-        depthLimit =
-            optional (option auto
-                             (long "depth" <>
-                              metavar "DEPTH" <>
-                              help ("Limit the depth of dependency resolution " <>
-                                    "(Default: No limit)")))
-        prunedPkgs = optional (strOption
-                                   (long "prune" <>
-                                    metavar "PACKAGES" <>
-                                    help ("Prune each package name " <>
-                                          "from the comma separated list " <>
-                                          "of package names PACKAGES")))
-
-        splitNames :: String -> [String]
-        splitNames = map (takeWhile (not . isSpace) . dropWhile isSpace) . splitOn ","
-

--- a/src/Stack/Options/DotParser.hs
+++ b/src/Stack/Options/DotParser.hs
@@ -53,4 +53,8 @@ listDepsOptsParser = ListDepsOpts
                                         "and package version.") <>
                                   value " " <>
                                   showDefault))
+                 <*> (boolFlags False
+                                "license"
+                                "printing of dependency licenses instead of versions"
+                                idm)
   where escapeSep sep = T.replace "\\t" "\t" (T.replace "\\n" "\n" sep)

--- a/src/Stack/Options/DotParser.hs
+++ b/src/Stack/Options/DotParser.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Stack.Options.DotParser where
+
+import           Data.Char                         (isSpace)
+import           Data.List.Split                   (splitOn)
+import           Data.Monoid.Extra
+import qualified Data.Set                          as Set
+import qualified Data.Text                         as T
+import           Options.Applicative
+import           Options.Applicative.Builder.Extra
+import           Stack.Dot
+
+-- | Parser for arguments to `stack dot`
+dotOptsParser :: Bool -> Parser DotOpts
+dotOptsParser externalDefault =
+  DotOpts <$> includeExternal
+          <*> includeBase
+          <*> depthLimit
+          <*> fmap (maybe Set.empty Set.fromList . fmap splitNames) prunedPkgs
+  where includeExternal = boolFlags externalDefault
+                                    "external"
+                                    "inclusion of external dependencies"
+                                    idm
+        includeBase = boolFlags True
+                                "include-base"
+                                "inclusion of dependencies on base"
+                                idm
+        depthLimit =
+            optional (option auto
+                             (long "depth" <>
+                              metavar "DEPTH" <>
+                              help ("Limit the depth of dependency resolution " <>
+                                    "(Default: No limit)")))
+        prunedPkgs = optional (strOption
+                                   (long "prune" <>
+                                    metavar "PACKAGES" <>
+                                    help ("Prune each package name " <>
+                                          "from the comma separated list " <>
+                                          "of package names PACKAGES")))
+
+        splitNames :: String -> [String]
+        splitNames = map (takeWhile (not . isSpace) . dropWhile isSpace) . splitOn ","
+
+-- | Parser for arguments to `stack list-dependencies`.
+listDepsOptsParser :: Parser ListDepsOpts
+listDepsOptsParser = ListDepsOpts
+                 <$> (dotOptsParser True) -- Default for --external is True.
+                 <*> fmap escapeSep
+                     (textOption (long "separator" <>
+                                  metavar "SEP" <>
+                                  help ("Separator between package name " <>
+                                        "and package version.") <>
+                                  value " " <>
+                                  showDefault))
+  where escapeSep sep = T.replace "\\t" "\t" (T.replace "\\n" "\n" sep)

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -213,6 +213,7 @@ packageFromPackageDescription packageConfig gpkg pkg =
     Package
     { packageName = name
     , packageVersion = fromCabalVersion (pkgVersion pkgId)
+    , packageLicense = license pkg
     , packageDeps = deps
     , packageFiles = pkgFiles
     , packageTools = packageDescTools pkg

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -33,6 +33,7 @@ import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8, decodeUtf8)
 import           Data.Word (Word64)
 import           Distribution.InstalledPackageInfo (PError)
+import           Distribution.License (License)
 import           Distribution.ModuleName (ModuleName)
 import           Distribution.Package hiding (Package,PackageName,packageName,packageVersion,PackageIdentifier)
 import           Distribution.PackageDescription (TestSuiteInterface)
@@ -88,6 +89,7 @@ instance Show PackageException where
 data Package =
   Package {packageName :: !PackageName                    -- ^ Name of the package.
           ,packageVersion :: !Version                     -- ^ Version of the package
+          ,packageLicense :: !License                     -- ^ The license the package was released under.
           ,packageFiles :: !GetPackageFiles               -- ^ Get all files of the package.
           ,packageDeps :: !(Map PackageName VersionRange) -- ^ Packages that the package depends on.
           ,packageTools :: ![Dependency]                  -- ^ A build tool name.

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -75,6 +75,7 @@ import           Stack.New
 import           Stack.Options.BuildParser
 import           Stack.Options.CleanParser
 import           Stack.Options.DockerParser
+import           Stack.Options.DotParser
 import           Stack.Options.ExecParser
 import           Stack.Options.GhciParser
 import           Stack.Options.GlobalParser
@@ -321,7 +322,7 @@ commandLineHandler progName isInterpreter = complicatedOptions
         addCommand' "dot"
                     "Visualize your project's dependency graph using Graphviz dot"
                     dotCmd
-                    dotOptsParser
+                    (dotOptsParser False) -- Default for --external is False.
         addCommand' "ghc"
                     "Run ghc"
                     execCmd
@@ -374,12 +375,7 @@ commandLineHandler progName isInterpreter = complicatedOptions
         addCommand' "list-dependencies"
                     "List the dependencies"
                     listDependenciesCmd
-                    (textOption (long "separator" <>
-                                 metavar "SEP" <>
-                                 help ("Separator between package name " <>
-                                       "and package version.") <>
-                                 value " " <>
-                                 showDefault))
+                    listDepsOptsParser
         addCommand' "query"
                     "Query general build information (experimental)"
                     queryCmd
@@ -901,9 +897,8 @@ dotCmd :: DotOpts -> GlobalOpts -> IO ()
 dotCmd dotOpts go = withBuildConfigAndLock go (\_ -> dot dotOpts)
 
 -- | List the dependencies
-listDependenciesCmd :: Text -> GlobalOpts -> IO ()
-listDependenciesCmd sep go = withBuildConfig go (listDependencies sep')
-  where sep' = T.replace "\\t" "\t" (T.replace "\\n" "\n" sep)
+listDependenciesCmd :: ListDepsOpts -> GlobalOpts -> IO ()
+listDependenciesCmd opts go = withBuildConfig go $ listDependencies opts
 
 -- | Query build information
 queryCmd :: [String] -> GlobalOpts -> IO ()

--- a/src/test/Stack/DotSpec.hs
+++ b/src/test/Stack/DotSpec.hs
@@ -22,8 +22,8 @@ import           Test.QuickCheck (forAll,choose,Gen)
 
 import           Stack.Dot
 
-dummyPayload :: (Maybe Version, Maybe License)
-dummyPayload = (parseVersionFromString "0.0.0.0", Just BSD3)
+dummyPayload :: DotPayload
+dummyPayload = DotPayload (parseVersionFromString "0.0.0.0") (Just BSD3)
 
 spec :: Spec
 spec = do
@@ -82,7 +82,7 @@ pkgName = fromMaybe failure . parsePackageName
    failure = error "Internal error during package name creation in DotSpec.pkgName"
 
 -- Stub, simulates the function to load package dependecies
-stubLoader :: PackageName -> Identity (Set PackageName, (Maybe Version, Maybe License))
+stubLoader :: PackageName -> Identity (Set PackageName, DotPayload)
 stubLoader name = return . (, dummyPayload) . Set.fromList . map pkgName $ case show name of
   "StateVar" -> ["stm","transformers"]
   "array" -> []

--- a/src/test/Stack/DotSpec.hs
+++ b/src/test/Stack/DotSpec.hs
@@ -13,6 +13,7 @@ import           Data.Maybe (fromMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Text (Text)
+import           Distribution.License (License (BSD3))
 import           Stack.Types.PackageName
 import           Stack.Types.Version
 import           Test.Hspec
@@ -21,14 +22,14 @@ import           Test.QuickCheck (forAll,choose,Gen)
 
 import           Stack.Dot
 
-dummyVersion :: Version
-dummyVersion = fromMaybe (error "dotspec: parser error") (parseVersionFromString "0.0.0.0")
+dummyPayload :: (Maybe Version, Maybe License)
+dummyPayload = (parseVersionFromString "0.0.0.0", Just BSD3)
 
 spec :: Spec
 spec = do
   let graph =
          Map.mapKeys pkgName
-       . fmap (\p -> (Set.map pkgName p, Just dummyVersion))
+       . fmap (\p -> (Set.map pkgName p, dummyPayload))
        . Map.fromList $ [("one",Set.fromList ["base","free"])
                         ,("two",Set.fromList ["base","free","mtl","transformers","one"])
                         ]
@@ -38,7 +39,7 @@ spec = do
 
     it "with depth 1, more dependencies are resolved" $ do
       let graph' = Map.insert (pkgName "cycle")
-                              (Set.singleton (pkgName "cycle"), Just dummyVersion)
+                              (Set.singleton (pkgName "cycle"), dummyPayload)
                               graph
           resultGraph = runIdentity (resolveDependencies (Just 0) graph stubLoader)
           resultGraph' = runIdentity (resolveDependencies (Just 1) graph' stubLoader)
@@ -46,7 +47,7 @@ spec = do
 
     it "cycles are ignored" $ do
        let graph' = Map.insert (pkgName "cycle")
-                               (Set.singleton (pkgName "cycle"), Just dummyVersion)
+                               (Set.singleton (pkgName "cycle"), dummyPayload)
                                 graph
            resultGraph = resolveDependencies Nothing graph stubLoader
            resultGraph' = resolveDependencies Nothing graph' stubLoader
@@ -81,8 +82,8 @@ pkgName = fromMaybe failure . parsePackageName
    failure = error "Internal error during package name creation in DotSpec.pkgName"
 
 -- Stub, simulates the function to load package dependecies
-stubLoader :: PackageName -> Identity (Set PackageName, Maybe Version)
-stubLoader name = return . (, Just dummyVersion) . Set.fromList . map pkgName $ case show name of
+stubLoader :: PackageName -> Identity (Set PackageName, (Maybe Version, Maybe License))
+stubLoader name = return . (, dummyPayload) . Set.fromList . map pkgName $ case show name of
   "StateVar" -> ["stm","transformers"]
   "array" -> []
   "bifunctors" -> ["semigroupoids","semigroups","tagged"]

--- a/src/test/Stack/GhciSpec.hs
+++ b/src/test/Stack/GhciSpec.hs
@@ -11,6 +11,7 @@ import qualified Data.Set as S
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import           Distribution.License (License (BSD3))
 import qualified Distribution.ModuleName as ModuleName
 import           Stack.Types.Package
 import           Stack.Types.PackageName
@@ -204,6 +205,7 @@ packages_singlePackage =
       Package
       { packageName = $(mkPackageName "package-a")
       , packageVersion = $(mkVersion "0.1.0.0")
+      , packageLicense = BSD3
       , packageFiles = GetPackageFiles undefined
       , packageDeps = M.empty
       , packageTools = []
@@ -236,6 +238,7 @@ packages_multiplePackages =
       Package
       { packageName = $(mkPackageName "package-a")
       , packageVersion = $(mkVersion "0.1.0.0")
+      , packageLicense = BSD3
       , packageFiles = GetPackageFiles undefined
       , packageDeps = M.empty
       , packageTools = []
@@ -264,6 +267,7 @@ packages_multiplePackages =
       Package
       { packageName = $(mkPackageName "package-b")
       , packageVersion = $(mkVersion "0.1.0.0")
+      , packageLicense = BSD3
       , packageFiles = GetPackageFiles undefined
       , packageDeps = M.empty
       , packageTools = []

--- a/stack.cabal
+++ b/stack.cabal
@@ -115,6 +115,7 @@ library
                      Stack.Options.CleanParser
                      Stack.Options.ConfigParser
                      Stack.Options.DockerParser
+                     Stack.Options.DotParser
                      Stack.Options.ExecParser
                      Stack.Options.GhcBuildParser
                      Stack.Options.GhciParser


### PR DESCRIPTION
Stack makes it a breeze to build a project with lots of (transitive) dependencies without worrying too much about them, but when it comes to distributing the final binary, it is useful to know what your dependencies actually are. In particular, I want to know the licenses of my dependencies, to make sure that they are compatible, and to make sure that I am not accidentally violating one.

For Cabal there is the [`cabal-dependency-licenses`](https://github.com/jaspervdj/cabal-dependency-licenses) package, but I haven’t been able to make it work with Stack. However, because Stack can already list all dependencies, I figured it shouldn’t be too hard to make Stack list the licenses too. So that is what this PR does.

* Add a `--license` flag to `stack list-dependencies`. When specified, `stack list-dependencies` will print the package license instead of the package version.
* As a drive-by change, unify the options for `stack dot` and `stack list-dependencies`. In order not to change the current behaviour,  `--external` defaults to false for `stack dot` and to true for `stack list-dependencies`.

My personal use case for this is that I want to validate the output of `stack list-dependencies --license --no-include-base` against a list of whitelisted licenses as part of CI, to ensure that I don’t accidentally depend on an incompatible library.

Also, I have a question about `--no-include-base`. Would it make sense to have this flag exclude the `template-haskell` and `integer-gmp` packages too? They appear to be “special” just like base.

This is my first time diving into the Stack codebase, so some things can likely be improved. Any feedback would be appreciated.