### PR TITLE
Script command #2805

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,15 @@ Release notes:
 
 Major changes:
 
+* A new command, `script`, has been added, intended to make the script
+  interpreter workflow more reliable, easier to use, and more
+  efficient. This command forces the user to provide a `--resolver`
+  value, ignores all config files for more reproducible results, and
+  optimizes the existing package check to make the common case of all
+  packages already being present much faster. This mode does require
+  that all packages be present in a snapshot, however.
+  [#2805](https://github.com/commercialhaskell/stack/issues/2805)
+
 Behavior changes:
 
 * The default package metadata backend has been changed from Git to

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1650,23 +1650,17 @@ running the file.
 An example will be easiest to understand:
 
 ```
-michael@d30748af6d3d:~$ cat turtle.hs
+michael@d30748af6d3d:~$ cat turtle-example.hs
 #!/usr/bin/env stack
--- stack --resolver lts-3.2 --install-ghc runghc --package turtle
+-- stack --resolver lts-6.25 script --package turtle
 {-# LANGUAGE OverloadedStrings #-}
 import Turtle
 main = echo "Hello World!"
-michael@d30748af6d3d:~$ chmod +x turtle.hs
-michael@d30748af6d3d:~$ ./turtle.hs
-Run from outside a project, using implicit global project config
-Using resolver: lts-3.2 specified on command line
-hashable-1.2.3.3: configure
-# installs some more dependencies
-Completed all 22 actions.
+michael@d30748af6d3d:~$ chmod +x turtle-example.hs
+michael@d30748af6d3d:~$ ./turtle-example.hs
+Completed 5 action(s).
 Hello World!
-michael@d30748af6d3d:~$ ./turtle.hs
-Run from outside a project, using implicit global project config
-Using resolver: lts-3.2 specified on command line
+michael@d30748af6d3d:~$ ./turtle-example.hs
 Hello World!
 ```
 
@@ -1684,11 +1678,30 @@ ensure the turtle package is available.
 If you're on Windows: you can run `stack turtle.hs` instead of `./turtle.hs`.
 The shebang line is not required in that case.
 
+### Using multiple packages
+
+You can also specify multiple packages, either with multiple `--package`
+arguments, or by providing a comma or space separated list. For example:
+
+```
+#!/usr/bin/env stack
+{- stack
+  script
+  --resolver lts-6.25
+  --package turtle
+  --package "stm async"
+  --package http-client,http-conduit
+-}
+```
+
 ### Stack configuration for scripts
 
-If the current working directory is inside a project then that project's stack
-configuration is effective when running the script. Otherwise the script uses
-the global project configuration specified in
+With the `script` command, all Stack configuration files are ignored to provide a
+completely reliable script running experience. However, see the example below
+with `runghc` for an approach to scripts which will respect your configuration
+files. When using `runghc`, if the current working directory is inside a
+project then that project's stack configuration is effective when running the
+script. Otherwise the script uses the global project configuration specified in
 `~/.stack/global-project/stack.yaml`.
 
 ### Specifying interpreter options
@@ -1707,49 +1720,60 @@ separating the stack options and ghc options with a `--`. Here is an example of
 a multi line block comment with ghc options:
 
 ```
-  #!/usr/bin/env stack
-  {- stack
-    --resolver lts-3.2
-    --install-ghc
-    runghc
-    --package turtle
-    --
-    -hide-all-packages
-  -}
+#!/usr/bin/env stack
+{- stack
+  script
+  --resolver lts-6.25
+  --package turtle
+  --
+  +RTS -s -RTS
+-}
 ```
 
 ### Writing independent and reliable scripts
 
-Independent means that the script is independent of any prior deployment
-specific configuration. If required, the script will install everything it
-needs automatically on any machine that it runs on. To make a script always
-work irrespective of any specific environment configuration you can do the
-following:
+With the release of Stack 1.2.1, there is a new command, `script`, which will
+automatically:
+
+* Install GHC and libraries if missing
+* Require that all packages used be explicitly stated on the command line
+
+This ensures that your scripts are _independent_ of any prior deployment
+specific configuration, and are _reliable_ by using exactly the same version of
+all packages every time it runs so that the script does not break by
+accidentally using incompatible package versions.
+
+In previous versions of Stack, the `runghc` command was used for scripts
+instead. In order to achieve the same effect with the `runghc` command, you can
+do the following:
 
 1. Use the `--install-ghc` option to install the compiler automatically
 2. Explicitly specify all packages required by the script using the
 `--package` option. Use `-hide-all-packages` ghc option to force
 explicit specification of all packages.
+3. Use the `--resolver` Stack option to ensure a specific GHC version and
+   package set is used.
 
-Reliable means the script will use exactly the same version of all packages
-every time it runs so that the script does not break by accidentally using
-incompatible package versions. To achieve that use an explicit `--resolver`
-stack option.
+Even with this configuration, it is still possible for configuration
+files to impact `stack runghc`, which is why `stack script` is strongly
+recommended in general. For those curious, here is an example with `runghc`:
 
-Here is an interpreter comment for a completely self-contained and reproducible
-version of our toy example:
 ```
-  #!/usr/bin/env stack
-  {- stack
-    --resolver lts-3.2
-    --install-ghc
-    runghc
-    --package base
-    --package turtle
-    --
-    -hide-all-packages
+#!/usr/bin/env stack
+{- stack
+  --resolver lts-6.25
+  --install-ghc
+  runghc
+  --package base
+  --package turtle
+  --
+  -hide-all-packages
   -}
 ```
+
+The `runghc` command is still very useful, especially when you're working on a
+project and want to access the package databases and configurations used by
+that project. See the next section for more information on configuration files.
 
 ## Finding project configs, and the implicit global
 

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -86,7 +86,7 @@ import qualified Control.Monad.Catch as Catch
 --   If a buildLock is passed there is an important contract here.  That lock must
 --   protect the snapshot, and it must be safe to unlock it if there are no further
 --   modifications to the snapshot to be performed by this build.
-build :: (StackM env m, HasEnvConfig env, MonadBaseUnlift IO m)
+build :: (StackM env m, HasMaybeEnvConfig env, MonadBaseUnlift IO m)
       => (Set (Path Abs File) -> IO ()) -- ^ callback after discovering all local files
       -> Maybe FileLock
       -> BuildOptsCLI
@@ -100,9 +100,9 @@ build setLocalFiles mbuildLk boptsCli = fixCodePage $ do
     (targets, mbp, locals, extraToBuild, extraDeps, sourceMap) <- loadSourceMapFull NeedTargets boptsCli
 
     -- Set local files, necessary for file watching
-    stackYaml <- view stackYamlL
+    mstackYaml <- view $ maybeBuildConfigLocalL.to (fmap bcStackYaml)
     liftIO $ setLocalFiles
-           $ Set.insert stackYaml
+           $ maybe id Set.insert mstackYaml
            $ Set.unions
            $ map lpFiles locals
 
@@ -279,7 +279,7 @@ splitObjsWarning = unwords
      ]
 
 -- | Get the @BaseConfigOpts@ necessary for constructing configure options
-mkBaseConfigOpts :: (MonadIO m, MonadReader env m, HasEnvConfig env, MonadThrow m)
+mkBaseConfigOpts :: (MonadIO m, MonadReader env m, HasMaybeEnvConfig env, MonadThrow m)
                  => BuildOptsCLI -> m BaseConfigOpts
 mkBaseConfigOpts boptsCli = do
     bopts <- view buildOptsL
@@ -304,7 +304,7 @@ withLoadPackage :: (StackM env m, HasEnvConfig env, MonadBaseUnlift IO m)
                 -> ((PackageName -> Version -> Map FlagName Bool -> [Text] -> IO Package) -> m a)
                 -> m a
 withLoadPackage menv inner = do
-    econfig <- view envConfigL
+    econfig <- view envConfigNoLocalL
     withCabalLoader menv $ \cabalLoader ->
         inner $ \name version flags ghcOptions -> do
             bs <- cabalLoader $ PackageIdentifier name version
@@ -316,7 +316,7 @@ withLoadPackage menv inner = do
             return pkg
   where
     -- | Package config to be used for dependencies
-    depPackageConfig :: EnvConfig -> Map FlagName Bool -> [Text] -> PackageConfig
+    depPackageConfig :: EnvConfigNoLocal -> Map FlagName Bool -> [Text] -> PackageConfig
     depPackageConfig econfig flags ghcOptions = PackageConfig
         { packageConfigEnableTests = False
         , packageConfigEnableBenchmarks = False

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -141,9 +141,11 @@ instance HasPlatform Ctx
 instance HasGHCVariant Ctx
 instance HasConfig Ctx
 instance HasBuildConfigNoLocal Ctx
+instance HasMaybeBuildConfig Ctx
 instance HasBuildConfig Ctx
 instance HasEnvConfigNoLocal Ctx where
     envConfigNoLocalL = envConfigL.envConfigNoLocalL
+instance HasMaybeEnvConfig Ctx
 instance HasEnvConfig Ctx where
     envConfigL = lens ctxEnvConfig (\x y -> x { ctxEnvConfig = y })
 
@@ -262,7 +264,7 @@ addFinal lp package isAllInOne = do
                 , taskConfigOpts = TaskConfigOpts missing $ \missing' ->
                     let allDeps = Map.union present missing'
                      in configureOpts
-                            (view envConfigL ctx)
+                            (view envConfigNoLocalL ctx)
                             (baseConfigOpts ctx)
                             allDeps
                             True -- local
@@ -443,7 +445,7 @@ installPackageGivenDeps isAllInOne ps package minstalled (missing, present, minL
                 let allDeps = Map.union present missing'
                     destLoc = piiLocation ps <> minLoc
                  in configureOpts
-                        (view envConfigL ctx)
+                        (view envConfigNoLocalL ctx)
                         (baseConfigOpts ctx)
                         allDeps
                         (psLocal ps)
@@ -555,7 +557,7 @@ checkDirtiness ps installed package present wanted = do
     ctx <- ask
     moldOpts <- flip runLoggingT (logFunc ctx) $ tryGetFlagCache installed
     let configOpts = configureOpts
-            (view envConfigL ctx)
+            (view envConfigNoLocalL ctx)
             (baseConfigOpts ctx)
             present
             (psLocal ps)

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -195,10 +195,10 @@ getCabalPkgVer menv wc = do
     maybe (throwM $ Couldn'tFindPkgId cabalPackageName) return mres
 
 -- | Get the value for GHC_PACKAGE_PATH
-mkGhcPackagePath :: Bool -> Path Abs Dir -> Path Abs Dir -> [Path Abs Dir] -> Path Abs Dir -> Text
-mkGhcPackagePath locals localdb deps extras globaldb =
+mkGhcPackagePath :: Maybe (Path Abs Dir) -> Path Abs Dir -> [Path Abs Dir] -> Path Abs Dir -> Text
+mkGhcPackagePath mlocaldb deps extras globaldb =
   T.pack $ intercalate [searchPathSeparator] $ concat
-    [ [toFilePathNoTrailingSep localdb | locals]
+    [ [toFilePathNoTrailingSep localdb | Just localdb <- [mlocaldb]]
     , [toFilePathNoTrailingSep deps]
     , [toFilePathNoTrailingSep db | db <- reverse extras]
     , [toFilePathNoTrailingSep globaldb]

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -122,6 +122,7 @@ instance HasConfig PathInfo
 instance HasBuildConfigNoLocal PathInfo where
     buildConfigNoLocalL = lens piBuildConfig (\x y -> x { piBuildConfig = y })
                         . buildConfigNoLocalL
+instance HasMaybeBuildConfig PathInfo
 instance HasBuildConfig PathInfo where
     buildConfigLocalL = lens piBuildConfig (\x y -> x { piBuildConfig = y })
                       . buildConfigLocalL
@@ -178,7 +179,7 @@ paths =
       , T.pack . toFilePathNoTrailingSep . piGlobalDb )
     , ( "GHC_PACKAGE_PATH environment variable"
       , "ghc-package-path"
-      , \pi' -> mkGhcPackagePath True (piLocalDb pi') (piSnapDb pi') (piExtraDbs pi') (piGlobalDb pi'))
+      , \pi' -> mkGhcPackagePath (Just (piLocalDb pi')) (piSnapDb pi') (piExtraDbs pi') (piGlobalDb pi'))
     , ( "Snapshot installation root"
       , "snapshot-install-root"
       , T.pack . toFilePathNoTrailingSep . piSnapRoot )

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -14,6 +14,7 @@
 
 module Stack.Setup
   ( setupEnv
+  , setupEnvNoFile
   , ensureCompiler
   , ensureDockerStackExe
   , getSystemCompiler
@@ -210,6 +211,8 @@ instance Show SetupException where
         , T.unpack dockerStackExeArgName
         , "' option to specify a location"]
 
+{- FIXME remove
+<<<<<<< HEAD
 -- | Modify the environment variables (like PATH) appropriately, possibly doing installation too
 setupEnv :: (StackM env m, HasBuildConfig env, HasGHCVariant env)
          => Maybe Text -- ^ Message to give user when necessary GHC is not available
@@ -231,6 +234,29 @@ setupEnv mResolveMissingGHC = do
             , soptsSanityCheck = False
             , soptsSkipGhcCheck = configSkipGHCCheck config
             , soptsSkipMsys = configSkipMsys config
+=======
+-}
+type TempTuple = (Map Text Text, EnvOverride, WhichCompiler, Path Abs Dir, CompilerVersion, Maybe ExtraDirs)
+
+setupEnvCommon
+  :: (StackM env m, HasBuildConfigNoFile env, HasGHCVariant env)
+  => Maybe Text
+  -> Maybe BuildConfig
+  -> m (TempTuple, EnvConfigNoFile)
+setupEnvCommon mResolveMissingGHC mbuildConfig = do
+    bconfig <- asks getBuildConfigNoFile
+    let platform = getPlatform bconfig
+        wc = whichCompiler (bcWantedCompiler bconfig)
+        sopts = SetupOpts
+            { soptsInstallIfMissing = configInstallGHC $ getConfig bconfig
+            , soptsUseSystem = configSystemGHC $ getConfig bconfig
+            , soptsWantedCompiler = bcWantedCompiler bconfig
+            , soptsCompilerCheck = configCompilerCheck $ getConfig bconfig
+            , soptsStackYaml = fmap bcStackYaml mbuildConfig
+            , soptsForceReinstall = False
+            , soptsSanityCheck = False
+            , soptsSkipGhcCheck = configSkipGHCCheck $ getConfig bconfig
+            , soptsSkipMsys = configSkipMsys $ getConfig bconfig
             , soptsUpgradeCabal = False
             , soptsResolveMissingGHC = mResolveMissingGHC
             , soptsSetupInfoYaml = defaultSetupInfoYaml
@@ -252,6 +278,8 @@ setupEnv mResolveMissingGHC = do
         <*> Concurrently (getGlobalDB menv wc)
 
     $logDebug "Resolving package entries"
+{- FIXME remove
+<<<<<<< HEAD
     packagesRef <- liftIO $ newIORef Nothing
     bcnl <- view buildConfigNoLocalL
     bcl <- view buildConfigLocalL
@@ -267,21 +295,52 @@ setupEnv mResolveMissingGHC = do
                 , envConfigPackagesRef = packagesRef
                 }
             }
+-}
+
+    return ((env, menv, wc, globaldb, compilerVer, mghcBin), EnvConfigNoFile
+        { envConfigBuildConfigNoFile = getBuildConfigNoFile bconfig
+        , envConfigCabalVersion = cabalVer
+        , envConfigCompilerVersion = compilerVer
+        , envConfigCompilerBuild = compilerBuild
+        })
+
+getModifiedConfig
+    :: (MonadIO m, MonadCatch m, MonadBaseControl IO m, MonadReader env m, MonadLogger m, HasEnvConfigNoFile env)
+    => TempTuple
+    -> Maybe EnvConfig
+    -> m Config
+getModifiedConfig (env, menv, wc, globaldb, compilerVer, mghcBin) meconfigFile = do
+    config <- asks getConfig
+    let platform = getPlatform config
 
     -- extra installation bin directories
-    mkDirs <- runReaderT extraBinDirs envConfig0
+    mkDirs <-
+      case meconfigFile of
+        Nothing -> fmap const extraBinDirsNoFile
+        Just econfigFile -> runReaderT extraBinDirs econfigFile
     let mpath = Map.lookup "PATH" env
     depsPath <- augmentPath (mkDirs False) mpath
     localsPath <- augmentPath (mkDirs True) mpath
 
-    deps <- runReaderT packageDatabaseDeps envConfig0
+    deps <- packageDatabaseDeps
     createDatabase menv wc deps
-    localdb <- runReaderT packageDatabaseLocal envConfig0
-    createDatabase menv wc localdb
-    extras <- runReaderT packageDatabaseExtra envConfig0
-    let mkGPP locals = mkGhcPackagePath locals localdb deps extras globaldb
+    mlocaldb <-
+      case meconfigFile of
+        Nothing -> return Nothing
+        Just econfigFile -> do
+          localdb <- runReaderT packageDatabaseLocal econfigFile
+          createDatabase menv wc localdb
+          return $ Just localdb
+    extras <-
+      case meconfigFile of
+        Nothing -> return []
+        Just econfigFile -> runReaderT packageDatabaseExtra econfigFile
+    let mkGPP locals = mkGhcPackagePath (if locals then mlocaldb else Nothing) deps extras globaldb
 
-    distDir <- runReaderT distRelativeDir envConfig0
+    mdistDir <-
+      case meconfigFile of
+        Nothing -> return Nothing
+        Just econfigFile -> fmap Just $ runReaderT distRelativeDir econfigFile
 
     executablePath <- liftIO getExecutablePath
 
@@ -309,7 +368,7 @@ setupEnv mResolveMissingGHC = do
                                 then Map.union utf8EnvVars
                                 else id)
 
-                        $ case (soptsSkipMsys sopts, platform) of
+                        $ case (configSkipMsys config, platform) of
                             (False, Platform Cabal.I386   Cabal.Windows)
                                 -> Map.insert "MSYSTEM" "MINGW32"
                             (False, Platform Cabal.X86_64 Cabal.Windows)
@@ -319,22 +378,25 @@ setupEnv mResolveMissingGHC = do
                         -- For reasoning and duplication, see: https://github.com/fpco/stack/issues/70
                         $ Map.insert "HASKELL_PACKAGE_SANDBOX" (T.pack $ toFilePathNoTrailingSep deps)
                         $ Map.insert "HASKELL_PACKAGE_SANDBOXES"
-                            (T.pack $ if esIncludeLocals es
-                                then intercalate [searchPathSeparator]
+                            (T.pack $ case (esIncludeLocals es, mlocaldb) of
+                                (True, Just localdb) ->
+                                     intercalate [searchPathSeparator]
                                         [ toFilePathNoTrailingSep localdb
                                         , toFilePathNoTrailingSep deps
                                         , ""
                                         ]
-                                else intercalate [searchPathSeparator]
+                                _ -> intercalate [searchPathSeparator]
                                         [ toFilePathNoTrailingSep deps
                                         , ""
                                         ])
-                        $ Map.insert "HASKELL_DIST_DIR" (T.pack $ toFilePathNoTrailingSep distDir) env
+                        $ maybe id (Map.insert "HASKELL_DIST_DIR" . T.pack . toFilePathNoTrailingSep) mdistDir
+                        $ env
 
                     () <- atomicModifyIORef envRef $ \m' ->
                         (Map.insert es eo m', ())
                     return eo
 
+{- FIXME remove
     bconfigl <- view buildConfigLocalL
     return EnvConfig
         { ecNoLocal = EnvConfigNoLocal
@@ -350,6 +412,44 @@ setupEnv mResolveMissingGHC = do
         , ecLocal = EnvConfigLocal
             { envConfigBuildConfigLocal = bconfigl
             , envConfigPackagesRef = envConfigPackagesRef $ ecLocal envConfig0
+-}
+    return $ maybe id addIncludeLib mghcBin config
+                { configEnvOverride = getEnvOverride' }
+
+setupEnvNoFile
+  :: (StackM env m, HasBuildConfigNoFile env, HasGHCVariant env)
+  => m EnvConfigNoFile
+setupEnvNoFile = do
+    (extra, envConfigNF) <- setupEnvCommon Nothing Nothing
+    config <- runReaderT (getModifiedConfig extra Nothing) envConfigNF
+    return envConfigNF
+        { envConfigBuildConfigNoFile = (envConfigBuildConfigNoFile envConfigNF)
+            { bcConfig = config
+            }
+        }
+
+-- | Modify the environment variables (like PATH) appropriately, possibly doing installation too
+setupEnv :: (StackM env m, HasBuildConfig env, HasGHCVariant env)
+         => Maybe Text -- ^ Message to give user when necessary GHC is not available
+         -> m EnvConfig
+setupEnv mResolveMissingGHC = do
+    bconfig <- asks getBuildConfig
+    (extra@(_, menv, _, _, _, _), envConfigNF) <- setupEnvCommon mResolveMissingGHC (Just bconfig)
+    packages <- mapM
+        (resolvePackageEntry menv (bcRoot bconfig))
+        (bcPackageEntries bconfig)
+    let envConfig0 = EnvConfig
+            { envConfigBuildConfig = bconfig
+            , envConfigNoFile = envConfigNF
+            , envConfigPackages = Map.fromList $ concat packages
+            }
+
+    config <- runReaderT (getModifiedConfig extra (Just envConfig0)) envConfig0
+    let bconfigNF = (getBuildConfigNoFile bconfig) { bcConfig = config }
+    return envConfig0
+        { envConfigBuildConfig = bconfig { bcBuildConfigNoFile = bconfigNF }
+        , envConfigNoFile = (envConfigNoFile envConfig0)
+            { envConfigBuildConfigNoFile = bconfigNF
             }
         }
 

--- a/src/Stack/Types/Internal.hs
+++ b/src/Stack/Types/Internal.hs
@@ -40,10 +40,14 @@ instance HasConfig config => HasConfig (Env config) where
     configL = envConfL.configL
 instance HasBuildConfigNoLocal config => HasBuildConfigNoLocal (Env config) where
     buildConfigNoLocalL = envConfL.buildConfigNoLocalL
+instance HasMaybeBuildConfig config => HasMaybeBuildConfig (Env config) where
+    maybeBuildConfigLocalL = envConfL.maybeBuildConfigLocalL
 instance HasBuildConfig config => HasBuildConfig (Env config) where
     buildConfigLocalL = envConfL.buildConfigLocalL
 instance HasEnvConfigNoLocal config => HasEnvConfigNoLocal (Env config) where
     envConfigNoLocalL = envConfL.envConfigNoLocalL
+instance HasMaybeEnvConfig config => HasMaybeEnvConfig (Env config) where
+    maybeEnvConfigLocalL = envConfL.maybeEnvConfigLocalL
 instance HasEnvConfig config => HasEnvConfig (Env config) where
     envConfigL = envConfL.envConfigL
 

--- a/stack.cabal
+++ b/stack.cabal
@@ -286,6 +286,7 @@ executable stack
   build-depends:  Cabal >= 1.18.1.5 && < 1.25
                 , base >=4.7 && < 5
                 , bytestring >= 0.10.4.0
+                , conduit
                 , containers >= 0.5.5.1
                 , directory >= 1.2.1.0
                 , either
@@ -302,6 +303,7 @@ executable stack
                 , optparse-applicative >= 0.13 && < 0.14
                 , path
                 , path-io >= 1.1.0 && < 2.0.0
+                , split
                 , stack
                 , text >= 1.2.0.4
                 , transformers >= 0.3.0.0 && < 0.6


### PR DESCRIPTION
This adds a basic script command. Most of the work involved has to do
with preventing config files from being loaded. There's at least one
ugly hack involved (adding a dummy bcStackYaml value), and some usages
of error that should probably be converted to proper exception types.

While this addresses reproducibility, it doesn't help with the speed
concerns: script is now about 100ms faster than runghc on my system for
the case where --package is provided, but it's still over a second for
Hello World. The slowdown is inherent right now in checking if the
relevant packages are installed. It would be nice to figure out a way to
optimize the package check.

Also, this should include some integration tests. It should be a simple
matter of a test that includes a bogus stack.yaml and proving that stack
script ignores it.