### PR TITLE
Allow configuring programs directory

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,6 +32,10 @@ Behavior changes:
 * If a remote package is specified (such as a Git repo) without an explicit
   `extra-dep` setting, a warning is given to the user to provide one
   explicitly.
+* On Windows, `stack setup` will now download and extract additional programs
+  such as GHC to `$STACK_ROOT\programs`, like on other platforms. You may need
+  to remove programs in `$LOCALAPPDATA\Programs\stack` manually.
+  [#1644](https://github.com/commercialhaskell/stack/issues/1644).
 
 Other enhancements:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,10 +32,6 @@ Behavior changes:
 * If a remote package is specified (such as a Git repo) without an explicit
   `extra-dep` setting, a warning is given to the user to provide one
   explicitly.
-* On Windows, `stack setup` will now download and extract additional programs
-  such as GHC to `$STACK_ROOT\programs`, like on other platforms. You may need
-  to remove programs in `$LOCALAPPDATA\Programs\stack` manually.
-  [#1644](https://github.com/commercialhaskell/stack/issues/1644).
 
 Other enhancements:
 
@@ -83,6 +79,9 @@ Other enhancements:
   [#2235](https://github.com/commercialhaskell/stack/issues/2235)
 * Replace enclosed-exceptions with safe-exceptions.
   [#2768](https://github.com/commercialhaskell/stack/issues/2768)
+* The install location for GHC and other programs can now be configured with the
+  `local-programs-path` option in `config.yaml`.
+  [#1644](https://github.com/commercialhaskell/stack/issues/1644)
 
 Bug fixes:
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -324,11 +324,12 @@ Cf. issue [#425](https://github.com/commercialhaskell/stack/issues/425).
 
 ## Can I change stack's default temporary directory?
 
-Stack downloads and extracts files to `$STACK_ROOT`, which defaults to
-`~/.stack`. If there is not enough free space in this directory, Stack may fail.
+Stack downloads and extracts files to `$STACK_ROOT/programs` on most platforms,
+which defaults to `~/.stack/programs`. On Windows `$LOCALAPPDATA\Programs\stack`
+is used. If there is not enough free space in this directory, Stack may fail.
 For instance, `stack setup` with a GHC installation requires roughly 1GB free.
-If this is an issue, you can change `$STACK_ROOT` to be on a file system with
-more free space.
+If this is an issue, you can set `local-programs-path` in your
+`~/.stack/config.yaml` to a directory on a file system with more free space.
 
 If you use Stack with Nix integration, be aware that Nix uses a `TMPDIR`
 variable, and if it is not set Nix sets it to some subdirectory of `/run`, which

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -324,22 +324,18 @@ Cf. issue [#425](https://github.com/commercialhaskell/stack/issues/425).
 
 ## Can I change stack's default temporary directory?
 
-Stack makes use of a temporary directory for some commands (/tmp by default on
-linux). If there is not enough free space in this directory, stack may fail
-(see issue [#429](https://github.com/commercialhaskell/stack/issues/429) ). For
-instance `stack setup` with a GHC installation requires roughly 1GB free.
+Stack downloads and extracts files to `$STACK_ROOT`, which defaults to
+`~/.stack`. If there is not enough free space in this directory, Stack may fail.
+For instance, `stack setup` with a GHC installation requires roughly 1GB free.
+If this is an issue, you can change `$STACK_ROOT` to be on a file system with
+more free space.
 
-A custom temporary directory can be forced:
-
-* on Linux by setting the environment variable TMPDIR (eg `$ TMPDIR=path-to-tmp stack setup`)
-* on Windows by setting one of the environment variable (given in priority order), TMP, TEMP, USERPROFILE
-
-If you use Stack with Nix integration, be aware that Nix _also_ uses that TMPDIR
+If you use Stack with Nix integration, be aware that Nix uses a `TMPDIR`
 variable, and if it is not set Nix sets it to some subdirectory of `/run`, which
-on most Linuxes is a Ramdir. Nix will run the builds in TMPDIR, therefore if you
-don't have enough RAM you will get errors about disk space.  If this happens to
-you, please _manually_ set TMPDIR before launching Stack to some directory on the
-disk.
+on most Linuxes is a Ramdir. Nix will run the builds in `TMPDIR`, therefore if
+you don't have enough RAM you will get errors about disk space. If this happens
+to you, please _manually_ set `TMPDIR` before launching Stack to some directory
+on the disk.
 
 ## Why doesn't stack rebuild my project when I specify `--ghc-options` on the command line?
 

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -294,7 +294,9 @@ configFromConfigMonoid configStackRoot configUserConfigPath mresolver mproject C
      origEnv <- mkEnvOverride configPlatform pathsEnv
      let configEnvOverride _ = return origEnv
 
-     configLocalProgramsBase <- getDefaultLocalProgramsBase configStackRoot configPlatform origEnv
+     configLocalProgramsBase <- case getFirst configMonoidLocalProgramsBase of
+       Nothing -> getDefaultLocalProgramsBase configStackRoot configPlatform origEnv
+       Just path -> return path
      platformOnlyDir <- runReaderT platformOnlyRelDir (configPlatform, configPlatformVariant)
      let configLocalPrograms = configLocalProgramsBase </> platformOnlyDir
 

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -783,6 +783,8 @@ data ConfigMonoid =
     -- ^ Additional paths to search for executables in
     ,configMonoidSetupInfoLocations  :: ![SetupInfoLocation]
     -- ^ Additional setup info (inline or remote) to use for installing tools
+    ,configMonoidLocalProgramsBase   :: !(First (Path Abs Dir))
+    -- ^ Override the default local programs dir, where e.g. GHC is installed.
     ,configMonoidPvpBounds           :: !(First PvpBounds)
     -- ^ See 'configPvpBounds'
     ,configMonoidModifyCodePage      :: !(First Bool)
@@ -860,6 +862,7 @@ parseConfigMonoidJSON obj = do
     configMonoidExtraPath <- obj ..:? configMonoidExtraPathName ..!= []
     configMonoidSetupInfoLocations <-
         maybeToList <$> jsonSubWarningsT (obj ..:?  configMonoidSetupInfoLocationsName)
+    configMonoidLocalProgramsBase <- First <$> obj ..:? configMonoidLocalProgramsBaseName
     configMonoidPvpBounds <- First <$> obj ..:? configMonoidPvpBoundsName
     configMonoidModifyCodePage <- First <$> obj ..:? configMonoidModifyCodePageName
     configMonoidExplicitSetupDeps <-
@@ -973,6 +976,9 @@ configMonoidExtraPathName = "extra-path"
 
 configMonoidSetupInfoLocationsName :: Text
 configMonoidSetupInfoLocationsName = "setup-info"
+
+configMonoidLocalProgramsBaseName :: Text
+configMonoidLocalProgramsBaseName = "local-programs-path"
 
 configMonoidPvpBoundsName :: Text
 configMonoidPvpBoundsName = "pvp-bounds"


### PR DESCRIPTION
This removes the hard-coded `$LOCALAPPDATA\Programs\stack` directory, and uses `$STACK_ROOT\programs` instead, unifying this path for all programs. This resolves #1644 and also [my comment](https://github.com/commercialhaskell/stack/issues/996#issuecomment-258642367) on #996.

@borsboom: You noted in #1644 that it would be good to make this configurable in `stack.yaml`. That would certainly be possible, but currently I do not see how that would be useful. I think it would introduce more knobs than necessary. Is there a compelling use case for downloading and extracting GHC to a different location than the snapshots?

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.