### PR TITLE
Put msys on the PATH before ghc, potential fix for #3154

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,8 @@ Behavior changes:
   currently have, Stack will automatically download and install that
   GHC. You can explicitly set `install-ghc: false` or pass the flag
   `--no-install-ghc` to regain the previous behavior.
+* On windows, the msys bin directory now comes before the ghc bin
+  directory. See [#3154](https://github.com/commercialhaskell/stack/issues/3154)
 
 Other enhancements:
 

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -487,7 +487,7 @@ ensureCompiler sopts = do
         Nothing -> return Nothing
         Just (compilerTool, mmsys2Tool) -> do
             -- Add GHC's and MSYS's paths to the config.
-            let idents = catMaybes [compilerTool, mmsys2Tool]
+            let idents = catMaybes [mmsys2Tool, compilerTool]
             paths <- mapM extraDirs idents
             return $ Just $ mconcat paths
 


### PR DESCRIPTION
As mentioned [here](https://github.com/commercialhaskell/stack/issues/3154#issuecomment-320775528), I'm really not sure if this is a good change.  It may fix that particular problem, but it is hard to predict all the impacts of this behavior change.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
