### PR TITLE
Add extra variables in the hastache context

### DIFF
--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -189,7 +189,11 @@ applyTemplate project template nonceParams dir templateText = do
       return $ T.pack . show $ year
     let context = M.union (M.union nonceParams extraParams) configParams
           where
+            nameAsVarId = T.replace "-" "_" $ packageNameText project
+            nameAsModule = T.filter (/= '-') $ T.toTitle $ packageNameText project
             extraParams = M.fromList [ ("name", packageNameText project)
+                                     , ("name-as-varid", nameAsVarId)
+                                     , ("name-as-module", nameAsModule)
                                      , ("year", currentYear) ]
             configParams = configTemplateParams config
     (applied,missingKeys) <-


### PR DESCRIPTION
When a cabal file contains a `data-files` attribute, `cabal` generates a path module.  The module name includes the package name with hyphens replaced by underscores.  Currently `stack new` only adds the variables `name` and `year` in the hastache context available in stack templates.  That breaks templates that include a `data-files` attribute when a package name contains hyphens is passed to `stack new`.

Adding a variable (name-as-varid) in the hastache context to be able to reliably be able to support such cases.  Also add another variable (name-as-module) to use the package name as a module name. 
