### PR TITLE
Download snapshots.json from S3

### DIFF
--- a/src/Stack/Config/Urls.hs
+++ b/src/Stack/Config/Urls.hs
@@ -13,7 +13,7 @@ urlsFromMonoid monoid =
         (fromFirst defaultNightlyBuildPlans $ urlsMonoidNightlyBuildPlans monoid)
     where
     defaultLatestSnapshot =
-        "https://www.stackage.org/download/snapshots.json"
+        "https://s3.amazonaws.com/haddock.stackage.org/snapshots.json"
     defaultLtsBuildPlans =
         "https://raw.githubusercontent.com/fpco/lts-haskell/master/"
     defaultNightlyBuildPlans =


### PR DESCRIPTION
S3 is more reliable than stackage.org. See discussion:
https://www.reddit.com/r/haskell/comments/556a43/stackageorg_down/d8818rh