### PR TITLE
for 'stack ghci', don't omit hsSourceDirs that have '..' in them. #2895

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,7 @@ Bug fixes:
 
 * Bump to hpack 0.16.0 to avoid character encoding issues when reading and
   writing on non-UTF8 systems.
+* `stack ghci` will no longer ignore hsSourceDirs that contain `..`. ([#2895](https://github.com/commercialhaskell/stack/issues/2895))
 
 ## 1.3.2
 

--- a/src/Path/Extra.hs
+++ b/src/Path/Extra.hs
@@ -44,7 +44,7 @@ parseCollapsedAbsDir = parseAbsDir . collapseFilePath
 parseCollapsedAbsFile :: MonadThrow m => FilePath -> m (Path Abs File)
 parseCollapsedAbsFile = parseAbsFile . collapseFilePath
 
--- | Combine a 'Path Abs Dir' and a relative 'FilePath' into a 'Path Abs Dir'
+-- | Add a relative FilePath to the end of a Path
 -- We can't parse the FilePath first because we need to account for ".."
 -- in the FilePath (#2895)
 concatAndColapseAbsDir :: MonadThrow m => Path Abs Dir -> FilePath -> m (Path Abs Dir)

--- a/src/Path/Extra.hs
+++ b/src/Path/Extra.hs
@@ -7,6 +7,7 @@ module Path.Extra
   ,dropRoot
   ,parseCollapsedAbsDir
   ,parseCollapsedAbsFile
+  ,concatAndColapseAbsDir
   ,rejectMissingFile
   ,rejectMissingDir
   ,pathToByteString
@@ -42,6 +43,12 @@ parseCollapsedAbsDir = parseAbsDir . collapseFilePath
 -- (probably should be moved to the Path module)
 parseCollapsedAbsFile :: MonadThrow m => FilePath -> m (Path Abs File)
 parseCollapsedAbsFile = parseAbsFile . collapseFilePath
+
+-- | Combine a 'Path Abs Dir' and a relative 'FilePath' into a 'Path Abs Dir'
+-- We can't parse the FilePath first because we need to account for ".."
+-- in the FilePath (#2895)
+concatAndColapseAbsDir :: MonadThrow m => Path Abs Dir -> FilePath -> m (Path Abs Dir)
+concatAndColapseAbsDir base rel = parseCollapsedAbsDir (toFilePath base FP.</> rel)
 
 -- | Collapse intermediate "." and ".." directories from a path.
 --

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -420,7 +420,7 @@ generateBuildInfoOpts BioInput {..} =
              | Just makeGenDir <- [fileGenDirFromComponentName biComponentName]]) ++
         ["-stubdir=" ++ toFilePathNoTrailingSep (buildDir biDistDir)]
     toIncludeDir "." = Just biCabalDir
-    toIncludeDir x = fmap (biCabalDir </>) (parseRelDir x)
+    toIncludeDir relDir = concatAndColapseAbsDir biCabalDir relDir
     includeOpts =
         map ("-I" <>) (configExtraIncludeDirs <> pkgIncludeOpts)
     configExtraIncludeDirs =


### PR DESCRIPTION
* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [NA] The documentation has been updated, if necessary.

Tested using [this test repo](https://github.com/tallen-imvu/stack-ghci-i)
With these code changes, all three examples can correctly load in `stack ghci`
