### PR TITLE
Link directly to shell autocompletion on doc site

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1985,7 +1985,7 @@ the following (or add it to `.bashrc`):
     eval "$(stack --bash-completion-script stack)"
 
 For more information and other shells, see [the Shell auto-completion wiki
-page](https://github.com/commercialhaskell/stack/wiki/Shell-autocompletion)
+page](https://docs.haskellstack.org/en/stable/shell_autocompletion)
 
 ### Docker
 


### PR DESCRIPTION
* [x ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x ] The documentation has been updated, if necessary.

This bypasses a link to [a pass through page in the stack wiki](https://github.com/commercialhaskell/stack/wiki/Shell-autocompletion) in the Guide's section on autocompletion in favor of the page in the [haskellstack.org](https://docs.haskellstack.org/en/stable/shell_autocompletion/) to which the pass through directs readers.
