### PR TITLE
Bump to LTS-8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,25 +35,25 @@ matrix:
       compiler: ": #stack 7.10.3 osx"
       os: osx
 
-    - env: BUILD=stack GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
-      compiler: ": #stack 8.0.1"
-      addons: {apt: {packages: [ghc-8.0.1], sources: [hvr-ghc]}}
+    - env: BUILD=stack GHCVER=8.0.2 STACK_YAML=stack-8.0.yaml
+      compiler: ": #stack 8.0.2"
+      addons: {apt: {packages: [ghc-8.0.2], sources: [hvr-ghc]}}
 
-    - env: BUILD=stack GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
-      compiler: ": #stack 8.0.1 osx"
+    - env: BUILD=stack GHCVER=8.0.2 STACK_YAML=stack-8.0.yaml
+      compiler: ": #stack 8.0.2 osx"
       os: osx
 
-    - env: BUILD=style GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
-      compiler: ": #stack 8.0.1"
-      addons: {apt: {packages: [ghc-8.0.1], sources: [hvr-ghc]}}
+    - env: BUILD=style GHCVER=8.0.2 STACK_YAML=stack-8.0.yaml
+      compiler: ": #stack 8.0.2"
+      addons: {apt: {packages: [ghc-8.0.2], sources: [hvr-ghc]}}
 
   allow_failures:
     - env: BUILD=stack STACK_YAML=stack.yaml
       compiler: ": #stack 7.10.3 osx"
       os: osx
 
-    - env: BUILD=stack GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
-      compiler: ": #stack 8.0.1 osx"
+    - env: BUILD=stack GHCVER=8.0.2 STACK_YAML=stack-8.0.yaml
+      compiler: ": #stack 8.0.2 osx"
       os: osx
 
 # Note: the distinction between `before_install` and `install` is not important.

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -1,4 +1,4 @@
-resolver: lts-7.9
+resolver: lts-8.0
 image:
   containers:
     - base: "fpco/stack-base" # see ./etc/docker/stack-base/Dockerfile
@@ -18,3 +18,4 @@ extra-deps:
 - store-core-0.3
 - hpack-0.17.0
 - aeson-1.0.2.1
+- th-utilities-0.2.0.1

--- a/stack.cabal
+++ b/stack.cabal
@@ -356,7 +356,7 @@ test-suite stack-test
                 , directory >= 1.2.1.0
                 , exceptions
                 , filepath
-                , hspec >= 2.2 && <2.4
+                , hspec >= 2.2 && <2.5
                 , hashable
                 , http-client-tls
                 , http-conduit
@@ -401,7 +401,7 @@ test-suite stack-integration-test
                 , containers >= 0.5.5.1
                 , directory >= 1.2.1.0
                 , filepath >= 1.3.0.2
-                , hspec >= 2.2 && < 2.4
+                , hspec >= 2.2 && < 2.5
                 , process >= 1.2.0.0 && < 1.5
                 , resourcet
                 , temporary


### PR DESCRIPTION
Not sure what policy is here but taking a stab. I suppose there should still be a `compiler: ": #stack 8.0.1"` in the build matrix? 