### PR TITLE
Cabal custom setup

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,7 +26,7 @@ Other enhancements:
 * `stack haddock` now shows index.html paths when documentation is alread up to
   date. Resolved [#781](https://github.com/commercialhaskell/stack/issues/781)
 * Respects the `custom-setup` field introduced in Cabal 1.24. This
-  supercedes any `explicit-setup-deps` setings in your `stack.yaml`
+  supercedes any `explicit-setup-deps` settings in your `stack.yaml`
   and trusts the package's `.cabal` file to explicitly state all its
   dependencies.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,10 @@ Other enhancements:
   closing [#877](https://github.com/commercialhaskell/stack/issues/877).
 * `stack haddock` now shows index.html paths when documentation is alread up to
   date. Resolved [#781](https://github.com/commercialhaskell/stack/issues/781)
+* Respects the `custom-setup` field introduced in Cabal 1.24. This
+  supercedes any `explicit-setup-deps` setings in your `stack.yaml`
+  and trusts the package's `.cabal` file to explicitly state all its
+  dependencies.
 
 Bug fixes:
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -563,6 +563,11 @@ explicit-setup-deps:
     entropy: false # override the new default for one package
 ```
 
+NOTE: since 1.4.0, Stack has support for Cabal's `custom-setup` block
+(introduced in Cabal 1.24). If a `custom-setup` block is provided in a `.cabal`
+file, it will override the setting of `explicit-setup-deps`, and instead rely
+on the stated dependencies.
+
 ### allow-newer
 
 (Since 0.1.7)

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -946,7 +946,7 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
                 getPackageArgs =
                     case (packageSetupDeps package, mdeps) of
                         -- The package is using the Cabal custom-setup
-                        -- configuraiton introduced in Cabal 1.24. In
+                        -- configuration introduced in Cabal 1.24. In
                         -- this case, the package is providing an
                         -- explicit list of dependencies, and we
                         -- should simply use all of them.

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -933,29 +933,58 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
                         ["-package=" ++ packageIdentifierString
                                             (PackageIdentifier cabalPackageName
                                                               eeCabalPkgVer)]
-                packageArgs =
-                    case mdeps of
+                packageDBArgs =
+                    ( "-clear-package-db"
+                    : "-global-package-db"
+                    : map (("-package-db=" ++) . toFilePathNoTrailingSep) (bcoExtraDBs eeBaseConfigOpts)
+                    ) ++
+                    ( ("-package-db=" ++ toFilePathNoTrailingSep (bcoSnapDB eeBaseConfigOpts))
+                    : ("-package-db=" ++ toFilePathNoTrailingSep (bcoLocalDB eeBaseConfigOpts))
+                    : ["-hide-all-packages"]
+                    )
+
+                getPackageArgs =
+                    case (packageSetupDeps package, mdeps) of
+                        -- The package is using the Cabal custom-setup
+                        -- configuraiton introduced in Cabal 1.24. In
+                        -- this case, the package is providing an
+                        -- explicit list of dependencies, and we
+                        -- should simply use all of them.
+                        (Just customSetupDeps, _) -> do
+                            allDeps <-
+                                case mdeps of
+                                    Just x -> return x
+                                    Nothing -> do
+                                        $logWarn "In getPackageArgs: custom-setup in use, but no dependency map present"
+                                        return Map.empty
+                            depsArgs <- forM (Map.toList customSetupDeps) $ \(name, range) -> do
+                                let matches (PackageIdentifier name' version) =
+                                        name == name' &&
+                                        version `withinRange` range
+                                case map snd (filter (matches . fst) (Map.toList allDeps)) of
+                                    x:xs -> do
+                                        unless (null xs)
+                                            ($logWarn (T.pack ("Found multiple installed packages for custom-setup dep: " ++ packageNameString name)))
+                                        return ("-package-id=" ++ ghcPkgIdString x)
+                                    [] -> do
+                                        $logWarn (T.pack ("Could not find custom-setup dep: " ++ packageNameString name))
+                                        return ("--package=" ++ packageNameString name)
+                            return (packageDBArgs ++ depsArgs)
+
                         -- This branch is taken when
                         -- 'explicit-setup-deps' is requested in your
                         -- stack.yaml file.
-                        Just deps | explicitSetupDeps (packageName package) config ->
+                        (Nothing, Just deps) | explicitSetupDeps (packageName package) config ->
                             -- Stack always builds with the global Cabal for various
                             -- reproducibility issues.
                             let depsMinusCabal
                                  = map ghcPkgIdString
                                  $ Set.toList
                                  $ addGlobalPackages deps (Map.elems eeGlobalDumpPkgs)
-                            in
-                                ( "-clear-package-db"
-                                : "-global-package-db"
-                                : map (("-package-db=" ++) . toFilePathNoTrailingSep) (bcoExtraDBs eeBaseConfigOpts)
-                                ) ++
-                                ( ("-package-db=" ++ toFilePathNoTrailingSep (bcoSnapDB eeBaseConfigOpts))
-                                : ("-package-db=" ++ toFilePathNoTrailingSep (bcoLocalDB eeBaseConfigOpts))
-                                : ["-hide-all-packages"]
-                                ) ++
+                            in return (
+                                packageDBArgs ++
                                 cabalPackageArg ++
-                                map ("-package-id=" ++) depsMinusCabal
+                                map ("-package-id=" ++) depsMinusCabal)
                         -- This branch is usually taken for builds, and
                         -- is always taken for `stack sdist`.
                         --
@@ -973,12 +1002,16 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
                         -- Currently, this branch is only taken via `stack
                         -- sdist` or when explicitly requested in the
                         -- stack.yaml file.
-                        _ ->
+                        (Nothing, _) -> return (
                               cabalPackageArg ++
+                            -- NOTE: This is different from
+                            -- packageDBArgs above inthat it does not
+                            -- include the local database and does not
+                            -- pass in the -hide-all-packages argument
                             ("-clear-package-db"
                             : "-global-package-db"
                             : map (("-package-db=" ++) . toFilePathNoTrailingSep) (bcoExtraDBs eeBaseConfigOpts)
-                           ++ ["-package-db=" ++ toFilePathNoTrailingSep (bcoSnapDB eeBaseConfigOpts)])
+                           ++ ["-package-db=" ++ toFilePathNoTrailingSep (bcoSnapDB eeBaseConfigOpts)]))
 
                 setupArgs = ("--builddir=" ++ toFilePathNoTrailingSep distRelativeDir') : args
                 runExe exeName fullArgs =
@@ -1027,6 +1060,7 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
                         case compiler of
                             Ghc -> getGhcPath
                             Ghcjs -> getGhcjsPath
+                    packageArgs <- getPackageArgs
                     runExe compilerPath $
                         [ "--make"
                         , "-odir", toFilePathNoTrailingSep setupDir

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -758,11 +758,7 @@ buildOtherSources build =
 
 -- | Get the target's JS sources.
 targetJsSources :: BuildInfo -> [FilePath]
-#if MIN_VERSION_Cabal(1, 22, 0)
 targetJsSources = jsSources
-#else
-targetJsSources = const []
-#endif
 
 -- | Get all dependencies of a package, including library,
 -- executables, tests, benchmarks.
@@ -868,11 +864,7 @@ resolveConditions rc addDeps (CondNode lib deps cs) = basic <> children
                       case (flavor, rcCompilerVersion rc) of
                         (GHC, GhcVersion vghc) -> vghc `withinRange` range
                         (GHC, GhcjsVersion _ vghc) -> vghc `withinRange` range
-#if MIN_VERSION_Cabal(1, 22, 0)
                         (GHCJS, GhcjsVersion vghcjs _) ->
-#else
-                        (OtherCompiler "ghcjs", GhcjsVersion vghcjs _) ->
-#endif
                           vghcjs `withinRange` range
                         _ -> False
 

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -244,6 +244,7 @@ packageFromPackageDescription packageConfig gpkg pkg =
           (not . null . exposedModules)
           (library pkg)
     , packageSimpleType = buildType pkg == Just Simple
+    , packageSetupDeps = msetupDeps
     }
   where
     pkgFiles = GetPackageFiles $
@@ -271,7 +272,17 @@ packageFromPackageDescription packageConfig gpkg pkg =
              return (componentModules, componentFiles, buildFiles <> dataFiles', warnings)
     pkgId = package pkg
     name = fromCabalPackageName (pkgName pkgId)
-    deps = M.filterWithKey (const . (/= name)) (packageDependencies pkg)
+    deps = M.filterWithKey (const . (/= name)) (M.union
+        (packageDependencies pkg)
+        -- We include all custom-setup deps - if present - in the
+        -- package deps themselves. Stack always works with the
+        -- invariant that there will be a single installed package
+        -- relating to a package name, and this applies at the setup
+        -- dependency level as well.
+        (fromMaybe M.empty msetupDeps))
+    msetupDeps = fmap
+        (M.fromList . map (depName &&& depRange) . setupDepends)
+        (setupBuildInfo pkg)
 
 -- | Generate GHC options for the package's components, and a list of
 -- options which apply generally to the package, not one specific

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -102,6 +102,8 @@ data Package =
           ,packageOpts :: !GetPackageOpts                 -- ^ Args to pass to GHC.
           ,packageHasExposedModules :: !Bool              -- ^ Does the package have exposed modules?
           ,packageSimpleType :: !Bool                     -- ^ Does the package of build-type: Simple
+          ,packageSetupDeps :: !(Maybe (Map PackageName VersionRange))
+                                                          -- ^ If present: custom-setup dependencies
           }
  deriving (Show,Typeable)
 

--- a/src/test/Stack/GhciSpec.hs
+++ b/src/test/Stack/GhciSpec.hs
@@ -221,6 +221,7 @@ packages_singlePackage =
       , packageOpts = GetPackageOpts undefined
       , packageHasExposedModules = True
       , packageSimpleType = True
+      , packageSetupDeps = Nothing
       }
     }
   ]
@@ -255,6 +256,7 @@ packages_multiplePackages =
       , packageOpts = GetPackageOpts undefined
       , packageHasExposedModules = True
       , packageSimpleType = True
+      , packageSetupDeps = Nothing
       }
     }
   , GhciPkgInfo
@@ -285,6 +287,7 @@ packages_multiplePackages =
       , packageOpts = GetPackageOpts undefined
       , packageHasExposedModules = True
       , packageSimpleType = True
+      , packageSetupDeps = Nothing
       }
     }
   ]

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -29,7 +29,7 @@ extra-deps:
 # For deepseq-1.4
 - deepseq-1.4.1.2
 - bytestring-0.10.6.0
-- Cabal-1.18.1.6
+- Cabal-1.24.2.0
 - containers-0.5.6.3
 - hpc-0.6.0.2
 - process-1.2.1.0

--- a/stack.cabal
+++ b/stack.cabal
@@ -176,7 +176,7 @@ library
                      System.Process.PagerEditor
                      System.Process.Read
                      System.Process.Run
-  build-depends:     Cabal >= 1.18.1.5 && < 1.25
+  build-depends:     Cabal >= 1.24 && < 1.25
                    , aeson (>= 1.0 && < 1.1)
                    , ansi-terminal >= 0.6.2.3
                    , async >= 2.0.2 && < 2.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,6 +12,7 @@ nix:
   packages:
     - zlib
 extra-deps:
+- Cabal-1.24.2.0
 - th-utilities-0.2.0.1
 - store-0.3
 - store-core-0.3


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I'm still testing this in a more complex use case. However, the simple test case I devised was:

* `stack new foo`
* Modify the `Setup.hs` file to add `import Acme.Missiles`
* Add `acme-missiles-0.3` as an extra-dep
*   Add the following `custom-setup` block to `foo.cabal`:

    ```
    custom-setup
      setup-depends: base >= 4.6,
                     Cabal >= 1.24 && < 1.25,
                     acme-missiles
    ```
* Set `build-type` to `Custom`
* Confirm that without the patch, the package refuses to compile. With the patch, it compiles just fine.

@borsboom Maybe we can sync up later on adding this as an integration test case?