### PR TITLE
Script command #2805

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,15 @@ Release notes:
 
 Major changes:
 
+* A new command, `script`, has been added, intended to make the script
+  interpreter workflow more reliable, easier to use, and more
+  efficient. This command forces the user to provide a `--resolver`
+  value, ignores all config files for more reproducible results, and
+  optimizes the existing package check to make the common case of all
+  packages already being present much faster. This mode does require
+  that all packages be present in a snapshot, however.
+  [#2805](https://github.com/commercialhaskell/stack/issues/2805)
+
 Behavior changes:
 
 * The default package metadata backend has been changed from Git to

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -140,10 +140,7 @@ data Ctx = Ctx
 instance HasPlatform Ctx
 instance HasGHCVariant Ctx
 instance HasConfig Ctx
-instance HasBuildConfigNoLocal Ctx
 instance HasBuildConfig Ctx
-instance HasEnvConfigNoLocal Ctx where
-    envConfigNoLocalL = envConfigL.envConfigNoLocalL
 instance HasEnvConfig Ctx where
     envConfigL = lens ctxEnvConfig (\x y -> x { ctxEnvConfig = y })
 

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -109,7 +109,7 @@ loadSourceMapFull omitWiredIn needTargets boptsCli = do
     -- Extend extra-deps to encompass targets requested on the command line
     -- that are not in the snapshot.
     extraDeps0 <- extendExtraDeps
-        (bcExtraDeps $ bcLocal bconfig)
+        (bcExtraDeps bconfig)
         cliExtraDeps
         (Map.keysSet $ Map.filter (== STUnknown) targets)
 
@@ -145,7 +145,7 @@ loadSourceMapFull omitWiredIn needTargets boptsCli = do
                 let flags =
                         case ( Map.lookup (Just n) $ boptsCLIFlags boptsCli
                              , Map.lookup Nothing $ boptsCLIFlags boptsCli
-                             , Map.lookup n $ unPackageFlags $ bcFlags $ bcLocal bconfig
+                             , Map.lookup n $ unPackageFlags $ bcFlags bconfig
                              ) of
                             -- Didn't have any flag overrides, fall back to the flags
                             -- defined in the snapshot.
@@ -195,7 +195,7 @@ getLocalFlags
 getLocalFlags bconfig boptsCli name = Map.unions
     [ Map.findWithDefault Map.empty (Just name) cliFlags
     , Map.findWithDefault Map.empty Nothing cliFlags
-    , Map.findWithDefault Map.empty name (unPackageFlags (bcFlags (bcLocal bconfig)))
+    , Map.findWithDefault Map.empty name (unPackageFlags (bcFlags bconfig))
     ]
   where
     cliFlags = boptsCLIFlags boptsCli
@@ -245,8 +245,7 @@ parseTargetsFromBuildOptsWith
     -> m (MiniBuildPlan, M.Map PackageName Version, M.Map PackageName SimpleTarget)
 parseTargetsFromBuildOptsWith rawLocals needTargets boptscli = do
     $logDebug "Parsing the targets"
-    bconfig <- view buildConfigNoLocalL
-    bconfigl <- view buildConfigLocalL
+    bconfig <- view buildConfigL
     mbp0 <-
         case bcResolver bconfig of
             ResolverCompiler _ -> do
@@ -264,16 +263,16 @@ parseTargetsFromBuildOptsWith rawLocals needTargets boptscli = do
     let snapshot = mpiVersion <$> mbpPackages mbp0
     flagExtraDeps <- convertSnapshotToExtra
         snapshot
-        (bcExtraDeps bconfigl)
+        (bcExtraDeps bconfig)
         rawLocals
         (catMaybes $ Map.keys $ boptsCLIFlags boptscli)
 
     (cliExtraDeps, targets) <-
         parseTargets
             needTargets
-            (bcImplicitGlobal bconfigl)
+            (bcImplicitGlobal bconfig)
             snapshot
-            (flagExtraDeps <> bcExtraDeps bconfigl)
+            (flagExtraDeps <> bcExtraDeps bconfig)
             (fst <$> rawLocals)
             workingDir
             (boptsCLITargets boptscli)
@@ -460,7 +459,7 @@ checkFlagsUsed :: (MonadThrow m, MonadReader env m, HasBuildConfig env)
                -> Map PackageName snapshot -- ^ snapshot, for error messages
                -> m ()
 checkFlagsUsed boptsCli lps extraDeps snapshot = do
-    bconfig <- view buildConfigLocalL
+    bconfig <- view buildConfigL
 
         -- Check if flags specified in stack.yaml and the command line are
         -- used, see https://github.com/commercialhaskell/stack/issues/617
@@ -512,7 +511,7 @@ extendExtraDeps extraDeps0 cliExtraDeps unknowns = do
     case errs of
         [] -> return $ Map.unions $ extraDeps1 : unknowns'
         _ -> do
-            bconfig <- view buildConfigLocalL
+            bconfig <- view buildConfigL
             throwM $ UnknownTargets
                 (Set.fromList errs)
                 Map.empty -- TODO check the cliExtraDeps for presence in index

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -32,6 +32,7 @@ module Stack.BuildPlan
     , showItems
     , showPackageFlags
     , parseCustomMiniBuildPlan
+    , loadBuildPlan
     ) where
 
 import           Control.Applicative

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -208,7 +208,7 @@ resolveBuildPlan
 resolveBuildPlan mbp isShadowed packages
     | Map.null (rsUnknown rs) && Map.null (rsShadowed rs) = return (rsToInstall rs, rsUsedBy rs)
     | otherwise = do
-        bconfig <- view buildConfigLocalL
+        bconfig <- view buildConfigL
         (caches, _gitShaCaches) <- getPackageCaches
         let maxVer =
                 Map.fromListWith max $

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -588,24 +588,20 @@ loadBuildConfig mproject config mresolver mcompiler = do
     extraPackageDBs <- mapM resolveDir' (projectExtraPackageDBs project)
 
     return BuildConfig
-        { bcNoLocal = BuildConfigNoLocal
-            { bcConfig = config
-            , bcResolver = loadedResolver
-            , bcWantedMiniBuildPlan = mbp
-            , bcGHCVariant = view ghcVariantL miniConfig
-            }
-        , bcLocal = BuildConfigLocal
-            { bcPackageEntries = projectPackages project
-            , bcExtraDeps = projectExtraDeps project
-            , bcExtraPackageDBs = extraPackageDBs
-            , bcStackYaml = stackYamlFP
-            , bcFlags = projectFlags project
-            , bcImplicitGlobal =
-                case mproject of
-                  LCSNoProject -> True
-                  LCSProject _ -> False
-                  LCSNoConfig  -> False
-            }
+        { bcConfig = config
+        , bcResolver = loadedResolver
+        , bcWantedMiniBuildPlan = mbp
+        , bcGHCVariant = view ghcVariantL miniConfig
+        , bcPackageEntries = projectPackages project
+        , bcExtraDeps = projectExtraDeps project
+        , bcExtraPackageDBs = extraPackageDBs
+        , bcStackYaml = stackYamlFP
+        , bcFlags = projectFlags project
+        , bcImplicitGlobal =
+            case mproject of
+                LCSNoProject -> True
+                LCSProject _ -> False
+                LCSNoConfig  -> False
         }
   where
     miniConfig = loadMiniConfig config
@@ -636,14 +632,14 @@ getLocalPackages
     :: (StackMiniM env m, HasEnvConfig env)
     => m (Map.Map (Path Abs Dir) TreatLikeExtraDep)
 getLocalPackages = do
-    cacheRef <- view $ envConfigLocalL.to envConfigPackagesRef
+    cacheRef <- view $ envConfigL.to envConfigPackagesRef
     mcached <- liftIO $ readIORef cacheRef
     case mcached of
         Just cached -> return cached
         Nothing -> do
             menv <- getMinimalEnvOverride
             root <- view projectRootL
-            entries <- view $ buildConfigLocalL.to bcPackageEntries
+            entries <- view $ buildConfigL.to bcPackageEntries
             liftM (Map.fromList . concat) $ mapM
                 (resolvePackageEntry menv root)
                 entries

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -39,6 +42,7 @@ module Stack.Config
   ,getInNixShell
   ,defaultConfigYaml
   ,getProjectConfig
+  ,LocalConfigStatus(..)
   ) where
 
 import qualified Codec.Archive.Tar as Tar
@@ -217,16 +221,38 @@ getLatestResolver = do
         snap = fromMaybe (Nightly (snapshotsNightly snapshots)) mlts
     return (ResolverSnapshot snap)
 
+-- | Create a 'Config' value when we're not using any local
+-- configuration files (e.g., the script command)
+configNoLocalConfig
+    :: (MonadLogger m, MonadIO m, MonadCatch m)
+    => Path Abs Dir -- ^ stack root
+    -> Maybe AbstractResolver
+    -> ConfigMonoid
+    -> m Config
+configNoLocalConfig _ Nothing _ = throwM NoResolverWhenUsingNoLocalConfig
+configNoLocalConfig stackRoot (Just resolver) configMonoid = do
+    userConfigPath <- getFakeConfigPath stackRoot resolver
+    configFromConfigMonoid
+      stackRoot
+      userConfigPath
+      False
+      (Just resolver)
+      Nothing -- project
+      configMonoid
+
 -- Interprets ConfigMonoid options.
 configFromConfigMonoid
     :: (MonadLogger m, MonadIO m, MonadCatch m)
     => Path Abs Dir -- ^ stack root, e.g. ~/.stack
     -> Path Abs File -- ^ user config file path, e.g. ~/.stack/config.yaml
+    -> Bool -- ^ allow locals?
     -> Maybe AbstractResolver
     -> Maybe (Project, Path Abs File)
     -> ConfigMonoid
     -> m Config
-configFromConfigMonoid configStackRoot configUserConfigPath mresolver mproject ConfigMonoid{..} = do
+configFromConfigMonoid
+    configStackRoot configUserConfigPath configAllowLocals mresolver
+    mproject ConfigMonoid{..} = do
      let configWorkDir = fromFirst $(mkRelDir ".stack-work") configMonoidWorkDir
      -- This code is to handle the deprecation of latest-snapshot-url
      configUrls <- case (getFirst configMonoidLatestSnapshotUrl, getFirst (urlsMonoidLatestSnapshot configMonoidUrls)) of
@@ -414,24 +440,36 @@ loadConfigMaybeProject
     -- ^ Config monoid from parsed command-line arguments
     -> Maybe AbstractResolver
     -- ^ Override resolver
-    -> Maybe (Project, Path Abs File, ConfigMonoid)
+    -> LocalConfigStatus (Project, Path Abs File, ConfigMonoid)
     -- ^ Project config to use, if any
     -> m (LoadConfig m)
 loadConfigMaybeProject configArgs mresolver mproject = do
     (stackRoot, userOwnsStackRoot) <- determineStackRootAndOwnership configArgs
-    userConfigPath <- getDefaultUserConfigPath stackRoot
-    extraConfigs0 <- getExtraConfigs userConfigPath >>= mapM loadConfigYaml
-    let extraConfigs =
-            -- non-project config files' existence of a docker section should never default docker
-            -- to enabled, so make it look like they didn't exist
-            map (\c -> c {configMonoidDockerOpts =
-                              (configMonoidDockerOpts c) {dockerMonoidDefaultEnable = Any False}})
-                extraConfigs0
-    let mproject' = (\(project, stackYaml, _) -> (project, stackYaml)) <$> mproject
-    config <- configFromConfigMonoid stackRoot userConfigPath mresolver mproject' $ mconcat $
+
+    let loadHelper mproject' = do
+          userConfigPath <- getDefaultUserConfigPath stackRoot
+          extraConfigs0 <- getExtraConfigs userConfigPath >>= mapM loadConfigYaml
+          let extraConfigs =
+                -- non-project config files' existence of a docker section should never default docker
+                -- to enabled, so make it look like they didn't exist
+                map (\c -> c {configMonoidDockerOpts =
+                                  (configMonoidDockerOpts c) {dockerMonoidDefaultEnable = Any False}})
+                    extraConfigs0
+
+          configFromConfigMonoid
+            stackRoot
+            userConfigPath
+            True -- allow locals
+            mresolver
+            (fmap (\(x, y, _) -> (x, y)) mproject')
+            $ mconcat $ configArgs
+            : maybe id (\(_, _, projectConfig) -> (projectConfig:)) mproject' extraConfigs
+
+    config <-
         case mproject of
-            Nothing -> configArgs : extraConfigs
-            Just (_, _, projectConfig) -> configArgs : projectConfig : extraConfigs
+          LCSNoConfig -> configNoLocalConfig stackRoot mresolver configArgs
+          LCSProject project -> loadHelper $ Just project
+          LCSNoProject -> loadHelper Nothing
     unless (fromCabalVersion Meta.version `withinRange` configRequireStackVersion config)
         (throwM (BadStackVersionException (configRequireStackVersion config)))
 
@@ -445,7 +483,11 @@ loadConfigMaybeProject configArgs mresolver mproject = do
     return LoadConfig
         { lcConfig          = config
         , lcLoadBuildConfig = loadBuildConfig mproject config mresolver
-        , lcProjectRoot     = mprojectRoot
+        , lcProjectRoot     =
+            case mprojectRoot of
+              LCSProject fp -> Just fp
+              LCSNoProject  -> Nothing
+              LCSNoConfig   -> Nothing
         }
 
 -- | Load the configuration, using current directory, environment variables,
@@ -456,7 +498,7 @@ loadConfig :: StackM env m
            -- ^ Config monoid from parsed command-line arguments
            -> Maybe AbstractResolver
            -- ^ Override resolver
-           -> Maybe (Path Abs File)
+           -> StackYamlLoc (Path Abs File)
            -- ^ Override stack.yaml
            -> m (LoadConfig m)
 loadConfig configArgs mresolver mstackYaml =
@@ -465,20 +507,22 @@ loadConfig configArgs mresolver mstackYaml =
 -- | Load the build configuration, adds build-specific values to config loaded by @loadConfig@.
 -- values.
 loadBuildConfig :: StackM env m
-                => Maybe (Project, Path Abs File, ConfigMonoid)
+                => LocalConfigStatus (Project, Path Abs File, ConfigMonoid)
                 -> Config
                 -> Maybe AbstractResolver -- override resolver
                 -> Maybe CompilerVersion -- override compiler
                 -> m BuildConfig
 loadBuildConfig mproject config mresolver mcompiler = do
     env <- ask
-    let miniConfig = loadMiniConfig config
 
     (project', stackYamlFP) <- case mproject of
-      Just (project, fp, _) -> do
+      LCSProject (project, fp, _) -> do
           forM_ (projectUserMsg project) ($logWarn . T.pack)
           return (project, fp)
-      Nothing -> do
+      LCSNoConfig -> do
+          p <- getEmptyProject
+          return (p, configUserConfigPath config)
+      LCSNoProject -> do
             $logDebug "Run from outside a project, using implicit global project config"
             destDir <- getImplicitGlobalProjectDir config
             let dest :: Path Abs File
@@ -507,26 +551,9 @@ loadBuildConfig mproject config mresolver mcompiler = do
                                          " specified on command line")
                    return (project, dest)
                else do
-                   r <- case mresolver of
-                       Just aresolver -> do
-                           r' <- runReaderT (makeConcreteResolver aresolver) miniConfig
-                           $logInfo ("Using resolver: " <> resolverName r' <> " specified on command line")
-                           return r'
-                       Nothing -> do
-                           r'' <- runReaderT getLatestResolver miniConfig
-                           $logInfo ("Using latest snapshot resolver: " <> resolverName r'')
-                           return r''
                    $logInfo ("Writing implicit global project config file to: " <> T.pack dest')
                    $logInfo "Note: You can change the snapshot via the resolver field there."
-                   let p = Project
-                           { projectUserMsg = Nothing
-                           , projectPackages = mempty
-                           , projectExtraDeps = mempty
-                           , projectFlags = mempty
-                           , projectResolver = r
-                           , projectCompiler = Nothing
-                           , projectExtraPackageDBs = []
-                           }
+                   p <- getEmptyProject
                    liftIO $ do
                        S.writeFile dest' $ S.concat
                            [ "# This is the implicit global project's config file, which is only used when\n"
@@ -573,8 +600,34 @@ loadBuildConfig mproject config mresolver mcompiler = do
             , bcExtraPackageDBs = extraPackageDBs
             , bcStackYaml = stackYamlFP
             , bcFlags = projectFlags project
-            , bcImplicitGlobal = isNothing mproject
+            , bcImplicitGlobal =
+                case mproject of
+                  LCSNoProject -> True
+                  LCSProject _ -> False
+                  LCSNoConfig  -> False
             }
+        }
+  where
+    miniConfig = loadMiniConfig config
+
+    getEmptyProject = do
+      r <- case mresolver of
+            Just aresolver -> do
+                r' <- runReaderT (makeConcreteResolver aresolver) miniConfig
+                $logInfo ("Using resolver: " <> resolverName r' <> " specified on command line")
+                return r'
+            Nothing -> do
+                r'' <- runReaderT getLatestResolver miniConfig
+                $logInfo ("Using latest snapshot resolver: " <> resolverName r'')
+                return r''
+      return Project
+        { projectUserMsg = Nothing
+        , projectPackages = mempty
+        , projectExtraDeps = mempty
+        , projectFlags = mempty
+        , projectResolver = r
+        , projectCompiler = Nothing
+        , projectExtraPackageDBs = []
         }
 
 -- | Get packages from EnvConfig, downloading and cloning as necessary.
@@ -866,19 +919,19 @@ loadYaml path = do
 
 -- | Get the location of the project config file, if it exists.
 getProjectConfig :: (MonadIO m, MonadThrow m, MonadLogger m)
-                 => Maybe (Path Abs File)
+                 => StackYamlLoc (Path Abs File)
                  -- ^ Override stack.yaml
-                 -> m (Maybe (Path Abs File))
-getProjectConfig (Just stackYaml) = return $ Just stackYaml
-getProjectConfig Nothing = do
+                 -> m (LocalConfigStatus (Path Abs File))
+getProjectConfig (SYLOverride stackYaml) = return $ LCSProject stackYaml
+getProjectConfig SYLDefault = do
     env <- liftIO getEnvironment
     case lookup "STACK_YAML" env of
         Just fp -> do
             $logInfo "Getting project config file from STACK_YAML environment"
-            liftM Just $ resolveFile' fp
+            liftM LCSProject $ resolveFile' fp
         Nothing -> do
             currDir <- getCurrentDir
-            findInParents getStackDotYaml currDir
+            maybe LCSNoProject LCSProject <$> findInParents getStackDotYaml currDir
   where
     getStackDotYaml dir = do
         let fp = dir </> stackDotYaml
@@ -888,29 +941,39 @@ getProjectConfig Nothing = do
         if exists
             then return $ Just fp
             else return Nothing
+getProjectConfig SYLNoConfig = return LCSNoConfig
+
+data LocalConfigStatus a
+    = LCSNoProject
+    | LCSProject a
+    | LCSNoConfig
+    deriving (Show,Functor,Foldable,Traversable)
 
 -- | Find the project config file location, respecting environment variables
 -- and otherwise traversing parents. If no config is found, we supply a default
 -- based on current directory.
 loadProjectConfig :: (MonadIO m, MonadThrow m, MonadLogger m)
-                  => Maybe (Path Abs File)
+                  => StackYamlLoc (Path Abs File)
                   -- ^ Override stack.yaml
-                  -> m (Maybe (Project, Path Abs File, ConfigMonoid))
+                  -> m (LocalConfigStatus (Project, Path Abs File, ConfigMonoid))
 loadProjectConfig mstackYaml = do
     mfp <- getProjectConfig mstackYaml
     case mfp of
-        Just fp -> do
+        LCSProject fp -> do
             currDir <- getCurrentDir
             $logDebug $ "Loading project config file " <>
                         T.pack (maybe (toFilePath fp) toFilePath (stripDir currDir fp))
-            load fp
-        Nothing -> do
+            LCSProject <$> load fp
+        LCSNoProject -> do
             $logDebug $ "No project config file found, using defaults."
-            return Nothing
+            return LCSNoProject
+        LCSNoConfig -> do
+            $logDebug "Ignoring config files"
+            return LCSNoConfig
   where
     load fp = do
         ProjectAndConfigMonoid project config <- loadConfigYaml fp
-        return $ Just (project, fp, config)
+        return (project, fp, config)
 
 -- | Get the location of the default stack configuration file.
 -- If a file already exists at the deprecated location, its location is returned.
@@ -946,6 +1009,23 @@ getDefaultUserConfigPath stackRoot = do
         ensureDir (parent path)
         liftIO $ S.writeFile (toFilePath path) defaultConfigYaml
     return path
+
+-- | Get a fake configuration file location, used when doing a "no
+-- config" run (the script command).
+getFakeConfigPath
+    :: (MonadIO m, MonadThrow m)
+    => Path Abs Dir -- ^ stack root
+    -> AbstractResolver
+    -> m (Path Abs File)
+getFakeConfigPath stackRoot ar = do
+  asString <-
+    case ar of
+      ARResolver r -> return $ T.unpack $ resolverName r
+      _ -> throwM $ InvalidResolverForNoLocalConfig $ show ar
+  asDir <- parseRelDir asString
+  let full = stackRoot </> $(mkRelDir "script") </> asDir </> $(mkRelFile "config.yaml")
+  ensureDir (parent full)
+  return full
 
 packagesParser :: Parser [String]
 packagesParser = many (strOption (long "package" <> help "Additional packages that must be installed"))

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -30,7 +30,7 @@ import           Path
 import           Path.IO
 import           Prelude -- Silence redundant import warnings
 import           Stack.BuildPlan
-import           Stack.Config (makeConcreteResolver, getProjectConfig, getImplicitGlobalProjectDir)
+import           Stack.Config (makeConcreteResolver, getProjectConfig, getImplicitGlobalProjectDir, LocalConfigStatus(..))
 import           Stack.Constants
 import           Stack.Types.Config
 import           Stack.Types.Resolver
@@ -67,8 +67,9 @@ cfgCmdSet go cmd = do
                      mstackYamlOption <- forM (globalStackYaml go) resolveFile'
                      mstackYaml <- getProjectConfig mstackYamlOption
                      case mstackYaml of
-                         Just stackYaml -> return stackYaml
-                         Nothing -> liftM (</> stackDotYaml) (getImplicitGlobalProjectDir conf)
+                         LCSProject stackYaml -> return stackYaml
+                         LCSNoProject -> liftM (</> stackDotYaml) (getImplicitGlobalProjectDir conf)
+                         LCSNoConfig -> error "config command used when no local configuration available"
                  CommandScopeGlobal -> return (configUserConfigPath conf))
     -- We don't need to worry about checking for a valid yaml here
     (config :: Yaml.Object) <-

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -246,7 +246,7 @@ checkTargets
 checkTargets mp = do
     let filtered = M.filter (== STUnknown) mp
     unless (M.null filtered) $ do
-        bconfig <- view buildConfigLocalL
+        bconfig <- view buildConfigL
         throwM $ UnknownTargets (M.keysSet filtered) M.empty (bcStackYaml bconfig)
 
 getAllLocalTargets
@@ -563,10 +563,8 @@ makeGhciPkgInfo
 makeGhciPkgInfo buildOptsCLI sourceMap installedMap locals addPkgs mfileTargets name cabalfp target = do
     bopts <- view buildOptsL
     econfig <- view envConfigL
-    bconfignl <- view buildConfigNoLocalL
-    bconfigl <- view buildConfigLocalL
+    bconfig <- view buildConfigL
     compilerVersion <- view actualCompilerVersionL
-    let bconfig = BuildConfig bconfignl bconfigl
     let config =
             PackageConfig
             { packageConfigEnableTests = True

--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -61,7 +61,7 @@ globalOptsFromMonoid defaultTerminal GlobalOptsMonoid{..} = GlobalOpts
     , globalCompiler = getFirst globalMonoidCompiler
     , globalTerminal = fromFirst defaultTerminal globalMonoidTerminal
     , globalColorWhen = fromFirst ColorAuto globalMonoidColorWhen
-    , globalStackYaml = getFirst globalMonoidStackYaml }
+    , globalStackYaml = maybe SYLDefault SYLOverride $ getFirst globalMonoidStackYaml }
 
 initOptsParser :: Parser InitOpts
 initOptsParser =

--- a/src/Stack/Options/ScriptParser.hs
+++ b/src/Stack/Options/ScriptParser.hs
@@ -1,0 +1,33 @@
+module Stack.Options.ScriptParser where
+
+import           Data.Monoid ((<>))
+import           Options.Applicative
+
+data ScriptOpts = ScriptOpts
+  { soPackages :: ![String]
+  , soFile :: !FilePath
+  , soArgs :: ![String]
+  , soCompile :: !ScriptExecute
+  }
+  deriving Show
+
+data ScriptExecute
+  = SEInterpret
+  | SECompile
+  | SEOptimize
+  deriving Show
+
+scriptOptsParser :: Parser ScriptOpts
+scriptOptsParser = ScriptOpts
+    <$> many (strOption (long "package" <> help "Additional packages that must be installed"))
+    <*> strArgument (metavar "FILENAME")
+    <*> many (strArgument (metavar "-- ARGS (e.g. stack ghc -- X.hs -o x)"))
+    <*> (flag' SECompile
+            ( long "compile"
+           <> help "Compile the script without optimization and run the executable"
+            ) <|>
+         flag' SEOptimize
+            ( long "optimize"
+           <> help "Compile the script with optimization and run the executable"
+            ) <|>
+         pure SEInterpret)

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -39,8 +39,7 @@ path
 path keys =
     do -- We must use a BuildConfig from an EnvConfig to ensure that it contains the
        -- full environment info including GHC paths etc.
-       bcnl <- view $ envConfigL.buildConfigNoLocalL
-       bcl <- view $ envConfigL.buildConfigLocalL
+       bc <- view $ envConfigL.buildConfigL
        -- This is the modified 'bin-path',
        -- including the local GHC or MSYS if not configured to operate on
        -- global GHC.
@@ -80,7 +79,7 @@ path keys =
                           else key <> ": ") <>
                       path'
                           (PathInfo
-                               (BuildConfig bcnl bcl)
+                               bc
                                menv
                                snap
                                plocal
@@ -119,12 +118,9 @@ data PathInfo = PathInfo
 
 instance HasPlatform PathInfo
 instance HasConfig PathInfo
-instance HasBuildConfigNoLocal PathInfo where
-    buildConfigNoLocalL = lens piBuildConfig (\x y -> x { piBuildConfig = y })
-                        . buildConfigNoLocalL
 instance HasBuildConfig PathInfo where
-    buildConfigLocalL = lens piBuildConfig (\x y -> x { piBuildConfig = y })
-                      . buildConfigLocalL
+    buildConfigL = lens piBuildConfig (\x y -> x { piBuildConfig = y })
+                 . buildConfigL
 
 -- | The paths of interest to a user. The first tuple string is used
 -- for a description that the optparse flag uses, and the second

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -108,7 +108,10 @@ withGlobalConfigAndLock
     -> IO ()
 withGlobalConfigAndLock go@GlobalOpts{..} inner = do
     lc <- runStackTGlobal () go $
-        loadConfigMaybeProject globalConfigMonoid Nothing Nothing
+        loadConfigMaybeProject
+            globalConfigMonoid
+            Nothing
+            LCSNoProject
     withUserFileLock go (configStackRoot $ lcConfig lc) $ \_lk ->
         runStackTGlobal (lcConfig lc) go inner
 
@@ -210,7 +213,10 @@ withMiniConfigAndLock go@GlobalOpts{..} inner = do
     miniConfig <-
         runStackTGlobal () go $
         (loadMiniConfig . lcConfig) <$>
-        loadConfigMaybeProject globalConfigMonoid globalResolver Nothing
+        loadConfigMaybeProject
+          globalConfigMonoid
+          globalResolver
+          LCSNoProject
     runStackTGlobal miniConfig go inner
 
 -- | Unlock a lock file, if the value is Just

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+module Stack.Script
+    ( scriptCmd
+    ) where
+
+import           Control.Exception          (assert)
+import           Control.Monad              (unless, void)
+import           Control.Monad.IO.Class     (liftIO)
+import           Control.Monad.Logger
+import qualified Data.ByteString.Char8      as S8
+import qualified Data.Conduit.List          as CL
+import           Data.List.Split            (splitWhen)
+import           Data.Monoid
+import qualified Data.Set                   as Set
+import qualified Data.Text                  as T
+import           Path
+import           Path.IO
+import qualified Stack.Build
+import           Stack.Exec
+import           Stack.GhcPkg               (ghcPkgExeName)
+import           Stack.Options.ScriptParser
+import           Stack.Runners
+import           Stack.Types.Compiler
+import           Stack.Types.Config
+import           Stack.Types.PackageName
+import           System.FilePath            (dropExtension, replaceExtension)
+import           System.Process.Read
+
+-- | Run a Stack Script
+scriptCmd :: ScriptOpts -> GlobalOpts -> IO ()
+scriptCmd opts go' = do
+    print opts
+    let go = go'
+            { globalConfigMonoid = (globalConfigMonoid go')
+                { configMonoidInstallGHC = First $ Just True
+                }
+            , globalStackYaml = SYLNoConfig
+            }
+    withBuildConfigAndLock go $ \lk -> do
+        -- Some warnings in case the user somehow tries to set a
+        -- stack.yaml location
+        case globalStackYaml go' of
+          SYLOverride fp -> $logWarn $ T.pack
+            $ "Ignoring override stack.yaml file for script command: " ++ fp
+          SYLDefault -> return ()
+          SYLNoConfig -> assert False (return ())
+
+        config <- view configL
+        menv <- liftIO $ configEnvOverride config defaultEnvSettings
+        wc <- view $ actualCompilerVersionL.whichCompilerL
+
+        let targets = concatMap wordsComma $ soPackages opts
+            targetsSet = Set.fromList targets
+
+        -- Ensure only package names are provided. We do not allow
+        -- overriding packages in a snapshot.
+        mapM_ parsePackageNameFromString targets
+
+        unless (null targets) $ do
+            -- Optimization: use the relatively cheap ghc-pkg list
+            -- --simple-output to check which packages are installed
+            -- already. If all needed packages are available, we can
+            -- skip the (rather expensive) build call below.
+            bss <- sinkProcessStdout
+                Nothing menv (ghcPkgExeName wc)
+                ["list", "--simple-output"] CL.consume -- FIXME use the package info from envConfigPackages, or is that crazy?
+            let installed = Set.fromList
+                          $ map toPackageName
+                          $ words
+                          $ S8.unpack
+                          $ S8.concat bss
+            if Set.null $ Set.difference targetsSet installed
+                then $logDebug "All packages already installed"
+                else do
+                    $logDebug "Missing packages, performing installation"
+                    Stack.Build.build (const $ return ()) lk defaultBuildOptsCLI
+                        { boptsCLITargets = map T.pack targets
+                        }
+
+        let ghcArgs = concat
+                [ ["-hide-all-packages"]
+                , map (\x -> "-package" ++ x)
+                    $ Set.toList
+                    $ Set.insert "base" targetsSet
+                , case soCompile opts of
+                    SEInterpret -> []
+                    SECompile -> []
+                    SEOptimize -> ["-O2"]
+                ]
+        munlockFile lk -- Unlock before transferring control away.
+        case soCompile opts of
+          SEInterpret -> exec menv ("run" ++ compilerExeName wc)
+                (ghcArgs ++ soFile opts : soArgs opts)
+          _ -> do
+            file <- resolveFile' $ soFile opts
+            let dir = parent file
+            void $ readProcessStderrStdout
+              (Just dir)
+              menv
+              (compilerExeName wc)
+              (ghcArgs ++ [soFile opts])
+            exec menv (toExeName $ toFilePath file) (soArgs opts)
+  where
+    toPackageName = reverse . drop 1 . dropWhile (/= '-') . reverse
+
+    -- Like words, but splits on both commas and spaces
+    wordsComma = splitWhen (\c -> c == ' ' || c == ',')
+
+    toExeName fp =
+      if isWindows
+        then replaceExtension fp "exe"
+        else dropExtension fp
+
+#ifdef WINDOWS
+    isWindows = True
+#else
+    isWindows = False
+#endif

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -170,7 +170,7 @@ getPackagesFromImports (Just (ARResolver (ResolverSnapshot name))) scriptFP = do
                                     , " appears in multiple packages: "
                                     , unwords $ map packageNameString pns'
                                     ]
-                        Nothing -> return $ Set.empty
+                        Nothing -> return Set.empty
                 return $ Set.unions pns
     return (Set.union pns1 pns2, modifyForWindows $ miCorePackages mi)
   where
@@ -194,11 +194,10 @@ toModuleInfo bp = ModuleInfo
     { miCorePackages = Map.keysSet $ siCorePackages $ bpSystemInfo bp
     , miModules =
               Map.unionsWith Set.union
-            $ map (\(pn, mns) ->
+            $ map ((\(pn, mns) ->
                     Map.fromList
                   $ map (\mn -> (ModuleName $ encodeUtf8 mn, Set.singleton pn))
-                  $ Set.toList mns)
-            $ map (fmap (sdModules . ppDesc))
+                  $ Set.toList mns) . fmap (sdModules . ppDesc))
             $ filter (\(_, pp) -> not $ pcHide $ ppConstraints pp)
             $ Map.toList (bpPackages bp)
     }

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -6,32 +6,43 @@ module Stack.Script
     ) where
 
 import           Control.Exception          (assert)
-import           Control.Monad              (unless, void)
+import           Control.Exception.Safe     (throwM)
+import           Control.Monad              (unless, void, forM)
 import           Control.Monad.IO.Class     (liftIO)
 import           Control.Monad.Logger
+import           Data.ByteString            (ByteString)
 import qualified Data.ByteString.Char8      as S8
 import qualified Data.Conduit.List          as CL
+import           Data.Foldable              (fold)
 import           Data.List.Split            (splitWhen)
+import           Data.Map                   (Map)
+import qualified Data.Map.Strict            as Map
+import           Data.Maybe                 (fromMaybe, mapMaybe)
 import           Data.Monoid
+import           Data.Set                   (Set)
 import qualified Data.Set                   as Set
 import qualified Data.Text                  as T
+import           Data.Text.Encoding         (encodeUtf8)
 import           Path
 import           Path.IO
 import qualified Stack.Build
+import           Stack.BuildPlan            (loadBuildPlan)
 import           Stack.Exec
 import           Stack.GhcPkg               (ghcPkgExeName)
 import           Stack.Options.ScriptParser
 import           Stack.Runners
+import           Stack.Types.BuildPlan
 import           Stack.Types.Compiler
 import           Stack.Types.Config
 import           Stack.Types.PackageName
+import           Stack.Types.Resolver
+import           Stack.Types.StackT
 import           System.FilePath            (dropExtension, replaceExtension)
 import           System.Process.Read
 
 -- | Run a Stack Script
 scriptCmd :: ScriptOpts -> GlobalOpts -> IO ()
 scriptCmd opts go' = do
-    print opts
     let go = go'
             { globalConfigMonoid = (globalConfigMonoid go')
                 { configMonoidInstallGHC = First $ Just True
@@ -51,14 +62,17 @@ scriptCmd opts go' = do
         menv <- liftIO $ configEnvOverride config defaultEnvSettings
         wc <- view $ actualCompilerVersionL.whichCompilerL
 
-        let targets = concatMap wordsComma $ soPackages opts
-            targetsSet = Set.fromList targets
+        (targetsSet, coresSet) <-
+            case soPackages opts of
+                [] -> do
+                    $logWarn "No packages provided, using experimental import parser"
+                    getPackagesFromImports (globalResolver go) (soFile opts)
+                packages -> do
+                    let targets = concatMap wordsComma packages
+                    targets' <- mapM parsePackageNameFromString targets
+                    return (Set.fromList targets', Set.empty)
 
-        -- Ensure only package names are provided. We do not allow
-        -- overriding packages in a snapshot.
-        mapM_ parsePackageNameFromString targets
-
-        unless (null targets) $ do
+        unless (Set.null targetsSet) $ do
             -- Optimization: use the relatively cheap ghc-pkg list
             -- --simple-output to check which packages are installed
             -- already. If all needed packages are available, we can
@@ -71,19 +85,20 @@ scriptCmd opts go' = do
                           $ words
                           $ S8.unpack
                           $ S8.concat bss
-            if Set.null $ Set.difference targetsSet installed
+            if Set.null $ Set.difference (Set.map packageNameString targetsSet) installed
                 then $logDebug "All packages already installed"
                 else do
                     $logDebug "Missing packages, performing installation"
                     Stack.Build.build (const $ return ()) lk defaultBuildOptsCLI
-                        { boptsCLITargets = map T.pack targets
+                        { boptsCLITargets = map packageNameText $ Set.toList targetsSet
                         }
 
         let ghcArgs = concat
                 [ ["-hide-all-packages"]
                 , map (\x -> "-package" ++ x)
                     $ Set.toList
-                    $ Set.insert "base" targetsSet
+                    $ Set.insert "base"
+                    $ Set.map packageNameString (Set.union targetsSet coresSet)
                 , case soCompile opts of
                     SEInterpret -> []
                     SECompile -> []
@@ -113,8 +128,97 @@ scriptCmd opts go' = do
         then replaceExtension fp "exe"
         else dropExtension fp
 
+isWindows :: Bool
 #ifdef WINDOWS
-    isWindows = True
+isWindows = True
 #else
-    isWindows = False
+isWindows = False
 #endif
+
+-- | Returns packages that need to be installed, and all of the core
+-- packages. Reason for the core packages:
+
+-- Ideally we'd have the list of modules per core package listed in
+-- the build plan, but that doesn't exist yet. Next best would be to
+-- list the modules available at runtime, but that gets tricky with when we install GHC. Instead, we'll just list all core packages
+getPackagesFromImports :: Maybe AbstractResolver
+                       -> FilePath
+                       -> StackT EnvConfig IO (Set PackageName, Set PackageName)
+getPackagesFromImports Nothing _ = throwM NoResolverWhenUsingNoLocalConfig
+getPackagesFromImports (Just (ARResolver (ResolverSnapshot name))) scriptFP = do
+    (pns1, mns) <- liftIO $ parseImports <$> S8.readFile scriptFP
+    mi <- loadModuleInfo name
+    pns2 <-
+        if Set.null mns
+            then return Set.empty
+            else do
+                pns <- forM (Set.toList mns) $ \mn ->
+                    case Map.lookup mn $ miModules mi of
+                        Just pns ->
+                            case Set.toList pns of
+                                [] -> assert False $ return Set.empty
+                                [pn] -> return $ Set.singleton pn
+                                pns' -> error $ concat
+                                    [ "Module "
+                                    , S8.unpack $ unModuleName mn
+                                    , " appears in multiple packages: "
+                                    , unwords $ map packageNameString pns'
+                                    ]
+                        Nothing -> return $ Set.empty
+                return $ Set.unions pns
+    return (Set.union pns1 pns2, modifyForWindows $ miCorePackages mi)
+  where
+    modifyForWindows
+        | isWindows = Set.insert $(mkPackageName "Win32") . Set.delete $(mkPackageName "unix")
+        | otherwise = id
+
+getPackagesFromImports (Just (ARResolver (ResolverCompiler _))) _ = return (Set.empty, Set.empty)
+getPackagesFromImports (Just aresolver) _ = throwM $ InvalidResolverForNoLocalConfig $ show aresolver
+
+newtype ModuleName = ModuleName { unModuleName :: ByteString }
+  deriving (Show, Eq, Ord)
+
+data ModuleInfo = ModuleInfo
+    { miCorePackages :: !(Set PackageName)
+    , miModules      :: !(Map ModuleName (Set PackageName))
+    }
+
+toModuleInfo :: BuildPlan -> ModuleInfo
+toModuleInfo bp = ModuleInfo
+    { miCorePackages = Map.keysSet $ siCorePackages $ bpSystemInfo bp
+    , miModules =
+              Map.unionsWith Set.union
+            $ map (\(pn, mns) ->
+                    Map.fromList
+                  $ map (\mn -> (ModuleName $ encodeUtf8 mn, Set.singleton pn))
+                  $ Set.toList mns)
+            $ map (fmap (sdModules . ppDesc))
+            $ filter (\(_, pp) -> not $ pcHide $ ppConstraints pp)
+            $ Map.toList (bpPackages bp)
+    }
+
+loadModuleInfo :: SnapName -> StackT EnvConfig IO ModuleInfo
+loadModuleInfo name = toModuleInfo <$> loadBuildPlan name -- FIXME caching
+
+parseImports :: ByteString -> (Set PackageName, Set ModuleName)
+parseImports =
+    fold . mapMaybe parseLine . S8.lines
+  where
+    stripPrefix x y
+      | x `S8.isPrefixOf` y = Just $ S8.drop (S8.length x) y
+      | otherwise = Nothing
+
+    parseLine bs0 = do
+        bs1 <- stripPrefix "import " bs0
+        let bs2 = S8.dropWhile (== ' ') bs1
+            bs3 = fromMaybe bs2 $ stripPrefix "qualified " bs2
+        case stripPrefix "\"" bs3 of
+            Just bs4 -> do
+                pn <- parsePackageNameFromString $ S8.unpack $ S8.takeWhile (/= '"') bs4
+                Just (Set.singleton pn, Set.empty)
+            Nothing -> Just
+                ( Set.empty
+                , Set.singleton
+                    $ ModuleName
+                    $ S8.takeWhile (\c -> c /= ' ' && c /= '(') bs3
+                )

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -51,9 +51,12 @@ scriptCmd opts go' = do
             }
     withBuildConfigAndLock go $ \lk -> do
         -- Some warnings in case the user somehow tries to set a
-        -- stack.yaml location
+        -- stack.yaml location. Note that in this functions we use
+        -- logError instead of logWarn because, when using the
+        -- interpreter mode, only error messages are shown. See:
+        -- https://github.com/commercialhaskell/stack/issues/3007
         case globalStackYaml go' of
-          SYLOverride fp -> $logWarn $ T.pack
+          SYLOverride fp -> $logError $ T.pack
             $ "Ignoring override stack.yaml file for script command: " ++ fp
           SYLDefault -> return ()
           SYLNoConfig -> assert False (return ())
@@ -65,7 +68,7 @@ scriptCmd opts go' = do
         (targetsSet, coresSet) <-
             case soPackages opts of
                 [] -> do
-                    $logWarn "No packages provided, using experimental import parser"
+                    $logError "No packages provided, using experimental import parser"
                     getPackagesFromImports (globalResolver go) (soFile opts)
                 packages -> do
                     let targets = concatMap wordsComma packages

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -216,8 +216,8 @@ setupEnv :: (StackM env m, HasBuildConfig env, HasGHCVariant env)
          -> m EnvConfig
 setupEnv mResolveMissingGHC = do
     config <- view configL
-    bconfig <- view buildConfigNoLocalL
-    stackYaml <- view $ buildConfigLocalL.to bcStackYaml
+    bconfig <- view buildConfigL
+    let stackYaml = bcStackYaml bconfig
     platform <- view platformL
     wcVersion <- view wantedCompilerVersionL
     wc <- view $ wantedCompilerVersionL.whichCompilerL
@@ -253,19 +253,13 @@ setupEnv mResolveMissingGHC = do
 
     $logDebug "Resolving package entries"
     packagesRef <- liftIO $ newIORef Nothing
-    bcnl <- view buildConfigNoLocalL
-    bcl <- view buildConfigLocalL
+    bc <- view buildConfigL
     let envConfig0 = EnvConfig
-            { ecNoLocal = EnvConfigNoLocal
-                { envConfigBuildConfigNoLocal = bcnl
-                , envConfigCabalVersion = cabalVer
-                , envConfigCompilerVersion = compilerVer
-                , envConfigCompilerBuild = compilerBuild
-                }
-            , ecLocal = EnvConfigLocal
-                { envConfigBuildConfigLocal = bcl
-                , envConfigPackagesRef = packagesRef
-                }
+            { envConfigBuildConfig = bc
+            , envConfigCabalVersion = cabalVer
+            , envConfigCompilerVersion = compilerVer
+            , envConfigCompilerBuild = compilerBuild
+            , envConfigPackagesRef = packagesRef
             }
 
     -- extra installation bin directories
@@ -335,22 +329,16 @@ setupEnv mResolveMissingGHC = do
                         (Map.insert es eo m', ())
                     return eo
 
-    bconfigl <- view buildConfigLocalL
     return EnvConfig
-        { ecNoLocal = EnvConfigNoLocal
-            { envConfigBuildConfigNoLocal = bconfig
-                { bcConfig = maybe id addIncludeLib mghcBin
-                            (view configL bconfig)
-                    { configEnvOverride = getEnvOverride' }
-                }
-            , envConfigCabalVersion = cabalVer
-            , envConfigCompilerVersion = compilerVer
-            , envConfigCompilerBuild = compilerBuild
+        { envConfigBuildConfig = bconfig
+            { bcConfig = maybe id addIncludeLib mghcBin
+                        (view configL bconfig)
+                { configEnvOverride = getEnvOverride' }
             }
-        , ecLocal = EnvConfigLocal
-            { envConfigBuildConfigLocal = bconfigl
-            , envConfigPackagesRef = envConfigPackagesRef $ ecLocal envConfig0
-            }
+        , envConfigCabalVersion = cabalVer
+        , envConfigCompilerVersion = compilerVer
+        , envConfigCompilerBuild = compilerBuild
+        , envConfigPackagesRef = envConfigPackagesRef envConfig0
         }
 
 -- | Add the include and lib paths to the given Config

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -1199,7 +1199,7 @@ loadGhcjsEnvConfig stackYaml binPath = runInnerStackT () $ do
             , configMonoidLocalBinPath = First (Just (toFilePath binPath))
             })
         Nothing
-        (Just stackYaml)
+        (SYLOverride stackYaml)
     bconfig <- lcLoadBuildConfig lc Nothing
     runInnerStackT bconfig $ setupEnv Nothing
 

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -622,10 +622,9 @@ solveExtraDeps
     => Bool -- ^ modify stack.yaml?
     -> m ()
 solveExtraDeps modStackYaml = do
-    bconfignl <- view buildConfigNoLocalL
-    bconfigl <- view buildConfigLocalL
+    bconfig <- view buildConfigL
 
-    let stackYaml = bcStackYaml bconfigl
+    let stackYaml = bcStackYaml bconfig
     relStackYaml <- prettyPath stackYaml
 
     $logInfo $ "Using configuration file: " <> T.pack relStackYaml
@@ -645,9 +644,9 @@ solveExtraDeps modStackYaml = do
     (bundle, _) <- cabalPackagesCheck cabalfps noPkgMsg (Just dupPkgFooter)
 
     let gpds              = Map.elems $ fmap snd bundle
-        oldFlags          = unPackageFlags (bcFlags bconfigl)
-        oldExtraVersions  = bcExtraDeps bconfigl
-        resolver          = bcResolver bconfignl
+        oldFlags          = unPackageFlags (bcFlags bconfig)
+        oldExtraVersions  = bcExtraDeps bconfig
+        resolver          = bcResolver bconfig
         oldSrcs           = gpdPackages gpds
         oldSrcFlags       = Map.intersection oldFlags oldSrcs
         oldExtraFlags     = Map.intersection oldFlags oldExtraVersions

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -135,6 +135,7 @@ data StackBuildException
   | SomeTargetsNotBuildable [(PackageName, NamedComponent)]
   | TestSuiteExeMissing Bool String String String
   | CabalCopyFailed Bool String
+  | LocalPackagesPresent [PackageIdentifier]
   deriving Typeable
 
 data FlagSource = FSCommandLine | FSStackYaml
@@ -338,6 +339,9 @@ instance Show StackBuildException where
             , "\n"
             ]
     show (ConstructPlanFailed msg) = msg
+    show (LocalPackagesPresent locals) = unlines
+      $ "Local packages are not allowed when using the script command. Packages found:"
+      : map (\ident -> "- " ++ packageIdentifierString ident) locals
 
 missingExeError :: Bool -> String -> String
 missingExeError isSimpleBuildType msg =

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -195,6 +195,7 @@ data PackageConstraints = PackageConstraints
     , pcBuildBenchmarks  :: Bool
     , pcFlagOverrides    :: Map FlagName Bool
     , pcEnableLibProfile :: Bool
+    , pcHide             :: Bool
     }
     deriving (Show, Eq)
 instance ToJSON PackageConstraints where
@@ -205,6 +206,7 @@ instance ToJSON PackageConstraints where
         , "build-benchmarks" .= pcBuildBenchmarks
         , "flags" .= pcFlagOverrides
         , "library-profiling" .= pcEnableLibProfile
+        , "hide" .= pcHide
         ]
       where
         addMaintainer = maybe id (\m -> (("maintainer" .= m):)) pcMaintainer
@@ -218,6 +220,7 @@ instance FromJSON PackageConstraints where
         pcFlagOverrides <- o .: "flags"
         pcMaintainer <- o .:? "maintainer"
         pcEnableLibProfile <- fmap (fromMaybe True) (o .:? "library-profiling")
+        pcHide <- o .:? "hide" .!= False
         return PackageConstraints {..}
 
 data TestState = ExpectSuccess

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -35,12 +35,9 @@ module Stack.Types.Config
   ,explicitSetupDeps
   ,getMinimalEnvOverride
   -- ** BuildConfig & HasBuildConfig
-  ,BuildConfigNoLocal(..)
-  ,BuildConfigLocal(..)
   ,BuildConfig(..)
   ,stackYamlL
   ,projectRootL
-  ,HasBuildConfigNoLocal(..)
   ,HasBuildConfig(..)
   -- ** GHCVariant & HasGHCVariant
   ,GHCVariant(..)
@@ -53,9 +50,6 @@ module Stack.Types.Config
   ,StackMiniM
   -- ** EnvConfig & HasEnvConfig
   ,EnvConfig(..)
-  ,EnvConfigNoLocal(..)
-  ,EnvConfigLocal(..)
-  ,HasEnvConfigNoLocal(..)
   ,HasEnvConfig(..)
   ,getCompilerPath
   -- * Details
@@ -175,7 +169,6 @@ module Stack.Types.Config
   ,configUrlsL
   ,cabalVersionL
   ,whichCompilerL
-  ,buildConfigL
   -- * Lens reexport
   ,view
   ,to
@@ -512,7 +505,7 @@ readColorWhen = do
 -- 'Config' in order to determine the values here.
 --
 -- These are the components which know nothing about local configuration.
-data BuildConfigNoLocal = BuildConfigNoLocal
+data BuildConfig = BuildConfig
     { bcConfig     :: !Config
     , bcResolver   :: !LoadedResolver
       -- ^ How we resolve which dependencies to install given a set of
@@ -521,11 +514,7 @@ data BuildConfigNoLocal = BuildConfigNoLocal
       -- ^ Build plan wanted for this build
     , bcGHCVariant :: !GHCVariant
       -- ^ The variant of GHC used to select a GHC bindist.
-    }
-
--- | The local parts of 'BuildConfigNoLocal'
-data BuildConfigLocal = BuildConfigLocal
-    { bcPackageEntries :: ![PackageEntry]
+    , bcPackageEntries :: ![PackageEntry]
       -- ^ Local packages
     , bcExtraDeps  :: !(Map PackageName Version)
       -- ^ Extra dependencies specified in configuration.
@@ -549,21 +538,16 @@ data BuildConfigLocal = BuildConfigLocal
       -- for providing better error messages.
     }
 
-data BuildConfig = BuildConfig
-    { bcNoLocal :: !BuildConfigNoLocal
-    , bcLocal   :: !BuildConfigLocal
-    }
-
 stackYamlL :: HasBuildConfig env => Lens' env (Path Abs File)
-stackYamlL = buildConfigLocalL.lens bcStackYaml (\x y -> x { bcStackYaml = y })
+stackYamlL = buildConfigL.lens bcStackYaml (\x y -> x { bcStackYaml = y })
 
 -- | Directory containing the project's stack.yaml file
 projectRootL :: HasBuildConfig env => Getting r env (Path Abs Dir)
 projectRootL = stackYamlL.to parent
 
 -- | Configuration after the environment has been setup.
-data EnvConfigNoLocal = EnvConfigNoLocal
-    {envConfigBuildConfigNoLocal :: !BuildConfigNoLocal
+data EnvConfig = EnvConfig
+    {envConfigBuildConfig :: !BuildConfig
     ,envConfigCabalVersion :: !Version
     -- ^ This is the version of Cabal that stack will use to compile Setup.hs files
     -- in the build process.
@@ -576,17 +560,8 @@ data EnvConfigNoLocal = EnvConfigNoLocal
     -- 'wantedCompilerL', which provides the version specified by the
     -- build plan.
     ,envConfigCompilerBuild :: !CompilerBuild
-    }
-
-data EnvConfigLocal = EnvConfigLocal
-    {envConfigBuildConfigLocal :: !BuildConfigLocal
     ,envConfigPackagesRef :: !(IORef (Maybe (Map (Path Abs Dir) TreatLikeExtraDep)))
     -- ^ Cache for 'getLocalPackages'.
-    }
-
-data EnvConfig = EnvConfig
-    { ecNoLocal :: !EnvConfigNoLocal
-    , ecLocal :: !EnvConfigLocal
     }
 
 -- | Value returned by 'Stack.Config.loadConfig'.
@@ -1312,7 +1287,7 @@ platformGhcRelDir
     :: (MonadReader env m, HasEnvConfig env, MonadThrow m)
     => m (Path Rel Dir)
 platformGhcRelDir = do
-    ec <- view envConfigNoLocalL
+    ec <- view envConfigL
     verOnly <- platformGhcVerOnlyRelDirStr
     parseRelDir (mconcat [ verOnly
                          , compilerBuildSuffix (envConfigCompilerBuild ec)])
@@ -1369,10 +1344,8 @@ packageDatabaseLocal = do
     return $ root </> $(mkRelDir "pkgdb")
 
 -- | Extra package databases
-packageDatabaseExtra :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m [Path Abs Dir]
-packageDatabaseExtra = do
-    bc <- view buildConfigLocalL
-    return $ bcExtraPackageDBs bc
+packageDatabaseExtra :: (MonadReader env m, HasEnvConfig env) => m [Path Abs Dir]
+packageDatabaseExtra = view $ buildConfigL.to bcExtraPackageDBs
 
 -- | Directory for holding flag cache information
 flagCacheLocal :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs Dir)
@@ -1824,39 +1797,25 @@ class HasPlatform env where
 -- | Class for environment values which have a GHCVariant
 class HasGHCVariant env where
     ghcVariantL :: Lens' env GHCVariant
-    default ghcVariantL :: HasBuildConfigNoLocal env => Lens' env GHCVariant
-    ghcVariantL = buildConfigNoLocalL.ghcVariantL
+    default ghcVariantL :: HasBuildConfig env => Lens' env GHCVariant
+    ghcVariantL = buildConfigL.ghcVariantL
     {-# INLINE ghcVariantL #-}
 
 -- | Class for environment values that can provide a 'Config'.
 class HasPlatform env => HasConfig env where
     configL :: Lens' env Config
-    default configL :: HasBuildConfigNoLocal env => Lens' env Config
-    configL = buildConfigNoLocalL.lens bcConfig (\x y -> x { bcConfig = y })
+    default configL :: HasBuildConfig env => Lens' env Config
+    configL = buildConfigL.lens bcConfig (\x y -> x { bcConfig = y })
     {-# INLINE configL #-}
 
-class HasConfig env => HasBuildConfigNoLocal env where
-    buildConfigNoLocalL :: Lens' env BuildConfigNoLocal
-    default buildConfigNoLocalL :: HasEnvConfigNoLocal env => Lens' env BuildConfigNoLocal
-    buildConfigNoLocalL = envConfigNoLocalL.lens
-        envConfigBuildConfigNoLocal
-        (\x y -> x { envConfigBuildConfigNoLocal = y })
+class HasConfig env => HasBuildConfig env where
+    buildConfigL :: Lens' env BuildConfig
+    default buildConfigL :: HasEnvConfig env => Lens' env BuildConfig
+    buildConfigL = envConfigL.lens
+        envConfigBuildConfig
+        (\x y -> x { envConfigBuildConfig = y })
 
--- | Class for environment values that can provide a 'BuildConfig'.
-class HasBuildConfigNoLocal env => HasBuildConfig env where
-    buildConfigLocalL :: Lens' env BuildConfigLocal
-    default buildConfigLocalL :: HasEnvConfig env => Lens' env BuildConfigLocal
-    buildConfigLocalL = envConfigLocalL.lens
-        envConfigBuildConfigLocal
-        (\x y -> x { envConfigBuildConfigLocal = y })
-
-class (HasBuildConfigNoLocal env, HasGHCVariant env) => HasEnvConfigNoLocal env where
-    envConfigNoLocalL :: Lens' env EnvConfigNoLocal
-
-class (HasBuildConfig env, HasEnvConfigNoLocal env) => HasEnvConfig env where
-    envConfigLocalL :: Lens' env EnvConfigLocal
-    envConfigLocalL = envConfigL.lens ecLocal (\x y -> x { ecLocal = y })
-    {-# INLINE envConfigLocalL #-}
+class (HasBuildConfig env, HasGHCVariant env) => HasEnvConfig env where
     envConfigL :: Lens' env EnvConfig
 
 -----------------------------------
@@ -1869,50 +1828,27 @@ instance HasPlatform (Platform,PlatformVariant) where
 instance HasPlatform Config where
     platformL = lens configPlatform (\x y -> x { configPlatform = y })
     platformVariantL = lens configPlatformVariant (\x y -> x { configPlatformVariant = y })
-instance HasPlatform BuildConfigNoLocal
 instance HasPlatform BuildConfig
-instance HasPlatform EnvConfigNoLocal
 instance HasPlatform EnvConfig
 
 instance HasGHCVariant GHCVariant where
     ghcVariantL = id
     {-# INLINE ghcVariantL #-}
-instance HasGHCVariant BuildConfigNoLocal where
+instance HasGHCVariant BuildConfig where
     ghcVariantL = lens bcGHCVariant (\x y -> x { bcGHCVariant = y })
-instance HasGHCVariant BuildConfig
-instance HasGHCVariant EnvConfigNoLocal
 instance HasGHCVariant EnvConfig
 
 instance HasConfig Config where
     configL = id
     {-# INLINE configL #-}
-instance HasConfig BuildConfigNoLocal where
+instance HasConfig BuildConfig where
     configL = lens bcConfig (\x y -> x { bcConfig = y })
-instance HasConfig BuildConfig
-instance HasConfig EnvConfigNoLocal
 instance HasConfig EnvConfig
 
-instance HasBuildConfigNoLocal BuildConfigNoLocal where
-    buildConfigNoLocalL = id
-    {-# INLINE buildConfigNoLocalL #-}
-instance HasBuildConfigNoLocal BuildConfig where
-    buildConfigNoLocalL = lens
-        bcNoLocal
-        (\x y -> x { bcNoLocal = y })
-instance HasBuildConfigNoLocal EnvConfigNoLocal
-instance HasBuildConfigNoLocal EnvConfig
-
 instance HasBuildConfig BuildConfig where
-    buildConfigLocalL = lens bcLocal (\x y -> x { bcLocal = y})
-    {-# INLINE buildConfigLocalL #-}
+    buildConfigL = id
+    {-# INLINE buildConfigL #-}
 instance HasBuildConfig EnvConfig
-
-instance HasEnvConfigNoLocal EnvConfigNoLocal where
-    envConfigNoLocalL = id
-    {-# INLINE envConfigNoLocalL #-}
-instance HasEnvConfigNoLocal EnvConfig where
-    envConfigNoLocalL = lens ecNoLocal (\x y -> x { ecNoLocal = y })
-    {-# INLINE envConfigNoLocalL #-}
 
 instance HasEnvConfig EnvConfig where
     envConfigL = id
@@ -1927,7 +1863,7 @@ stackRootL = configL.lens configStackRoot (\x y -> x { configStackRoot = y })
 
 -- | The compiler specified by the @MiniBuildPlan@. This may be
 -- different from the actual compiler used!
-wantedCompilerVersionL :: HasBuildConfigNoLocal s => Lens' s CompilerVersion
+wantedCompilerVersionL :: HasBuildConfig s => Lens' s CompilerVersion
 wantedCompilerVersionL = miniBuildPlanL.lens
     mbpCompilerVersion
     (\x y -> x { mbpCompilerVersion = y })
@@ -1935,18 +1871,18 @@ wantedCompilerVersionL = miniBuildPlanL.lens
 -- | The version of the compiler which will actually be used. May be
 -- different than that specified in the 'MiniBuildPlan' and returned
 -- by 'wantedCompilerVersionL'.
-actualCompilerVersionL :: HasEnvConfigNoLocal s => Lens' s CompilerVersion
-actualCompilerVersionL = envConfigNoLocalL.lens
+actualCompilerVersionL :: HasEnvConfig s => Lens' s CompilerVersion
+actualCompilerVersionL = envConfigL.lens
     envConfigCompilerVersion
     (\x y -> x { envConfigCompilerVersion = y })
 
-loadedResolverL :: HasBuildConfigNoLocal s => Lens' s LoadedResolver
-loadedResolverL = buildConfigNoLocalL.lens
+loadedResolverL :: HasBuildConfig s => Lens' s LoadedResolver
+loadedResolverL = buildConfigL.lens
     bcResolver
     (\x y -> x { bcResolver = y })
 
-miniBuildPlanL :: HasBuildConfigNoLocal s => Lens' s MiniBuildPlan
-miniBuildPlanL = buildConfigNoLocalL.lens
+miniBuildPlanL :: HasBuildConfig s => Lens' s MiniBuildPlan
+miniBuildPlanL = buildConfigL.lens
     bcWantedMiniBuildPlan
     (\x y -> x { bcWantedMiniBuildPlan = y })
 
@@ -2003,15 +1939,10 @@ packageCachesL = configL.lens configPackageCaches (\x y -> x { configPackageCach
 configUrlsL :: HasConfig env => Lens' env Urls
 configUrlsL = configL.lens configUrls (\x y -> x { configUrls = y })
 
-cabalVersionL :: HasEnvConfigNoLocal env => Lens' env Version
-cabalVersionL = envConfigNoLocalL.lens
+cabalVersionL :: HasEnvConfig env => Lens' env Version
+cabalVersionL = envConfigL.lens
     envConfigCabalVersion
     (\x y -> x { envConfigCabalVersion = y })
 
 whichCompilerL :: Getting r CompilerVersion WhichCompiler
 whichCompilerL = to whichCompiler
-
-buildConfigL :: HasBuildConfig env => Getting r env BuildConfig
-buildConfigL = to $ \env -> BuildConfig
-    (view buildConfigNoLocalL env)
-    (view buildConfigLocalL env)

--- a/src/Stack/Types/Config.hs-boot
+++ b/src/Stack/Types/Config.hs-boot
@@ -32,4 +32,6 @@ data ConfigException
   | FailedToCloneRepo String
   | ManualGHCVariantSettingsAreIncompatibleWithSystemGHC
   | NixRequiresSystemGhc
+  | NoResolverWhenUsingNoLocalConfig
+  | InvalidResolverForNoLocalConfig String
 instance Exception ConfigException

--- a/src/Stack/Types/Internal.hs
+++ b/src/Stack/Types/Internal.hs
@@ -38,12 +38,8 @@ instance HasGHCVariant config => HasGHCVariant (Env config) where
     ghcVariantL = envConfL.ghcVariantL
 instance HasConfig config => HasConfig (Env config) where
     configL = envConfL.configL
-instance HasBuildConfigNoLocal config => HasBuildConfigNoLocal (Env config) where
-    buildConfigNoLocalL = envConfL.buildConfigNoLocalL
 instance HasBuildConfig config => HasBuildConfig (Env config) where
-    buildConfigLocalL = envConfL.buildConfigLocalL
-instance HasEnvConfigNoLocal config => HasEnvConfigNoLocal (Env config) where
-    envConfigNoLocalL = envConfL.envConfigNoLocalL
+    buildConfigL = envConfL.buildConfigL
 instance HasEnvConfig config => HasEnvConfig (Env config) where
     envConfigL = envConfL.envConfigL
 

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -239,7 +239,7 @@ sourceUpgrade gConfigMonoid mresolver builtHash (SourceOpts gitRepo) =
         lc <- loadConfig
             gConfigMonoid
             mresolver
-            (Just $ dir </> $(mkRelFile "stack.yaml"))
+            (SYLOverride $ dir </> $(mkRelFile "stack.yaml"))
         bconfig <- lcLoadBuildConfig lc Nothing
         envConfig1 <- runInnerStackT bconfig $ setupEnv $ Just $
             "Try rerunning with --install-ghc to install the correct GHC into " <>

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -24,15 +24,11 @@ import           Control.Monad.Trans.Either (EitherT)
 import           Control.Monad.Writer.Lazy (Writer)
 import           Data.Attoparsec.Args (parseArgs, EscapingMode (Escaping))
 import           Data.Attoparsec.Interpreter (getInterpreterArgs)
-import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy as L
-import qualified Data.Conduit.List as CL
 import           Data.List
-import           Data.List.Split (splitWhen)
 import qualified Data.Map as Map
 import           Data.Maybe
 import           Data.Monoid
-import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Traversable
@@ -68,7 +64,7 @@ import           Stack.Coverage
 import qualified Stack.Docker as Docker
 import           Stack.Dot
 import           Stack.Exec
-import           Stack.GhcPkg (findGhcPkgField, ghcPkgExeName)
+import           Stack.GhcPkg (findGhcPkgField)
 import qualified Stack.Nix as Nix
 import           Stack.Fetch
 import           Stack.FileWatch
@@ -94,6 +90,7 @@ import           Stack.Options.Utils
 import qualified Stack.PackageIndex
 import qualified Stack.Path
 import           Stack.Runners
+import           Stack.Script
 import           Stack.SDist (getSDistTarball, checkSDistTarball, checkSDistTarball')
 import           Stack.SetupCmd
 import qualified Stack.Sig as Sig
@@ -103,14 +100,13 @@ import           Stack.Types.Config
 import           Stack.Types.Compiler
 import           Stack.Types.Resolver
 import           Stack.Types.Nix
-import           Stack.Types.PackageName (parsePackageNameFromString)
 import           Stack.Types.StackT
 import           Stack.Upgrade
 import qualified Stack.Upload as Upload
 import qualified System.Directory as D
 import           System.Environment (getProgName, getArgs, withArgs)
 import           System.Exit
-import           System.FilePath (pathSeparator, replaceExtension, dropExtension)
+import           System.FilePath (pathSeparator)
 import           System.IO (hIsTerminalDevice, stderr, stdin, stdout, hSetBuffering, BufferMode(..), hPutStrLn, Handle, hGetEncoding, hSetEncoding)
 
 -- | Change the character encoding of the given Handle to transliterate
@@ -800,97 +796,6 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
           wc <- view $ actualCompilerVersionL.whichCompilerL
           pkgopts <- getPkgOpts menv wc pkgs
           return (prefix ++ compilerExeName wc, pkgopts ++ args)
-
--- | Run a Stack Script
-scriptCmd :: ScriptOpts -> GlobalOpts -> IO ()
-scriptCmd opts go' = do
-    print opts
-    let go = go'
-            { globalConfigMonoid = (globalConfigMonoid go')
-                { configMonoidInstallGHC = First $ Just True
-                }
-            , globalStackYaml = SYLNoConfig
-            }
-    withBuildConfigAndLock go $ \lk -> do
-        -- Some warnings in case the user somehow tries to set a
-        -- stack.yaml location
-        case globalStackYaml go' of
-          SYLOverride fp -> $logWarn $ T.pack
-            $ "Ignoring override stack.yaml file for script command: " ++ fp
-          SYLDefault -> return ()
-          SYLNoConfig -> assert False (return ())
-
-        config <- view configL
-        menv <- liftIO $ configEnvOverride config defaultEnvSettings
-        wc <- view $ actualCompilerVersionL.whichCompilerL
-
-        let targets = concatMap wordsComma $ soPackages opts
-            targetsSet = Set.fromList targets
-
-        -- Ensure only package names are provided. We do not allow
-        -- overriding packages in a snapshot.
-        mapM_ parsePackageNameFromString targets
-
-        unless (null targets) $ do
-            -- Optimization: use the relatively cheap ghc-pkg list
-            -- --simple-output to check which packages are installed
-            -- already. If all needed packages are available, we can
-            -- skip the (rather expensive) build call below.
-            bss <- sinkProcessStdout
-                Nothing menv (ghcPkgExeName wc)
-                ["list", "--simple-output"] CL.consume -- FIXME use the package info from envConfigPackages, or is that crazy?
-            let installed = Set.fromList
-                          $ map toPackageName
-                          $ words
-                          $ S8.unpack
-                          $ S8.concat bss
-            if Set.null $ Set.difference targetsSet installed
-                then $logDebug "All packages already installed"
-                else do
-                    $logDebug "Missing packages, performing installation"
-                    Stack.Build.build (const $ return ()) lk defaultBuildOptsCLI
-                        { boptsCLITargets = map T.pack targets
-                        }
-
-        let ghcArgs = concat
-                [ ["-hide-all-packages"]
-                , map (\x -> "-package" ++ x)
-                    $ Set.toList
-                    $ Set.insert "base" targetsSet
-                , case soCompile opts of
-                    SEInterpret -> []
-                    SECompile -> []
-                    SEOptimize -> ["-O2"]
-                ]
-        munlockFile lk -- Unlock before transferring control away.
-        case soCompile opts of
-          SEInterpret -> exec menv ("run" ++ compilerExeName wc)
-                (ghcArgs ++ soFile opts : soArgs opts)
-          _ -> do
-            file <- resolveFile' $ soFile opts
-            let dir = parent file
-            void $ readProcessStderrStdout
-              (Just dir)
-              menv
-              (compilerExeName wc)
-              (ghcArgs ++ [soFile opts])
-            exec menv (toExeName $ toFilePath file) (soArgs opts)
-  where
-    toPackageName = reverse . drop 1 . dropWhile (/= '-') . reverse
-
-    -- Like words, but splits on both commas and spaces
-    wordsComma = splitWhen (\c -> c == ' ' || c == ',')
-
-    toExeName fp =
-      if isWindows
-        then replaceExtension fp "exe"
-        else dropExtension fp
-
-#ifdef WINDOWS
-    isWindows = True
-#else
-    isWindows = False
-#endif
 
 -- | Evaluate some haskell code inline.
 evalCmd :: EvalOpts -> GlobalOpts -> IO ()

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -24,11 +24,15 @@ import           Control.Monad.Trans.Either (EitherT)
 import           Control.Monad.Writer.Lazy (Writer)
 import           Data.Attoparsec.Args (parseArgs, EscapingMode (Escaping))
 import           Data.Attoparsec.Interpreter (getInterpreterArgs)
+import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy as L
+import qualified Data.Conduit.List as CL
 import           Data.List
+import           Data.List.Split (splitWhen)
 import qualified Data.Map as Map
 import           Data.Maybe
 import           Data.Monoid
+import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Traversable
@@ -64,7 +68,7 @@ import           Stack.Coverage
 import qualified Stack.Docker as Docker
 import           Stack.Dot
 import           Stack.Exec
-import           Stack.GhcPkg (findGhcPkgField)
+import           Stack.GhcPkg (findGhcPkgField, ghcPkgExeName)
 import qualified Stack.Nix as Nix
 import           Stack.Fetch
 import           Stack.FileWatch
@@ -98,6 +102,7 @@ import           Stack.Types.Config
 import           Stack.Types.Compiler
 import           Stack.Types.Resolver
 import           Stack.Types.Nix
+import           Stack.Types.PackageName (parsePackageNameFromString)
 import           Stack.Types.StackT
 import           Stack.Upgrade
 import qualified Stack.Upload as Upload
@@ -357,6 +362,10 @@ commandLineHandler progName isInterpreter = complicatedOptions
                   "Run runghc (alias for 'runghc')"
                   execCmd
                   (execOptsParser $ Just ExecRunGhc)
+      addCommand' "script"
+                  "Run a Stack Script"
+                  scriptCmd
+                  scriptOptsParser
 
       unless isInterpreter (do
         addCommand' "eval"
@@ -790,6 +799,77 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
           wc <- view $ actualCompilerVersionL.whichCompilerL
           pkgopts <- getPkgOpts menv wc pkgs
           return (prefix ++ compilerExeName wc, pkgopts ++ args)
+
+scriptOptsParser :: Parser ([String], [String])
+scriptOptsParser = (,)
+    <$> many (strOption (long "package" <> help "Additional packages that must be installed"))
+    <*> many (strArgument (metavar "-- ARGS (e.g. stack ghc -- X.hs -o x)"))
+
+-- | Run a Stack Script
+scriptCmd :: ([String], [String]) -> GlobalOpts -> IO ()
+scriptCmd (packages', args') go' = do
+    let go = go'
+            { globalConfigMonoid = (globalConfigMonoid go')
+                { configMonoidInstallGHC = First $ Just True
+                }
+            , globalStackYaml = SYLNoConfig
+            }
+    withBuildConfigAndLock go $ \lk -> do
+        -- Some warnings in case the user somehow tries to set a
+        -- stack.yaml location
+        case globalStackYaml go' of
+          SYLOverride fp -> $logWarn $ T.pack
+            $ "Ignoring override stack.yaml file for script command: " ++ fp
+          SYLDefault -> return ()
+          SYLNoConfig -> assert False (return ())
+
+        config <- view configL
+        menv <- liftIO $ configEnvOverride config defaultEnvSettings
+        wc <- view $ actualCompilerVersionL.whichCompilerL
+
+        let targets = concatMap wordsComma packages'
+            targetsSet = Set.fromList targets
+
+        -- Ensure only package names are provided. We do not allow
+        -- overriding packages in a snapshot.
+        mapM_ parsePackageNameFromString targets
+
+        unless (null targets) $ do
+            -- Optimization: use the relatively cheap ghc-pkg list
+            -- --simple-output to check which packages are installed
+            -- already. If all needed packages are available, we can
+            -- skip the (rather expensive) build call below.
+            bss <- sinkProcessStdout
+                Nothing menv (ghcPkgExeName wc)
+                ["list", "--simple-output"] CL.consume -- FIXME use the package info from envConfigPackages, or is that crazy?
+            let installed = Set.fromList
+                          $ map toPackageName
+                          $ words
+                          $ S8.unpack
+                          $ S8.concat bss
+            if Set.null $ Set.difference targetsSet installed
+                then $logDebug "All packages already installed"
+                else do
+                    $logDebug "Missing packages, performing installation"
+                    Stack.Build.build (const $ return ()) lk defaultBuildOptsCLI
+                        { boptsCLITargets = map T.pack targets
+                        }
+
+        let args = concat
+                [ ["-hide-all-packages"]
+                , map (\x -> "-package" ++ x)
+                    $ Set.toList
+                    $ Set.insert "base" targetsSet
+                , args'
+                ]
+        let cmd = "run" ++ compilerExeName wc
+        munlockFile lk -- Unlock before transferring control away.
+        exec menv cmd args
+  where
+    toPackageName = reverse . drop 1 . dropWhile (/= '-') . reverse
+
+    -- Like words, but splits on both commas and spaces
+    wordsComma = splitWhen (\c -> c == ' ' || c == ',')
 
 -- | Evaluate some haskell code inline.
 evalCmd :: EvalOpts -> GlobalOpts -> IO ()

--- a/src/test/Stack/BuildPlanSpec.hs
+++ b/src/test/Stack/BuildPlanSpec.hs
@@ -33,7 +33,7 @@ main = hspec spec
 spec :: Spec
 spec = beforeAll setup $ do
     let logLevel = LevelDebug
-    let loadConfig' = runStackT () logLevel True False ColorAuto False (loadConfig mempty Nothing Nothing)
+    let loadConfig' = runStackT () logLevel True False ColorAuto False (loadConfig mempty Nothing SYLDefault)
     let loadBuildConfigRest = runStackT () logLevel True False ColorAuto False
     let inTempDir action = do
             currentDirectory <- getCurrentDirectory

--- a/src/test/Stack/ConfigSpec.hs
+++ b/src/test/Stack/ConfigSpec.hs
@@ -80,7 +80,7 @@ spec = beforeAll setup $ do
         bracket_ setVar resetVar action
 
   describe "loadConfig" $ do
-    let loadConfig' = runStackT () logLevel True False ColorAuto False (loadConfig mempty Nothing Nothing)
+    let loadConfig' = runStackT () logLevel True False ColorAuto False (loadConfig mempty Nothing SYLDefault)
     let loadBuildConfigRest = runStackT () logLevel True False ColorAuto False
     -- TODO(danburton): make sure parent dirs also don't have config file
     it "works even if no config file exists" $ example $ do

--- a/src/test/Stack/ConfigSpec.hs
+++ b/src/test/Stack/ConfigSpec.hs
@@ -132,8 +132,8 @@ spec = beforeAll setup $ do
           LoadConfig{..} <- loadConfig'
           BuildConfig{..} <- loadBuildConfigRest
                                 (lcLoadBuildConfig Nothing)
-          bcStackYaml bcLocal `shouldBe` dir </> stackDotYaml
-          parent (bcStackYaml bcLocal)`shouldBe` dir
+          bcStackYaml `shouldBe` dir </> stackDotYaml
+          parent bcStackYaml `shouldBe` dir
 
     it "STACK_YAML can be relative" $ inTempDir $ do
         parentDir <- getCurrentDirectory >>= parseAbsDir
@@ -146,7 +146,7 @@ spec = beforeAll setup $ do
             LoadConfig{..} <- loadConfig'
             BuildConfig{..} <- loadBuildConfigRest
                                 (lcLoadBuildConfig Nothing)
-            bcStackYaml bcLocal `shouldBe` yamlAbs
+            bcStackYaml `shouldBe` yamlAbs
 
   describe "defaultConfigYaml" $
     it "is parseable" $ \_ -> do

--- a/src/test/Stack/NixSpec.hs
+++ b/src/test/Stack/NixSpec.hs
@@ -47,7 +47,7 @@ setup = unsetEnv "STACK_YAML"
 
 spec :: Spec
 spec = beforeAll setup $ do
-  let loadConfig' cmdLineArgs = runStackT () LevelDebug True False ColorAuto False (loadConfig cmdLineArgs Nothing Nothing)
+  let loadConfig' cmdLineArgs = runStackT () LevelDebug True False ColorAuto False (loadConfig cmdLineArgs Nothing SYLDefault)
       inTempDir test = do
         currentDirectory <- getCurrentDirectory
         withSystemTempDirectory "Stack_ConfigSpec" $ \tempDir -> do

--- a/stack.cabal
+++ b/stack.cabal
@@ -134,6 +134,7 @@ library
                      Stack.Options.NixParser
                      Stack.Options.PackageParser
                      Stack.Options.ResolverParser
+                     Stack.Options.ScriptParser
                      Stack.Options.SolverParser
                      Stack.Options.TestParser
                      Stack.Options.Utils

--- a/stack.cabal
+++ b/stack.cabal
@@ -144,6 +144,7 @@ library
                      Stack.Path
                      Stack.PrettyPrint
                      Stack.Runners
+                     Stack.Script
                      Stack.SDist
                      Stack.Setup
                      Stack.Setup.Installed

--- a/stack.cabal
+++ b/stack.cabal
@@ -293,6 +293,7 @@ executable stack
   build-depends:  Cabal >= 1.18.1.5 && < 1.25
                 , base >=4.7 && < 5
                 , bytestring >= 0.10.4.0
+                , conduit
                 , containers >= 0.5.5.1
                 , directory >= 1.2.1.0 && < 1.4
                 , either
@@ -309,6 +310,7 @@ executable stack
                 , optparse-applicative >= 0.13 && < 0.14
                 , path
                 , path-io >= 1.1.0 && < 2.0.0
+                , split
                 , stack
                 , text >= 1.2.0.4
                 , transformers >= 0.3.0.0 && < 0.6


### PR DESCRIPTION
This adds a basic script command. Most of the work involved has to do
with preventing config files from being loaded. Originally we planned on
creating an alternative set of config types for with and without a local
config. That turned out to be prohibitively invasive. Instead, we now
just create a dummy config file instead ~/.stack/script/lts-x.y (or
/nightly-...).

While this addresses reproducibility, it doesn't help with the speed
concerns: script is now about 100ms faster than runghc on my system for
the case where --package is provided, but it's still over a second for
Hello World. The slowdown is inherent right now in checking if the
relevant packages are installed. It would be nice to figure out a way to
optimize the package check.

Also, this should include some integration tests. It should be a simple
matter of a test that includes a bogus stack.yaml and proving that stack
script ignores it.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

Manual testing so far. We should definitely add some test cases. I used the same example as from the GUIDE.md update:

```haskell
#!/usr/bin/env stack
-- stack --resolver lts-6.25 script --package turtle
{-# LANGUAGE OverloadedStrings #-}
import Turtle
main = echo "Hello World!"
```