### PR TITLE
Pass -threaded when building Setup.hs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -66,6 +66,8 @@ Bug fixes:
   [#2658](https://github.com/commercialhaskell/stack/pull/2658)
 * Fixed a regression in "stack ghci --no-load", where it would prompt for a main
   module to load. [#2603](https://github.com/commercialhaskell/stack/pull/2603)
+* Build Setup.hs files with the threaded RTS, mirroring the behavior of
+  cabal-install and enabling more complex build systems in those files.
 
 ## 1.2.0
 

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -289,6 +289,7 @@ getSetupExe setupHs tmpdir = do
                     , "-o"
                     , toFilePath tmpOutputPath
                     , "-rtsopts"
+                    , "-threaded"
                     ] ++
                     ["-build-runner" | wc == Ghcjs]
             runCmd' (\cp -> cp { std_out = UseHandle stderr }) (Cmd (Just tmpdir) (compilerExeName wc) menv args) Nothing
@@ -996,6 +997,7 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
                         ] ++ packageArgs ++
                         [ toFilePath setuphs
                         , "-o", toFilePath outputFile
+                        , "-threaded"
                         ] ++
                         (case compiler of
                             Ghc -> []


### PR DESCRIPTION
Cabal-install builds `Setup.hs` files with `-threaded`, this patch changes Stack so it does too. This makes it possible to have concurrent build systems inside `Setup.hs`. Found in the context of ndmitchell/shake#490.

This was real quick and I don't know Stack internals, so it might be wrong. Tests pass, and my test in the linked issue works passes now.