### PR TITLE
Switch to tarball backend as default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,15 @@ Major changes:
 
 Behavior changes:
 
+* The default package metadata backend has been changed from Git to
+  the 01-index.tar.gz file, from the hackage-security project. This is
+  intended to address some download speed issues from Github for
+  people in certain geographic regions. There is now full support for
+  checking out specific cabal file revisions from downloaded tarballs
+  as well. If you manually specify a package index with only a Git
+  URL, Git will still be used. See
+  [#2780](https://github.com/commercialhaskell/stack/issues/2780)
+
 Other enhancements:
 
 Bug fixes:

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -208,7 +208,7 @@ resolveBuildPlan mbp isShadowed packages
     | Map.null (rsUnknown rs) && Map.null (rsShadowed rs) = return (rsToInstall rs, rsUsedBy rs)
     | otherwise = do
         bconfig <- asks getBuildConfig
-        caches <- getPackageCaches
+        (caches, _gitShaCaches) <- getPackageCaches
         let maxVer =
                 Map.fromListWith max $
                 map toTuple $

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -237,7 +237,7 @@ configFromConfigMonoid configStackRoot configUserConfigPath mresolver mproject C
                 { indexName = IndexName "Hackage"
                 , indexLocation = ILGitHttp
                         "https://github.com/commercialhaskell/all-cabal-hashes.git"
-                        "https://s3.amazonaws.com/hackage.fpcomplete.com/00-index.tar.gz"
+                        "https://s3.amazonaws.com/hackage.fpcomplete.com/01-index.tar.gz"
                 , indexDownloadPrefix = "https://s3.amazonaws.com/hackage.fpcomplete.com/package/"
                 , indexGpgVerify = False
                 , indexRequireHashes = False

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -249,7 +249,7 @@ getCabalConfig dir constraintType constraints = do
     goIndex index = do
         src <- configPackageIndex $ indexName index
         let dstdir = dir FP.</> T.unpack (indexNameText $ indexName index)
-            dst = dstdir FP.</> "00-index.tar"
+            dst = dstdir FP.</> "01-index.tar"
         liftIO $ void $ tryIO $ do
             D.createDirectoryIfMissing True dstdir
             D.copyFile (toFilePath src) dst

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -455,7 +455,7 @@ instance Store MiniPackageInfo
 instance NFData MiniPackageInfo
 
 newtype GitSHA1 = GitSHA1 ByteString
-    deriving (Generic, Show, Eq, NFData, Store, Data, Typeable)
+    deriving (Generic, Show, Eq, NFData, Store, Data, Typeable, Ord, Hashable)
 
 newtype SnapshotHash = SnapshotHash { unShapshotHash :: ByteString }
     deriving (Generic, Show, Eq)

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -168,6 +168,7 @@ import           Data.Attoparsec.Args
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as S8
 import           Data.Either (partitionEithers)
+import           Data.HashMap.Strict (HashMap)
 import           Data.IORef (IORef)
 import           Data.List (stripPrefix)
 import           Data.List.NonEmpty (NonEmpty)
@@ -196,7 +197,7 @@ import qualified Options.Applicative as OA
 import qualified Options.Applicative.Types as OA
 import           Path
 import qualified Paths_stack as Meta
-import           Stack.Types.BuildPlan (MiniBuildPlan(..), SnapName, renderSnapName)
+import           Stack.Types.BuildPlan (GitSHA1, MiniBuildPlan(..), SnapName, renderSnapName)
 import           Stack.Types.Compiler
 import           Stack.Types.CompilerBuild
 import           Stack.Types.Docker
@@ -333,7 +334,8 @@ data Config =
          ,configAllowDifferentUser  :: !Bool
          -- ^ Allow users other than the stack root owner to use the stack
          -- installation.
-         ,configPackageCaches       :: !(IORef (Maybe (Map PackageIdentifier (PackageIndex, PackageCache))))
+         ,configPackageCaches       :: !(IORef (Maybe (Map PackageIdentifier (PackageIndex, PackageCache),
+                                                       HashMap GitSHA1 (PackageIndex, OffsetSize))))
          -- ^ In memory cache of hackage index.
          ,configDumpLogs            :: !DumpLogs
          -- ^ Dump logs of local non-dependencies when doing a build.
@@ -1207,17 +1209,17 @@ configPackageIndexRepo name = do
                     return $ Just $ suDir </> repoName
         _ -> assert False $ return Nothing
 
--- | Location of the 00-index.cache file
+-- | Location of the 01-index.cache file
 configPackageIndexCache :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> m (Path Abs File)
-configPackageIndexCache = liftM (</> $(mkRelFile "00-index.cache")) . configPackageIndexRoot
+configPackageIndexCache = liftM (</> $(mkRelFile "01-index.cache")) . configPackageIndexRoot
 
--- | Location of the 00-index.tar file
+-- | Location of the 01-index.tar file
 configPackageIndex :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> m (Path Abs File)
-configPackageIndex = liftM (</> $(mkRelFile "00-index.tar")) . configPackageIndexRoot
+configPackageIndex = liftM (</> $(mkRelFile "01-index.tar")) . configPackageIndexRoot
 
--- | Location of the 00-index.tar.gz file
+-- | Location of the 01-index.tar.gz file
 configPackageIndexGz :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> m (Path Abs File)
-configPackageIndexGz = liftM (</> $(mkRelFile "00-index.tar.gz")) . configPackageIndexRoot
+configPackageIndexGz = liftM (</> $(mkRelFile "01-index.tar.gz")) . configPackageIndexRoot
 
 -- | Location of a package tarball
 configPackageTarball :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> PackageIdentifier -> m (Path Abs File)

--- a/src/Stack/Types/PackageIndex.hs
+++ b/src/Stack/Types/PackageIndex.hs
@@ -10,6 +10,7 @@ module Stack.Types.PackageIndex
     ( PackageDownload (..)
     , PackageCache (..)
     , PackageCacheMap (..)
+    , OffsetSize (..)
     -- ** PackageIndex, IndexName & IndexLocation
     , PackageIndex(..)
     , IndexName(..)
@@ -23,6 +24,7 @@ import           Data.Aeson.Extended
 import           Data.ByteString (ByteString)
 import           Data.Hashable (Hashable)
 import           Data.Data (Data, Typeable)
+import           Data.HashMap.Strict (HashMap)
 import           Data.Int (Int64)
 import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
@@ -33,13 +35,11 @@ import           Data.Text.Encoding (encodeUtf8, decodeUtf8)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           Path
+import           Stack.Types.BuildPlan (GitSHA1)
 import           Stack.Types.PackageIdentifier
 
 data PackageCache = PackageCache
-    { pcOffset :: !Int64
-    -- ^ offset in bytes into the 00-index.tar file for the .cabal file contents
-    , pcSize :: !Int64
-    -- ^ size in bytes of the .cabal file
+    { pcOffsetSize :: {-# UNPACK #-}!OffsetSize
     , pcDownload :: !(Maybe PackageDownload)
     }
     deriving (Generic, Eq, Show, Data, Typeable)
@@ -47,8 +47,23 @@ data PackageCache = PackageCache
 instance Store PackageCache
 instance NFData PackageCache
 
-newtype PackageCacheMap = PackageCacheMap (Map PackageIdentifier PackageCache)
-    deriving (Generic, Store, NFData, Eq, Show, Data, Typeable)
+-- | offset in bytes into the 01-index.tar file for the .cabal file
+-- contents, and size in bytes of the .cabal file
+data OffsetSize = OffsetSize !Int64 !Int64
+    deriving (Generic, Eq, Show, Data, Typeable)
+
+instance Store OffsetSize
+instance NFData OffsetSize
+
+data PackageCacheMap = PackageCacheMap
+    { pcmIdent :: !(Map PackageIdentifier PackageCache)
+    -- ^ most recent revision of the package
+    , pcmSHA :: !(HashMap GitSHA1 OffsetSize)
+    -- ^ lookup via the GitSHA1 of the cabal file contents
+    }
+    deriving (Generic, Eq, Show, Data, Typeable)
+instance Store PackageCacheMap
+instance NFData PackageCacheMap
 
 data PackageDownload = PackageDownload
     { pdSHA512 :: !ByteString

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -209,7 +209,7 @@ sourceUpgrade gConfigMonoid mresolver builtHash (SourceOpts gitRepo) =
                 return $ Just $ tmp </> $(mkRelDir "stack")
       Nothing -> do
         updateAllIndices menv
-        caches <- getPackageCaches
+        (caches, _gitShaCaches) <- getPackageCaches
         let latest = Map.fromListWith max
                    $ map toTuple
                    $ Map.keys

--- a/src/test/Stack/StoreSpec.hs
+++ b/src/test/Stack/StoreSpec.hs
@@ -10,6 +10,8 @@ module Stack.StoreSpec where
 import           Control.Applicative
 import qualified Data.ByteString as BS
 import           Data.Containers (mapFromList, setFromList)
+import           Data.Hashable (Hashable)
+import           Data.HashMap.Strict (HashMap)
 import           Data.Int
 import           Data.Map (Map)
 import           Data.Sequences (fromList)
@@ -32,6 +34,9 @@ import           Test.SmallCheck.Series
 -- smallcheck.
 
 instance (Monad m, Serial m k, Serial m a, Ord k) => Serial m (Map k a) where
+    series = fmap mapFromList series
+
+instance (Monad m, Serial m k, Serial m a, Eq k, Hashable k) => Serial m (HashMap k a) where
     series = fmap mapFromList series
 
 instance Monad m => Serial m Text where

--- a/stack.cabal
+++ b/stack.cabal
@@ -348,6 +348,7 @@ test-suite stack-test
                 , exceptions
                 , filepath
                 , hspec >= 2.2 && <2.4
+                , hashable
                 , http-client-tls
                 , http-conduit
                 , monad-logger
@@ -366,6 +367,7 @@ test-suite stack-test
                 , bytestring
                 , store >= 0.2.1.0
                 , vector
+                , unordered-containers
                 , template-haskell
                 , yaml
   default-language:    Haskell2010


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

I tested in a clean project and confirmed that the cabal files were found by their Git SHA.

* [x] Tests do not currently build, the following error appears (thoughts @mgsloan?):

```
/Users/michael/Documents/stack/src/test/Stack/StoreSpec.hs:60:3:
    Expecting two more arguments to ‘unordered-containers-0.2.7.1:Data.HashMap.Base.Leaf’
    The second argument of ‘Serial’ should have kind ‘*’,
      but ‘unordered-containers-0.2.7.1:Data.HashMap.Base.Leaf’ has kind ‘*
                                                                          -> * -> *’
    In the instance declaration for
      ‘Serial m_aATT unordered-containers-0.2.7.1:Data.HashMap.Base.Leaf’
             
/Users/michael/Documents/stack/src/test/Stack/StoreSpec.hs:60:3:
    Expecting one more argument to ‘unordered-containers-0.2.7.1:Data.HashMap.Array.Array’
    The second argument of ‘Serial’ should have kind ‘*’,
      but ‘unordered-containers-0.2.7.1:Data.HashMap.Array.Array’ has kind ‘*
                                                                            -> *’
    In the instance declaration for
      ‘Serial m_aATS unordered-containers-0.2.7.1:Data.HashMap.Array.Array’
             
/Users/michael/Documents/stack/src/test/Stack/StoreSpec.hs:60:3:
    Expecting two more arguments to ‘unordered-containers-0.2.7.1:Data.HashMap.Base.HashMap’
    The second argument of ‘Serial’ should have kind ‘*’,
      but ‘unordered-containers-0.2.7.1:Data.HashMap.Base.HashMap’ has kind ‘*
                                                                             -> * -> *’
    In the instance declaration for
      ‘Serial m_aATR unordered-containers-0.2.7.1:Data.HashMap.Base.HashMap’
```

Adds support for getting specific cabal revisions from tarballs, which
was previously lacking.