### PR TITLE
Fix handling of missing image message with newer versions of Docker

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -73,6 +73,8 @@ Bug fixes:
 * Switching a package between extra-dep and local package now forces
   rebuild (previously it wouldn't if versions were the same).
   See [#2147](https://github.com/commercialhaskell/stack/issues/2147)
+* Fixed an issue where Stack wouldn't detect missing Docker images properly
+  with newer Docker versions.
 
 
 ## 1.4.0

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -664,8 +664,9 @@ inspects envOverride images =
            Left msg -> throwM (InvalidInspectOutputException msg)
            Right results -> return (Map.fromList (map (\r -> (iiId r,r)) results))
        Left (ProcessFailed _ _ _ err)
-         | "Error: No such image" `LBS.isPrefixOf` err -> return Map.empty
+         |  any (`LBS.isPrefixOf` err) missingImagePrefixes -> return Map.empty
        Left e -> throwM e
+  where missingImagePrefixes = ["Error: No such image", "Error: No such object:"]
 
 -- | Pull latest version of configured Docker image from registry.
 pull :: (StackM env m, HasConfig env) => m ()


### PR DESCRIPTION
At some unknown version, `docker inspect` stopped outputting "Error: No such
image" and started outputting "Error: No such object:" when the image is
question was missing. That change broke detecting that situation.

This commit checks for either version of the message.


Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Tested by running `stack build` in a project that needed a docker image that wasn't on this machine. Output before commit:
```
$ ../stack/.stack-work/install/x86_64-linux-nopie/lts-8.5/8.0.2/bin/stack build -v
Version 1.4.1, Git revision 0ddbaa7fd1cfe8ec4c8cb17364dc8f0aa6d4314d (4766 commits) x86_64 hpack-0.17.0
2017-05-11 16:44:39.636920: [debug] Checking for project config at: /home/enolan/mystuff/code/emp-pl-site/stack.yaml
@(Stack/Config.hs:949:9)
2017-05-11 16:44:39.637307: [debug] Loading project config file stack.yaml
@(Stack/Config.hs:974:13)
2017-05-11 16:44:39.641121: [debug] Run process: /usr/bin/docker --version
@(System/Process/Read.hs:306:3)
2017-05-11 16:44:39.655740: [debug] Process finished in 14ms: /usr/bin/docker --version
@(System/Process/Read.hs:306:3)
2017-05-11 16:44:39.656427: [debug] Run process: /usr/bin/docker inspect fpco/stack-build:lts-8.13
@(System/Process/Read.hs:306:3)
Running /usr/bin/docker inspect fpco/stack-build:lts-8.13 exited with ExitFailure 1

[]

Error: No such object: fpco/stack-build:lts-8.13
```

And after:
```
$ ../stack/.stack-work/install/x86_64-linux-nopie/lts-8.5/8.0.2/bin/stack build -v
Version 1.4.1, Git revision 0ddbaa7fd1cfe8ec4c8cb17364dc8f0aa6d4314d (4766 commits) x86_64 hpack-0.17.0
2017-05-11 17:00:09.534096: [debug] Checking for project config at: /home/enolan/mystuff/code/emp-pl-site/stack.yaml
@(Stack/Config.hs:949:9)
2017-05-11 17:00:09.534578: [debug] Loading project config file stack.yaml
@(Stack/Config.hs:974:13)
2017-05-11 17:00:09.539702: [debug] Run process: /usr/bin/docker --version
@(System/Process/Read.hs:306:3)
2017-05-11 17:00:09.552763: [debug] Process finished in 12ms: /usr/bin/docker --version
@(System/Process/Read.hs:306:3)
2017-05-11 17:00:09.553652: [debug] Run process: /usr/bin/docker inspect fpco/stack-build:lts-8.13
@(System/Process/Read.hs:306:3)
The Docker image referenced by your configuration file has not
been downloaded:
    fpco/stack-build:lts-8.13

Run 'stack docker pull' to download it, then try again.
```