### PR TITLE
Actually use haddock-arguments

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,7 +31,9 @@ Other enhancements:
 * Can now use relative paths for `extra-include-dirs` and `extra-lib-dirs`.
   See [#2830](https://github.com/commercialhaskell/stack/issues/2830)
 * Improved bash completion for many options, including `--ghc-options`,
-  --flag`, targets, and project executables for `exec`.
+  `--flag`, targets, and project executables for `exec`.
+* `--haddock-arguments` is actually used now when `haddock` is invoked
+  during documentation generation.
 
 Bug fixes:
 

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1387,8 +1387,12 @@ singleBuild runInBase ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} in
                             ("Warning: haddock not generating hyperlinked sources because 'HsColour' not\n" <>
                              "found on PATH (use 'stack install hscolour' to install).")
                         return ["--hyperlink-source" | hscolourExists]
-            cabal False (concat [["haddock", "--html", "--hoogle", "--html-location=../$pkg-$version/"]
-                                ,sourceFlag, ["--internal" | boptsHaddockInternal eeBuildOpts]])
+            cabal False (concat [ ["haddock", "--html", "--html-location=../$pkg-$version/"]
+                                , sourceFlag
+                                , ["--internal" | boptsHaddockInternal eeBuildOpts]
+                                , [ "--haddock-option=" <> opt
+                                  | opt <- hoAdditionalArgs (boptsHaddockOpts eeBuildOpts) ]
+                                ])
 
         let shouldCopy = not isFinalBuild && (packageHasLibrary package || not (Set.null (packageExes package)))
         when shouldCopy $ withMVar eeInstallLock $ \() -> do

--- a/test/integration/tests/haddock-options/Main.hs
+++ b/test/integration/tests/haddock-options/Main.hs
@@ -1,0 +1,12 @@
+import StackTest
+
+main :: IO ()
+main = do
+    -- Fails to work because BAR is defined here and FOO in stack file
+    stackErr ["haddock", "--haddock-arguments", "--optghc=-DBAR"]
+    stack ["clean"]
+    -- Works just fine
+    stack ["haddock"]
+    stack ["clean"]
+    -- Fails to work because we have bad argument
+    stackErr ["haddock", "--haddock-arguments", "--stack_it_badhaddockargument"]

--- a/test/integration/tests/haddock-options/files/haddock-options.cabal
+++ b/test/integration/tests/haddock-options/files/haddock-options.cabal
@@ -1,0 +1,10 @@
+name:                haddock-options
+version:             0.1.0.0
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:    src
+  exposed-modules:   Lib
+  build-depends:     base
+  default-language:  Haskell2010

--- a/test/integration/tests/haddock-options/files/src/Lib.hs
+++ b/test/integration/tests/haddock-options/files/src/Lib.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE CPP #-}
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"
+
+#if defined(FOO) && defined(BAR)
+#error FOO and BAR is defined
+#endif

--- a/test/integration/tests/haddock-options/files/stack.yaml
+++ b/test/integration/tests/haddock-options/files/stack.yaml
@@ -1,0 +1,9 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: lts-8.0
+build:
+  haddock-arguments:
+    haddock-args:
+      - --optghc=-DFOO


### PR DESCRIPTION
Until now, the only place I can tell that these arguments are being used
is when generating index.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* Any changes that could be relevant to users have been recorded in the ChangeLog.md
Done
* The documentation has been updated, if necessary.
Do we need it?

Please also shortly describe how you tested your change. Bonus points for added tests!
`stack --nix test --flag stack:integration-tests stack:stack-integration-test --test-arguments "-m haddock-options"`
