### PR TITLE
Don't clean packages listed as extra-deps

### DIFF
--- a/src/Stack/Clean.hs
+++ b/src/Stack/Clean.hs
@@ -43,10 +43,10 @@ dirsToDelete
     -> m [Path Abs Dir]
 dirsToDelete cleanOpts = do
     packages <- getLocalPackages
-    let localPkgDirs = Map.keys packages
     case cleanOpts of
-        CleanShallow [] -> do
-            mapM distDirFromDir localPkgDirs
+        CleanShallow [] ->
+            -- Filter out packages listed as extra-deps
+            mapM distDirFromDir . Map.keys . Map.filter (== False) $ packages
         CleanShallow targets -> do
             localPkgViews <- getLocalPackageViews
             let localPkgNames = Map.keys localPkgViews
@@ -55,7 +55,7 @@ dirsToDelete cleanOpts = do
                 [] -> mapM distDirFromDir (mapMaybe getPkgDir targets)
                 xs -> throwM (NonLocalPackages xs)
         CleanFull -> do
-            pkgWorkDirs <- mapM workDirFromDir localPkgDirs
+            pkgWorkDirs <- mapM workDirFromDir (Map.keys packages)
             projectWorkDir <- getProjectWorkDir
             return (projectWorkDir : pkgWorkDirs)
 


### PR DESCRIPTION
* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

(I don't know if either items above apply.)

This resolves #3121 with the following choices made:

1. packages listed as extra-deps are not cleaned with `stack clean`
2. extra-dep packages can still be cleaned with `stack clean <extra-dep>`
3. `stack clean --full` still cleans all packages, extra-dep or otherwise.

The 3rd choice was made conservatively since I don't use --full.

I tested this change by running it on snowdrift, given the steps below. If someone wants to suggest how a test could be made for this, I can make one and add it to the PR. (I found the integration test directory, but I'm not sure the best way to programatically test that a package has *not* been cleaned.)

Steps I used to test:

```
git clone https://chreekat@git.snowdrift.coop/sd/snowdrift.git
cd snowdrift
./build.sh shell # takes a wee while
stack build
stack clean
stack build
# Make sure only non-extra-deps rebuild
stack clean postgresql-simple-migration # clean an extra dep
# Make sure there are no errors in last command
stack build
# Make sure everything builds again
stack clean --full
stack build
# Make sure everything builds again
```
 