### PR TITLE
Introduces $locals et al ghc-options keys

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -59,6 +59,9 @@ Other enhancements:
 * Added `stack ghci --only-main` flag, to skip loading / importing
   all but main modules. See the ghci documentation page
   for further info.
+* Extended the `ghc-options` field to support `$locals`, `$targets`,
+  and `$everything`. See:
+  [#3329](https://github.com/commercialhaskell/stack/issues/3329)
 
 Bug fixes:
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -499,21 +499,29 @@ Allows specifying per-package and global GHC options:
 ```yaml
 ghc-options:
     # All packages
-    "*": -Wall
+    "$locals": -Wall
+    "$targets": -Werror
+    "$everything": -O2
     some-package: -DSOME_CPP_FLAG
 ```
 
-Since 0.1.6, setting a GHC options for a specific package will
+Since 1.6.0, setting a GHC options for a specific package will
 automatically promote it to a local package (much like setting a
-custom package flag). However, setting options via `"*"` on all flags
+custom package flag). However, setting options via `$everything` on all flags
 will not do so (see
 [Github discussion](https://github.com/commercialhaskell/stack/issues/849#issuecomment-320892095)
 for reasoning). This can lead to unpredicable behavior by affecting
 your snapshot packages.
 
-By contrast, the `ghc-options` command line flag will only affect the
-packages specified by the
-[`apply-ghc-options` option](yaml_configuration.md#apply-ghc-options).
+The behavior of the `$locals`, `$targets`, and `$everything` special
+keys mirrors the behavior for the
+[`apply-ghc-options` setting](#apply-ghc-options), which affects
+command line parameters.
+
+NOTE: Prior to version 1.6.0, the `$locals`, `$targets`, and
+`$everything` keys were not support. Instead, you could use `"*"` for
+the behavior represented now by `$everything`. It is highly
+recommended to switch to the new, more expressive, keys.
 
 ### apply-ghc-options
 

--- a/src/Data/Aeson/Extended.hs
+++ b/src/Data/Aeson/Extended.hs
@@ -147,6 +147,8 @@ data WarningParserMonoid = WarningParserMonoid
 instance Monoid WarningParserMonoid where
     mempty = memptydefault
     mappend = mappenddefault
+instance IsString WarningParserMonoid where
+    fromString s = mempty { wpmWarnings = [fromString s] }
 
 -- Parsed JSON value with its warnings
 data WithJSONWarnings a = WithJSONWarnings a [JSONWarning]
@@ -159,8 +161,12 @@ instance Monoid a => Monoid (WithJSONWarnings a) where
 
 -- | Warning output from 'WarningParser'.
 data JSONWarning = JSONUnrecognizedFields String [Text]
+                 | JSONGeneralWarning !Text
 instance Show JSONWarning where
     show (JSONUnrecognizedFields obj [field]) =
         "Unrecognized field in " <> obj <> ": " <> T.unpack field
     show (JSONUnrecognizedFields obj fields) =
         "Unrecognized fields in " <> obj <> ": " <> T.unpack (T.intercalate ", " fields)
+    show (JSONGeneralWarning t) = T.unpack t
+instance IsString JSONWarning where
+  fromString = JSONGeneralWarning . T.pack

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -128,7 +128,13 @@ getLocalFlags bconfig boptsCli name = Map.unions
 getGhcOptions :: BuildConfig -> BuildOptsCLI -> PackageName -> Bool -> Bool -> [Text]
 getGhcOptions bconfig boptsCli name isTarget isLocal = concat
     [ Map.findWithDefault [] name (configGhcOptionsByName config)
-    , configGhcOptionsAll config
+    , if isTarget
+        then Map.findWithDefault [] AGOTargets (configGhcOptionsByCat config)
+        else []
+    , if isLocal
+        then Map.findWithDefault [] AGOLocals (configGhcOptionsByCat config)
+        else []
+    , Map.findWithDefault [] AGOEverything (configGhcOptionsByCat config)
     , concat [["-fhpc"] | isLocal && toCoverage (boptsTestOpts bopts)]
     , if boptsLibProfile bopts || boptsExeProfile bopts
          then ["-auto-all","-caf-all"]

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -359,7 +359,7 @@ configFromConfigMonoid
      let configTemplateParams = configMonoidTemplateParameters
          configScmInit = getFirst configMonoidScmInit
          configGhcOptionsByName = configMonoidGhcOptionsByName
-         configGhcOptionsAll = configMonoidGhcOptionsAll
+         configGhcOptionsByCat = configMonoidGhcOptionsByCat
          configSetupInfoLocations = configMonoidSetupInfoLocations
          configPvpBounds = fromFirst (PvpBounds PvpBoundsNone False) configMonoidPvpBounds
          configModifyCodePage = fromFirst True configMonoidModifyCodePage

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -300,8 +300,10 @@ runGhci GhciOpts{..} targets mainIsTargets pkgs extraFiles = do
             | otherwise = bioOneWordOpts bio
         genOpts = nubOrd (concatMap (concatMap (oneWordOpts . snd) . ghciPkgOpts) pkgs)
         (omittedOpts, ghcOpts) = partition badForGhci $
-            concatMap (concatMap (bioOpts . snd) . ghciPkgOpts) pkgs ++
-            map T.unpack (configGhcOptionsAll config ++ concatMap (getUserOptions . ghciPkgName) pkgs)
+            concatMap (concatMap (bioOpts . snd) . ghciPkgOpts) pkgs ++ map T.unpack
+              ( fold (configGhcOptionsByCat config) -- include everything, locals, and targets
+             ++ concatMap (getUserOptions . ghciPkgName) pkgs
+              )
         getUserOptions pkg = M.findWithDefault [] pkg (configGhcOptionsByName config)
         badForGhci x =
             isPrefixOf "-O" x || elem x (words "-debug -threaded -ticky -static -Werror")


### PR DESCRIPTION
Closes #3329. This also fixes a regression I introduced in the previous
commit on ghc-options, which mistakenly assumed ghc-options were
supposed to be given as a list instead of a single Text value.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
