### PR TITLE
Turn on --install-ghc by default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,11 @@ Behavior changes:
   benchmarks and tests to the beginning of the args, instead of the end.
   See [#2399](https://github.com/commercialhaskell/stack/issues/2399)
 * Support for Git-based indices has been removed.
+* The `--install-ghc` flag is now on by default. For example, if you
+  run `stack build` in a directory requiring a GHC that you do not
+  currently have, Stack will automatically download and install that
+  GHC. You can explicitly set `install-ghc: false` or pass the flag
+  `--no-install-ghc` to regain the previous behavior.
 
 Other enhancements:
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -357,8 +357,9 @@ system-ghc: true
 
 ### install-ghc
 
-Whether or not to automatically install GHC when necessary. Default is `false`,
-which means stack will prompt you to run `stack setup` as needed.
+Whether or not to automatically install GHC when necessary. Since
+Stack 1.5.0, the default is `true`, which means Stack will not ask you
+before downloading and installing GHC.
 
 ### skip-ghc-check
 

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -293,7 +293,7 @@ configFromConfigMonoid
 
          configGHCVariant0 = getFirst configMonoidGHCVariant
          configGHCBuild = getFirst configMonoidGHCBuild
-         configInstallGHC = fromFirst False configMonoidInstallGHC
+         configInstallGHC = fromFirst True configMonoidInstallGHC
          configSkipGHCCheck = fromFirst False configMonoidSkipGHCCheck
          configSkipMsys = fromFirst False configMonoidSkipMsys
 


### PR DESCRIPTION
This is in response to feedback from the Haskell website working group,
who requested this change to ease the new user onboarding process.

__NOTE__ Please feel free to click on the 👍 or 👎 buttons on this description to indicate your support or opposition to this change.