### PR TITLE
Detect PIE on Hardened Gentoo

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,7 +38,7 @@ Other enhancements:
 * Add `ghc-build` option to override autodetected GHC build to use (e.g. gmp4,
   tinfo6, nopie) on Linux.
 * `stack setup` detects systems where gcc enables PIE by default (such as Ubuntu
-  16.10) and adjusts the GHC `configure` options accordingly.
+  16.10 and Hardened Gentoo) and adjusts the GHC `configure` options accordingly.
   [#2542](https://github.com/commercialhaskell/stack/issues/2542)
 * Upload to Hackage with HTTP digest instead of HTTP basic.
 * Make `stack list-dependencies` understand all of the `stack dot` options too.

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -554,8 +554,12 @@ getGhcBuild menv = do
                         libT = T.pack (toFilePath lib)
                     noPie = case egccErrOut of
                         Right (gccErr,gccOut) ->
-                            "--enable-default-pie" `elem` S8.words (gccOut <> gccErr)
+                            "--enable-default-pie" `elem` S8.words gccOutput || "Gentoo Hardened" `S8.isInfixOf` gccOutput
+                                where gccOutput = gccOut <> gccErr
                         Left _ -> False
+                $logDebug $ if noPie
+                               then "PIE disabled"
+                               else "PIE enabled"
                 hastinfo5 <- checkLib $(mkRelFile "libtinfo.so.5")
                 hastinfo6 <- checkLib $(mkRelFile "libtinfo.so.6")
                 hasncurses6 <- checkLib $(mkRelFile "libncursesw.so.6")


### PR DESCRIPTION
## General summary
Stack setup is unable to download a working copy of GHC under Sabayon, as it does not detect the need for a PIE variant. Sabayon is a derivative of [Hardened Gentoo](https://wiki.gentoo.org/wiki/Hardened_Gentoo), which has a patched version of GCC that does not produce the same output as Ubuntu (see below).

This PR adds support for detecting it, and also improves the logging to match what we currently have for tinfo, gmp, etc.

~~Please note that this is an *incomplete* fix, as we'll also need upload a `linux64-tinfo6-nopie` build of GHC.~~


Related: #2542.

### GCC Output
```
$ gcc -v
Using built-in specs.
COLLECT_GCC=/usr/x86_64-pc-linux-gnu/gcc-bin/4.9.3/gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-pc-linux-gnu/4.9.3/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /var/tmp/portage/sys-devel/gcc-4.9.3/work/gcc-4.9.3/configure --host=x86_64-pc-linux-gnu --build=x86_64-pc-linux-gnu --prefix=/usr --bindir=/usr/x86_64-pc-linux-gnu/gcc-bin/4.9.3 --includedir=/usr/lib/gcc/x86_64-pc-linux-gnu/4.9.3/include --datadir=/usr/share/gcc-data/x86_64-pc-linux-gnu/4.9.3 --mandir=/usr/share/gcc-data/x86_64-pc-linux-gnu/4.9.3/man --infodir=/usr/share/gcc-data/x86_64-pc-linux-gnu/4.9.3/info --with-gxx-include-dir=/usr/lib/gcc/x86_64-pc-linux-gnu/4.9.3/include/g++-v4 --with-python-dir=/share/gcc-data/x86_64-pc-linux-gnu/4.9.3/python --enable-objc-gc --enable-languages=c,c++,java,go,objc,obj-c++,fortran --enable-obsolete --enable-secureplt --disable-werror --with-system-zlib --enable-nls --without-included-gettext --enable-checking=release --with-bugurl=https://bugs.gentoo.org/ --with-pkgversion='Gentoo Hardened 4.9.3 p1.1, pie-0.6.2' --enable-esp --enable-libstdcxx-time --enable-shared --enable-threads=posix --enable-__cxa_atexit --enable-clocale=gnu --enable-multilib --with-multilib-list=m32,m64 --disable-altivec --disable-fixed-point --enable-targets=all --enable-libgomp --disable-libmudflap --disable-libssp --disable-libcilkrts --enable-lto --with-cloog --disable-isl-version-check --enable-libsanitizer
Thread model: posix
gcc version 4.9.3 (Gentoo Hardened 4.9.3 p1.1, pie-0.6.2) 

```



### Current Output when running `stack -v setup` (abbreviated)
```
2016-11-04 21:59:59.935047: [debug] Process finished in 977ms: /home/reuben/.stack/programs/x86_64-linux/ghc-tinfo6-8.0.1.temp/ghc-8.0.1/configure --prefix=/home/reuben/.stack/programs/x86_64-linux/ghc-tinfo6-8.0.1/
@(System/Process/Read.hs:306:3)
2016-11-04 21:59:59.935363: [debug] Run process: /usr/bin/gmake install
@(System/Process/Read.hs:306:3)
2016-11-04 22:00:15.850900: [debug] Process finished in 15915ms: /usr/bin/gmake install
@(System/Process/Read.hs:306:3)
Installed GHC.    
2016-11-04 22:00:15.851060: [debug] GHC installed to /home/reuben/.stack/programs/x86_64-linux/ghc-tinfo6-8.0.1/
@(Stack/Setup.hs:1017:5)
2016-11-04 22:00:16.568091: [debug] Performing a sanity check on: /home/reuben/.stack/programs/x86_64-linux/ghc-tinfo6-8.0.1/bin/ghc
@(Stack/Setup.hs:1534:5)
2016-11-04 22:00:16.568236: [debug] Run process: /home/reuben/.stack/programs/x86_64-linux/ghc-tinfo6-8.0.1/bin/ghc /tmp/stack-sanity-check11417/Main.hs -no-user-package-db
@(System/Process/Read.hs:306:3)
The GHC located at /home/reuben/.stack/programs/x86_64-linux/ghc-tinfo6-8.0.1/bin/ghc failed to compile a sanity check. Please see:

    http://docs.haskellstack.org/en/stable/install_and_upgrade/

for more information. Exception was:
Running /home/reuben/.stack/programs/x86_64-linux/ghc-tinfo6-8.0.1/bin/ghc /tmp/stack-sanity-check11417/Main.hs -no-user-package-db in directory /tmp/stack-sanity-check11417/ exited with ExitFailure 1

[1 of 1] Compiling Main             ( /tmp/stack-sanity-check11417/Main.hs, /tmp/stack-sanity-check11417/Main.o )
Linking /tmp/stack-sanity-check11417/Main ...

/usr/lib/gcc/x86_64-pc-linux-gnu/4.9.3/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/stack-sanity-check11417/Main.o: relocation R_X86_64_32S against `stg_bh_upd_frame_info' can not be used when making a shared object; recompile with -fPIC
/tmp/stack-sanity-check11417/Main.o: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
`gcc' failed in phase `Linker'. (Exit code: 1)
```

### Output with fix
```
2016-11-04 23:05:23.577621: [debug] Run process: /usr/bin/gcc -v
@(System/Process/Read.hs:306:3)
2016-11-04 23:05:23.581892: [debug] Process finished in 4ms: /usr/bin/gcc -v
@(System/Process/Read.hs:306:3)
2016-11-04 23:05:23.581999: [debug] PIE disabled
@(Stack/Setup.hs:560:17)
2016-11-04 23:05:23.587185: [debug] Did not find shared library libtinfo.so.5
@(Stack/Setup.hs:550:38)
2016-11-04 23:05:23.587302: [debug] Found shared library libtinfo.so.6 in 'ldconfig -p' output
@(Stack/Setup.hs:536:29)
2016-11-04 23:05:23.587400: [debug] Found shared library libncursesw.so.6 in 'ldconfig -p' output
@(Stack/Setup.hs:536:29)
2016-11-04 23:05:23.587542: [debug] Found shared library libgmp.so.10 in 'ldconfig -p' output
@(Stack/Setup.hs:536:29)
2016-11-04 23:05:23.587735: [debug] Did not find shared library libgmp.so.3
@(Stack/Setup.hs:550:38)
2016-11-04 23:05:23.587781: [debug] Using tinfo6-nopie GHC build
@(Stack/Setup.hs:586:9)
Unable to find installation URLs for OS key: linux64-tinfo6-nopie
```


### Stack version
```
$ stack --version
Version 1.2.1, Git revision 00cf71cf986c302508969467d0d628f09a365b7b (4292 commits) x86_64 hpack-0.14.1
```

### Method of installation
`stack install` of master.