### PR TITLE
Rts opts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -65,6 +65,9 @@ Other enhancements:
 * `stack ghci` now takes `--flag` and `--ghc-options` again (inadverently
   removed in 1.3.0).
   ([#2986](https://github.com/commercialhaskell/stack/issues/2986))
+* `stack exec` now takes `--rts-options` which passes the given arguments inside of
+  `+RTS ... args .. -RTS` to the executable. This works around stack itself consuming
+  the RTS flags on Windows. ([#2986](https://github.com/commercialhaskell/stack/issues/2640))
 
 Bug fixes:
 

--- a/src/Stack/Options/ExecParser.hs
+++ b/src/Stack/Options/ExecParser.hs
@@ -51,7 +51,7 @@ execOptsExtraParser = eoPlainParser <|>
     eoPackagesParser = many (strOption (long "package" <> help "Additional packages that must be installed"))
 
     eoRtsOptionsParser :: Parser [String]
-    eoRtsOptionsParser = many (strOption (long "rts" <> help "Explicit RTS options to pass to application"))
+    eoRtsOptionsParser = many (strOption (long "rts-options" <> help "Explicit RTS options to pass to application"))
 
     eoPlainParser :: Parser ExecOptsExtra
     eoPlainParser = flag' ExecOptsPlain

--- a/src/Stack/Options/ExecParser.hs
+++ b/src/Stack/Options/ExecParser.hs
@@ -3,6 +3,7 @@ module Stack.Options.ExecParser where
 import           Data.Monoid.Extra
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
+import           Options.Applicative.Args
 import           Stack.Types.Config
 
 -- | Parser for exec command
@@ -51,7 +52,10 @@ execOptsExtraParser = eoPlainParser <|>
     eoPackagesParser = many (strOption (long "package" <> help "Additional packages that must be installed"))
 
     eoRtsOptionsParser :: Parser [String]
-    eoRtsOptionsParser = many (strOption (long "rts-options" <> help "Explicit RTS options to pass to application"))
+    eoRtsOptionsParser = concat <$> many (argsOption 
+        ( long "rts-options"
+        <> help "Explicit RTS options to pass to application"
+        <> metavar "RTSFLAG"))
 
     eoPlainParser :: Parser ExecOptsExtra
     eoPlainParser = flag' ExecOptsPlain

--- a/src/Stack/Options/ExecParser.hs
+++ b/src/Stack/Options/ExecParser.hs
@@ -32,6 +32,7 @@ execOptsExtraParser = eoPlainParser <|>
                       ExecOptsEmbellished
                          <$> eoEnvSettingsParser
                          <*> eoPackagesParser
+                         <*> eoRtsOptionsParser
   where
     eoEnvSettingsParser :: Parser EnvSettings
     eoEnvSettingsParser = EnvSettings
@@ -48,6 +49,9 @@ execOptsExtraParser = eoPlainParser <|>
 
     eoPackagesParser :: Parser [String]
     eoPackagesParser = many (strOption (long "package" <> help "Additional packages that must be installed"))
+
+    eoRtsOptionsParser :: Parser [String]
+    eoRtsOptionsParser = many (strOption (long "rts" <> help "Explicit RTS options to pass to application"))
 
     eoPlainParser :: Parser ExecOptsExtra
     eoPlainParser = flag' ExecOptsPlain

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -436,6 +436,7 @@ data ExecOptsExtra
     | ExecOptsEmbellished
         { eoEnvSettings :: !EnvSettings
         , eoPackages :: ![String]
+        , eoRtsOptions :: ![String]
         }
     deriving (Show)
 

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -773,7 +773,7 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
                 -- Add RTS options to arguments
                 let argsWithRts args = if null eoRtsOptions 
                             then args :: [String]
-                            else args ++ ["+RTS"] ++ eoRtsOptions ++ ["-RTS"]
+                            else args ++ ["+RTS"] ++ concatMap words eoRtsOptions ++ ["-RTS"]
                 (cmd, args) <- case (eoCmd, argsWithRts eoArgs) of
                     (ExecCmd cmd, args) -> return (cmd, args)
                     (ExecGhc, args) -> getGhcCmd "" menv eoPackages args

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -730,13 +730,12 @@ sdistCmd (dirs, mpvpBounds, ignoreCheck, sign, sigServerUrl) go =
 -- | Execute a command.
 execCmd :: ExecOpts -> GlobalOpts -> IO ()
 execCmd e@ExecOpts {..} go@GlobalOpts{..} =
-    print e >>
     case eoExtra of
         ExecOptsPlain -> do
             (cmd, args) <- case (eoCmd, eoArgs) of
-                 (ExecCmd cmd, args) -> return (cmd, args)
-                 (ExecGhc, args) -> return ("ghc", args)
-                 (ExecRunGhc, args) -> return ("runghc", args)
+                (ExecCmd cmd, args) -> return (cmd, args)
+                (ExecGhc, args) -> return ("ghc", args)
+                (ExecRunGhc, args) -> return ("runghc", args)
             lc <- liftIO $ loadConfigWithOpts go
             withUserFileLock go (configStackRoot $ lcConfig lc) $ \lk -> do
               let getCompilerVersion = loadCompilerVersion go lc
@@ -756,30 +755,28 @@ execCmd e@ExecOpts {..} go@GlobalOpts{..} =
                     Nothing
                     Nothing -- Unlocked already above.
         ExecOptsEmbellished {..} ->
-           withBuildConfigAndLock go $ \lk -> do
-               let targets = concatMap words eoPackages
-               unless (null targets) $
-                   Stack.Build.build (const $ return ()) lk defaultBuildOptsCLI
-                       { boptsCLITargets = map T.pack targets
-                       }
+            withBuildConfigAndLock go $ \lk -> do
+                let targets = concatMap words eoPackages
+                unless (null targets) $
+                    Stack.Build.build (const $ return ()) lk defaultBuildOptsCLI
+                        { boptsCLITargets = map T.pack targets
+                        }
 
-               config <- view configL
-               menv <- liftIO $ configEnvOverride config eoEnvSettings
-               (cmd, args) <- case (eoCmd, eoArgs) of
-                   (ExecCmd cmd, args) -> do
-                        -- Add RTS options to arguments
-                        let argsWithRts = if null eoRtsOptions 
+                config <- view configL
+                menv <- liftIO $ configEnvOverride config eoEnvSettings
+                -- Add RTS options to arguments
+                let argsWithRts args = if null eoRtsOptions 
                             then args :: [String]
                             else args ++ ["+RTS"] ++ eoRtsOptions ++ ["-RTS"]
-                        return (cmd, argsWithRts)
-
-                   (ExecGhc, args) -> getGhcCmd "" menv eoPackages args
+                (cmd, args) <- case (eoCmd, argsWithRts eoArgs) of
+                    (ExecCmd cmd, args) -> return (cmd, args)
+                    (ExecGhc, args) -> getGhcCmd "" menv eoPackages args
                     -- NOTE: this won't currently work for GHCJS, because it doesn't have
                     -- a runghcjs binary. It probably will someday, though.
-                   (ExecRunGhc, args) ->
-                       getGhcCmd "run" menv eoPackages args
-               munlockFile lk -- Unlock before transferring control away.
-               exec menv cmd args
+                    (ExecRunGhc, args) ->
+                        getGhcCmd "run" menv eoPackages args
+                munlockFile lk -- Unlock before transferring control away.
+                exec menv cmd args
   where
       -- return the package-id of the first package in GHC_PACKAGE_PATH
       getPkgId menv wc name = do
@@ -797,6 +794,7 @@ execCmd e@ExecOpts {..} go@GlobalOpts{..} =
           wc <- view $ actualCompilerVersionL.whichCompilerL
           pkgopts <- getPkgOpts menv wc pkgs
           return (prefix ++ compilerExeName wc, pkgopts ++ args)
+    
 
 -- | Evaluate some haskell code inline.
 evalCmd :: EvalOpts -> GlobalOpts -> IO ()

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -773,7 +773,7 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
                 -- Add RTS options to arguments
                 let argsWithRts args = if null eoRtsOptions 
                             then args :: [String]
-                            else args ++ ["+RTS"] ++ concatMap words eoRtsOptions ++ ["-RTS"]
+                            else args ++ ["+RTS"] ++ eoRtsOptions ++ ["-RTS"]
                 (cmd, args) <- case (eoCmd, argsWithRts eoArgs) of
                     (ExecCmd cmd, args) -> return (cmd, args)
                     (ExecGhc, args) -> getGhcCmd "" menv eoPackages args

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -735,7 +735,7 @@ sdistCmd (dirs, mpvpBounds, ignoreCheck, sign, sigServerUrl) go =
 
 -- | Execute a command.
 execCmd :: ExecOpts -> GlobalOpts -> IO ()
-execCmd e@ExecOpts {..} go@GlobalOpts{..} =
+execCmd ExecOpts {..} go@GlobalOpts{..} =
     case eoExtra of
         ExecOptsPlain -> do
             (cmd, args) <- case (eoCmd, eoArgs) of


### PR DESCRIPTION
* [X ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ X?] The documentation has been updated, if necessary. 
 I'm not sure if the change should also be documented in the user guide. For not it's only in the Changelog

I've tested it by running various variants of stack exec with --rts-options to make sure the arguments are passed properly. Mostly with echo but also on other executables.

This provides a workaround for https://github.com/commercialhaskell/stack/issues/2022 and allows the same invocation to work on both Linux and Windows.