### PR TITLE
Mention apt-get update for Ubuntu

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,8 +30,9 @@ Other enhancements:
   supercedes any `explicit-setup-deps` settings in your `stack.yaml`
   and trusts the package's `.cabal` file to explicitly state all its
   dependencies.
-* If system package installation fails, `stack` won't be installed. Also shows a
-  warning suggesting to run `apt-get update` or similar, depending on the OS.
+* If system package installation fails, `get-stack.sh` will fail as well. Also
+  shows warning suggesting to run `apt-get update` or similar, depending on the
+  OS.
   ([#2898](https://github.com/commercialhaskell/stack/issues/2898))
 
 Bug fixes:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,12 +24,15 @@ Other enhancements:
   with new `--no-strip`, `--no-library-stripping`, and `--no-executable-shipping` flags,
   closing [#877](https://github.com/commercialhaskell/stack/issues/877). 
   Also turned error message for missing targets more readable ([#2384](https://github.com/commercialhaskell/stack/issues/2384))
-* `stack haddock` now shows index.html paths when documentation is alread up to
+* `stack haddock` now shows index.html paths when documentation is already up to
   date. Resolved [#781](https://github.com/commercialhaskell/stack/issues/781)
 * Respects the `custom-setup` field introduced in Cabal 1.24. This
   supercedes any `explicit-setup-deps` settings in your `stack.yaml`
   and trusts the package's `.cabal` file to explicitly state all its
   dependencies.
+* If system package installation fails, `stack` won't be installed. Also shows a
+  warning suggesting to run `apt-get update` or similar, depending on the OS.
+  ([#2898](https://github.com/commercialhaskell/stack/issues/2898))
 
 Bug fixes:
 

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -156,7 +156,9 @@ do_ubuntu_install() {
 do_debian_install() {
 
   install_dependencies() {
-    apt_install_dependencies g++ gcc libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev
+    if ! apt_install_dependencies g++ gcc libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev; then
+      die "Dependencies could not be installed. Please run 'apt-get update' and try again."
+    fi
   }
 
   if is_arm ; then
@@ -180,7 +182,9 @@ do_debian_install() {
 # and install the necessary dependencies explicitly.
 do_fedora_install() {
   install_dependencies() {
-    dnf_install_pkgs perl make automake gcc gmp-devel libffi zlib xz tar
+    if ! dnf_install_pkgs perl make automake gcc gmp-devel libffi zlib xz tar; then
+      die "Dependencies could not be installed. Please run 'dnf check-update' and try again."
+    fi
   }
 
   if is_64_bit ; then
@@ -200,7 +204,9 @@ do_fedora_install() {
 # and install the necessary dependencies explicitly.
 do_centos_install() {
   install_dependencies() {
-    yum_install_pkgs perl make automake gcc gmp-devel libffi zlib xz tar
+    if ! yum_install_pkgs perl make automake gcc gmp-devel libffi zlib xz tar; then
+      die "Dependencies could not be installed. Please run 'yum check-update' and try again."
+    fi
   }
 
   if is_64_bit ; then
@@ -238,7 +244,9 @@ do_osx_install() {
 # 'pkg install' and then downloads bindist.
 do_freebsd_install() {
   install_dependencies() {
-    sudocmd pkg install -y devel/gmake perl5 lang/gcc misc/compat8x misc/compat9x converters/libiconv ca_root_nss
+    if ! sudocmd pkg install -y devel/gmake perl5 lang/gcc misc/compat8x misc/compat9x converters/libiconv ca_root_nss; then
+      die "Dependencies could not be installed. Please run 'pkg update' and try again."
+    fi
   }
   if is_64_bit ; then
     install_dependencies
@@ -251,7 +259,9 @@ do_freebsd_install() {
 # Alpine distro install
 do_alpine_install() {
   install_dependencies() {
-    apk_install_pkgs gmp libgcc xz make
+    if ! apk_install_pkgs gmp libgcc xz make; then
+      die "Dependencies could not be installed. Please run 'apk update' and try again."
+    fi
   }
   install_dependencies
   if is_64_bit ; then

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -128,7 +128,9 @@ apt_install_dependencies() {
 do_ubuntu_install() {
 
   install_dependencies() {
-    apt_install_dependencies g++ gcc libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev git gnupg
+    if ! apt_install_dependencies g++ gcc libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev git gnupg; then
+      die "Dependencies could not be installed. Please run 'apt-get update' and try again."
+    fi
   }
 
   if is_arm ; then


### PR DESCRIPTION
#2898 

If system package installation fails, stack should not be installed.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I've tried running a new Ubuntu 16.04 EC2 instance, it behaves as expected: fails at first, after `apt-get update` installs stack properly.