### PR TITLE
Use a shim to invoke initialBuildSteps for ghci #1364

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -51,7 +51,6 @@ Other enhancements:
 * `stack dot` and `stack list-dependencies` now take targets and flags.
   [#1919](https://github.com/commercialhaskell/stack/issues/1919)
 
-
 Bug fixes:
 
 * Fixed a gnarly bug where programs and package tarballs sometimes have
@@ -77,6 +76,10 @@ Bug fixes:
   module to load. [#2603](https://github.com/commercialhaskell/stack/pull/2603)
 * Build Setup.hs files with the threaded RTS, mirroring the behavior of
   cabal-install and enabling more complex build systems in those files.
+* Fixed dirtiness checking for GHCJS packages by assuming dirtiness, since we
+  don't get .ddump-hi info. See
+  [#2341](https://github.com/commercialhaskell/stack/issues/2341) and
+  [ghcjs/#533](https://github.com/ghcjs/ghcjs/issues/533)
 
 ## 1.2.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,12 @@ Release notes:
 
 Major changes:
 
+* `stack ghci` now defaults to skipping the build of target packages, because
+  support has been added for invoking "initial build steps", which create
+  autogen files and run preprocessors. The `--no-build` flag is now deprecated
+  because it should no longer be necessary. See
+  [#1364](https://github.com/commercialhaskell/stack/issues/1364)
+
 Behavior changes:
 
 * Switch the "Run from outside project" messages to debug-level, to

--- a/src/Stack/Options/BuildParser.hs
+++ b/src/Stack/Options/BuildParser.hs
@@ -76,7 +76,11 @@ buildOptsParser cmd =
         (long "only-configure" <>
          help
              "Only perform the configure step, not any builds. Intended for tool usage, may break when used on multiple packages at once!") <*>
-    pure cmd
+    pure cmd <*>
+    switch
+        (long "initial-build-steps" <>
+         help "For target packages, only run initial build steps needed for GHCi" <>
+         internal)
 
 targetsParser :: Parser [Text]
 targetsParser =

--- a/src/Stack/Options/GhciParser.hs
+++ b/src/Stack/Options/GhciParser.hs
@@ -12,8 +12,7 @@ import           Stack.Types.Config
 -- | Parser for GHCI options
 ghciOptsParser :: Parser GhciOpts
 ghciOptsParser = GhciOpts
-             <$> switch (long "no-build" <> help "Don't build before launching GHCi")
-             <*> fmap concat (many (argsOption (long "ghci-options" <>
+             <$> fmap concat (many (argsOption (long "ghci-options" <>
                                        metavar "OPTION" <>
                                        help "Additional options passed to GHCi")))
              <*> optional
@@ -33,3 +32,4 @@ ghciOptsParser = GhciOpts
              <*> switch (long "skip-intermediate-deps" <> help "Skip loading intermediate target dependencies")
              <*> boolFlags True "package-hiding" "package hiding" idm
              <*> buildOptsParser Build
+             <*> switch (long "no-build" <> help "Don't build before launching GHCi (deprecated, should be unneeded)")

--- a/src/Stack/Types/Config/Build.hs
+++ b/src/Stack/Types/Config/Build.hs
@@ -117,6 +117,7 @@ defaultBuildOptsCLI = BuildOptsCLI
     , boptsCLIExec = []
     , boptsCLIOnlyConfigure = False
     , boptsCLICommand = Build
+    , boptsCLIInitialBuildSteps = False
     }
 
 -- | Build options that may only be specified from the CLI
@@ -130,6 +131,7 @@ data BuildOptsCLI = BuildOptsCLI
     , boptsCLIExec :: ![(String, [String])]
     , boptsCLIOnlyConfigure :: !Bool
     , boptsCLICommand :: !BuildCommand
+    , boptsCLIInitialBuildSteps :: !Bool
     } deriving Show
 
 -- | Command sum type for conditional arguments.

--- a/src/setup-shim/StackSetupShim.hs
+++ b/src/setup-shim/StackSetupShim.hs
@@ -1,0 +1,31 @@
+module StackSetupShim where
+import Main
+import Distribution.PackageDescription (PackageDescription, emptyHookedBuildInfo)
+import Distribution.Simple
+import Distribution.Simple.Build
+import Distribution.Simple.Setup (ReplFlags, fromFlag, replDistPref, replVerbosity)
+import Distribution.Simple.LocalBuildInfo (LocalBuildInfo)
+import System.Environment (getArgs)
+
+mainOverride :: IO ()
+mainOverride = do
+    args <- getArgs
+    if "repl" `elem` args && "stack-initial-build-steps" `elem` args
+        then do
+            defaultMainWithHooks simpleUserHooks
+                { preRepl = \_ _ -> return emptyHookedBuildInfo
+                , replHook = stackReplHook
+                , postRepl = \_ _ _ _ -> return ()
+                }
+        else main
+
+stackReplHook :: PackageDescription -> LocalBuildInfo -> UserHooks -> ReplFlags -> [String] -> IO ()
+stackReplHook pkg_descr lbi hooks flags args = do
+    let distPref = fromFlag (replDistPref flags)
+        verbosity = fromFlag (replVerbosity flags)
+    case args of
+        ("stack-initial-build-steps":rest)
+            | null rest -> initialBuildSteps distPref pkg_descr lbi verbosity
+            | otherwise ->
+                fail "Misuse of running Setup.hs with stack-initial-build-steps, expected no arguments"
+        _ -> replHook simpleUserHooks pkg_descr lbi hooks flags args

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -75,6 +75,7 @@ extra-deps:
 - optparse-applicative-0.13.0.0
 - text-metrics-0.1.0
 - pid1-0.1.0.0
+- file-embed-0.0.10
 flags:
   time-locale-compat:
     old-locale: false

--- a/stack.cabal
+++ b/stack.cabal
@@ -263,6 +263,7 @@ library
                    , hpack >= 0.14.0 && < 0.16
                    , store >= 0.2.1.0
                    , annotated-wl-pprint
+                   , file-embed >= 0.0.10
   if os(windows)
     cpp-options:     -DWINDOWS
     build-depends:   Win32


### PR DESCRIPTION
Here's how this works:

* Outputs a `StackSetupShim.hs` file to the build's temporary directory.

* Builds both simple setup and custom setup files using this file as an input, along with `-main-is: StackSetupShim.mainOverride`.

* When we want to run the `initialBuildSteps` cabal function, we run the setup exe with the arguments `repl stack-initial-build-steps`.  This condition is special-cased by the shim, and causes the function we want to be run.  Any other invocations of the executable get passed through to the standard simple / default setup.

In summary, this is a bit of a hack, but I think it works perfectly in all cases we care about.