### PR TITLE
Clear index cache if it is old #3033

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -98,6 +98,10 @@ Bug fixes:
 * Modified the flag parser within Stack to match the behavior of
   Cabal's flag parser, which allows multiple sequential dashes. See
   [#3345](https://github.com/commercialhaskell/stack/issues/3345)
+* Now clears the hackage index cache if it is older than the
+  downloaded index.  Fixes potential issue if stack was interrupted when
+  updating index.
+  See [#3033](https://github.com/commercialhaskell/stack/issues/3033)
 
 ## 1.5.1
 

--- a/src/Path/Extra.hs
+++ b/src/Path/Extra.hs
@@ -14,17 +14,20 @@ module Path.Extra
   ,pathToByteString
   ,pathToLazyByteString
   ,pathToText
+  ,tryGetModificationTime
   ) where
 
-import qualified Data.ByteString.Lazy.Char8 as BSL
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
-import           Stack.Prelude
 import           Data.Bool (bool)
+import           Data.Time (UTCTime)
 import           Path
 import           Path.IO
 import           Path.Internal (Path(..))
+import           Stack.Prelude
+import           System.IO.Error (isDoesNotExistError)
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import qualified System.FilePath as FP
 
 -- | Convert to FilePath but don't add a trailing slash.
@@ -116,3 +119,6 @@ pathToByteString = T.encodeUtf8 . pathToText
 
 pathToText :: Path b t -> T.Text
 pathToText = T.pack . toFilePath
+
+tryGetModificationTime :: MonadIO m => Path Abs File -> m (Either () UTCTime)
+tryGetModificationTime = liftIO . tryJust (guard . isDoesNotExistError) . getModificationTime

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -39,7 +39,6 @@ import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageName
 import           Stack.Types.Runner
 import qualified System.FilePath as FP
-import           System.IO.Error (isDoesNotExistError)
 import           System.Process.Read
 import           Web.Browser (openBrowser)
 
@@ -261,8 +260,6 @@ generateHaddockIndex descr envOverride wc bco dumpPackages docRelFP destDir = do
                                 , srcInterfaceModTime
                                 , srcInterfaceAbsFile
                                 , destInterfaceAbsFile )
-    tryGetModificationTime :: Path Abs File -> IO (Either () UTCTime)
-    tryGetModificationTime = tryJust (guard . isDoesNotExistError) . getModificationTime
     copyPkgDocs :: (a, UTCTime, Path Abs File, Path Abs File) -> IO ()
     copyPkgDocs (_,srcInterfaceModTime,srcInterfaceAbsFile,destInterfaceAbsFile) = do
         -- Copy dependencies' haddocks to documentation directory.  This way, relative @../$pkg-$ver@


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Not sure if this fixes the problem described in #3033, but I believe this will help in cases where stack is terminated after downloading the index but before clearing the cache.