### PR TITLE
Fixed pid1 ownership inside fpco/stack-build docker image

### DIFF
--- a/etc/dockerfiles/stack-build/lts-8.0/Dockerfile
+++ b/etc/dockerfiles/stack-build/lts-8.0/Dockerfile
@@ -43,6 +43,7 @@ RUN stack --system-ghc --resolver=$LTS_SLUG --local-bin-path=/usr/local/bin inst
 #
 
 RUN wget -O- "https://github.com/fpco/pid1/releases/download/pid1%2F$PID1_VERSION/pid1-$PID1_VERSION-linux-x86_64.tar.gz" |tar xzf - -C /usr/local
+RUN chown -R root:root /usr/local/sbin
 
 #
 # Set up pid1 entrypoint and default command


### PR DESCRIPTION
Here is the issue with the file ownership that this PR fixes.
```bash
$ docker run --rm fpco/stack-build ls -laF /usr/local/sbin
total 372
drwxr-xr-x  2  501 staff   4096 Nov 23 06:15 ./
drwxr-xr-x 16 root root    4096 Feb 12 23:38 ../
-rwxr-xr-x  1  501 staff 371956 Nov 23 06:15 pid1*
```