### PR TITLE
Suppress password echoing from stack upload on MinTTY consoles

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -63,6 +63,9 @@ Bug fixes:
 * Switching a package between extra-dep and local package now forces
   rebuild (previously it wouldn't if versions were the same).
   See [#2147](https://github.com/commercialhaskell/stack/issues/2147)
+* `stack upload` no longer reveals your password when you type it on
+  MinTTY-based Windows shells, such as Cygwin and MSYS2.
+  See [#3142](https://github.com/commercialhaskell/stack/issues/3142)
 
 
 ## 1.4.0

--- a/src/Stack/Upload.hs
+++ b/src/Stack/Upload.hs
@@ -28,7 +28,6 @@ module Stack.Upload
     ) where
 
 import           Control.Applicative
-import           Control.Exception                     (bracket)
 import qualified Control.Exception                     as E
 import           Control.Monad                         (when)
 import           Data.Aeson                            (FromJSON (..),
@@ -63,8 +62,8 @@ import           Stack.Types.StringError
 import           System.Directory                      (createDirectoryIfMissing,
                                                         removeFile)
 import           System.FilePath                       ((</>), takeFileName)
-import           System.IO                             (hFlush, hGetEcho, hSetEcho,
-                                                        stdin, stdout)
+import           System.IO                             (hFlush, stdout)
+import           System.IO.Echo                        (withoutInputEcho)
 
 -- | Username and password to log into Hackage.
 --
@@ -175,10 +174,8 @@ promptPassword :: IO Text
 promptPassword = do
   putStr "Hackage password: "
   hFlush stdout
-  -- save/restore the terminal echoing status
-  passwd <- bracket (hGetEcho stdin) (hSetEcho stdin) $ \_ -> do
-    hSetEcho stdin False  -- no echoing for entering the password
-    fmap T.pack getLine
+  -- save/restore the terminal echoing status (no echoing for entering the password)
+  passwd <- withoutInputEcho $ fmap T.pack getLine
   putStrLn ""
   return passwd
 

--- a/src/Stack/Upload.hs
+++ b/src/Stack/Upload.hs
@@ -14,7 +14,7 @@ module Stack.Upload
     ) where
 
 import           Control.Applicative
-import           Control.Exception.Safe                (bracket, handleIO, tryIO)
+import           Control.Exception.Safe                (handleIO, tryIO)
 import qualified Control.Exception                     as E
 import           Control.Monad                         (void, when, unless)
 import           Data.Aeson                            (FromJSON (..),

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -35,3 +35,4 @@ extra-deps:
 - ed25519-0.0.5.0
 - hackage-security-0.5.2.2
 - echo-0.1.3
+- mintty-0.1.1

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -34,3 +34,4 @@ extra-deps:
 - cryptohash-sha256-0.11.100.1
 - ed25519-0.0.5.0
 - hackage-security-0.5.2.2
+- echo-0.1.3

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -14,6 +14,8 @@ nix:
 flags:
   stack:
     hide-dependency-versions: true
+  mintty:
+    win32-2-5: false
 extra-deps:
 - Cabal-1.24.2.0
 - th-utilities-0.2.0.1

--- a/stack.cabal
+++ b/stack.cabal
@@ -229,6 +229,7 @@ library
                    , memory >= 0.13 && < 0.15
                    , microlens >= 0.3.0.0
                    , microlens-mtl
+                   , mintty >= 0.1.1
                    , monad-control
                    , monad-logger >= 0.3.13.1
                    , monad-unlift < 0.3

--- a/stack.cabal
+++ b/stack.cabal
@@ -205,6 +205,7 @@ library
                    , cryptonite >= 0.19 && < 0.22
                    , cryptonite-conduit >= 0.1 && < 0.3
                    , directory >= 1.2.1.0 && < 1.4
+                   , echo >= 0.1.3 && < 0.2
                    , either
                    , errors < 2.2
                    , exceptions >= 0.8.0.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,5 +17,5 @@ flags:
   mintty:
     win32-2-5: false
 extra-deps:
-- mintty-0.1
+- mintty-0.1.1
 - store-0.4.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,4 +15,5 @@ flags:
   stack:
     hide-dependency-versions: true
 extra-deps:
+- mintty-0.1
 - store-0.4.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,8 @@ nix:
 flags:
   stack:
     hide-dependency-versions: true
+  mintty:
+    win32-2-5: false
 extra-deps:
 - mintty-0.1
 - store-0.4.1


### PR DESCRIPTION
Fixes #3142. I tested this by, well, running `stack upload` in MSYS2 and confirming that my password wasn't echoed back to me. This adds a fairly light dependency, `echo`.