### PR TITLE
Don't treat local extra-dep packages as targets

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,9 @@ Bug fixes:
 
 * Add proper support for non-ASCII characters in file paths for the `sdist` command.
   See [#2549](https://github.com/commercialhaskell/stack/issues/2549)
+* Never treat `extra-dep` local packages as targets. This ensures
+  things like test suites are not run for these packages, and that
+  build output is not hidden due to their presence.
 
 ## 1.2.0
 

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -410,6 +410,14 @@ loadLocalPackage boptsCli targets (name, (lpv, gpkg)) = do
         , lpCabalFile = lpvCabalFP lpv
         , lpDir = lpvRoot lpv
         , lpWanted = isJust mtarget
+                  -- A local package marked as extra-dep should never
+                  -- be treated as a target. Perhaps we should be
+                  -- fixing this upstream of this function, not
+                  -- certain, but this works for now. If in the future
+                  -- we decide to move the extra-dep checking logic
+                  -- upstream, this lpvExtraDep check should be
+                  -- changed to an assertion.
+                  && not (lpvExtraDep lpv)
         , lpComponents = toComponents exes tests benches
         -- TODO: refactor this so that it's easier to be sure that these
         -- components are indeed unbuildable.

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -351,10 +351,10 @@ loadLocalPackage boptsCli targets (name, (lpv, gpkg)) = do
                 Just (STLocalComps comps) -> splitComponents $ Set.toList comps
                 Just STLocalAll ->
                     ( packageExes pkg
-                    , if boptsTests bopts
+                    , if boptsTests bopts && not (lpvExtraDep lpv)
                         then Map.keysSet (packageTests pkg)
                         else Set.empty
-                    , if boptsBenchmarks bopts
+                    , if boptsBenchmarks bopts && not (lpvExtraDep lpv)
                         then packageBenchmarks pkg
                         else Set.empty
                     )


### PR DESCRIPTION
The immediate problem I noticed was that, when running `stack build`
with two local packages, one an extra-dep, the build output was not sent
to the console. This fixes the problem, but I believe there's still an
issue with the test suite being spuriously run. Still investigating
that.