### PR TITLE
Fix build with path 0.6.1

### DIFF
--- a/src/Network/HTTP/Download/Verified.hs
+++ b/src/Network/HTTP/Download/Verified.hs
@@ -55,7 +55,7 @@ import              Network.HTTP.Types.Header (hContentLength, hContentMD5)
 import              Path
 import              Prelude -- Fix AMP warning
 import              System.Directory
-import              System.FilePath ((<.>))
+import qualified    System.FilePath as FP ((<.>))
 import              System.IO
 
 -- | A request together with some checks to perform.
@@ -243,7 +243,7 @@ verifiedDownload DownloadRequest{..} destpath progressSink = do
         if p then m >> return True else return False
 
     fp = toFilePath destpath
-    fptmp = fp <.> "tmp"
+    fptmp = fp FP.<.> "tmp"
     dir = toFilePath $ parent destpath
 
     getShouldDownload = do

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -75,7 +75,6 @@ import              Stack.Types.PackageIdentifier
 import              Stack.Types.PackageIndex
 import              Stack.Types.PackageName
 import              Stack.Types.Version
-import              System.FilePath ((<.>))
 import qualified    System.FilePath as FP
 import              System.IO
 import              System.PosixCompat (setFileMode)
@@ -561,7 +560,7 @@ fetchPackages' mdistDir toFetchAll = do
                 let cabalFP =
                         innerDest FP.</>
                         packageNameString (packageIdentifierName ident)
-                        <.> "cabal"
+                        FP.<.> "cabal"
                 S.writeFile cabalFP $ tfCabal toFetch
 
                 atomically $ modifyTVar outputVar $ Map.insert ident destDir


### PR DESCRIPTION
Fixes #3239

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.