### PR TITLE
Fix #2886: include package names in the haddock index.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -84,6 +84,8 @@ Bug fixes:
   See [#3142](https://github.com/commercialhaskell/stack/issues/3142)
 * `stack script`'s import parser will now properly parse files that
   have Windows-style line endings (CRLF)
+* `stack haddock` now includes package names for all modules in the
+   Haddock index page.
 
 
 ## 1.4.0

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -138,7 +138,7 @@ generateLocalHaddockIndex envOverride wc bco localDumpPkgs locals = do
         "local packages"
         envOverride
         wc
-        (boptsHaddockOpts (bcoBuildOpts bco))
+        bco
         dumpPackages
         "."
         (localDocDir bco)
@@ -161,7 +161,7 @@ generateDepsHaddockIndex envOverride wc bco globalDumpPkgs snapshotDumpPkgs loca
         "local packages and dependencies"
         envOverride
         wc
-        (boptsHaddockOpts (bcoBuildOpts bco))
+        bco
         deps
         ".."
         depDocDir
@@ -202,7 +202,7 @@ generateSnapHaddockIndex envOverride wc bco globalDumpPkgs snapshotDumpPkgs =
         "snapshot packages"
         envOverride
         wc
-        (boptsHaddockOpts (bcoBuildOpts bco))
+        bco
         (Map.elems snapshotDumpPkgs ++ Map.elems globalDumpPkgs)
         "."
         (snapDocDir bco)
@@ -213,12 +213,12 @@ generateHaddockIndex
     => Text
     -> EnvOverride
     -> WhichCompiler
-    -> HaddockOpts
+    -> BaseConfigOpts
     -> [DumpPackage () () ()]
     -> FilePath
     -> Path Abs Dir
     -> m ()
-generateHaddockIndex descr envOverride wc hdopts dumpPackages docRelFP destDir = do
+generateHaddockIndex descr envOverride wc bco dumpPackages docRelFP destDir = do
     ensureDir destDir
     interfaceOpts <- (liftIO . fmap nubOrd . mapMaybeM toInterfaceOpt) dumpPackages
     unless (null interfaceOpts) $ do
@@ -239,7 +239,9 @@ generateHaddockIndex descr envOverride wc hdopts dumpPackages docRelFP destDir =
                     (Just destDir)
                     envOverride
                     (haddockExeName wc)
-                    (hoAdditionalArgs hdopts ++
+                    (map (("--optghc=-package-db=" ++ ) . toFilePathNoTrailingSep)
+                        [bcoSnapDB bco, bcoLocalDB bco] ++
+                     hoAdditionalArgs (boptsHaddockOpts (bcoBuildOpts bco)) ++
                      ["--gen-contents", "--gen-index"] ++
                      [x | (xs,_,_,_) <- interfaceOpts, x <- xs])
             else


### PR DESCRIPTION
It turned out that Haddock expects to see packages with those names
in the GHC package DB, and omits the names otherwise.  Pointing
Haddock to the local and snapshot DBs resolved the issue.

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md

Tested by running "stack haddock" for a local package and verifying that all the generated `index.html` files (local packages, local packages and deps, snapshot packages) list the package name for each module.