### PR TITLE
Wipe out the 00-index.cache file when copying (fixes #2964)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,12 +69,6 @@ before_install:
      cabal)
        export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH;;
    esac
- # Hacky attempted workaround for
- # https://github.com/commercialhaskell/stack/issues/2964
- - case "$BUILD" in
-     stack)
-       rm -f ~/.stack/indices/Hackage/0?-index.*;;
-   esac
  - ./.travis-setup.sh
 
 install:

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -648,11 +648,11 @@ resolvePackageLocation menv projRoot (PLRemote url remotePackageType) = do
         -- TODO: dedupe with code for snapshot hash?
         name = T.unpack $ decodeUtf8 $ S.take 12 $ B64URL.encode $ SHA256.hash $ encodeUtf8 nameBeforeHashing
         root = projRoot </> workDir </> $(mkRelDir "downloaded")
-        fileExtension = case remotePackageType of
+        fileExtension' = case remotePackageType of
             RPTHttp -> ".http-archive"
             _       -> ".unused"
 
-    fileRel <- parseRelFile $ name ++ fileExtension
+    fileRel <- parseRelFile $ name ++ fileExtension'
     dirRel <- parseRelDir name
     dirRelTmp <- parseRelDir $ name ++ ".tmp"
     let file = root </> fileRel

--- a/src/Stack/PackageIndex.hs
+++ b/src/Stack/PackageIndex.hs
@@ -262,9 +262,12 @@ updateIndex menv index =
         (_, SILHttp url HTVanilla) -> updateIndexHTTP name index url
         (_, SILHttp url (HTHackageSecurity hs)) -> updateIndexHackageSecurity name index url hs
 
-     -- Copy to the 00-index.tar filename for backwards compatibility
+     -- Copy to the 00-index.tar filename for backwards
+     -- compatibility. First wipe out the cache file if present.
      tarFile <- configPackageIndex name
      oldTarFile <- configPackageIndexOld name
+     oldCacheFile <- configPackageIndexCacheOld name
+     ignoringAbsence (removeFile oldCacheFile)
      runConduitRes $ sourceFile (toFilePath tarFile) .| sinkFile (toFilePath oldTarFile)
 
 -- | Update the index Git repo and the index tarball

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -93,6 +93,7 @@ module Stack.Types.Config
   ,configPackageIndex
   ,configPackageIndexOld
   ,configPackageIndexCache
+  ,configPackageIndexCacheOld
   ,configPackageIndexGz
   ,configPackageIndexRoot
   ,configPackageIndexRepo
@@ -1190,6 +1191,10 @@ configPackageIndexRepo name = do
 -- | Location of the 01-index.cache file
 configPackageIndexCache :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> m (Path Abs File)
 configPackageIndexCache = liftM (</> $(mkRelFile "01-index.cache")) . configPackageIndexRoot
+
+-- | Location of the 00-index.cache file
+configPackageIndexCacheOld :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> m (Path Abs File)
+configPackageIndexCacheOld = liftM (</> $(mkRelFile "00-index.cache")) . configPackageIndexRoot
 
 -- | Location of the 01-index.tar file
 configPackageIndex :: (MonadReader env m, HasConfig env, MonadThrow m) => IndexName -> m (Path Abs File)


### PR DESCRIPTION
Turns out @mgsloan was right, and #2964 was caused by Hackage Security,
just indirectly. We added a feature to copy the 01-index.tar file over
to 00-index.tar for compatibility. In general, no problem. However, on
Travis, what occured was:

* Download current Stack, which uses 00-index.tar and 00-index.cache
* Run test suites, which updates 01-index.tar and copies it over to
    00-index.tar
* Since the files are different, the 00-index.cache is now invalid
* Next time around, Stack looks in the wrong place in the file
    for cabal files

This should fix it.
