### PR TITLE
stack uninstall: Update the static help message

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -631,7 +631,7 @@ uninstallCmd :: [String] -> GlobalOpts -> IO ()
 uninstallCmd _ go = withConfigAndLock go $ do
     $logError "stack does not manage installations in global locations"
     $logError "The only global mutation stack performs is executable copying"
-    $logError "For the default executable destination, please run 'stack path --local-bin-path'"
+    $logError "For the default executable destination, please run 'stack path --local-bin'"
 
 -- | Unpack packages to the filesystem
 unpackCmd :: [String] -> GlobalOpts -> IO ()


### PR DESCRIPTION
It seems like --local-bin-path is deprecated in favour of --local-bin.

----

I've not compiled this change, but I did run the two commands and indeed there's no deprecation warning printed for the latter.

```
❯ stack path --local-bin-path

'--local-bin-path' will be removed in a future release.
Please use '--local-bin' instead.


/home/arash/.local/bin
```
```
❯ stack path --local-bin     
/home/arash/.local/bin
```
