### PR TITLE
Add optional shorter form for `--test-arguments`.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ Other enhancements:
 * Upstream packages unpacked to a temp dir are now deleted as soon as
   possible to avoid running out of space in `/tmp`.
   See [#3018](https://github.com/commercialhaskell/stack/issues/3018)
+* Add short synonyms for `test-arguments` and `benchmark-arguments` options.
 
 Bug fixes:
 

--- a/src/Stack/Options/BenchParser.hs
+++ b/src/Stack/Options/BenchParser.hs
@@ -13,6 +13,7 @@ import           Stack.Types.Config
 benchOptsParser :: Bool -> Parser BenchmarkOptsMonoid
 benchOptsParser hide0 = BenchmarkOptsMonoid
         <$> optionalFirst (strOption (long "benchmark-arguments" <>
+                                      long "ba" <>
                                  metavar "BENCH_ARGS" <>
                                  help ("Forward BENCH_ARGS to the benchmark suite. " <>
                                        "Supports templates from `cabal bench`") <>

--- a/src/Stack/Options/TestParser.hs
+++ b/src/Stack/Options/TestParser.hs
@@ -22,6 +22,7 @@ testOptsParser hide0 =
                 (optional
                     (argsOption
                         (long "test-arguments" <>
+                         long "ta" <>
                          metavar "TEST_ARGS" <>
                          help "Arguments passed in to the test suite program" <>
                          hide)))


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

I could just be lazy but it is handy when fooling around with tasty framework args.

Looks like:

```
  --ta,--test-arguments TEST_ARGS
                           Arguments passed in to the test suite program
```
