### PR TITLE
Update on missing SHA

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,17 @@ Behavior changes:
   as well. If you manually specify a package index with only a Git
   URL, Git will still be used. See
   [#2780](https://github.com/commercialhaskell/stack/issues/2780)
+* When you provide the `--resolver` argument to the `stack unpack`
+  command, any packages passed in by name only will be looked up in
+  the given snapshot instead of taking the latest version. For
+  example, `stack --resolver lts-7.14 unpack mtl` will get version
+  2.2.1 of `mtl`, regardless of the latest version available in the
+  package indices. This will also force the same cabal file revision
+  to be used as is specified in the snapshot.
+
+  Unpacking via a package identifier (e.g. `stack --resolver lts-7.14
+  unpack mtl-2.2.1`) will ignore any settings in the snapshot and take
+  the most recent revision.
 
 Other enhancements:
 

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -285,7 +285,7 @@ addDeps allowMissing compilerVersion toCalc = do
         if allowMissing
             then do
                 (missingNames, missingIdents, m) <-
-                    resolvePackagesAllowMissing Nothing shaMap Set.empty
+                    resolvePackagesAllowMissing menv Nothing shaMap Set.empty
                 assert (Set.null missingNames)
                     $ return (m, missingIdents)
             else do

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -285,11 +285,11 @@ addDeps allowMissing compilerVersion toCalc = do
         if allowMissing
             then do
                 (missingNames, missingIdents, m) <-
-                    resolvePackagesAllowMissing shaMap Set.empty
+                    resolvePackagesAllowMissing Nothing shaMap Set.empty
                 assert (Set.null missingNames)
                     $ return (m, missingIdents)
             else do
-                m <- resolvePackages menv shaMap Set.empty
+                m <- resolvePackages menv Nothing shaMap Set.empty
                 return (m, Set.empty)
     let byIndex = Map.fromListWith (++) $ flip map (Map.toList resolvedMap)
             $ \(ident, rp) ->

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -323,8 +323,9 @@ withCabalFiles name pkgs f = do
                 $logWarn $ mconcat
                     [ "Did not find .cabal file for "
                     , T.pack $ packageIdentifierString ident
-                    , " with Git SHA of "
+                    , " with SHA of "
                     , decodeUtf8 sha
+                    , " in the Git repository"
                     ]
                 $logDebug (T.pack (show e))
                 goPkg h Nothing (ident, pc, Nothing, tf)
@@ -337,7 +338,7 @@ withCabalFiles name pkgs f = do
             Just (GitSHA1 sha) -> $logWarn $ mconcat
                 [ "Did not find .cabal file for "
                 , T.pack $ packageIdentifierString ident
-                , " with Git SHA of "
+                , " with SHA of "
                 , decodeUtf8 sha
                 , " in tarball-based cache"
                 ]

--- a/src/Stack/Hoogle.hs
+++ b/src/Stack/Hoogle.hs
@@ -100,6 +100,17 @@ hoogleCmd (args,setup,rebuild) go = withBuildConfig go pathToHaddocks
         hooglePackageIdentifier <-
             do (_,_,resolved) <-
                    resolvePackagesAllowMissing
+
+                       -- FIXME this Nothing means "do not follow any
+                       -- specific snapshot", which matches old
+                       -- behavior. However, since introducing the
+                       -- logic to pin a name to a package in a
+                       -- snapshot, we may arguably want to ensure
+                       -- that we're grabbing the version of Hoogle
+                       -- present in the snapshot currently being
+                       -- used.
+                       Nothing
+
                        mempty
                        (Set.fromList [hooglePackageName])
                return

--- a/src/Stack/Hoogle.hs
+++ b/src/Stack/Hoogle.hs
@@ -98,8 +98,10 @@ hoogleCmd (args,setup,rebuild) go = withBuildConfig go pathToHaddocks
             hoogleMinIdent =
                 PackageIdentifier hooglePackageName hoogleMinVersion
         hooglePackageIdentifier <-
-            do (_,_,resolved) <-
+            do menv <- getMinimalEnvOverride
+               (_,_,resolved) <-
                    resolvePackagesAllowMissing
+                       menv
 
                        -- FIXME this Nothing means "do not follow any
                        -- specific snapshot", which matches old

--- a/src/Stack/PackageIndex.hs
+++ b/src/Stack/PackageIndex.hs
@@ -222,11 +222,10 @@ updateIndex menv index =
   do let name = indexName index
          logUpdate mirror = $logSticky $ "Updating package index " <> indexNameText (indexName index) <> " (mirrored at " <> mirror  <> ") ..."
      git <- isGitInstalled menv
-     case (git, indexLocation index) of
-        (True, ILGit url) -> logUpdate url >> updateIndexGit menv name index url
-        (False, ILGit url) -> logUpdate url >> throwM (GitNotAvailable name)
-        (_, ILGitHttp _ url) -> logUpdate url >> updateIndexHTTP name index url
-        (_, ILHttp url) -> logUpdate url >> updateIndexHTTP name index url
+     case (git, simplifyIndexLocation $ indexLocation index) of
+        (True, SILGit url) -> logUpdate url >> updateIndexGit menv name index url
+        (False, SILGit url) -> logUpdate url >> throwM (GitNotAvailable name)
+        (_, SILHttp url) -> logUpdate url >> updateIndexHTTP name index url
 
 -- | Update the index Git repo and the index tarball
 updateIndexGit :: (StackMiniM env m, HasConfig env)

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -641,7 +641,7 @@ upgradeCabal :: (StackM env m, HasConfig env, HasGHCVariant env)
              -> m ()
 upgradeCabal menv wc = do
     let name = $(mkPackageName "Cabal")
-    rmap <- resolvePackages menv Map.empty (Set.singleton name)
+    rmap <- resolvePackages menv Nothing Map.empty (Set.singleton name)
     newest <-
         case Map.keys rmap of
             [] -> error "No Cabal library found in index, cannot upgrade"

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1172,12 +1172,9 @@ configPackageIndexRepo name = do
     case filter (\p -> indexName p == name) indices of
         [index] -> do
             let murl =
-                    case indexLocation index of
-                        ILGit x -> Just x
-                        ILHttp _ -> Nothing
-                        -- See logic in updateIndex, which prefers
-                        -- HTTP to Git in this case
-                        ILGitHttp _ _ -> Nothing
+                    case simplifyIndexLocation $ indexLocation index of
+                        SILGit x -> Just x
+                        SILHttp _ -> Nothing
             case murl of
                 Nothing -> return Nothing
                 Just url -> do

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1175,7 +1175,9 @@ configPackageIndexRepo name = do
                     case indexLocation index of
                         ILGit x -> Just x
                         ILHttp _ -> Nothing
-                        ILGitHttp x _ -> Just x
+                        -- See logic in updateIndex, which prefers
+                        -- HTTP to Git in this case
+                        ILGitHttp _ _ -> Nothing
             case murl of
                 Nothing -> return Nothing
                 Just url -> do

--- a/src/Stack/Types/PackageIndex.hs
+++ b/src/Stack/Types/PackageIndex.hs
@@ -16,6 +16,8 @@ module Stack.Types.PackageIndex
     , IndexName(..)
     , indexNameText
     , IndexLocation(..)
+    , SimplifiedIndexLocation (..)
+    , simplifyIndexLocation
     ) where
 
 import           Control.DeepSeq (NFData)
@@ -108,6 +110,15 @@ instance FromJSON IndexName where
 data IndexLocation = ILGit !Text | ILHttp !Text | ILGitHttp !Text !Text
     deriving (Show, Eq, Ord)
 
+-- | Simplified 'IndexLocation', which will either be a Git repo or HTTP URL.
+data SimplifiedIndexLocation = SILGit !Text | SILHttp !Text
+    deriving (Show, Eq, Ord)
+
+simplifyIndexLocation :: IndexLocation -> SimplifiedIndexLocation
+simplifyIndexLocation (ILGit t) = SILGit t
+simplifyIndexLocation (ILHttp t) = SILHttp t
+-- Prefer HTTP over Git
+simplifyIndexLocation (ILGitHttp _ t) = SILHttp t
 
 -- | Information on a single package index
 data PackageIndex = PackageIndex


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

OK, this is a bit involved. Ignoring cabal file revisions for a moment, consider you run `stack build` in a project using lts-7.15, and the project uses `foldl-1.2.2`. Suppose you had last updated your package index when foldl-1.2.2 wasn't available. Stack will automatically update your index before trying to build so that it can get the .cabal file for foldl-1.2.2.

Now consider a similar situation: your project uses yesod-core, which for nightly-2017-01-10 is version 1.4.30, with cabal file revision #1. If your index is missing that revision, previously you would get an error message about a missing revision. With this patch, you'll instead get the behavior that the index will automatically update.

In addition, there are commits here to improve the error messages delivered (to indicate whether the lookup occurred in a Git repo or in the tarball), and to standardize logic around choosing Git vs HTTP index methods.

## Testing

In order to test, I first created a `00-index.tar` file with the most recent content (by running `stack update`), and then pruned all recent .cabal files (including the first revision of yesod-core-1.4.30) with the following program run from `~/.stack/indices/Hackage`:

```haskell
#!/usr/bin/env stack
{- stack --resolver lts-7.14 --install-ghc runghc
    --package tar
    --package classy-prelude-conduit
-}
{-# LANGUAGE NoImplicitPrelude, OverloadedStrings #-}
import ClassyPrelude.Conduit
import qualified Codec.Archive.Tar as Tar
import qualified Codec.Archive.Tar.Entry as Tar
import Codec.Compression.GZip (decompress)
import System.Directory

main :: IO ()
main = do
    void $ tryIO $ removeFile "01-index.cache"
    void $ tryIO $ removeFile "01-index.tar"
    lbs <- readFile "01-index.tar.gz"
    let entries = Tar.read $ decompress lbs
    writeFile "01-index.tar" $ Tar.write $ go entries
  where
    go (Tar.Next e es)
        | toKeep e = e : go es
        | otherwise = go es
    go Tar.Done = []
    go (Tar.Fail e) = impureThrow e

    toKeep e = Tar.entryTime e < 1483747200
```

Then, I ran the following:

```
$ rm -rf yesod-core-1.4.30/ && stack --resolver nightly-2017-01-10 unpack yesod-core
```

Before this change: I would get an error message about a missing Git SHA. After this change, I get the following:

```
$ rm -rf yesod-core-1.4.30/ && stack --resolver nightly-2017-01-10 unpack yesod-core
Missing some cabal revision files, updating indices
Downloading package index from https://s3.amazonaws.com/hackage.fpcomplete.com/01-index.tar.gz                  
Populated index cache.                                                                                          
Unpacked yesod-core-1.4.30 to /Users/michael/Desktop/yesod-core-1.4.30/
```

I also confirmed that the output yesod-core-1.4.30/yesod-core.cabal file contains:

```
x-revision: 1
```