### PR TITLE
Reword message shown when binary upgrade is skipped

### DIFF
--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -160,7 +160,7 @@ binaryUpgrade (BinaryOpts mplatform force' mver morg mrepo) = do
 
     toUpgrade <- case (force, isNewer) of
         (False, False) -> do
-            $logInfo "Skipping binary upgrade, your version is already more recent"
+            $logInfo "Skipping binary upgrade, you are already running the most recent version"
             return False
         (True, False) -> do
             $logInfo "Forcing binary upgrade"


### PR DESCRIPTION
This seems a bit more accurate: When the user is already running the most recent version, the message "your version is already *more* recent" is incorrect and ever so slightly confusing. The other case -- where the user is running a more recent version than is available as a binary, for which the old message is accurate -- likely occurs much less frequently.

---

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
