### PR TITLE
Clarify documentation for `i.c.entrypoints`

### DIFF
--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -224,6 +224,29 @@ You can also specify `entrypoints`. By default all your executables are placed
 in `/usr/local/bin`, but you can specify a list using `executables` to only add
 some.
 
+When you specify `entrypoints`, multiple containers will be built:  a project
+container, and one container for each entrypoint.
+
+For example the following configuration:
+
+```yaml
+image:
+  containers:
+  - name: myproject
+    base: fpco/stack-run
+    add:
+      production/app-backend/conf/: /etc/app-backend
+    entrypoints:
+    - app-backend
+```
+
+will build one container tagged `myproject:latest` which contains the project 
+including the `/etc/app-backend` configuration data.
+
+Another container tagged `myproject-app-backend:latest` based on the `myproject:latest`
+will additionally contain the logic for starting the `app-backend` entrypoint.
+
+
 ### user-message
 
 A user-message is inserted by `stack init` when it omits packages or adds


### PR DESCRIPTION
Document how the `entrypoints` work wrt which docker images are created.

Fixes #2832

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
