### PR TITLE
Guard fixOutput with setOutput instead of setInput

### DIFF
--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -351,7 +351,7 @@ fixCodePage inner = do
                     (liftIO $ setConsoleCP origCPI)
                 | otherwise = id
             fixOutput
-                | setInput = Catch.bracket_
+                | setOutput = Catch.bracket_
                     (liftIO $ do
                         setConsoleOutputCP expected)
                     (liftIO $ setConsoleOutputCP origCPO)


### PR DESCRIPTION
I adapted the `fixCodePage` function for use in my standalone [`code-page`](http://hackage.haskell.org/package/code-page) library, and while doing so I noticed a small mix-up in its implementation. `fixCodePage` uses the internal functions `fixInput` and `fixOutput` to actually change the input and output codepages respectively, but while `fixInput` is guarded by the value `setInput`, `fixOutput` isn't guarded by `setOutput`—it's guarded by `setInput` too! This seems like a mistake, unless I'm mistaken.