### PR TITLE
Fix script base

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1818,7 +1818,7 @@ extraBuildOptions wc bopts = do
     colorOpt <- appropriateGhcColorFlag
     let ddumpOpts = " -ddump-hi -ddump-to-file"
         optsFlag = compilerOptionsCabalFlag wc
-        baseOpts = ddumpOpts ++ " " ++ colorOpt
+        baseOpts = ddumpOpts ++ maybe "" (" " ++) colorOpt
     if toCoverage (boptsTestOpts bopts)
       then do
         hpcIndexDir <- toFilePathNoTrailingSep <$> hpcRelativeDir

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -88,7 +88,7 @@ scriptCmd opts go' = do
 
         let ghcArgs = concat
                 [ ["-hide-all-packages"]
-                , [colorFlag]
+                , maybeToList colorFlag
                 , map (\x -> "-package" ++ x)
                     $ Set.toList
                     $ Set.insert "base"

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1962,7 +1962,7 @@ shouldForceGhcColorFlag = do
     return $ canDoColor && shouldDoColor
 
 appropriateGhcColorFlag :: (HasRunner env, HasEnvConfig env)
-                        => RIO env String
+                        => RIO env (Maybe String)
 appropriateGhcColorFlag = f <$> shouldForceGhcColorFlag
-  where f True = ghcColorForceFlag
-        f False = ""
+  where f True = Just ghcColorForceFlag
+        f False = Nothing

--- a/src/System/Process/Log.hs
+++ b/src/System/Process/Log.hs
@@ -65,7 +65,7 @@ timeSpecMilliSecondText t =
 -- debugging purposes, not functionally important.
 showProcessArgDebug :: String -> Text
 showProcessArgDebug x
-    | any special x = T.pack (show x)
+    | any special x || null x = T.pack (show x)
     | otherwise = T.pack x
   where special '"' = True
         special ' ' = True


### PR DESCRIPTION
Fixes regression introduced in the color output patch when using GHC < 8.2