### PR TITLE
Fill out Travis matrix more completely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,20 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
 
     - env: BUILD=stack STACK_YAML=stack.yaml
+      compiler: ": #stack 7.10.3"
+      addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
+
+    - env: BUILD=stack STACK_YAML=stack.yaml
       compiler: ": #stack 7.10.3 osx"
       os: osx
 
     - env: BUILD=stack GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
       compiler: ": #stack 8.0.1"
       addons: {apt: {packages: [ghc-8.0.1], sources: [hvr-ghc]}}
+
+    - env: BUILD=stack GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
+      compiler: ": #stack 8.0.1 osx"
+      os: osx
 
     - env: BUILD=style GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
       compiler: ": #stack 8.0.1"
@@ -42,6 +50,10 @@ matrix:
   allow_failures:
     - env: BUILD=stack STACK_YAML=stack.yaml
       compiler: ": #stack 7.10.3 osx"
+      os: osx
+
+    - env: BUILD=stack GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
+      compiler: ": #stack 8.0.1 osx"
       os: osx
 
 # Note: the distinction between `before_install` and `install` is not important.


### PR DESCRIPTION
It seemed surprising to me that some combinations of stack.yaml and OS weren't filled out in the matrix. I'm not sure if there was a reason for this decision, so not merging myself.