### PR TITLE
Bump http-client version to fix broken https proxy functionality

### DIFF
--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -20,7 +20,7 @@ extra-deps:
 - project-template-0.2.0
 - filelock-0.1.0.1
 - gitrev-1.2.0
-- http-client-0.5.3.1
+- http-client-0.5.3.3
 - http-conduit-2.2.0
 - ignore-0.1.1.0
 - binary-tagged-0.1.3.1

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -9,7 +9,7 @@ nix:
   packages:
     - zlib
 extra-deps:
-- http-client-0.5.3.1
+- http-client-0.5.3.3
 - http-conduit-2.2.0
 - http-client-tls-0.3.3
 - optparse-applicative-0.13.0.0

--- a/stack.cabal
+++ b/stack.cabal
@@ -209,7 +209,7 @@ library
                    , hashable >= 1.2.3.2
                    , hit
                    , hpc
-                   , http-client >= 0.5.3.1
+                   , http-client >= 0.5.3.3
                    , http-client-tls >= 0.3.3
                    , http-conduit >= 2.2.0
                    , http-types >= 0.8.6 && < 0.10
@@ -290,7 +290,7 @@ executable stack
                 , filelock >= 0.1.0.1
                 , filepath >= 1.3.0.2
                 , hpack >= 0.14.0 && < 0.16
-                , http-client >= 0.5.0
+                , http-client >= 0.5.3.3
                   -- https://github.com/basvandijk/lifted-base/issues/31
                 , lifted-base < 0.2.3.7 || > 0.2.3.7
                 , microlens >= 0.3.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,7 +16,7 @@ extra-deps:
 - store-0.2.1.2
 - store-core-0.2.0.2
 - th-orphans-0.13.1
-- http-client-0.5.3.1
+- http-client-0.5.3.3
 - http-client-tls-0.3.3
 - http-conduit-2.2.0
 - optparse-applicative-0.13.0.0


### PR DESCRIPTION
Not sure if I'm doing this correctly, but http-client version needs to be bumped, else https proxy does not work. See https://github.com/snoyberg/http-client/pull/235.