### PR TITLE
Add warning if Cabal mismatch detected.

### DIFF
--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -196,11 +196,13 @@ processLoadResult _ True (WrongVersion actual wanted, lh)
             ]
         return (Just lh)
 processLoadResult mdb _ (reason, lh) = do
+    let pkgName = packageNameText (fst (lhPair lh))
+    warnIfCabalUpgradeNecessary pkgName reason
     $logDebug $ T.concat $
-        [ "Ignoring package "
-        , packageNameText (fst (lhPair lh))
-        ] ++
-        maybe [] (\db -> [", from ", T.pack (show db), ","]) mdb ++
+        ["Ignoring package ", pkgName]
+        ++
+        maybe [] (\db -> [", from ", T.pack (show db), ","]) mdb
+        ++
         [ " due to"
         , case reason of
             Allowed -> " the impossible?!?!"
@@ -217,6 +219,14 @@ processLoadResult mdb _ (reason, lh) = do
                 ]
         ]
     return Nothing
+
+warnIfCabalUpgradeNecessary :: MonadLogger m => T.Text -> Allowed -> m ()
+warnIfCabalUpgradeNecessary pkg reason = do
+  let msg = "Cabal version mismatch detected. Try running 'stack setup --upgrade-cabal'"
+  case reason of
+    WrongVersion _ _ -> when (pkg == T.pack "Cabal") $ do
+                            $logWarn msg
+    _                -> return ()
 
 data Allowed
     = Allowed


### PR DESCRIPTION
* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Following from https://github.com/commercialhaskell/stack/issues/2928. I didn't test it. @conklech, could you grab this change and give it a run? I'm not really sure how to mismatch my Cabal and I don't think I want to ;)
