### PR TITLE
Support warning detection for GHC 8

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -107,6 +107,8 @@ Bug fixes:
 * `stack upgrade --git` now works properly.  Workaround for affected
   versions (>= 1.3.0) is to instead run `stack upgrade --git --source-only`.
   ([#2977](https://github.com/commercialhaskell/stack/issues/2977))
+* Added support for GHC 8's slightly different warning format for
+  dumping warnings from logs.
 
 ## 1.3.2
 

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -429,7 +429,8 @@ withExecuteEnv menv bopts boptsCli baseConfigOpts locals globalPackages snapshot
          =$ CL.take 1
       unless (null firstWarning) $ dumpLog " due to warnings" (pkgDir, filepath)
 
-    isWarning t = ": Warning:" `T.isSuffixOf` t
+    isWarning t = ": Warning:" `T.isSuffixOf` t -- prior to GHC 8
+               || ": warning:" `T.isInfixOf` t -- GHC 8 is slightly different
 
     dumpLog msgSuffix (pkgDir, filepath) = do
         $logInfo $ T.pack $ concat ["\n--  Dumping log file", msgSuffix, ": ", toFilePath filepath, "\n"]


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
