### PR TITLE
Rename PathException to InvalidPathException to avoid conflict with path 0.6+

### DIFF
--- a/src/System/Process/Read.hs
+++ b/src/System/Process/Read.hs
@@ -423,11 +423,11 @@ getEnvOverride platform =
           mkEnvOverride platform
         . Map.fromList . map (T.pack *** T.pack)
 
-newtype PathException = PathsInvalidInPath [FilePath]
+newtype InvalidPathException = PathsInvalidInPath [FilePath]
     deriving Typeable
 
-instance Exception PathException
-instance Show PathException where
+instance Exception InvalidPathException
+instance Show InvalidPathException where
     show (PathsInvalidInPath paths) = unlines $
         [ "Would need to add some paths to the PATH environment variable \
           \to continue, but they would be invalid because they contain a "


### PR DESCRIPTION
Fixes #3223

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
