### PR TITLE
Allow `stack config set resolver` to accept ghc-X resolvers.

### DIFF
--- a/HLint.hs
+++ b/HLint.hs
@@ -34,3 +34,4 @@ ignore "Use fmap"  -- specific to GHC 7.8 compat
 ignore "Parse error"  -- we trust the compiler over HLint
 ignore "Use ==" -- Creates infinite loops in `EQ` using expressions
 ignore "Evaluate"
+ignore "Use unless"

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -10,6 +10,7 @@
 module Stack.Types.BuildPlan
     ( -- * Types
       BuildPlan (..)
+    , BuildPlanTypesException
     , PackagePlan (..)
     , PackageConstraints (..)
     , TestState (..)

--- a/test/integration/tests/2747-config-set-resolver/Main.hs
+++ b/test/integration/tests/2747-config-set-resolver/Main.hs
@@ -1,0 +1,14 @@
+import StackTest
+
+main :: IO ()
+main = do
+    stack ["config", "set", "resolver", "ghc-8.0.1"]
+    stack ["config", "set", "resolver", "ghc-8.0"]
+    stack ["config", "set", "resolver", "ghc-8"]
+    stack ["config", "set", "resolver", "nightly"]
+    stack ["config", "set", "resolver", "lts-7"]
+
+    stackErr ["config", "set", "resolver", "lts-9999"]
+    stackErr ["config", "set", "resolver", "lts-foo"]
+    stackErr ["config", "set", "resolver", "ghc-foo"]
+    stackErr ["config", "set", "resolver", "foo"]

--- a/test/integration/tests/2747-config-set-resolver/files/stack.yaml
+++ b/test/integration/tests/2747-config-set-resolver/files/stack.yaml
@@ -1,0 +1,1 @@
+resolver: nightly


### PR DESCRIPTION
~~What would `defaultGhcBuildPlans` be? Doing a lot of guessing in this PR ;)~~

~~Also, I don't see any tests for `parseSnapName`. Should I add some?~~

Closes https://github.com/commercialhaskell/stack/issues/2678.
