### PR TITLE
Copy 01-index.tar to 00-index.tar

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,13 @@ Behavior changes:
   URL, Git will still be used. See
   [#2780](https://github.com/commercialhaskell/stack/issues/2780)
 
+  For backwards compatibility with tools relying on the presence of a
+  `00-index.tar`, Stack will copy the `01-index.tar` file to
+  `00-index.tar`. Note, however, that these files are different; most
+  importantly, 00-index contains only the newest revisions of cabal
+  files, while 01-index contains all versions. You may still need to
+  update your tooling.
+
 Other enhancements:
 
 * Internal cleanup: configuration types are now based much more on lenses

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -91,6 +91,7 @@ module Stack.Types.Config
   ,IndexLocation(..)
   -- Config fields
   ,configPackageIndex
+  ,configPackageIndexOld
   ,configPackageIndexCache
   ,configPackageIndexGz
   ,configPackageIndexRoot
@@ -1194,6 +1195,12 @@ configPackageIndexCache = liftM (</> $(mkRelFile "01-index.cache")) . configPack
 -- | Location of the 01-index.tar file
 configPackageIndex :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> m (Path Abs File)
 configPackageIndex = liftM (</> $(mkRelFile "01-index.tar")) . configPackageIndexRoot
+
+-- | Location of the 00-index.tar file. This file is just a copy of
+-- the 01-index.tar file, provided for tools which still look for the
+-- 00-index.tar file.
+configPackageIndexOld :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> m (Path Abs File)
+configPackageIndexOld = liftM (</> $(mkRelFile "00-index.tar")) . configPackageIndexRoot
 
 -- | Location of the 01-index.tar.gz file
 configPackageIndexGz :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> m (Path Abs File)


### PR DESCRIPTION
This is done for backwards compatibility with any external tools relying
on the presence of a 00-index.tar file.