### PR TITLE
Use ‘text-metrics-0.3.0’

### DIFF
--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -26,7 +26,7 @@ extra-deps:
 - http-client-tls-0.3.4
 - http-conduit-2.2.3
 - optparse-applicative-0.13.0.0
-- text-metrics-0.1.0
+- text-metrics-0.3.0
 - pid1-0.1.0.0
 - aeson-1.0.2.1
 - hpack-0.17.0

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -6,6 +6,7 @@ image:
 extra-deps:
 - store-0.4.1
 - store-core-0.4
+- text-metrics-0.3.0
 nix:
   # --nix on the command-line to enable.
   enable: false

--- a/stack.cabal
+++ b/stack.cabal
@@ -262,7 +262,7 @@ library
                    , temporary >= 1.2.0.3
                    , text >= 1.2.0.4
                    , text-binary
-                   , text-metrics >= 0.1 && < 0.3
+                   , text-metrics >= 0.3 && < 0.4
                    , time >= 1.4.2 && < 1.7
                    , tls >= 1.3.8
                    , transformers >= 0.3.0.0 && < 0.6

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,3 +19,4 @@ flags:
 extra-deps:
 - mintty-0.1.1
 - store-0.4.1
+- text-metrics-0.3.0


### PR DESCRIPTION
No code change is necessary in this case, but I bumped upper/lower bounds for `text-metrics` because `damerauLevenshtein` returns `Int` now instead of `Natural` and it's kinda safer to bump (in case there will be new code that uses the library).

Testing: manual check, try:

```
$ stack install text-merics-0.3.0
Warning: Some extra-deps are neither installed nor in the index:
    * text-merics-0.3.0
Didn't see text-merics-0.3.0 in your package indices.
Updating and trying again.
Selected mirror https://s3.amazonaws.com/hackage.fpcomplete.com/
Downloading timestamp
No updates to your package list were found
Updating package index Hackage (mirrored at https://s3.amazonaws.com/hackage.fpcomplete.com/) ...The following package identifiers were not found in your indices: text-merics-0.3.0
Perhaps you meant text-metrics?
~/projects/programs/haskell/stack $ stack install parse-3.11.0

Warning: Some extra-deps are neither installed nor in the index:
    * parse-3.11.0
Didn't see parse-3.11.0 in your package indices.
Updating and trying again.
Selected mirror https://s3.amazonaws.com/hackage.fpcomplete.com/
Downloading timestamp
No updates to your package list were found
Updating package index Hackage (mirrored at https://s3.amazonaws.com/hackage.fpcomplete.com/) ...The following package identifiers were not found in your indices: parse-3.11.0
Perhaps you meant parsec, parsek, or sparse?
```

These "Perhaps you meant" phrases appear to be correct.
