### PR TITLE
Local extra-dep packages can be targets #2849

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,12 @@ Bug fixes:
   [#2852](https://github.com/commercialhaskell/stack/issues/2852).
 * `get-stack.sh` now installs correct binary on ARM for generic linux and raspbian,
   closing [#2856](https://github.com/commercialhaskell/stack/issues/2856).
+* Revert a change in the previous release which made it impossible to
+  set local extra-dep packages as targets. This was overkill; we
+  really only wanted to disable their test suites, which was already
+  handled by a later
+  patch. [#2849](https://github.com/commercialhaskell/stack/issues/2849)
+
 ## 1.3.0
 
 Release notes:

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -429,14 +429,6 @@ loadLocalPackage boptsCli targets (name, (lpv, gpkg)) = do
         , lpCabalFile = lpvCabalFP lpv
         , lpDir = lpvRoot lpv
         , lpWanted = isJust mtarget
-                  -- A local package marked as extra-dep should never
-                  -- be treated as a target. Perhaps we should be
-                  -- fixing this upstream of this function, not
-                  -- certain, but this works for now. If in the future
-                  -- we decide to move the extra-dep checking logic
-                  -- upstream, this lpvExtraDep check should be
-                  -- changed to an assertion.
-                  && not (lpvExtraDep lpv)
         , lpComponents = toComponents exes tests benches
         -- TODO: refactor this so that it's easier to be sure that these
         -- components are indeed unbuildable.


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Confirmed that the reported problem in #2849 is no longer present.

Pinging @wolftune and @mitchellwrosen for confirmation.