### PR TITLE
`--nix-*` should not imply `--nix` by default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,9 @@ Behavior changes:
   as well. If you manually specify a package index with only a Git
   URL, Git will still be used. See
   [#2780](https://github.com/commercialhaskell/stack/issues/2780)
+* Passing `--(no-)nix-*` options now no longer implies `--nix`, except for
+  `--nix-pure`, so that the user preference whether or not to use Nix is
+  honored even in the presence of options that change the Nix behavior.
 
 Other enhancements:
 

--- a/src/Stack/Options/NixParser.hs
+++ b/src/Stack/Options/NixParser.hs
@@ -17,7 +17,7 @@ nixOptsParser hide0 = overrideActivation <$>
                      "use of a Nix-shell. Implies 'system-ghc: true'"
                      hide
   <*> firstBoolFlags "nix-pure"
-                     "use of a pure Nix-shell. Implies 'system-ghc: true'"
+                     "use of a pure Nix-shell. Implies '--nix' and 'system-ghc: true'"
                      hide
   <*> optionalFirst
           (textArgsOption
@@ -51,6 +51,7 @@ nixOptsParser hide0 = overrideActivation <$>
   where
     hide = hideMods hide0
     overrideActivation m =
-      if m /= mempty then m { nixMonoidEnable = (First . Just . fromFirst True) (nixMonoidEnable m) }
-      else m
+      if fromFirst False (nixMonoidPureShell m)
+        then m { nixMonoidEnable = (First . Just . fromFirst True) (nixMonoidEnable m) }
+        else m
     textArgsOption = fmap (map T.pack) . argsOption

--- a/src/test/Stack/NixSpec.hs
+++ b/src/test/Stack/NixSpec.hs
@@ -5,13 +5,16 @@ module Stack.NixSpec where
 
 import Control.Exception
 import Control.Monad.Logger
+import Data.Maybe
 import Data.Monoid
+import Options.Applicative
 import Path
 import Prelude -- to remove the warning about Data.Monoid being redundant on GHC 7.10
 import Stack.Config
+import Stack.Options.NixParser
 import Stack.Config.Nix
-import Stack.Types.Config
 import Stack.Types.Compiler
+import Stack.Types.Config
 import Stack.Types.Nix
 import Stack.Types.StackT
 import Stack.Types.Version
@@ -44,29 +47,61 @@ setup = unsetEnv "STACK_YAML"
 
 spec :: Spec
 spec = beforeAll setup $ do
-  let loadConfig' = runStackT () LevelDebug True False ColorAuto False (loadConfig mempty Nothing Nothing)
-      inTempDir action = do
+  let loadConfig' cmdLineArgs = runStackT () LevelDebug True False ColorAuto False (loadConfig cmdLineArgs Nothing Nothing)
+      inTempDir test = do
         currentDirectory <- getCurrentDirectory
         withSystemTempDirectory "Stack_ConfigSpec" $ \tempDir -> do
           let enterDir = setCurrentDirectory tempDir
               exitDir = setCurrentDirectory currentDirectory
-          bracket_ enterDir exitDir action
+          bracket_ enterDir exitDir test
       withStackDotYaml config test = inTempDir $ do
         writeFile (toFilePath stackDotYaml) config
         test
-  describe "nix disabled in config file" $ do
-    it "sees that the nix shell is not enabled" $
-      withStackDotYaml sampleConfigNixDisabled $ do
-        lc <- loadConfig'
+      parseNixOpts cmdLineOpts = fromJust $ getParseResult $ execParserPure
+        defaultPrefs
+        (info (nixOptsParser False) mempty)
+        cmdLineOpts
+      parseOpts cmdLineOpts = mempty { configMonoidNixOpts = parseNixOpts cmdLineOpts }
+  describe "nix disabled in config file" $
+    around_ (withStackDotYaml sampleConfigNixDisabled) $ do
+      it "sees that the nix shell is not enabled" $ do
+        lc <- loadConfig' mempty
         nixEnable (configNix $ lcConfig lc) `shouldBe` False
-  describe "nix enabled in config file" $ do
-    it "sees that the nix shell is enabled" $
-      withStackDotYaml sampleConfigNixEnabled $ do
-        lc <- loadConfig'
+      describe "--nix given on command line" $
+        it "sees that the nix shell is enabled" $ do
+          lc <- loadConfig' (parseOpts ["--nix"])
+          nixEnable (configNix $ lcConfig lc) `shouldBe` True
+      describe "--nix-pure given on command line" $
+        it "sees that the nix shell is enabled" $ do
+          lc <- loadConfig' (parseOpts ["--nix-pure"])
+          nixEnable (configNix $ lcConfig lc) `shouldBe` True
+      describe "--no-nix given on command line" $
+        it "sees that the nix shell is not enabled" $ do
+          lc <- loadConfig' (parseOpts ["--no-nix"])
+          nixEnable (configNix $ lcConfig lc) `shouldBe` False
+      describe "--no-nix-pure given on command line" $
+        it "sees that the nix shell is not enabled" $ do
+          lc <- loadConfig' (parseOpts ["--no-nix-pure"])
+          nixEnable (configNix $ lcConfig lc) `shouldBe` False
+  describe "nix enabled in config file" $
+    around_ (withStackDotYaml sampleConfigNixEnabled) $ do
+      it "sees that the nix shell is enabled" $ do
+        lc <- loadConfig' mempty
         nixEnable (configNix $ lcConfig lc) `shouldBe` True
-    it "sees that the only package asked for is glpk and asks for the correct GHC derivation" $
-      withStackDotYaml sampleConfigNixEnabled $ do
-        lc <- loadConfig'
+      describe "--no-nix given on command line" $
+        it "sees that the nix shell is not enabled" $ do
+          lc <- loadConfig' (parseOpts ["--no-nix"])
+          nixEnable (configNix $ lcConfig lc) `shouldBe` False
+      describe "--nix-pure given on command line" $
+        it "sees that the nix shell is enabled" $ do
+          lc <- loadConfig' (parseOpts ["--nix-pure"])
+          nixEnable (configNix $ lcConfig lc) `shouldBe` True
+      describe "--no-nix-pure given on command line" $
+        it "sees that the nix shell is enabled" $ do
+          lc <- loadConfig' (parseOpts ["--no-nix-pure"])
+          nixEnable (configNix $ lcConfig lc) `shouldBe` True
+      it "sees that the only package asked for is glpk and asks for the correct GHC derivation" $ do
+        lc <- loadConfig' mempty
         nixPackages (configNix $ lcConfig lc) `shouldBe` ["glpk"]
         v <- parseVersion "7.10.3"
         nixCompiler (GhcVersion v) `shouldBe` "haskell.compiler.ghc7103"

--- a/stack.cabal
+++ b/stack.cabal
@@ -354,6 +354,7 @@ test-suite stack-test
                 , http-conduit
                 , monad-logger
                 , neat-interpolation >= 0.3
+                , optparse-applicative >= 0.13 && < 0.14
                 , path >= 0.5.7
                 , path-io >= 1.1.0 && < 2.0.0
                 , resourcet


### PR DESCRIPTION
Only enabling `--nix-pure` explicitly on the command line implies `--nix`.

### Rationale:

Users who prefer to use Nix (e.g. NixOS users) will have `--nix` enabled
globally in their `~/.stack/config.yaml`. On the other hand, users who
do not have nix installed will not have a `nix` section in their global
stack config.

When distributing scripts runnable by stack (`#!/usr/bin/env stack`),
they should be runnable independent from the user's Nix preference. In
order to run in a Nix environment, however, sometimes certain tweakings
have to be made to the Nix settings:
* Disabling a pure build because of missing locale (see also #2358)
* Adding packages like `ncurses` or `zlib` that are usually present
  in the user environment, but not in a pure nix-shell.

This was not possible before, since any of the `--nix-*` options, even
`--no-nix-pure`, would enable `--nix` as well, therefore breaking
portability for scripts on systems without Nix installed.

This change preserves the implication for `--nix-pure`, but removes it
for all other `--nix-*` options.

### ChangeLog & Documentation

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
    * Added documentation for the `--nix-pure` ⇒ `--nix` implication to the parser. The other implications were undocumented anyways.

### See also
Corresponding issue: #2825 