### PR TITLE
Fix retry of file download to not append #2657

### DIFF
--- a/src/Network/HTTP/Download/Verified.hs
+++ b/src/Network/HTTP/Download/Verified.hs
@@ -233,8 +233,8 @@ verifiedDownload DownloadRequest{..} destpath progressSink = do
         $logDebug $ "Downloading " <> decodeUtf8With lenientDecode (path req)
         liftIO $ do
             createDirectoryIfMissing True dir
-            withBinaryFile fptmp WriteMode $ \h ->
-                recoveringHttp drRetryPolicy $
+            recoveringHttp drRetryPolicy $
+                withBinaryFile fptmp WriteMode $ \h ->
                     flip runReaderT env $
                         withResponse req (go h)
             renameFile fptmp fp


### PR DESCRIPTION
@snoyberg @borsboom Please review, I believe this has been a bad longstanding bug in the download code.  When retry occurs, it continues appending to the same file.  The fix is simple - have `withBinaryFile` be within the retry.  Since it uses `WriteMode`, writing will restart from the beginning.