### PR TITLE
Switch to getGlobalManager #2359

### DIFF
--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -25,6 +25,7 @@ import           Control.Monad.Trans.Control
 import           Data.IORef
 import           Data.Traversable
 import           Network.HTTP.Client
+import           Network.HTTP.Client.TLS (getGlobalManager)
 import           Path
 import           Path.IO
 import           Stack.Config
@@ -109,7 +110,7 @@ withGlobalConfigAndLock
     -> StackT Config IO ()
     -> IO ()
 withGlobalConfigAndLock go@GlobalOpts{..} inner = do
-    manager <- newTLSManager
+    manager <- getGlobalManager
     lc <- runStackLoggingTGlobal manager go $
         loadConfigMaybeProject globalConfigMonoid Nothing Nothing
     withUserFileLock go (configStackRoot $ lcConfig lc) $ \_lk ->
@@ -195,7 +196,7 @@ withBuildConfigExt go@GlobalOpts{..} mbefore inner mafter = do
 -- throughout this module.
 loadConfigWithOpts :: GlobalOpts -> IO (Manager,LoadConfig (StackLoggingT IO))
 loadConfigWithOpts go@GlobalOpts{..} = do
-    manager <- newTLSManager
+    manager <- getGlobalManager
     mstackYaml <- forM globalStackYaml resolveFile'
     lc <- runStackLoggingTGlobal manager go $ do
         lc <- loadConfig globalConfigMonoid globalResolver mstackYaml
@@ -213,7 +214,7 @@ withMiniConfigAndLock
     -> StackT MiniConfig IO ()
     -> IO ()
 withMiniConfigAndLock go@GlobalOpts{..} inner = do
-    manager <- newTLSManager
+    manager <- getGlobalManager
     miniConfig <- runStackLoggingTGlobal manager go $ do
         lc <- loadConfigMaybeProject globalConfigMonoid globalResolver Nothing
         loadMiniConfig manager (lcConfig lc)

--- a/src/Stack/Types/StackT.hs
+++ b/src/Stack/Types/StackT.hs
@@ -22,7 +22,6 @@ module Stack.Types.StackT
   ,runStackLoggingTGlobal
   ,runInnerStackT
   ,runInnerStackLoggingT
-  ,newTLSManager
   ,logSticky
   ,logStickyDone)
   where
@@ -222,10 +221,6 @@ runStackLoggingT manager logLevel terminal reExec m = do
                   , lenvReExec = reExec
                   , lenvSupportsUnicode = canUseUnicode
                   })
-
--- | Convenience for getting a 'Manager'
-newTLSManager :: MonadIO m => m Manager
-newTLSManager = liftIO $ newManager tlsManagerSettings
 
 --------------------------------------------------------------------------------
 -- Logging functionality

--- a/src/Stack/Upload.hs
+++ b/src/Stack/Upload.hs
@@ -48,14 +48,13 @@ import           Network.HTTP.Client                   (BodyReader, Manager,
                                                         Response,
                                                         RequestBody(RequestBodyLBS),
                                                         brRead,
-                                                        newManager,
                                                         parseRequest,
                                                         requestHeaders,
                                                         responseBody,
                                                         responseStatus,
                                                         withResponse)
 import           Network.HTTP.Client.MultipartFormData (formDataBody, partFileRequestBody)
-import           Network.HTTP.Client.TLS               (tlsManagerSettings,
+import           Network.HTTP.Client.TLS               (getGlobalManager,
                                                         applyDigestAuth,
                                                         displayDigestAuthException)
 import           Network.HTTP.Types                    (statusCode)
@@ -295,7 +294,7 @@ data UploadSettings = UploadSettings
 defaultUploadSettings :: UploadSettings
 defaultUploadSettings = UploadSettings
     { usUploadUrl = "https://hackage.haskell.org/packages/"
-    , usGetManager = newManager tlsManagerSettings
+    , usGetManager = getGlobalManager
     , usCredsSource = fromAnywhere
     , usSaveCreds = True
     }
@@ -310,7 +309,7 @@ setUploadUrl x us = us { usUploadUrl = x }
 
 -- | How to get an HTTP connection manager.
 --
--- Default: @newManager tlsManagerSettings@
+-- Default: @getGlobalManager@
 --
 -- Since 0.1.0.0
 setGetManager :: IO Manager -> UploadSettings -> UploadSettings

--- a/src/test/Network/HTTP/Download/VerifiedSpec.hs
+++ b/src/test/Network/HTTP/Download/VerifiedSpec.hs
@@ -8,6 +8,7 @@ import Control.Monad.Trans.Reader
 import Control.Retry (limitRetries)
 import Data.Maybe
 import Network.HTTP.Client.Conduit
+import Network.HTTP.Client.TLS (getGlobalManager)
 import Network.HTTP.Download.Verified
 import Path
 import Path.IO
@@ -71,7 +72,7 @@ runWith manager = runStdoutLoggingT . flip runReaderT manager
 
 setup :: IO T
 setup = do
-  manager <- newManager
+  manager <- getGlobalManager
   return T{..}
 
 teardown :: T -> IO ()

--- a/src/test/Stack/BuildPlanSpec.hs
+++ b/src/test/Stack/BuildPlanSpec.hs
@@ -11,6 +11,7 @@ import Control.Monad.Catch (try)
 import Data.Monoid
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import Network.HTTP.Client.TLS (getGlobalManager)
 import Network.HTTP.Conduit (Manager)
 import Prelude -- Fix redundant import warnings
 import System.Directory
@@ -31,7 +32,7 @@ data T = T
 
 setup :: IO T
 setup = do
-  manager <- newTLSManager
+  manager <- getGlobalManager
   unsetEnv "STACK_YAML"
   return T{..}
 

--- a/src/test/Stack/ConfigSpec.hs
+++ b/src/test/Stack/ConfigSpec.hs
@@ -8,6 +8,7 @@ import Control.Monad.Logger
 import Control.Exception
 import Data.Maybe
 import Data.Monoid
+import Network.HTTP.Client.TLS (getGlobalManager)
 import Network.HTTP.Conduit (Manager)
 import Path
 import Path.IO
@@ -62,7 +63,7 @@ data T = T
 
 setup :: IO T
 setup = do
-  manager <- newTLSManager
+  manager <- getGlobalManager
   unsetEnv "STACK_YAML"
   return T{..}
 

--- a/src/test/Stack/NixSpec.hs
+++ b/src/test/Stack/NixSpec.hs
@@ -7,6 +7,7 @@ import Control.Exception
 import Control.Monad.Logger
 import Data.Monoid
 import Network.HTTP.Conduit (Manager)
+import Network.HTTP.Client.TLS (getGlobalManager)
 import Path
 import Prelude -- to remove the warning about Data.Monoid being redundant on GHC 7.10
 import Stack.Config
@@ -38,7 +39,7 @@ data T = T
 
 setup :: IO T
 setup = do
-  manager <- newTLSManager
+  manager <- getGlobalManager
   unsetEnv "STACK_YAML"
   return T{..}
 

--- a/stack.cabal
+++ b/stack.cabal
@@ -343,6 +343,7 @@ test-suite stack-test
                 , exceptions
                 , filepath
                 , hspec >= 2.2 && <2.3
+                , http-client-tls
                 , http-conduit
                 , monad-logger
                 , neat-interpolation >= 0.3


### PR DESCRIPTION
Related to snoyberg/http-client#214. The fixes to improve latency in
creating a manager may give the biggest improvement to the global
manager, so switching over to using that makes sense. As it stands,
Stack is not modifying the manager configuration at all, so this
shouldn't be a problem, and if that changes in the future, we can always
modify the global manager directly with setGlobalManager.

A more invasive change is to remove the Manager from the configuration
environments entirely and either (1) use getGlobalManager throughout the
codebase or (2) switch over to the Network.HTTP.Simple module. I'm not
opposed to doing that necessarily, but wanted to kick off with the
simpler change.

EDIT by @Blaisorblade: fixes #2359.