### PR TITLE
Kadoban ghc color output

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -55,6 +55,11 @@ Other enhancements:
 * Added `stack ghci --only-main` flag, to skip loading / importing
   all but main modules. See the ghci documentation page
   for further info.
+* Allow GHC's colored output to show through. GHC colors output
+  starting with version 8.2.1, for older GHC this does nothing.
+  Sometimes GHC's heuristics would work fine even before this change,
+  for example in `stack ghci`, but this override's GHC's heuristics
+  when they're broken by our collecting and processing GHC's output.
 
 Bug fixes:
 

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1789,12 +1789,8 @@ getSetupHs dir = do
 extraBuildOptions :: (HasEnvConfig env, HasRunner env)
                   => WhichCompiler -> BuildOpts -> RIO env [String]
 extraBuildOptions wc bopts = do
-    canDoColor <- (>= $(mkVersion "8.2.1")) . getGhcVersion
-              <$> view actualCompilerVersionL
-    shouldDoColor <- logUseColor <$> view logOptionsL
+    colorOpt <- appropriateGhcColorFlag
     let ddumpOpts = " -ddump-hi -ddump-to-file"
-        colorOpt = if canDoColor && shouldDoColor
-                     then "-fdiagnostics-color=always" else ""
         optsFlag = compilerOptionsCabalFlag wc
         baseOpts = ddumpOpts ++ " " ++ colorOpt
     if toCoverage (boptsTestOpts bopts)

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -27,6 +27,7 @@ module Stack.Constants
     ,defaultGlobalConfigPath
     ,platformVariantEnvVar
     ,compilerOptionsCabalFlag
+    ,ghcColorForceFlag
     )
     where
 
@@ -212,3 +213,6 @@ platformVariantEnvVar = stackProgNameUpper ++ "_PLATFORM_VARIANT"
 compilerOptionsCabalFlag :: WhichCompiler -> String
 compilerOptionsCabalFlag Ghc = "--ghc-options"
 compilerOptionsCabalFlag Ghcjs = "--ghcjs-options"
+
+ghcColorForceFlag :: String
+ghcColorForceFlag = "-fdiagnostics-color=always"

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -52,6 +52,7 @@ scriptCmd opts go' = do
         config <- view configL
         menv <- liftIO $ configEnvOverride config defaultEnvSettings
         wc <- view $ actualCompilerVersionL.whichCompilerL
+        colorFlag <- appropriateGhcColorFlag
 
         targetsSet <-
             case soPackages opts of
@@ -87,6 +88,7 @@ scriptCmd opts go' = do
 
         let ghcArgs = concat
                 [ ["-hide-all-packages"]
+                , [colorFlag]
                 , map (\x -> "-package" ++ x)
                     $ Set.toList
                     $ Set.insert "base"


### PR DESCRIPTION
Just adds in one extra commit to the original PR, which strips ANSI codes from the log files.