### PR TITLE
Fix location of global config file

### DIFF
--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -16,7 +16,7 @@ and [non-project-specific](#non-project-specific-config) options in:
 - The project file itself may also contain non-project specific options
 
 *Note:* When stack is invoked outside a stack project it will source project
-specific options from `~/.stack/global/stack.yaml`.  Options in this file will
+specific options from `~/.stack/global-project/stack.yaml`.  Options in this file will
 be ignored for a project with its own `<project dir>/stack.yaml`.
 
 ## Project-specific config


### PR DESCRIPTION
Apparently the location of the global `stack.yaml` has changed.
