### PR TITLE
Add missing word to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,10 @@ and use the provided template to include all necessary details.
 
 The more detailed your report, the faster it can be resolved and will ensure it
 is resolved in the right way. Once your bug has been resolved, the responsible
-will tag the issue as _Needs confirmation_ and assign the issue back to you.
-Once you have tested and confirmed that the issue is resolved, close the issue.
-If you are not a member of the project, you will be asked for confirmation and
-we will close it.
+person will tag the issue as _Needs confirmation_ and assign the issue back to
+you. Once you have tested and confirmed that the issue is resolved, close the 
+issue. If you are not a member of the project, you will be asked for
+confirmation and we will close it.
 
 
 ## Documentation


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

The sentence "Once your bug has been resolved, the responsible will tag the issue as _Needs confirmation_ and assign the issue back to you." seems to be missing a word after "responsible". I added "person".