### PR TITLE
Implementation of "--copy-compiler-tool" #2643

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -36,6 +36,9 @@ Behavior changes:
   without an accompanying `-RTS`.
 * When auto-detecting `--ghc-build`, `tinfo6` is now preferred over
   `standard` if both versions of libtinfo are installed
+* Addition of `stack build --copy-compiler-tool`, to allow tools like
+  intero to be installed globally for a particular compiler.
+  [#2643](https://github.com/commercialhaskell/stack/issues/2643)
 
 Other enhancements:
 

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -208,7 +208,8 @@ constructPlan ls0 baseConfigOpts0 locals extraToBuild0 localDumpPkgs loadPackage
                 , planFinals = M.fromList finals
                 , planUnregisterLocal = mkUnregisterLocal tasks dirtyReason localDumpPkgs sourceMap initialBuildSteps
                 , planInstallExes =
-                    if boptsInstallExes $ bcoBuildOpts baseConfigOpts0
+                    if boptsInstallExes (bcoBuildOpts baseConfigOpts0) ||
+                       boptsInstallCompilerTool (bcoBuildOpts baseConfigOpts0)
                         then installExes
                         else Map.empty
                 }

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -509,7 +509,10 @@ copyExecutables exes | Map.null exes = return ()
 copyExecutables exes = do
     snapBin <- (</> bindirSuffix) `liftM` installationRootDeps
     localBin <- (</> bindirSuffix) `liftM` installationRootLocal
-    destDir <- view $ configL.to configLocalBin
+    compilerSpecific <- boptsInstallCompilerTool <$> view buildOptsL
+    destDir <- if compilerSpecific
+                   then bindirCompilerTools
+                   else view $ configL.to configLocalBin
     ensureDir destDir
 
     destDir' <- liftIO . D.canonicalizePath . toFilePath $ destDir
@@ -560,7 +563,7 @@ copyExecutables exes = do
             , T.pack destDir'
             , ":"]
     forM_ installed $ \exe -> $logInfo ("- " <> exe)
-    warnInstallSearchPathIssues destDir' installed
+    unless compilerSpecific $ warnInstallSearchPathIssues destDir' installed
 
 
 -- | Windows can't write over the current executable. Instead, we rename the

--- a/src/Stack/Config/Build.hs
+++ b/src/Stack/Config/Build.hs
@@ -43,6 +43,9 @@ buildOptsFromMonoid BuildOptsMonoid{..} = BuildOpts
     , boptsInstallExes = fromFirst
           (boptsInstallExes defaultBuildOpts)
           buildMonoidInstallExes
+    , boptsInstallCompilerTool = fromFirst
+          (boptsInstallCompilerTool defaultBuildOpts)
+          buildMonoidInstallCompilerTool
     , boptsPreFetch = fromFirst
           (boptsPreFetch defaultBuildOpts)
           buildMonoidPreFetch

--- a/src/Stack/Options/BuildMonoidParser.hs
+++ b/src/Stack/Options/BuildMonoidParser.hs
@@ -18,8 +18,9 @@ buildOptsMonoidParser hide0 =
     libProfiling <*> exeProfiling <*> libStripping <*>
     exeStripping <*> haddock <*> haddockOptsParser hideBool <*>
     openHaddocks <*> haddockDeps <*> haddockInternal <*>
-    haddockHyperlinkSource <*> copyBins <*> preFetch <*> keepGoing <*>
-    forceDirty <*> tests <*> testOptsParser hideBool <*> benches <*>
+    haddockHyperlinkSource <*> copyBins <*> copyCompilerTool <*>
+    preFetch <*> keepGoing <*> forceDirty <*>
+    tests <*> testOptsParser hideBool <*> benches <*>
     benchOptsParser hideBool <*> reconfigure <*> cabalVerbose <*> splitObjs <*> skipComponents
   where
     hideBool = hide0 /= BuildCmdGlobalOpts
@@ -62,7 +63,6 @@ buildOptsMonoidParser hide0 =
                       \debuggers/profiling tools/other utilities that use \
                       \debugging symbols." <>
              hideExceptGhci)
-
     libProfiling =
         firstBoolFlags
             "library-profiling"
@@ -109,6 +109,11 @@ buildOptsMonoidParser hide0 =
         firstBoolFlags
             "copy-bins"
             "copying binaries to the local-bin-path (see 'stack path')"
+            hide
+    copyCompilerTool =
+        firstBoolFlags
+            "copy-compiler-tool"
+            "copying binaries of targets to compiler-tools-bin (see 'stack path')"
             hide
     keepGoing =
         firstBoolFlags

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -50,6 +50,7 @@ path keys =
        global <- GhcPkg.getGlobalDB menv whichCompiler
        snaproot <- installationRootDeps
        localroot <- installationRootLocal
+       toolsDir <- bindirCompilerTools
        distDir <- distRelativeDir
        hpcDir <- hpcReportDir
        compiler <- getCompilerPath whichCompiler
@@ -83,6 +84,7 @@ path keys =
                                global
                                snaproot
                                localroot
+                               toolsDir
                                distDir
                                hpcDir
                                extra
@@ -107,6 +109,7 @@ data PathInfo = PathInfo
     , piGlobalDb     :: Path Abs Dir
     , piSnapRoot     :: Path Abs Dir
     , piLocalRoot    :: Path Abs Dir
+    , piToolsDir     :: Path Abs Dir
     , piDistDir      :: Path Rel Dir
     , piHpcDir       :: Path Abs Dir
     , piExtraDbs     :: [Path Abs Dir]
@@ -155,6 +158,9 @@ paths =
     , ( "Directory containing the compiler binary (e.g. ghc)"
       , "compiler-bin"
       , T.pack . toFilePathNoTrailingSep . parent . piCompiler )
+    , ( "Directory containing binaries specific to a particular compiler (e.g. intero)"
+      , "compiler-tools-bin"
+      , T.pack . toFilePathNoTrailingSep . piToolsDir )
     , ( "Local bin dir where stack installs executables (e.g. ~/.local/bin)"
       , "local-bin"
       , view $ configL.to configLocalBin.to toFilePathNoTrailingSep.to T.pack)

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1236,9 +1236,9 @@ installationRootLocal = do
 -- | Installation root for compiler tools
 bindirCompilerTools :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs Dir)
 bindirCompilerTools = do
-    config <- asks getConfig
+    config <- view configL
     platform <- platformGhcRelDir
-    compilerVersion <- asks (envConfigCompilerVersion . getEnvConfig)
+    compilerVersion <- envConfigCompilerVersion <$> view envConfigL
     compiler <- parseRelDir $ compilerVersionString compilerVersion
     return $
         configStackRoot config </>

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -116,6 +116,7 @@ module Stack.Types.Config
   ,hpcReportDir
   ,installationRootDeps
   ,installationRootLocal
+  ,bindirCompilerTools
   ,hoogleRoot
   ,hoogleDatabasePath
   ,packageDatabaseDeps
@@ -1232,6 +1233,20 @@ installationRootLocal = do
     psc <- useShaPathOnWindows =<< platformSnapAndCompilerRel
     return $ workDir </> $(mkRelDir "install") </> psc
 
+-- | Installation root for compiler tools
+bindirCompilerTools :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs Dir)
+bindirCompilerTools = do
+    config <- asks getConfig
+    platform <- platformGhcRelDir
+    compilerVersion <- asks (envConfigCompilerVersion . getEnvConfig)
+    compiler <- parseRelDir $ compilerVersionString compilerVersion
+    return $
+        configStackRoot config </>
+        $(mkRelDir "compiler-tools") </>
+        platform </>
+        compiler </>
+        bindirSuffix
+
 -- | Hoogle directory.
 hoogleRoot :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs Dir)
 hoogleRoot = do
@@ -1376,9 +1391,10 @@ extraBinDirs :: (MonadThrow m, MonadReader env m, HasEnvConfig env)
 extraBinDirs = do
     deps <- installationRootDeps
     local <- installationRootLocal
+    tools <- bindirCompilerTools
     return $ \locals -> if locals
-        then [local </> bindirSuffix, deps </> bindirSuffix]
-        else [deps </> bindirSuffix]
+        then [local </> bindirSuffix, deps </> bindirSuffix, tools]
+        else [deps </> bindirSuffix, tools]
 
 -- | Get the minimal environment override, useful for just calling external
 -- processes like git or ghc

--- a/src/Stack/Types/Config/Build.hs
+++ b/src/Stack/Types/Config/Build.hs
@@ -57,6 +57,8 @@ data BuildOpts =
             -- @hscolour@. Disable for no sources.
             ,boptsInstallExes :: !Bool
             -- ^ Install executables to user path after building?
+            ,boptsInstallCompilerTool :: !Bool
+            -- ^ Install executables to compiler tools path after building?
             ,boptsPreFetch :: !Bool
             -- ^ Fetch all packages immediately
             -- ^ Watch files for changes and automatically rebuild
@@ -100,6 +102,7 @@ defaultBuildOpts = BuildOpts
     , boptsHaddockInternal = False
     , boptsHaddockHyperlinkSource = True
     , boptsInstallExes = False
+    , boptsInstallCompilerTool = False
     , boptsPreFetch = False
     , boptsKeepGoing = Nothing
     , boptsForceDirty = False
@@ -166,6 +169,7 @@ data BuildOptsMonoid = BuildOptsMonoid
     , buildMonoidHaddockInternal :: !(First Bool)
     , buildMonoidHaddockHyperlinkSource :: !(First Bool)
     , buildMonoidInstallExes :: !(First Bool)
+    , buildMonoidInstallCompilerTool :: !(First Bool)
     , buildMonoidPreFetch :: !(First Bool)
     , buildMonoidKeepGoing :: !(First Bool)
     , buildMonoidForceDirty :: !(First Bool)
@@ -195,6 +199,7 @@ instance FromJSON (WithJSONWarnings BuildOptsMonoid) where
               buildMonoidHaddockInternal <- First <$> o ..:? buildMonoidHaddockInternalArgName
               buildMonoidHaddockHyperlinkSource <- First <$> o ..:? buildMonoidHaddockHyperlinkSourceArgName
               buildMonoidInstallExes <- First <$> o ..:? buildMonoidInstallExesArgName
+              buildMonoidInstallCompilerTool <- First <$> o ..:? buildMonoidInstallCompilerToolArgName
               buildMonoidPreFetch <- First <$> o ..:? buildMonoidPreFetchArgName
               buildMonoidKeepGoing <- First <$> o ..:? buildMonoidKeepGoingArgName
               buildMonoidForceDirty <- First <$> o ..:? buildMonoidForceDirtyArgName
@@ -240,6 +245,9 @@ buildMonoidHaddockHyperlinkSourceArgName = "haddock-hyperlink-source"
 
 buildMonoidInstallExesArgName :: Text
 buildMonoidInstallExesArgName = "copy-bins"
+
+buildMonoidInstallCompilerToolArgName :: Text
+buildMonoidInstallCompilerToolArgName = "copy-compiler-tool"
 
 buildMonoidPreFetchArgName :: Text
 buildMonoidPreFetchArgName = "prefetch"

--- a/test/integration/tests/2643-copy-compiler-tool/Main.hs
+++ b/test/integration/tests/2643-copy-compiler-tool/Main.hs
@@ -7,10 +7,10 @@ main = do
 
   -- check assumptions on exec and the build flags and clean
   stack ["build", "--flag", "*:build-baz"]
-  stack ["exec", "--", "baz-exe"]
-  stackErr ["exec", "--", "bar-exe"]
+  stack ["exec", "--", "baz-exe" ++ exeExt]
+  stackErr ["exec", "--", "bar-exe" ++ exeExt]
   stack ["clean", "--full"]
-  stackErr ["exec", "--", "baz-exe"]
+  stackErr ["exec", "--", "baz-exe" ++ exeExt]
 
   -- install one exe normally and two compiler-tools, opposite ways
   -- (build or install)
@@ -23,11 +23,11 @@ main = do
   stack ["clean", "--full"]
 
   -- bar and baz were installed as compiler tools, should work fine
-  stack ["exec", "--", "bar-exe"]
-  stack ["exec", "--", "baz-exe"]
+  stack ["exec", "--", "bar-exe" ++ exeExt]
+  stack ["exec", "--", "baz-exe" ++ exeExt]
 
   -- foo was installed as a normal exe (in .local/bin/), so shouldn't
   -- TODO: Check this in a more reliable fashion
-  stackErr ["exec", "--", "foo-exe"]
+  stackErr ["exec", "--", "foo-exe" ++ exeExt]
 
   -- TODO: check paths against `stack path`

--- a/test/integration/tests/2643-copy-compiler-tool/Main.hs
+++ b/test/integration/tests/2643-copy-compiler-tool/Main.hs
@@ -1,0 +1,33 @@
+import StackTest
+
+main :: IO ()
+main = do
+  -- init
+  stack ["init", defaultResolverArg]
+
+  -- check assumptions on exec and the build flags and clean
+  stack ["build", "--flag", "*:build-baz"]
+  stack ["exec", "--", "baz-exe"]
+  stackErr ["exec", "--", "bar-exe"]
+  stack ["clean", "--full"]
+  stackErr ["exec", "--", "baz-exe"]
+
+  -- install one exe normally and two compiler-tools, opposite ways
+  -- (build or install)
+  stack ["install", "--flag", "*:build-foo"]
+  stack ["build", "--copy-compiler-tool", "--flag", "*:build-bar"]
+  stack ["install", "--copy-compiler-tool", "--flag", "*:build-baz"]
+
+  -- nuke the built things that go in .stack-work/, so we can test if
+  -- the installed ones exist for sure
+  stack ["clean", "--full"]
+
+  -- bar and baz were installed as compiler tools, should work fine
+  stack ["exec", "--", "bar-exe"]
+  stack ["exec", "--", "baz-exe"]
+
+  -- foo was installed as a normal exe (in .local/bin/), so shouldn't
+  -- TODO: Check this in a more reliable fashion
+  stackErr ["exec", "--", "foo-exe"]
+
+  -- TODO: check paths against `stack path`

--- a/test/integration/tests/2643-copy-compiler-tool/files/Bar.hs
+++ b/test/integration/tests/2643-copy-compiler-tool/files/Bar.hs
@@ -1,0 +1,1 @@
+main = putStrLn "twotwotwo"

--- a/test/integration/tests/2643-copy-compiler-tool/files/Baz.hs
+++ b/test/integration/tests/2643-copy-compiler-tool/files/Baz.hs
@@ -1,0 +1,1 @@
+main = putStrLn "threethreethree"

--- a/test/integration/tests/2643-copy-compiler-tool/files/Foo.hs
+++ b/test/integration/tests/2643-copy-compiler-tool/files/Foo.hs
@@ -1,0 +1,1 @@
+main = putStrLn "oneoneone"

--- a/test/integration/tests/2643-copy-compiler-tool/files/LICENSE
+++ b/test/integration/tests/2643-copy-compiler-tool/files/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2017
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Your name here nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/integration/tests/2643-copy-compiler-tool/files/Setup.hs
+++ b/test/integration/tests/2643-copy-compiler-tool/files/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/test/integration/tests/2643-copy-compiler-tool/files/copy-compiler-tool-test.cabal
+++ b/test/integration/tests/2643-copy-compiler-tool/files/copy-compiler-tool-test.cabal
@@ -1,0 +1,54 @@
+name:                copy-compiler-tool-test
+version:             0.1.0.0
+synopsis:            Initial project template from stack
+description:         Please see README.md
+homepage:            http://invalid/
+license:             BSD3
+license-file:        LICENSE
+author:              Your name here
+maintainer:          your.address@example.com
+-- copyright:
+category:            Web
+build-type:          Simple
+-- extra-source-files:
+cabal-version:       >=1.10
+
+flag build-foo
+  manual: True
+  default: False
+  description: Build foo
+
+flag build-bar
+  manual: True
+  default: False
+  description: Build bar
+
+flag build-baz
+  manual: True
+  default: False
+  description: Build baz
+
+executable foo-exe
+  main-is:             Foo.hs
+  build-depends:       base
+  default-language:    Haskell2010
+  if !flag(build-foo)
+    buildable: False
+
+executable bar-exe
+  main-is:             Bar.hs
+  build-depends:       base
+  default-language:    Haskell2010
+  if !flag(build-bar)
+    buildable: False
+
+executable baz-exe
+  main-is:             Baz.hs
+  build-depends:       base
+  default-language:    Haskell2010
+  if !flag(build-baz)
+    buildable: False
+
+source-repository head
+  type:     git
+  location: https://invalid/


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

As described in #2643, this implements a mechanism for having a bin directory for tools that match a particular ghc version.  This compiler specific dir looks like is `/home/mgsloan/.stack/compiler-tools/x86_64-linux/ghc-8.0.1/bin`.  It is included on the PATH when stack is building projects and when running exec. It adds:

1) `stack path --compiler-tool-bin`, yielding a path to the dir compiler-specific tools are installed to
2) `stack build --copy-compiler-tool`, which causes executables for target packages to get copied to the compiler-specific dir.

Tested this change by using it to install a local intero.  Querying `stack exec -- which intero` yielded the correct path.  `stack path --local