### PR TITLE
Always launch Docker command from the project root

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -104,7 +104,9 @@ Bug fixes:
 * Fixed a bug in passing along `--ghc-options` to ghcjs.  They were being
   provided as `--ghc-options` to Cabal, when it needs to be `--ghcjs-options`.
   [#2714](https://github.com/commercialhaskell/stack/issues/2714)
-
+* Launch Docker from the project root regardless of the working
+  directory Stack is invoked from. This means paths relative to the project root
+  (e.g. environment files) can be specified in `stack.yaml`'s docker `run-args`.
 
 ## 1.2.0
 


### PR DESCRIPTION
This PR makes it so docker create is always launched with its working
directory set to the project root. That means relative paths in the docker
run-args field work regardless of which directory stack is launched from.
Processes inside the container still run in the working directory stack was
launched from.

Fixes #2757.

Tested with the instructions in the above issue, my Yesod project and via `stack test --flag stack:integration-tests`.