### PR TITLE
Resolved #781: stack haddock displays index.html paths

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@ Other enhancements:
 * `stack build` and related commands now allow the user to disable debug symbol stripping
   with new `--no-strip`, `--no-library-stripping`, and `--no-executable-shipping` flags,
   closing [#877](https://github.com/commercialhaskell/stack/issues/877).
+* `stack haddock` now shows index.html paths when documentation is alread up to
+  date. Resolved [#781](https://github.com/commercialhaskell/stack/issues/781)
 
 Bug fixes:
 

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -228,18 +228,23 @@ generateHaddockIndex descr envOverride wc hdopts dumpPackages docRelFP destDir =
                     Left _ -> True
                     Right indexModTime ->
                         or [mt > indexModTime | (_,mt,_,_) <- interfaceOpts]
-        when needUpdate $ do
-            $logInfo
-                (T.concat ["Updating Haddock index for ", descr, " in\n",
-                           T.pack (toFilePath destIndexFile)])
-            liftIO (mapM_ copyPkgDocs interfaceOpts)
-            readProcessNull
-                (Just destDir)
-                envOverride
-                (haddockExeName wc)
-                (hoAdditionalArgs hdopts ++
-                 ["--gen-contents", "--gen-index"] ++
-                 [x | (xs,_,_,_) <- interfaceOpts, x <- xs])
+        if needUpdate
+            then do
+                $logInfo
+                    (T.concat ["Updating Haddock index for ", descr, " in\n",
+                               T.pack (toFilePath destIndexFile)])
+                liftIO (mapM_ copyPkgDocs interfaceOpts)
+                readProcessNull
+                    (Just destDir)
+                    envOverride
+                    (haddockExeName wc)
+                    (hoAdditionalArgs hdopts ++
+                     ["--gen-contents", "--gen-index"] ++
+                     [x | (xs,_,_,_) <- interfaceOpts, x <- xs])
+            else
+              $logInfo
+                    (T.concat ["Haddock index for ", descr, " already up to date at:\n",
+                               T.pack (toFilePath destIndexFile)])
   where
     toInterfaceOpt :: DumpPackage a b c -> IO (Maybe ([String], UTCTime, Path Abs File, Path Abs File))
     toInterfaceOpt DumpPackage {..} =


### PR DESCRIPTION
Fix for #781

* [x ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x ] The documentation has been updated, if necessary. (Not neccesary)

Change was tested by:
* Running stack haddock on a project with changed code:
Output as before
* Running stack haddock on a project twice
Outputs 
C:\shared\life>stack haddock
Haddock index for local packages already up to date at:
```
C:\shared\life\.stack-work\install\1bb99e24\doc\index.html
Haddock index for local packages and dependencies already up to date at:
C:\shared\life\.stack-work\install\1bb99e24\doc\all\index.html
Haddock index for snapshot packages already up to date at:
C:\stack\snapshots\e1c674d9\doc\index.html
```