### PR TITLE
Small document typo fix

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1246,7 +1246,7 @@ executables to the local bin path. You may recognize the default value for that
 path:
 
 ```
-michael@d30748af6d3d:~/helloworld$ stack path --local-bin-path
+michael@d30748af6d3d:~/helloworld$ stack path --local-bin
 /home/michael/.local/bin
 ```
 


### PR DESCRIPTION
The actual arg should be `--local-bin`:

> '--local-bin-path' will be removed in a future release.
> Please use '--local-bin' instead.

* [x] No changes to be recorded in the ChangeLog.md
* [x] No documentation updates necessary.

I tested this change simply looking at the GitHub preview 👀 