### PR TITLE
When extracting local GHC from tarball on windows, use temp dir #3188

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -215,6 +215,9 @@ Other enhancements:
   on the PATH or shadowed by another entry.
 * Allow running tests on tarball created by sdist and upload
   [#717](https://github.com/commercialhaskell/stack/issues/717).
+* For filesystem setup-info paths, it's no longer assumed that the
+  directory is writable, instead a temp dir is used.  See
+  [#3188](https://github.com/commercialhaskell/stack/issues/3188).
 
 Bug fixes:
 


### PR DESCRIPTION
This change hasn't yet been tested.  Intended to fix #3188

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

