### PR TITLE
Fix createDatabase by checking for package.cache

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,10 @@ Bug fixes:
   [#2852](https://github.com/commercialhaskell/stack/issues/2852).
 * `get-stack.sh` now installs correct binary on ARM for generic linux and raspbian,
   closing [#2856](https://github.com/commercialhaskell/stack/issues/2856).
+* Correct the testing of whether a package database exists by checking
+  for the `package.cache` file itself instead of the containing
+  directory.
+
 ## 1.3.0
 
 Release notes:

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -34,7 +34,7 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import           Data.Text.Extra (stripCR)
-import           Path (Path, Abs, Dir, toFilePath, parent)
+import           Path (Path, Abs, Dir, toFilePath, parent, mkRelFile, (</>))
 import           Path.Extra (toFilePathNoTrailingSep)
 import           Path.IO
 import           Prelude hiding (FilePath)
@@ -87,7 +87,7 @@ ghcPkg menv wc pkgDbs args = do
 createDatabase :: (MonadIO m, MonadLogger m, MonadBaseControl IO m, MonadCatch m)
                => EnvOverride -> WhichCompiler -> Path Abs Dir -> m ()
 createDatabase menv wc db = do
-    exists <- doesDirExist db
+    exists <- doesFileExist (db </> $(mkRelFile "package.cache"))
     unless exists $ do
         -- Creating the parent doesn't seem necessary, as ghc-pkg
         -- seems to be sufficiently smart. But I don't feel like


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I manually deleted the `package.cache` file, confirmed that it previously broke Stack, and with this change Stack continues to work.