### PR TITLE
Update `doc/travis-simple.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@
 # sane build environment. In CI, we want to make our life more difficult, so we
 # use cabal without any Stackage snapshots.
 #
-language: c
+language: generic
 sudo: false
 
 cache:

--- a/doc/travis-complex.yml
+++ b/doc/travis-complex.yml
@@ -11,8 +11,8 @@
 # Use new container infrastructure to enable caching
 sudo: false
 
-# Choose a lightweight base image; we provide our own build tools.
-language: c
+# Do not choose a language; we provide our own build tools.
+language: generic
 
 # Caching so the next build will be fast too.
 cache:

--- a/doc/travis-simple.yml
+++ b/doc/travis-simple.yml
@@ -11,8 +11,8 @@
 # Use new container infrastructure to enable caching
 sudo: false
 
-# Choose a lightweight base image; we provide our own build tools.
-language: c
+# Do not choose a language; we provide our own build tools.
+language: generic
 
 # Caching so the next build will be fast too.
 cache:


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

`doc/travis-simple.yml` cannot be found in the stable branch.

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

The only change is the documentation.

Although `language: generic` is undocumented, it is widely used. See [Setting invalid/no language in .travis.yml silently defaults to Ruby · Issue #4895 · travis-ci/travis-ci](https://github.com/travis-ci/travis-ci/issues/4895#issuecomment-150703192).
