### PR TITLE
Use hackage security

### DIFF
--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -321,6 +321,11 @@ package-indices:
   # optional fields, both default to false
   gpg-verify: false
   require-hashes: false
+
+  # Starting with stack 1.4, we default to using Hackage Security
+  hackage-security:
+    keyids: ["deadbeef", "12345"] # list of all approved keys
+    key-threshold: 3 # number of keys required
 ```
 
 One thing you should be aware of: if you change the contents of package-version

--- a/src/Hackage/Security/Client/Repository/HttpLib/HttpClient.hs
+++ b/src/Hackage/Security/Client/Repository/HttpLib/HttpClient.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- Taken from
+-- https://github.com/well-typed/hackage-security/tree/master/hackage-security-http-client
+-- to avoid extra dependencies
+module Hackage.Security.Client.Repository.HttpLib.HttpClient (
+    withClient
+  , makeHttpLib
+    -- ** Re-exports
+  , Manager -- opaque
+  ) where
+
+import Control.Exception
+import Control.Monad (void)
+import Data.ByteString (ByteString)
+import Network.URI
+import Network.HTTP.Client (Manager)
+import qualified Data.ByteString              as BS
+import qualified Data.ByteString.Char8        as BS.C8
+import qualified Network.HTTP.Client          as HttpClient
+import qualified Network.HTTP.Client.Internal as HttpClient
+import qualified Network.HTTP.Types           as HttpClient
+
+import Hackage.Security.Client hiding (Header)
+import Hackage.Security.Client.Repository.HttpLib
+import Hackage.Security.Util.Checked
+import qualified Hackage.Security.Util.Lens as Lens
+
+{-------------------------------------------------------------------------------
+  Top-level API
+-------------------------------------------------------------------------------}
+
+-- | Initialization
+--
+-- The proxy must be specified at initialization because @http-client@ does not
+-- allow to change the proxy once the 'Manager' is created.
+withClient :: ProxyConfig HttpClient.Proxy -> (Manager -> HttpLib -> IO a) -> IO a
+withClient proxyConfig callback = do
+    manager <- HttpClient.newManager (setProxy HttpClient.defaultManagerSettings)
+    callback manager $ makeHttpLib manager
+  where
+    setProxy = HttpClient.managerSetProxy $
+      case proxyConfig of
+        ProxyConfigNone  -> HttpClient.noProxy
+        ProxyConfigUse p -> HttpClient.useProxy p
+        ProxyConfigAuto  -> HttpClient.proxyEnvironment Nothing
+
+-- | Create an 'HttpLib' value from a preexisting 'Manager'.
+makeHttpLib :: Manager -> HttpLib
+makeHttpLib manager = HttpLib
+    { httpGet      = get      manager
+    , httpGetRange = getRange manager
+    }
+
+{-------------------------------------------------------------------------------
+  Individual methods
+-------------------------------------------------------------------------------}
+
+get :: Throws SomeRemoteError
+    => Manager
+    -> [HttpRequestHeader] -> URI
+    -> ([HttpResponseHeader] -> BodyReader -> IO a)
+    -> IO a
+get manager reqHeaders uri callback = wrapCustomEx $ do
+    -- TODO: setUri fails under certain circumstances; in particular, when
+    -- the URI contains URL auth. Not sure if this is a concern.
+    request' <- HttpClient.setUri HttpClient.defaultRequest uri
+    let request = setRequestHeaders reqHeaders request'
+    checkHttpException $ HttpClient.withResponse request manager $ \response -> do
+      let br = wrapCustomEx $ HttpClient.responseBody response
+      callback (getResponseHeaders response) br
+
+getRange :: Throws SomeRemoteError
+         => Manager
+         -> [HttpRequestHeader] -> URI -> (Int, Int)
+         -> (HttpStatus -> [HttpResponseHeader] -> BodyReader -> IO a)
+         -> IO a
+getRange manager reqHeaders uri (from, to) callback = wrapCustomEx $ do
+    request' <- HttpClient.setUri HttpClient.defaultRequest uri
+    let request = setRange from to
+                $ setRequestHeaders reqHeaders request'
+    checkHttpException $ HttpClient.withResponse request manager $ \response -> do
+      let br = wrapCustomEx $ HttpClient.responseBody response
+      case () of
+         () | HttpClient.responseStatus response == HttpClient.partialContent206 ->
+           callback HttpStatus206PartialContent (getResponseHeaders response) br
+         () | HttpClient.responseStatus response == HttpClient.ok200 ->
+           callback HttpStatus200OK (getResponseHeaders response) br
+         _otherwise ->
+           throwChecked $ HttpClient.HttpExceptionRequest request
+                        $ HttpClient.StatusCodeException (void response) ""
+
+-- | Wrap custom exceptions
+--
+-- NOTE: The only other exception defined in @http-client@ is @TimeoutTriggered@
+-- but it is currently disabled <https://github.com/snoyberg/http-client/issues/116>
+wrapCustomEx :: (Throws HttpClient.HttpException => IO a)
+             -> (Throws SomeRemoteError => IO a)
+wrapCustomEx act = handleChecked (\(ex :: HttpClient.HttpException) -> go ex) act
+  where
+    go ex = throwChecked (SomeRemoteError ex)
+
+checkHttpException :: Throws HttpClient.HttpException => IO a -> IO a
+checkHttpException = handle $ \(ex :: HttpClient.HttpException) ->
+                       throwChecked ex
+
+{-------------------------------------------------------------------------------
+  http-client auxiliary
+-------------------------------------------------------------------------------}
+
+hAcceptRanges :: HttpClient.HeaderName
+hAcceptRanges = "Accept-Ranges"
+
+hAcceptEncoding :: HttpClient.HeaderName
+hAcceptEncoding = "Accept-Encoding"
+
+setRange :: Int -> Int
+         -> HttpClient.Request -> HttpClient.Request
+setRange from to req = req {
+      HttpClient.requestHeaders = (HttpClient.hRange, rangeHeader)
+                                : HttpClient.requestHeaders req
+    }
+  where
+    -- Content-Range header uses inclusive rather than exclusive bounds
+    -- See <http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html>
+    rangeHeader = BS.C8.pack $ "bytes=" ++ show from ++ "-" ++ show (to - 1)
+
+-- | Set request headers
+setRequestHeaders :: [HttpRequestHeader]
+                  -> HttpClient.Request -> HttpClient.Request
+setRequestHeaders opts req = req {
+      HttpClient.requestHeaders = trOpt disallowCompressionByDefault opts
+    }
+  where
+    trOpt :: [(HttpClient.HeaderName, [ByteString])]
+          -> [HttpRequestHeader]
+          -> [HttpClient.Header]
+    trOpt acc [] =
+      concatMap finalizeHeader acc
+    trOpt acc (HttpRequestMaxAge0:os) =
+      trOpt (insert HttpClient.hCacheControl ["max-age=0"] acc) os
+    trOpt acc (HttpRequestNoTransform:os) =
+      trOpt (insert HttpClient.hCacheControl ["no-transform"] acc) os
+
+    -- disable content compression (potential security issue)
+    disallowCompressionByDefault :: [(HttpClient.HeaderName, [ByteString])]
+    disallowCompressionByDefault = [(hAcceptEncoding, [])]
+
+    -- Some headers are comma-separated, others need multiple headers for
+    -- multiple options.
+    --
+    -- TODO: Right we we just comma-separate all of them.
+    finalizeHeader :: (HttpClient.HeaderName, [ByteString])
+                   -> [HttpClient.Header]
+    finalizeHeader (name, strs) = [(name, BS.intercalate ", " (reverse strs))]
+
+    insert :: Eq a => a -> [b] -> [(a, [b])] -> [(a, [b])]
+    insert x y = Lens.modify (Lens.lookupM x) (++ y)
+
+-- | Extract the response headers
+getResponseHeaders :: HttpClient.Response a -> [HttpResponseHeader]
+getResponseHeaders response = concat [
+      [ HttpResponseAcceptRangesBytes
+      | (hAcceptRanges, "bytes") `elem` headers
+      ]
+    ]
+  where
+    headers = HttpClient.responseHeaders response

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -93,6 +93,7 @@ import           Stack.Types.Config
 import           Stack.Types.Docker
 import           Stack.Types.Internal
 import           Stack.Types.Nix
+import           Stack.Types.PackageIndex (HttpType (HTHackageSecurity), HackageSecurity (..))
 import           Stack.Types.Resolver
 import           Stack.Types.StackT
 import           Stack.Types.Urls
@@ -238,7 +239,21 @@ configFromConfigMonoid configStackRoot configUserConfigPath mresolver mproject C
                 { indexName = IndexName "Hackage"
                 , indexLocation = ILGitHttp
                         "https://github.com/commercialhaskell/all-cabal-hashes.git"
-                        "https://s3.amazonaws.com/hackage.fpcomplete.com/01-index.tar.gz"
+                        "https://s3.amazonaws.com/hackage.fpcomplete.com/"
+                        (HTHackageSecurity HackageSecurity
+                            { hsKeyIds =
+                                [ "0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d"
+                                , "1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42"
+                                , "280b10153a522681163658cb49f632cde3f38d768b736ddbc901d99a1a772833"
+                                , "2a96b1889dc221c17296fcc2bb34b908ca9734376f0f361660200935916ef201"
+                                , "2c6c3627bd6c982990239487f1abd02e08a02e6cf16edb105a8012d444d870c3"
+                                , "51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921"
+                                , "772e9f4c7db33d251d5c6e357199c819e569d130857dc225549b40845ff0890d"
+                                , "aa315286e6ad281ad61182235533c41e806e5a787e0b6d1e7eef3f09d137d2e9"
+                                , "fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0"
+                                ]
+                            , hsKeyThreshold = 3
+                            })
                 , indexDownloadPrefix = "https://s3.amazonaws.com/hackage.fpcomplete.com/package/"
                 , indexGpgVerify = False
                 , indexRequireHashes = False

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -308,7 +308,7 @@ resolvePackagesAllowMissing menv mMiniBuildPlan idents0 names0 = do
                                         SILGit _ -> False
 
                                         -- Index using HTTP, so we're missing the Git SHA
-                                        SILHttp _ -> True)
+                                        SILHttp _ _ -> True)
                  in Right ResolvedPackage
                     { rpIdent = ident
                     , rpCache = cache'

--- a/src/Stack/PackageIndex.hs
+++ b/src/Stack/PackageIndex.hs
@@ -60,9 +60,18 @@ import           Data.Streaming.Process (ProcessExitedUnsuccessfully(..))
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Text.Unsafe (unsafeTail)
+import           Data.Time (getCurrentTime)
 import           Data.Traversable (forM)
 import           Data.Typeable (Typeable)
+import qualified Hackage.Security.Client as HS
+import qualified Hackage.Security.Client.Repository.Cache as HS
+import qualified Hackage.Security.Client.Repository.Remote as HS
+import qualified Hackage.Security.Client.Repository.HttpLib.HttpClient as HS
+import qualified Hackage.Security.Util.Path as HS
+import qualified Hackage.Security.Util.Pretty as HS
+import           Network.HTTP.Client.TLS (getGlobalManager)
 import           Network.HTTP.Download
+import           Network.URI (parseURI)
 import           Path (mkRelDir, mkRelFile, parent, parseRelDir, toFilePath, parseAbsFile, (</>))
 import           Path.IO
 import           Prelude -- Fix AMP warning
@@ -73,6 +82,7 @@ import           Stack.Types.PackageIndex
 import           Stack.Types.PackageName
 import           Stack.Types.StackT
 import           Stack.Types.Version
+import qualified System.Directory as D
 import           System.FilePath (takeBaseName, (<.>))
 import           System.IO (IOMode (ReadMode, WriteMode), withBinaryFile)
 import           System.Process.Read (EnvOverride, ReadProcessException(..), doesExecutableExist, readProcessNull, tryProcessStdout)
@@ -220,12 +230,20 @@ updateIndex :: (StackMiniM env m, HasConfig env)
             => EnvOverride -> PackageIndex -> m ()
 updateIndex menv index =
   do let name = indexName index
-         logUpdate mirror = $logSticky $ "Updating package index " <> indexNameText (indexName index) <> " (mirrored at " <> mirror  <> ") ..."
+         sloc = simplifyIndexLocation $ indexLocation index
+     $logSticky $ "Updating package index "
+               <> indexNameText (indexName index)
+               <> " (mirrored at "
+               <> (case sloc of
+                     SILGit url -> url
+                     SILHttp url _ -> url)
+               <> ") ..."
      git <- isGitInstalled menv
-     case (git, simplifyIndexLocation $ indexLocation index) of
-        (True, SILGit url) -> logUpdate url >> updateIndexGit menv name index url
-        (False, SILGit url) -> logUpdate url >> throwM (GitNotAvailable name)
-        (_, SILHttp url) -> logUpdate url >> updateIndexHTTP name index url
+     case (git, sloc) of
+        (True, SILGit url) -> updateIndexGit menv name index url
+        (False, SILGit _) -> throwM (GitNotAvailable name)
+        (_, SILHttp url HTVanilla) -> updateIndexHTTP name index url
+        (_, SILHttp url (HTHackageSecurity hs)) -> updateIndexHackageSecurity name index url hs
 
      -- Copy to the 00-index.tar filename for backwards compatibility
      tarFile <- configPackageIndex name
@@ -357,6 +375,64 @@ updateIndexHTTP indexName' index url = do
                     $$ ungzip
                     =$ sinkHandle output
             renameFile tmpPath tar
+
+    when (indexGpgVerify index)
+        $ $logWarn
+        $ "You have enabled GPG verification of the package index, " <>
+          "but GPG verification only works with Git downloading"
+
+-- | Update the index tarball via Hackage Security
+updateIndexHackageSecurity
+    :: (StackMiniM env m, HasConfig env)
+    => IndexName
+    -> PackageIndex
+    -> Text -- ^ base URL
+    -> HackageSecurity
+    -> m ()
+updateIndexHackageSecurity indexName' index url (HackageSecurity keyIds threshold) = do
+    baseURI <-
+        case parseURI $ T.unpack url of
+            Nothing -> error $ "Invalid Hackage Security base URL: " ++ T.unpack url
+            Just x -> return x
+    manager <- liftIO getGlobalManager
+    root <- configPackageIndexRoot indexName'
+    logTUF <- embed_ ($logInfo . T.pack . HS.pretty)
+    let withRepo = HS.withRepository
+            (HS.makeHttpLib manager)
+            [baseURI]
+            HS.defaultRepoOpts
+            HS.Cache
+                { HS.cacheRoot = HS.fromAbsoluteFilePath $ toFilePath root
+                , HS.cacheLayout = HS.cabalCacheLayout
+                    -- Have Hackage Security write to a temporary file
+                    -- to avoid invalidating the cache... continued
+                    -- below at case didUpdate
+                    { HS.cacheLayoutIndexTar = HS.rootPath $ HS.fragment "01-index.tar-tmp"
+                    }
+                }
+            HS.hackageRepoLayout
+            HS.hackageIndexLayout
+            logTUF
+    didUpdate <- liftIO $ withRepo $ \repo -> HS.uncheckClientErrors $ do
+        needBootstrap <- HS.requiresBootstrap repo
+        when needBootstrap $ do
+            HS.bootstrap
+                repo
+                (map (HS.KeyId . T.unpack) keyIds)
+                (HS.KeyThreshold (fromIntegral threshold))
+        now <- getCurrentTime
+        HS.checkForUpdates repo (Just now)
+
+    case didUpdate of
+        HS.HasUpdates -> do
+            -- The index actually updated. Delete the old cache, and
+            -- then move the temporary unpacked file to its real
+            -- location
+            tar <- configPackageIndex indexName'
+            deleteCache indexName'
+            liftIO $ D.renameFile (toFilePath tar ++ "-tmp") (toFilePath tar)
+            $logInfo "Updated package list downloaded"
+        HS.NoUpdates -> $logInfo "No updates to your package list were found"
 
     when (indexGpgVerify index)
         $ $logWarn

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1175,7 +1175,7 @@ configPackageIndexRepo name = do
             let murl =
                     case simplifyIndexLocation $ indexLocation index of
                         SILGit x -> Just x
-                        SILHttp _ -> Nothing
+                        SILHttp _ _ -> Nothing
             case murl of
                 Nothing -> return Nothing
                 Just url -> do

--- a/stack.cabal
+++ b/stack.cabal
@@ -181,6 +181,7 @@ library
                      System.Process.PagerEditor
                      System.Process.Read
                      System.Process.Run
+  other-modules:     Hackage.Security.Client.Repository.HttpLib.HttpClient
   build-depends:     Cabal >= 1.24 && < 1.25
                    , aeson (>= 1.0 && < 1.1)
                    , ansi-terminal >= 0.6.2.3
@@ -211,6 +212,7 @@ library
                    , filepath >= 1.3.0.2
                    , fsnotify >= 0.2.1
                    , generic-deriving < 1.12
+                   , hackage-security
                    , hashable >= 1.2.3.2
                    , hit
                    , hpc
@@ -227,6 +229,7 @@ library
                    , monad-logger >= 0.3.13.1
                    , monad-unlift < 0.3
                    , mtl >= 2.1.3.1
+                   , network-uri
                    , open-browser >= 0.2.1
                    , optparse-applicative >= 0.13 && < 0.14
                    , path >= 0.5.8

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,6 +28,9 @@ extra-deps:
 - persistent-2.6
 - persistent-template-2.5.1.6
 - persistent-sqlite-2.6
+- cryptohash-sha256-0.11.100.1
+- ed25519-0.0.5.0
+- hackage-security-0.5.2.2
 flags:
   stack:
     hide-dependency-versions: true


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Normal usage of Stack will test this out plenty. I made this change because, once we switched from the Git index to HTTPS, updates became very slow, which I'm not happy with. As long as we're doing partial updates, may as well use hackage-security I suppose.

Since the hackage-security-http-client package isn't yet on Hackage, I inlined that module. Also, manually specified indices will be able to opt in or out of Hackage Security for downloads, so compatibility with existing non-HS indices will be retained.

I know the initial build will fail due to missing extra-deps. After that, I'm planning on using this myself a bit before merging. Review certainly welcome, this was far more complicated to get right than I would have ever expected.