### PR TITLE
Upgrade stack to the latest version of hpack

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -40,6 +40,8 @@ Other enhancements:
   assist with the user experience when the `PATH` environment variable
   has not been properly configured, see
   [#3232](https://github.com/commercialhaskell/stack/issues/3232).
+* The `hpack` dependency was updated allowing projects with Alex and Happy files
+  to build successfully with `stack`.
 
 Bug fixes:
 

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -1186,11 +1186,7 @@ hpack pkgDir = do
     when exists $ do
         let fpt = T.pack (toFilePath hpackFile)
         $logDebug $ "Running hpack on " <> fpt
-#if MIN_VERSION_hpack(0,18,0)
         r <- liftIO $ Hpack.hpackResult (Just $ toFilePath pkgDir)
-#else
-        r <- liftIO $ Hpack.hpackResult (toFilePath pkgDir)
-#endif
         forM_ (Hpack.resultWarnings r) $ \w -> $logWarn ("WARNING: " <> T.pack w)
         let cabalFile = T.pack (Hpack.resultCabalFile r)
         case Hpack.resultStatus r of

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -39,3 +39,4 @@ extra-deps:
 - unliftio-core-0.1.0.0
 - unliftio-0.1.0.0
 - async-2.1.1.1
+- hpack-0.18.1

--- a/stack.cabal
+++ b/stack.cabal
@@ -263,7 +263,7 @@ library
                    , hastache
                    , project-template >= 0.2
                    , zip-archive >= 0.2.3.7 && < 0.4
-                   , hpack >= 0.17.0 && < 0.19
+                   , hpack >= 0.18.0 && < 0.19
                    , store >= 0.4.1 && < 0.5
                    , store-core >= 0.4 && < 0.5
                    , annotated-wl-pprint
@@ -292,7 +292,7 @@ executable stack
                 , directory >= 1.2.1.0 && < 1.4
                 , filelock >= 0.1.0.1
                 , filepath >= 1.3.0.2
-                , hpack >= 0.17.0 && < 0.19
+                , hpack >= 0.18.0 && < 0.19
                 , http-client >= 0.5.3.3
                 , microlens >= 0.3.0.0
                 , monad-logger >= 0.3.13.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,3 +21,4 @@ extra-deps:
 - text-metrics-0.3.0
 - unliftio-core-0.1.0.0
 - unliftio-0.1.0.0
+- hpack-0.18.1


### PR DESCRIPTION
hpack recently updated to version 0.18 and one of the big changes from
that is the ability to handle Happy and Alex files. Previously this made
using hpack with projects that contained these files impossible. As such
they were stuck with using cabal files.

This commit updates stack to this newer version of hpack so that stack
can be used with hpack or cabal based projects interchangeably if Alex
or Happy files are involved.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

We have a large Haskell code base at work that we were trying to migrate over to hpack that failed because of the lack of Alex and Happy support. This was added to hpack but stack still didn't have it. I tested this version of stack on my machine and it worked but I'd like another set of eyes if possible.