### PR TITLE
Parse .dump-hi files of library components only once

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -54,6 +54,9 @@ Bug fixes:
   [#2568](https://github.com/commercialhaskell/stack/issues/2568)
 * Fixed running `stack hpc report` on package targets.
   [#2664](https://github.com/commercialhaskell/stack/issues/2664)
+* Fix a long-standing performance regression where stack would parse the .dump-hi
+  files of the library components of local packages twice.
+  [#2658](https://github.com/commercialhaskell/stack/pull/2658)
 
 ## 1.2.0
 

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -734,7 +734,7 @@ libraryFiles lib = do
         resolveFilesAndDeps
             Nothing
             (dirs ++ [dir])
-            (names <> exposed)
+            names
             haskellModuleExts
     cfiles <- buildOtherSources build
     return (modules, files <> cfiles, warnings)


### PR DESCRIPTION
This fixes a performance regression introduced in 5f3ffe5ea8b4d8d1f4d1e4d15bee8b481ec6a8d4.