### PR TITLE
Use cryptonite directly instead of cryptohash

### DIFF
--- a/src/Network/HTTP/Download/Verified.hs
+++ b/src/Network/HTTP/Download/Verified.hs
@@ -34,9 +34,10 @@ import              Control.Monad.Catch
 import              Control.Monad.IO.Class
 import              Control.Monad.Logger (logDebug, MonadLogger)
 import              Control.Retry (recovering,limitRetries,RetryPolicy,constantDelay)
-import "cryptohash" Crypto.Hash
+import              Crypto.Hash
 import              Crypto.Hash.Conduit (sinkHash)
-import              Data.Byteable (toBytes)
+import              Data.ByteArray as Mem (convert)
+import              Data.ByteArray.Encoding as Mem (convertToBase, Base(Base16))
 import              Data.ByteString (ByteString)
 import              Data.ByteString.Char8 (readInteger)
 import              Data.Conduit
@@ -153,8 +154,8 @@ sinkCheckHash :: MonadThrow m
 sinkCheckHash req HashCheck{..} = do
     digest <- sinkHashUsing hashCheckAlgorithm
     let actualDigestString = show digest
-    let actualDigestHexByteString = digestToHexByteString digest
-    let actualDigestBytes = toBytes digest
+    let actualDigestHexByteString = Mem.convertToBase Mem.Base16 digest
+    let actualDigestBytes = Mem.convert digest
 
     let passedCheck = case hashCheckHexDigest of
           CheckHexDigestString s -> s == actualDigestString

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -32,8 +32,9 @@ import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import           Control.Monad.Trans.Control (liftBaseWith)
 import           Control.Monad.Trans.Resource
-import qualified Crypto.Hash.SHA256 as SHA256
+import           Crypto.Hash
 import           Data.Attoparsec.Text hiding (try)
+import qualified Data.ByteArray as Mem (convert)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Base64.URL as B64URL
 import           Data.Char (isSpace)
@@ -255,7 +256,7 @@ simpleSetupCode = "import Distribution.Simple\nmain = defaultMain"
 
 simpleSetupHash :: String
 simpleSetupHash =
-    T.unpack $ decodeUtf8 $ S.take 8 $ B64URL.encode $ SHA256.hash $
+    T.unpack $ decodeUtf8 $ S.take 8 $ B64URL.encode $ Mem.convert $ hashWith SHA256 $
     encodeUtf8 (T.pack (unwords buildSetupArgs)) <> setupGhciShimCode <> simpleSetupCode
 
 -- | Get a compiled Setup exe

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -31,10 +31,10 @@ import              Control.Monad.IO.Class
 import              Control.Monad.Logger
 import              Control.Monad.Reader (MonadReader)
 import              Control.Monad.Trans.Resource
-import "cryptohash" Crypto.Hash (Digest, SHA256)
+import              Crypto.Hash (Digest, SHA256(..))
 import              Crypto.Hash.Conduit (sinkHash)
+import qualified    Data.ByteArray as Mem (convert)
 import qualified    Data.ByteString as S
-import              Data.Byteable (toBytes)
 import              Data.Conduit (($$), ZipSink (..))
 import qualified    Data.Conduit.Binary as CB
 import qualified    Data.Conduit.List as CL
@@ -633,7 +633,7 @@ calcFci modTime' fp = liftIO $
         return FileCacheInfo
             { fciModTime = modTime'
             , fciSize = size
-            , fciHash = toBytes (digest :: Digest SHA256)
+            , fciHash = Mem.convert (digest :: Digest SHA256)
             }
 
 checkComponentsBuildable :: MonadThrow m => [LocalPackage] -> m ()

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -43,9 +43,10 @@ import           Control.Monad.Logger
 import           Control.Monad.Reader (MonadReader)
 import           Control.Monad.State.Strict      (State, execState, get, modify,
                                                   put)
-import qualified Crypto.Hash.SHA256 as SHA256
+import           Crypto.Hash (hashWith, SHA256(..))
 import           Data.Aeson.Extended (WithJSONWarnings(..), logJSONWarnings)
 import           Data.Store.VersionTagged
+import qualified Data.ByteArray as Mem (convert)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Base64.URL as B64URL
 import qualified Data.ByteString.Char8 as S8
@@ -1061,7 +1062,7 @@ parseCustomMiniBuildPlan mconfigPath0 url0 = do
     getCustomPlanDir = do
         root <- view stackRootL
         return $ root </> $(mkRelDir "custom-plan")
-    doHash = SnapshotHash . B64URL.encode . SHA256.hash
+    doHash = SnapshotHash . B64URL.encode . Mem.convert . hashWith SHA256
 
 applyCustomSnapshot
     :: (StackMiniM env m, HasConfig env)

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -53,8 +53,9 @@ import           Control.Monad.Extra (firstJustM)
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger hiding (Loc)
 import           Control.Monad.Reader (ask, runReaderT)
-import qualified Crypto.Hash.SHA256 as SHA256
+import           Crypto.Hash (hashWith, SHA256(..))
 import           Data.Aeson.Extended
+import qualified Data.ByteArray as Mem (convert)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Base64.URL as B64URL
 import qualified Data.ByteString.Lazy as L
@@ -646,7 +647,7 @@ resolvePackageLocation menv projRoot (PLRemote url remotePackageType) = do
             RPTGit commit -> T.unwords [url, commit]
             RPTHg commit -> T.unwords [url, commit, "hg"]
         -- TODO: dedupe with code for snapshot hash?
-        name = T.unpack $ decodeUtf8 $ S.take 12 $ B64URL.encode $ SHA256.hash $ encodeUtf8 nameBeforeHashing
+        name = T.unpack $ decodeUtf8 $ S.take 12 $ B64URL.encode $ Mem.convert $ hashWith SHA256 $ encodeUtf8 nameBeforeHashing
         root = projRoot </> workDir </> $(mkRelDir "downloaded")
         fileExtension' = case remotePackageType of
             RPTHttp -> ".http-archive"

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -30,7 +30,7 @@ import           Control.Monad.Logger (MonadLogger,logError,logInfo,logWarn)
 import           Control.Monad.Reader (MonadReader,runReaderT)
 import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Control.Monad.Writer (execWriter,runWriter,tell)
-import qualified "cryptohash" Crypto.Hash as Hash
+import qualified Crypto.Hash as Hash (Digest, MD5, hash)
 import           Data.Aeson.Extended (FromJSON(..),(.:),(.:?),(.!=),eitherDecode)
 import           Data.ByteString.Builder (stringUtf8,charUtf8,toLazyByteString)
 import qualified Data.ByteString.Char8 as BS
@@ -285,7 +285,7 @@ runContainerAndExit getCmdArgs
      sandboxDir <- projectDockerSandboxDir projectRoot
      let ImageConfig {..} = iiConfig
          imageEnvVars = map (break (== '=')) icEnv
-         platformVariant = BS.unpack $ Hash.digestToHexByteString $ hashRepoName image
+         platformVariant = show $ hashRepoName image
          stackRoot = configStackRoot config
          sandboxHomeDir = sandboxDir </> homeDirName
          isTerm = not (dockerDetach docker) &&

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -42,7 +42,7 @@ import              Control.Monad.Logger
 import              Control.Monad.Reader (ask, runReaderT)
 import              Control.Monad.Trans.Control
 import              Control.Monad.Trans.Unlift (MonadBaseUnlift, askRunBase)
-import "cryptohash" Crypto.Hash (SHA256 (..))
+import              Crypto.Hash (SHA256 (..))
 import              Data.ByteString (ByteString)
 import qualified    Data.ByteString as S
 import qualified    Data.ByteString.Lazy as L

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -41,7 +41,7 @@ import              Control.Monad.Logger
 import              Control.Monad.Reader (MonadReader, ReaderT (..))
 import              Control.Monad.State (get, put, modify)
 import              Control.Monad.Trans.Control
-import "cryptohash" Crypto.Hash (SHA1(SHA1))
+import "cryptonite" Crypto.Hash (SHA1(..))
 import              Data.Aeson.Extended
 import qualified    Data.ByteString as S
 import qualified    Data.ByteString.Char8 as S8

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -247,8 +247,8 @@ import           System.Process.Read (EnvOverride, findExecutable)
 import           Stack.Types.Config.Build as X
 
 #ifdef mingw32_HOST_OS
-import qualified Crypto.Hash.SHA1 as SHA1
-import qualified Data.ByteString.Base16 as B16
+import           Crypto.Hash (hashWith, SHA1(..))
+import qualified Data.ByteArray.Encoding as Mem (convertToBase, Base(Base16))
 #endif
 
 -- | The top-level Stackage configuration.
@@ -1327,7 +1327,7 @@ platformGhcVerOnlyRelDirStr = do
 useShaPathOnWindows :: MonadThrow m => Path Rel Dir -> m (Path Rel Dir)
 useShaPathOnWindows =
 #ifdef mingw32_HOST_OS
-    parseRelDir . S8.unpack . S8.take 8 . B16.encode . SHA1.hash . encodeUtf8 . T.pack . toFilePath
+    parseRelDir . S8.unpack . S8.take 8 . Mem.convertToBase Mem.Base16 . hashWith SHA1 . encodeUtf8 . T.pack . toFilePath
 #else
     return
 #endif

--- a/stack.cabal
+++ b/stack.cabal
@@ -189,19 +189,17 @@ library
                    , attoparsec >= 0.12.1.5 && < 0.14
                    , base >= 4.8 && <5
                    , base-compat >=0.6 && <0.10
-                   , base16-bytestring
                    , base64-bytestring
                    , binary >= 0.7 && < 0.9
                    , binary-tagged >= 0.1.1
                    , blaze-builder
-                   , byteable
                    , bytestring >= 0.10.4.0
                    , clock >= 0.7.2
                    , conduit >= 1.2.8
                    , conduit-extra >= 1.1.14
                    , containers >= 0.5.5.1
-                   , cryptohash >= 0.11.6
-                   , cryptohash-conduit
+                   , cryptonite >= 0.20.0
+                   , cryptonite-conduit >= 0.2.0
                    , directory >= 1.2.1.0 && < 1.4
                    , either
                    , errors < 2.2
@@ -223,6 +221,7 @@ library
                    , lifted-async
                        -- https://github.com/basvandijk/lifted-base/issues/31
                    , lifted-base < 0.2.3.7 || > 0.2.3.7
+                   , memory
                    , microlens >= 0.3.0.0
                    , microlens-mtl
                    , monad-control
@@ -352,7 +351,7 @@ test-suite stack-test
                 , conduit
                 , conduit-extra
                 , containers >= 0.5.5.1
-                , cryptohash
+                , cryptonite
                 , directory >= 1.2.1.0 && < 1.4
                 , exceptions
                 , filepath

--- a/stack.cabal
+++ b/stack.cabal
@@ -198,8 +198,8 @@ library
                    , conduit >= 1.2.8
                    , conduit-extra >= 1.1.14
                    , containers >= 0.5.5.1
-                   , cryptonite >= 0.20.0
-                   , cryptonite-conduit >= 0.2.0
+                   , cryptonite
+                   , cryptonite-conduit
                    , directory >= 1.2.1.0 && < 1.4
                    , either
                    , errors < 2.2


### PR DESCRIPTION
As a side effect:

* Add a direct dependency to memory instead of byteable
* No new dependencies cryptohash depends on cryptonite, and byteable on memory
* Remove 3 dependencies (byteable, bytestring-base16, cryptohash

ran `stack tests` succesfully, but not sure how much that cover the code that I changed.