### PR TITLE
Add PID-1 support for stack exec

### DIFF
--- a/src/Stack/Exec.hs
+++ b/src/Stack/Exec.hs
@@ -25,7 +25,7 @@ import           System.Process.Run (callProcess, callProcessObserveStdout, Cmd(
 #ifdef WINDOWS
 import           System.Process.Read (EnvOverride)
 #else
-import           System.Posix.Process (executeFile)
+import qualified System.Process.PID1 as PID1
 import           System.Process.Read (EnvOverride, envHelper, preProcess)
 #endif
 
@@ -63,7 +63,7 @@ exec = execSpawn
 exec menv cmd0 args = do
     cmd <- preProcess Nothing menv cmd0
     $withProcessTimeLog cmd args $
-        liftIO $ executeFile cmd True args (envHelper menv)
+        liftIO $ PID1.run cmd args (envHelper menv)
 #endif
 
 -- | Like 'exec', but does not use 'execv' on non-windows. This way, there

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -74,6 +74,7 @@ extra-deps:
 - neat-interpolation-0.3.2
 - optparse-applicative-0.13.0.0
 - text-metrics-0.1.0
+- pid1-0.1.0.0
 flags:
   time-locale-compat:
     old-locale: false

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -13,3 +13,4 @@ extra-deps:
 - http-conduit-2.2.0
 - http-client-tls-0.3.3
 - optparse-applicative-0.13.0.0
+- pid1-0.1.0.0

--- a/stack.cabal
+++ b/stack.cabal
@@ -267,6 +267,7 @@ library
     build-depends:   Win32
   else
     build-depends:   unix >= 2.7.0.1
+                   , pid1 >= 0.1 && < 0.2
   default-language:  Haskell2010
 
 executable stack

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,6 +21,7 @@ extra-deps:
 - http-conduit-2.2.0
 - optparse-applicative-0.13.0.0
 - text-metrics-0.1.0
+- pid1-0.1.0.0
 flags:
   stack:
     hide-dependency-versions: true


### PR DESCRIPTION
This improves behavior of stack exec in the Docker use case, ensuring
signals are properly handled and orphan processes are reaped.