### PR TITLE
#3126 Use MinGW bin folder for dynamic libraries searching

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,7 +49,7 @@ Other enhancements:
   a method to ensure PVP compliance without having to proactively fix
   bounds issues for Stackage maintenance.
 * Expose a `save-hackage-creds` configuration option
-* MinGW bin folder now is searched for dynamic libraries. See [#3126]
+* MinGW bin folder now is searched for dynamic libraries. See [#3126](https://github.com/commercialhaskell/stack/issues/3126)
 
 Bug fixes:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,6 +49,7 @@ Other enhancements:
   a method to ensure PVP compliance without having to proactively fix
   bounds issues for Stackage maintenance.
 * Expose a `save-hackage-creds` configuration option
+* MinGW bin folder now is searched for dynamic libraries. See [#3126]
 
 Bug fixes:
 

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -142,6 +142,7 @@ extraDirs tool = do
                 ]
             , edLib =
                 [ dir </> $(mkRelDir "mingw32") </> $(mkRelDir "lib")
+                , dir </> $(mkRelDir "mingw32") </> $(mkRelDir "bin")
                 ]
             }
         (Platform Cabal.X86_64 Cabal.Windows, "msys2") -> return mempty
@@ -155,6 +156,7 @@ extraDirs tool = do
                 ]
             , edLib =
                 [ dir </> $(mkRelDir "mingw64") </> $(mkRelDir "lib")
+                , dir </> $(mkRelDir "mingw64") </> $(mkRelDir "bin")
                 ]
             }
         (_, isGHC -> True) -> return mempty


### PR DESCRIPTION
This is related to issue #3126 which describe the problem and solution.
I have tested it on Windows 8 and it adds bin path correctly and built the problematic module.

