### PR TITLE
Remove --upgrade-cabal recommendation

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -982,14 +982,21 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
                         -- This branch is taken when
                         -- 'explicit-setup-deps' is requested in your
                         -- stack.yaml file.
-                        (Nothing, Just deps) | explicitSetupDeps (packageName package) config ->
+                        (Nothing, Just deps) | explicitSetupDeps (packageName package) config -> do
+                            $logWarn $ T.pack $ concat
+                                [ "Package "
+                                , packageNameString $ packageName package
+                                , " uses a custom Cabal build, but does not use a custom-setup stanza"
+                                ]
+                            $logWarn "Using the explicit setup deps approach based on configuration"
+                            $logWarn "Strongly recommend fixing the package's cabal file"
                             -- Stack always builds with the global Cabal for various
                             -- reproducibility issues.
                             let depsMinusCabal
                                  = map ghcPkgIdString
                                  $ Set.toList
                                  $ addGlobalPackages deps (Map.elems eeGlobalDumpPkgs)
-                            in return (
+                            return (
                                 packageDBArgs ++
                                 cabalPackageArg ++
                                 map ("-package-id=" ++) depsMinusCabal)
@@ -1010,16 +1017,23 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
                         -- Currently, this branch is only taken via `stack
                         -- sdist` or when explicitly requested in the
                         -- stack.yaml file.
-                        (Nothing, _) -> return (
-                              cabalPackageArg ++
-                            -- NOTE: This is different from
-                            -- packageDBArgs above in that it does not
-                            -- include the local database and does not
-                            -- pass in the -hide-all-packages argument
-                            ("-clear-package-db"
-                            : "-global-package-db"
-                            : map (("-package-db=" ++) . toFilePathNoTrailingSep) (bcoExtraDBs eeBaseConfigOpts)
-                           ++ ["-package-db=" ++ toFilePathNoTrailingSep (bcoSnapDB eeBaseConfigOpts)]))
+                        (Nothing, _) -> do
+                            $logWarn $ T.pack $ concat
+                                [ "Package "
+                                , packageNameString $ packageName package
+                                , " uses a custom Cabal build, but does not use a custom-setup stanza"
+                                ]
+                            $logWarn "Not using the explicit setup deps approach based on configuration"
+                            $logWarn "Strongly recommend fixing the package's cabal file"
+                            return $ cabalPackageArg ++
+                                    -- NOTE: This is different from
+                                    -- packageDBArgs above in that it does not
+                                    -- include the local database and does not
+                                    -- pass in the -hide-all-packages argument
+                                    ("-clear-package-db"
+                                    : "-global-package-db"
+                                    : map (("-package-db=" ++) . toFilePathNoTrailingSep) (bcoExtraDBs eeBaseConfigOpts)
+                                ++ ["-package-db=" ++ toFilePathNoTrailingSep (bcoSnapDB eeBaseConfigOpts)])
 
                 setupArgs = ("--builddir=" ++ toFilePathNoTrailingSep distRelativeDir') : args
                 runExe exeName fullArgs =

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1013,7 +1013,7 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
                         (Nothing, _) -> return (
                               cabalPackageArg ++
                             -- NOTE: This is different from
-                            -- packageDBArgs above inthat it does not
+                            -- packageDBArgs above in that it does not
                             -- include the local database and does not
                             -- pass in the -hide-all-packages argument
                             ("-clear-package-db"

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -970,7 +970,7 @@ withSingleContext runInBase ActionContext {..} ExecuteEnv {..} task@Task {..} md
                                         return ("-package-id=" ++ ghcPkgIdString (snd x), Just (toCabalPackageIdentifier (fst x)))
                                     [] -> do
                                         $logWarn (T.pack ("Could not find custom-setup dep: " ++ packageNameString name))
-                                        return ("--package=" ++ packageNameString name, Nothing)
+                                        return ("-package=" ++ packageNameString name, Nothing)
                             let depsArgs = map fst matchedDeps
                             -- Generate setup_macros.h and provide it to ghc
                             let macroDeps = mapMaybe snd matchedDeps

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -196,13 +196,11 @@ processLoadResult _ True (WrongVersion actual wanted, lh)
             ]
         return (Just lh)
 processLoadResult mdb _ (reason, lh) = do
-    let pkgName = packageNameText (fst (lhPair lh))
-    warnIfCabalUpgradeNecessary pkgName reason
     $logDebug $ T.concat $
-        ["Ignoring package ", pkgName]
-        ++
-        maybe [] (\db -> [", from ", T.pack (show db), ","]) mdb
-        ++
+        [ "Ignoring package "
+        , packageNameText (fst (lhPair lh))
+        ] ++
+        maybe [] (\db -> [", from ", T.pack (show db), ","]) mdb ++
         [ " due to"
         , case reason of
             Allowed -> " the impossible?!?!"
@@ -219,14 +217,6 @@ processLoadResult mdb _ (reason, lh) = do
                 ]
         ]
     return Nothing
-
-warnIfCabalUpgradeNecessary :: MonadLogger m => T.Text -> Allowed -> m ()
-warnIfCabalUpgradeNecessary pkg reason = do
-  let msg = "Cabal version mismatch detected. Try running 'stack setup --upgrade-cabal'"
-  case reason of
-    WrongVersion _ _ -> when (pkg == T.pack "Cabal") $ do
-                            $logWarn msg
-    _                -> return ()
 
 data Allowed
     = Allowed


### PR DESCRIPTION
As we started discussing on Slack, and related to #2795. The original issue is no longer present in Stack due to the usage of custom setup deps now being fully supported. If I manually remove the custom-setup stanza from the glib cabal file, the problem reappears. In theory, the right solution is to notice that there's a Cabal library present in the snapshot database and use that instead. I don't want to do that though, because:

1. It will add extra code (and possibly a performance hit) to do all of the checking for Cabal library versions. I _think_ this information is already loaded up by Stack, but if not, it's an extra `ghc-pkg` call, which isn't cheap.
2. It adds some level of non-reproducibility to build plans, as the results will depend on whether we first ran `stack build Cabal` or not.

I've instead added a warning in the case of a missing `custom-setup` stanza. I believe this is the right approach: all of these build issues will disappear (in theory) with properly provided custom-setup, so we should be encouraging them.

I'd go so far as to say that, in the not-too-distant future, removing the ability to upgrade the global Cabal library entirely may be the right approach.

Pinging @lwm @borsboom 