### PR TITLE
Update YAML configuration docs to include `scm-init` option

### DIFF
--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -600,6 +600,15 @@ templates:
     github-username: yourusername
 ```
 
+Additionally, `stack new` can automatically initialize source control repositories
+in the directories it creates.  Source control tools can be specified with the
+`scm-init` option.  At the moment, only `git` is supported.
+
+```yaml
+templates:
+  scm-init: git
+```
+  
 # urls
 
 Customize the URLs where `stack` looks for snapshot build plans.


### PR DESCRIPTION
I was about to patch this `git init` feature in before noticing it was already in the source code.  I was unable to find documentation for it anywhere so I thought I would add some.  The documentation is based on my preliminary understanding of the code and my own experimentation.

This is also my first pull request, so I apologize if I neglected any protocol.