### PR TITLE
Revert "Set NoBuffering mode io, before exec #2702"

### DIFF
--- a/src/Stack/Exec.hs
+++ b/src/Stack/Exec.hs
@@ -21,7 +21,6 @@ import           System.Process.Log
 import           Control.Exception.Lifted
 import           Data.Streaming.Process (ProcessExitedUnsuccessfully(..))
 import           System.Exit
-import           System.IO (stderr, stdin, stdout, hSetBuffering, BufferMode(..))
 import           System.Process.Run (callProcess, callProcessObserveStdout, Cmd(..))
 #ifdef WINDOWS
 import           System.Process.Read (EnvOverride)
@@ -62,7 +61,6 @@ exec :: (MonadIO m, MonadLogger m, MonadBaseControl IO m)
 exec = execSpawn
 #else
 exec menv cmd0 args = do
-    setNoBuffering
     cmd <- preProcess Nothing menv cmd0
     $withProcessTimeLog cmd args $
         liftIO $ PID1.run cmd args (envHelper menv)
@@ -75,7 +73,6 @@ exec menv cmd0 args = do
 execSpawn :: (MonadIO m, MonadLogger m, MonadBaseControl IO m)
      => EnvOverride -> String -> [String] -> m b
 execSpawn menv cmd0 args = do
-    setNoBuffering
     e <- $withProcessTimeLog cmd0 args $
         try (callProcess (Cmd Nothing cmd0 menv args))
     liftIO $ case e of
@@ -90,9 +87,3 @@ execObserve menv cmd0 args = do
     case e of
         Left (ProcessExitedUnsuccessfully _ ec) -> liftIO $ exitWith ec
         Right s -> return s
-
-setNoBuffering :: MonadIO m => m ()
-setNoBuffering = liftIO $ do
-    hSetBuffering stdout NoBuffering
-    hSetBuffering stdin  NoBuffering
-    hSetBuffering stderr NoBuffering


### PR DESCRIPTION
This reverts commit 6c876293a4ca215c2645de162aa0314f415fb754.

Running `hSetBuffering` just before exec had no effect on any actual buffering, but it screwed up the persistent terminal state in such a way that the runtime fails to reset it.  The effect was that keys like Backspace, Ctrl-C, Ctrl-D, etc. were not working correctly in programs launched inside `stack exec` and after `stack exec`.

Closes: #2884.

Reopens: #2702 (actually, that was never fixed in the first place).

> Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

> Please also shortly describe how you tested your change. Bonus points for added tests!

Tested using the example in #2702, and by running `stty sane; stty; stack exec stty; stty` (which should show the same state three times).