### PR TITLE
[WIP] Fix bash completion for --[no-]* options #2737

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,8 @@ Bug fixes:
   your project.
 * `stack clean --full` now works when docker is enabled.
   See [#2010](https://github.com/commercialhaskell/stack/issues/2010)
+* Bash completion fixed for `--[no-]*` options.
+  See [#2737](https://github.com/commercialhaskell/stack/issues/2737)
 
 ## 1.4.0
 

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -194,8 +194,8 @@ main = do
 -- Vertically combine only the error component of the first argument with the
 -- error component of the second.
 vcatErrorHelp :: ParserHelp -> ParserHelp -> ParserHelp
-vcatErrorHelp (ParserHelp e1 _ _ _ _) (ParserHelp e2 h2 u2 b2 f2) =
-  ParserHelp (vcatChunks [e2, e1]) h2 u2 b2 f2
+vcatErrorHelp (ParserHelp e1 _ _ _ _ _) (ParserHelp e2 s2 h2 u2 b2 f2) =
+  ParserHelp (vcatChunks [e2, e1]) s2 h2 u2 b2 f2
 
 commandLineHandler
   :: FilePath
@@ -553,8 +553,8 @@ interpreterHandler currentDir args f = do
       then overrideErrorHelp
       else vcatErrorHelp
 
-    overrideErrorHelp (ParserHelp e1 _ _ _ _) (ParserHelp _ h2 u2 b2 f2) =
-      ParserHelp e1 h2 u2 b2 f2
+    overrideErrorHelp (ParserHelp e1 _ _ _ _ _) (ParserHelp _ s2 h2 u2 b2 f2) =
+      ParserHelp e1 s2 h2 u2 b2 f2
 
     parseResultHandler fn = handleParseResult (overFailure fn (Failure f))
     noSuchFile name = errorHelp $ stringChunk


### PR DESCRIPTION
Fixes #2737 .  This is not ready to be merged, because first https://github.com/pcapriotti/optparse-applicative/pull/251 needs to be merged, and a new version of optparse-applicative released.  Then, this PR can be updated to specify the new version of optparse-applicative in the cabal constraints / stack configs.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.