### PR TITLE
Fix HLint/CPP failure in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,9 @@ install:
 script:
  - set -e; case "$BUILD" in
      style)
-       hlint src/ test/ --cpp-simple --hint=HLint.hs;
+       hlint src/ --hint=HLint.hs;
+       hlint src/ --cpp-define=WINDOWS=1 --hint=HLint.hs;
+       hlint test/ --cpp-simple --hint=HLint.hs;
        stack --no-terminal build --pedantic;;
      stack)
        stack --no-terminal test --haddock --no-haddock-deps --ghc-options="-Werror";;


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

HLint was failing because it was using --cpp-simple, which just strips
every directive, which in turn created duplicate import statements. This
commit turns off --cpp-simple and lints with the WINDOWS macro on and off.
--cpp-simple is kept on for the tests, which don't have the duplicate import
problem and some of which use CPP in more complex ways than just turning a
single variable on and off.

Tested via Travis. No need to do anything else since `.travis.yml` is the only file changed.