### PR TITLE
Allow cryptonite 0.24 and path 0.6

### DIFF
--- a/stack.cabal
+++ b/stack.cabal
@@ -201,7 +201,7 @@ library
                    , conduit >= 1.2.8
                    , conduit-extra >= 1.1.14
                    , containers >= 0.5.5.1
-                   , cryptonite >= 0.19 && < 0.24
+                   , cryptonite >= 0.19 && < 0.25
                    , cryptonite-conduit >= 0.1 && < 0.3
                    , directory >= 1.2.1.0 && < 1.4
                    , echo >= 0.1.3 && < 0.2
@@ -228,7 +228,7 @@ library
                    , network-uri
                    , open-browser >= 0.2.1
                    , optparse-applicative >= 0.13 && < 0.14
-                   , path >= 0.5.8 && < 0.6
+                   , path >= 0.5.8 && < 0.7
                    , path-io >= 1.1.0 && < 2.0.0
                    , persistent >= 2.1.2 && < 2.8
                        -- persistent-sqlite-2.5.0.1 has a bug


### PR DESCRIPTION
They build fine and work here.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.