### PR TITLE
Allow to pass additional options to ghcjs-boot

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,9 @@ Other enhancements:
 * Upgraded `http-client-tls` version, which now offers support for the
   `socks5://` and `socks5h://` values in the `http_proxy` and `https_proxy`
   environment variables.
-
+* `stack setup` allow to control options passed to ghcjs-boot with 
+  `--ghcjs-boot-options` (one word at a time) and `--[no-]ghcjs-boot-clean`
+  
 Bug fixes:
 
 ## 1.4.0 (unreleased)

--- a/doc/ghcjs.md
+++ b/doc/ghcjs.md
@@ -9,6 +9,9 @@ To use GHCJS with stack, place a GHCJS version in the [`compiler`](yaml_configur
 You can also build existing stack projects which target GHC, and instead build
 them with GHCJS.  For example: `stack build --compiler ghcjs-0.2.0.9006020_ghc-7.10.3`
 
+There are advanced options for `stack setup`: `--ghcjs-boot-options` (one word at a time) and `--[no-]ghcjs-boot-clean`
+which will passyour settings down to the `ghcjs-boot`. You will need to know exacty what you are doing with them.  
+
 Sidenote: If you receive a message like
 `The program 'ghcjs' version >=0.1 is required but the version of .../ghcjs could not be determined.`,
 then you may need to install a different version of `node`. See

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -146,6 +146,8 @@ data SetupOpts = SetupOpts
     -- ^ Location of the main stack-setup.yaml file
     , soptsGHCBindistURL :: !(Maybe String)
     -- ^ Alternate GHC binary distribution (requires custom GHCVariant)
+    , soptsGHCJSBootOpts :: [String]
+    -- ^ Additional ghcjs-boot options, the default is "--clean"
     }
     deriving Show
 data SetupException = UnsupportedSetupCombo OS Arch
@@ -235,6 +237,7 @@ setupEnv mResolveMissingGHC = do
             , soptsResolveMissingGHC = mResolveMissingGHC
             , soptsSetupInfoYaml = defaultSetupInfoYaml
             , soptsGHCBindistURL = Nothing
+            , soptsGHCJSBootOpts = ["--clean"]
             }
 
     (mghcBin, compilerBuild, _) <- ensureCompiler sopts
@@ -496,7 +499,7 @@ ensureCompiler sopts = do
         upgradeCabal menv wc
 
     case mtools of
-        Just (Just (ToolGhcjs cv), _) -> ensureGhcjsBooted menv cv (soptsInstallIfMissing sopts)
+        Just (Just (ToolGhcjs cv), _) -> ensureGhcjsBooted menv cv (soptsInstallIfMissing sopts) (soptsGHCJSBootOpts sopts)
         _ -> return ()
 
     when (soptsSanityCheck sopts) $ sanityCheck menv wc
@@ -1086,8 +1089,8 @@ installGHCJS si archiveFile archiveType _tempDir destDir = do
     $logStickyDone "Installed GHCJS."
 
 ensureGhcjsBooted :: (StackM env m, HasConfig env)
-                  => EnvOverride -> CompilerVersion -> Bool -> m ()
-ensureGhcjsBooted menv cv shouldBoot  = do
+                  => EnvOverride -> CompilerVersion -> Bool -> [String] -> m ()
+ensureGhcjsBooted menv cv shouldBoot bootOpts = do
     eres <- try $ sinkProcessStdout Nothing menv "ghcjs" [] (return ())
     case eres of
         Right () -> return ()
@@ -1117,12 +1120,12 @@ ensureGhcjsBooted menv cv shouldBoot  = do
                 actualStackYamlExists <- doesFileExist actualStackYaml
                 unless actualStackYamlExists $
                     fail "Couldn't find GHCJS stack.yaml in old or new location."
-                bootGhcjs ghcjsVersion actualStackYaml destDir
+                bootGhcjs ghcjsVersion actualStackYaml destDir bootOpts
         Left err -> throwM err
 
 bootGhcjs :: StackM env m
-          => Version -> Path Abs File -> Path Abs Dir -> m ()
-bootGhcjs ghcjsVersion stackYaml destDir = do
+          => Version -> Path Abs File -> Path Abs Dir -> [String] -> m ()
+bootGhcjs ghcjsVersion stackYaml destDir bootOpts = do
     envConfig <- loadGhcjsEnvConfig stackYaml (destDir </> $(mkRelDir "bin"))
     menv <- liftIO $ configEnvOverride (view configL envConfig) defaultEnvSettings
     -- Install cabal-install if missing, or if the installed one is old.
@@ -1175,7 +1178,7 @@ bootGhcjs ghcjsVersion stackYaml destDir = do
                     "This version is specified by the stack.yaml file included in the ghcjs tarball.\n"
             _ -> return ()
     $logSticky "Booting GHCJS (this will take a long time) ..."
-    logProcessStderrStdout Nothing "ghcjs-boot" menv' ["--clean"]
+    logProcessStderrStdout Nothing "ghcjs-boot" menv' bootOpts
     $logStickyDone "GHCJS booted."
 
 loadGhcjsEnvConfig :: StackM env m

--- a/src/Stack/SetupCmd.hs
+++ b/src/Stack/SetupCmd.hs
@@ -33,6 +33,8 @@ data SetupCmdOpts = SetupCmdOpts
     , scoUpgradeCabal    :: !Bool
     , scoSetupInfoYaml   :: !String
     , scoGHCBindistURL   :: !(Maybe String)
+    , scoGHCJSBootOpts   :: ![String]
+    , scoGHCJSBootClean  :: !Bool
     }
 
 setupYamlCompatParser :: OA.Parser String
@@ -67,6 +69,14 @@ setupParser = SetupCmdOpts
             (OA.long "ghc-bindist"
            <> OA.metavar "URL"
            <> OA.help "Alternate GHC binary distribution (requires custom --ghc-variant)"))
+    <*> OA.many (OA.strOption
+            (OA.long "ghcjs-boot-options"
+           <> OA.metavar "GHCJS_BOOT"
+           <> OA.help "Additional ghcjs-boot options"))
+    <*> OA.boolFlags True
+            "ghcjs-boot-clean"
+            "Control if ghcjs-boot should have --clean option present"
+            OA.idm
   where
     readVersion = do
         s <- OA.readerAsk
@@ -100,6 +110,7 @@ setup SetupCmdOpts{..} wantedCompiler compilerCheck mstack = do
         , soptsResolveMissingGHC = Nothing
         , soptsSetupInfoYaml = scoSetupInfoYaml
         , soptsGHCBindistURL = scoGHCBindistURL
+        , soptsGHCJSBootOpts = scoGHCJSBootOpts ++ ["--clean" | scoGHCJSBootClean]
         }
     let compiler = case wantedCompiler of
             GhcVersion _ -> "GHC"

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -301,8 +301,9 @@ setupCompiler compiler = do
         , soptsSkipMsys          = configSkipMsys config
         , soptsUpgradeCabal      = False
         , soptsResolveMissingGHC = msg
-        , soptsSetupInfoYaml    = defaultSetupInfoYaml
+        , soptsSetupInfoYaml     = defaultSetupInfoYaml
         , soptsGHCBindistURL     = Nothing
+        , soptsGHCJSBootOpts     = ["--clean"]
         }
     return dirs
 


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Manually tested.

Stab at https://github.com/commercialhaskell/stack/issues/2952

It was tested with
```
stack setup --ghcjs-boot-clean \
  --ghcjs-boot-options --jobs --ghcjs-boot-options 4 \
  --ghcjs-boot-options --no-prof \
  --ghcjs-boot-options --no-haddock \
  --ghcjs-boot-options -q
```
in a project having `ghcjs` as default. 