### PR TITLE
Global project config creation respects `--resolver X`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,9 @@ Major changes:
 
 Behavior changes:
 
+* Passing `--resolver X` with a Stack command which forces creation of a global
+  project config, will pass resolver X into the initial config.
+  See [#2579](https://github.com/commercialhaskell/stack/issues/2229).
 * Switch the "Run from outside project" messages to debug-level, to
   avoid spamming users in the normal case of non-project usage
 * If a remote package is specified (such as a Git repo) without an explicit

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -485,8 +485,15 @@ loadBuildConfig mproject config mresolver mcompiler = do
                                          " specified on command line")
                    return (project, dest)
                else do
-                   r <- runReaderT getLatestResolver miniConfig
-                   $logInfo ("Using latest snapshot resolver: " <> resolverName r)
+                   r <- case mresolver of
+                       Just aresolver -> do
+                           r' <- runReaderT (makeConcreteResolver aresolver) miniConfig
+                           $logInfo ("Using resolver: " <> resolverName r' <> " specified on command line")
+                           return r'
+                       Nothing -> do
+                           r'' <- runReaderT getLatestResolver miniConfig
+                           $logInfo ("Using latest snapshot resolver: " <> resolverName r'')
+                           return r''
                    $logInfo ("Writing implicit global project config file to: " <> T.pack dest')
                    $logInfo "Note: You can change the snapshot via the resolver field there."
                    let p = Project


### PR DESCRIPTION
Closes #2579.