### PR TITLE
Have switching on/off profiling cause package dirtiness #2984

### DIFF
--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -495,10 +495,13 @@ isStackOpt t = any (`T.isPrefixOf` t)
     , "--haddockdir="
     , "--enable-tests"
     , "--enable-benchmarks"
-    , "--enable-library-profiling"
-    , "--enable-executable-profiling"
-    , "--enable-profiling"
     , "--exact-configuration"
+    -- Treat these as causing dirtiness, to resolve
+    -- https://github.com/commercialhaskell/stack/issues/2984
+    --
+    -- , "--enable-library-profiling"
+    -- , "--enable-executable-profiling"
+    -- , "--enable-profiling"
     ] || t == "--user"
 
 configureOptsDirs :: BaseConfigOpts


### PR DESCRIPTION
This seems like the simplest way to fix https://github.com/commercialhaskell/stack/issues/2984 .

I suspect it may cause unnecessary rebuilds, as there's likely a reason for these to be present in the list.  Thoughts, @snoyberg ?  The alternative seems complicated / error prone - https://github.com/commercialhaskell/stack/issues/2984#issuecomment-284611410