### PR TITLE
stack new always uses UTF-8 encoding

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,6 +38,9 @@ Bug fixes:
   really only wanted to disable their test suites, which was already
   handled by a later
   patch. [#2849](https://github.com/commercialhaskell/stack/issues/2849)
+* `stack new` always treats templates as being UTF-8 encoding,
+  ignoring locale settings on a local machine. See
+  [Yesod mailing list discussion](https://groups.google.com/d/msg/yesodweb/ZyWLsJOtY0c/aejf9E7rCAAJ)
 
 ## 1.3.0
 

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -25,6 +25,7 @@ import           Control.Monad.Logger
 import           Control.Monad.Trans.Writer.Strict
 import           Data.Aeson
 import           Data.Aeson.Types
+import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
 import           Data.Conduit
 import           Data.Foldable (asum)
@@ -40,6 +41,7 @@ import qualified Data.Set as S
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified Data.Text.Encoding.Error as T (lenientDecode)
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as LT
 import           Data.Time.Calendar
@@ -156,7 +158,7 @@ loadTemplate name logIt = do
                                                 <> "\"")
         exists <- doesFileExist path
         if exists
-            then liftIO (T.readFile (toFilePath path))
+            then liftIO (fmap (T.decodeUtf8With T.lenientDecode) (SB.readFile (toFilePath path)))
             else throwM (FailedToLoadTemplate name (toFilePath path))
     relRequest :: MonadThrow n => Path Rel File -> n Request
     relRequest rel = parseRequest (defaultTemplateUrl <> "/" <> toFilePath rel)


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Basic sanity checking of using `stack new`, which worked. I'd like to have the user who reported the original problem confirm that this fixes it.