### PR TITLE
Upgrade to hpack 0.16.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,6 +37,9 @@ Other enhancements:
 
 Bug fixes:
 
+* Bump to hpack 0.16.0 to avoid character encoding issues when reading and
+  writing on non-UTF8 systems.
+
 ## 1.3.2
 
 Bug fixes:

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -35,7 +35,7 @@ extra-deps:
 - process-1.2.1.0
 - time-1.5.0.1
 - base-compat-0.9.1
-- hpack-0.15.0
+- hpack-0.16.0
 - microlens-0.4.1.0
 - microlens-mtl-0.1.10.0
 - open-browser-0.2.1.0

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -16,5 +16,5 @@ extra-deps:
 - pid1-0.1.0.0
 - store-0.3
 - store-core-0.3
-- hpack-0.15.0
+- hpack-0.16.0
 - aeson-1.0.2.1

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -8,3 +8,5 @@ nix:
   enable: false
   packages:
     - zlib
+extra-deps:
+- hpack-0.16.0

--- a/stack.cabal
+++ b/stack.cabal
@@ -263,7 +263,7 @@ library
                    , hastache
                    , project-template >= 0.2
                    , zip-archive < 0.4
-                   , hpack >= 0.14.0 && < 0.16
+                   , hpack >= 0.16.0 && < 0.17
                    , store >= 0.2.1.0
                    , annotated-wl-pprint
                    , file-embed >= 0.0.10
@@ -291,7 +291,7 @@ executable stack
                 , either
                 , filelock >= 0.1.0.1
                 , filepath >= 1.3.0.2
-                , hpack >= 0.14.0 && < 0.16
+                , hpack >= 0.16.0 && < 0.17
                 , http-client >= 0.5.3.3
                   -- https://github.com/basvandijk/lifted-base/issues/31
                 , lifted-base < 0.2.3.7 || > 0.2.3.7

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,7 +24,7 @@ extra-deps:
 - text-metrics-0.1.0
 - pid1-0.1.0.0
 - aeson-1.0.2.1
-- hpack-0.15.0
+- hpack-0.16.0
 - persistent-2.6
 - persistent-template-2.5.1.6
 - persistent-sqlite-2.6


### PR DESCRIPTION
See:

https://github.com/sol/hpack/pull/142
https://github.com/sol/hpack/pull/143

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
