### PR TITLE
When using Nix, depend on git.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,8 @@ Behavior changes:
 
 Other enhancements:
 
+* When using Nix, nix-shell now depends always on git to prevent runtime errors
+  while fetching metadata
 * Internal cleanup: configuration types are now based much more on lenses
 * `stack build` and related commands now allow the user to disable debug symbol stripping
   with new `--no-strip`, `--no-library-stripping`, and `--no-executable-shipping` flags,

--- a/src/Stack/Nix.hs
+++ b/src/Stack/Nix.hs
@@ -83,7 +83,7 @@ runShellAndExit mprojectRoot getCompilerVersion getCmdArgs = do
      inContainer <- getInContainer
      let pkgsInConfig = nixPackages (configNix config)
          ghc = nixCompiler compilerVersion
-         pkgs = pkgsInConfig ++ [ghc]
+         pkgs = pkgsInConfig ++ [ghc, "git"]
          pkgsStr = "[" <> T.intercalate " " pkgs <> "]"
          pureShell = nixPureShell (configNix config)
          addGCRoots = nixAddGCRoots (configNix config)


### PR DESCRIPTION
Partially addresses #2287, as git is used in stack internally
to fetch package index and LTS.
