### PR TITLE
http-client 0.3.4 for SOCKS proxy support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,10 @@ Behavior changes:
 
 Other enhancements:
 
+* Upgraded `http-client-tls` version, which now offers support for the
+  `socks5://` and `socks5h://` values in the `http_proxy` and `https_proxy`
+  environment variables.
+
 Bug fixes:
 
 ## 1.4.0 (unreleased)

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -12,3 +12,4 @@ extra-deps:
 - store-0.3.1
 - store-core-0.3
 - th-utilities-0.2.0.1
+- http-client-tls-0.3.4

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -8,3 +8,4 @@ nix:
   enable: false
   packages:
     - zlib
+    - http-client-tls-0.3.4

--- a/stack.cabal
+++ b/stack.cabal
@@ -217,7 +217,7 @@ library
                    , hit
                    , hpc
                    , http-client >= 0.5.3.3
-                   , http-client-tls >= 0.3.3
+                   , http-client-tls >= 0.3.4
                    , http-conduit >= 2.2.3
                    , http-types >= 0.8.6 && < 0.10
                    , lifted-async

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@ extra-deps:
 - store-core-0.3
 - th-orphans-0.13.1
 - http-client-0.5.3.3
-- http-client-tls-0.3.3
+- http-client-tls-0.3.4
 - http-conduit-2.2.3
 - optparse-applicative-0.13.0.0
 - text-metrics-0.1.0


### PR DESCRIPTION
This may be worth merging into the 1.4 release branch as well.