### PR TITLE
Support archives as a package location

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -75,6 +75,10 @@ Other enhancements:
   format in the future.
 * `GitSHA1` is now `StaticSHA256` and is implemented using the `StaticSize 64 ByteString` for improved performance.
   See [#3006](https://github.com/commercialhaskell/stack/issues/3006)
+* Dependencies via HTTP(S) archives have been generalized to allow
+  local file path archives, as well as to support setting a
+  cryptographic hash (SHA256) of the contents for better
+  reproducibility.
 
 Bug fixes:
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -80,10 +80,12 @@ There are two types of packages that can be defined in your
 * __Extra dependencies__, which are packages provided locally on top
   of the snapshot definition of available packages. These can come
   from Hackage (or an alternative package index you've defined, see
-  [package-indices](#package-indices)), an HTTP(S) tarball, a Git or
-  Mercurial repository, or a local file path.
+  [package-indices](#package-indices)), an HTTP(S) or local archive, a
+  Git or Mercurial repository, or a local file path.
 
-These two sets of packages are both installed into your local package database within your project. However, beyond that, they are completely different:
+These two sets of packages are both installed into your local package
+database within your project. However, beyond that, they are
+completely different:
 
 * Project packages will be built by default with a `stack build`
   without specific targets. Extra dependencies will only be built if
@@ -210,10 +212,10 @@ extra-deps:
 If unspecified, `subdirs` defaults to `subdirs: [.]`, or looking for a
 package in the root of the repo.
 
-#### HTTP(S) URLs
+#### Archives (HTTP(S) or local filepath)
 
-This one's pretty straightforward: you can use HTTP and HTTPS URLs
-referring to either tarballs or ZIP files.
+This one's pretty straightforward: you can use HTTP and HTTPS URLs and
+local filepaths referring to either tarballs or ZIP files.
 
 __NOTE__ Stack assumes that these files never change after downloading
 to avoid needing to make an HTTP request on each build.
@@ -221,10 +223,12 @@ to avoid needing to make an HTTP request on each build.
 ```yaml
 extra-deps:
 - https://example.com/foo/bar/baz-0.0.2.tar.gz
-- location: http://github.com/yesodweb/wai/archive/2f8a8e1b771829f4a8a77c0111352ce45a14c30f.zip
+- archive: http://github.com/yesodweb/wai/archive/2f8a8e1b771829f4a8a77c0111352ce45a14c30f.zip
   subdirs:
   - wai
   - warp
+- archive: ../acme-missiles-0.3.tar.gz
+  sha256: e563d8b524017a06b32768c4db8eff1f822f3fb22a90320b7e414402647b735b
 ```
 
 Note that HTTP(S) URLs also support `subdirs` like repos to allow for

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -17,6 +17,7 @@ module Stack.Types.BuildPlan
     , PackageLocationIndex (..)
     , RepoType (..)
     , Repo (..)
+    , Archive (..)
     , ExeName (..)
     , LoadedSnapshot (..)
     , loadedSnapshotVC
@@ -142,8 +143,7 @@ data PackageLocation subdirs
   = PLFilePath !FilePath
     -- ^ Note that we use @FilePath@ and not @Path@s. The goal is: first parse
     -- the value raw, and then use @canonicalizePath@ and @parseAbsDir@.
-  | PLHttp !Text !subdirs
-  -- ^ URL
+  | PLArchive !(Archive subdirs)
   | PLRepo !(Repo subdirs)
   -- ^ Stored in a source control repository
     deriving (Generic, Show, Eq, Data, Typeable, Functor)
@@ -163,6 +163,18 @@ data PackageLocationIndex subdirs
     deriving (Generic, Show, Eq, Data, Typeable, Functor)
 instance (Store a) => Store (PackageLocationIndex a)
 instance (NFData a) => NFData (PackageLocationIndex a)
+
+-- | A package archive, could be from a URL or a local file
+-- path. Local file path archives are assumed to be unchanging
+-- over time, and so are allowed in custom snapshots.
+data Archive subdirs = Archive
+  { archiveUrl :: !Text
+  , archiveSubdirs :: !subdirs
+  , archiveHash :: !(Maybe StaticSHA256)
+  }
+    deriving (Generic, Show, Eq, Data, Typeable, Functor)
+instance Store a => Store (Archive a)
+instance NFData a => NFData (Archive a)
 
 -- | The type of a source control repository.
 data RepoType = RepoGit | RepoHg
@@ -187,10 +199,15 @@ instance subdirs ~ [FilePath] => ToJSON (PackageLocationIndex subdirs) where
 
 instance subdirs ~ [FilePath] => ToJSON (PackageLocation subdirs) where
     toJSON (PLFilePath fp) = toJSON fp
-    toJSON (PLHttp t ["."]) = toJSON t
-    toJSON (PLHttp t subdirs) = object
-        [ "location" .= t
-        , "subdirs"  .= subdirs
+    toJSON (PLArchive (Archive t ["."] Nothing)) = toJSON t
+    toJSON (PLArchive (Archive t subdirs msha)) = object $ concat
+        [ ["location" .= t]
+        , case subdirs of
+            ["."] -> []
+            _     -> ["subdirs" .= subdirs]
+        , case msha of
+            Nothing -> []
+            Just sha -> ["sha256" .= staticSHA256ToText sha]
         ]
     toJSON (PLRepo (Repo url commit typ subdirs)) = object $
         (if null subdirs then id else (("subdirs" .= subdirs):))
@@ -218,22 +235,28 @@ instance subdirs ~ [FilePath] => FromJSON (WithJSONWarnings (PackageLocation sub
         http t =
             case parseRequest $ T.unpack t of
                 Left  _ -> fail $ "Could not parse URL: " ++ T.unpack t
-                Right _ -> return $ PLHttp t ["."]
+                Right _ -> return $ PLArchive $ Archive t ["."] Nothing
 
         repo = withObjectWarnings "PLRepo" $ \o -> do
           (repoType, repoUrl) <-
             ((RepoGit, ) <$> o ..: "git") <|>
             ((RepoHg, ) <$> o ..: "hg")
           repoCommit <- o ..: "commit"
-          repoSubdirs <- o ..:? "subdirs" ..!= []
+          repoSubdirs <- o ..:? "subdirs" ..!= ["."]
           return $ PLRepo Repo {..}
 
         httpSubdirs = withObjectWarnings "PLHttp" $ \o -> do
-          url <- o ..: "location"
-          subdirs <- o ..: "subdirs"
-          case parseRequest $ T.unpack url of
-            Left _ -> fail $ "Could not parse URL: " ++ T.unpack url
-            Right _ -> return $ PLHttp url subdirs
+          url <- o ..: "archive"
+          subdirs <- o ..:? "subdirs" ..!= ["."]
+          msha <- o ..:? "sha256"
+          msha' <-
+            case msha of
+              Nothing -> return Nothing
+              Just t ->
+                case mkStaticSHA256FromText t of
+                  Nothing -> fail $ "Invalid SHA256: " ++ T.unpack t
+                  Just x -> return $ Just x
+          return $ PLArchive $ Archive url subdirs msha'
 
 -- | Name of an executable.
 newtype ExeName = ExeName { unExeName :: Text }
@@ -255,7 +278,7 @@ instance Store LoadedSnapshot
 instance NFData LoadedSnapshot
 
 loadedSnapshotVC :: VersionConfig LoadedSnapshot
-loadedSnapshotVC = storeVersionConfig "ls-v2" "xsmhHqmPKKcyHNzCLkKRGZ_StxE="
+loadedSnapshotVC = storeVersionConfig "ls-v3" "8mR6zrGi2ZQosRgcKQRkT2dS-ac="
 
 -- | Information on a single package for the 'LoadedSnapshot' which
 -- can be installed.


### PR DESCRIPTION
Generalizes HTTP(S) into archives (allowing local paths), and adds in
support for cryptographic hashes on archives.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
