### PR TITLE
Improve filtering of ghc messages

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1686,6 +1686,7 @@ mungeBuildOutput excludeTHLoading makeAbsolute pkgDir = void $
     CT.lines
     =$ CL.map stripCR
     =$ CL.filter (not . isTHLoading)
+    =$ CL.filter (not . isLinkerWarning)
     =$ toAbsolute
   where
     -- | Is this line a Template Haskell "Loading package" line
@@ -1696,6 +1697,11 @@ mungeBuildOutput excludeTHLoading makeAbsolute pkgDir = void $
         ExcludeTHLoading -> \bs ->
             "Loading package " `T.isPrefixOf` bs &&
             ("done." `T.isSuffixOf` bs || "done.\r" `T.isSuffixOf` bs)
+
+    isLinkerWarning :: Text -> Bool
+    isLinkerWarning str =
+      ("ghc.exe: warning:" `T.isPrefixOf` str || "ghc.EXE: warning:" `T.isPrefixOf` str) &&
+      "is linked instead of __imp_" `T.isInfixOf` str
 
     -- | Convert GHC error lines with file paths to have absolute file paths
     toAbsolute :: ConduitM Text Text m ()

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -266,7 +266,7 @@ getSDistFileList lp =
             $ \ee ->
             withSingleContext runInBase ac ee task Nothing (Just "sdist") $ \_package cabalfp _pkgDir cabal _announce _console _mlogFile -> do
                 let outFile = toFilePath tmpdir FP.</> "source-files-list"
-                cabal False ["sdist", "--list-sources", outFile]
+                cabal KeepTHLoading ["sdist", "--list-sources", outFile]
                 contents <- liftIO (readFile outFile)
                 return (contents, cabalfp)
   where


### PR DESCRIPTION
I added stripping of linker warnings on ghc 7.8 on windows (x64 IIRC). I'm not sure how useful it would be in general going forwards, but it's really annoying when it occurs.

I also took liberty to improve `Stack.Build.Execute` module a bit by adding type signatures no non-obvious parts and by introducing (hopefully) descriptive enums instead of booleans.