### PR TITLE
Prefer more recent version of libtinfo when selecting GHC build

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,8 @@ Behavior changes:
 * Options passsed via `--ghci-options` are now passed to the end of the
   invocation of ghci, instead of the middle.  This allows using `+RTS`
   without an accompanying `-RTS`.
+* When auto-detecting `--ghc-build`, `tinfo6` is now preferred over
+  `standard` if both versions of libtinfo are installed
 
 Other enhancements:
 

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -591,8 +591,8 @@ getGhcBuild menv = do
                 hasgmp5 <- checkLib $(mkRelFile "libgmp.so.10")
                 hasgmp4 <- checkLib $(mkRelFile "libgmp.so.3")
                 let libComponents =
-                        if  | hastinfo5 && hasgmp5 -> []
-                            | hastinfo6 && hasgmp5 -> ["tinfo6"]
+                        if  | hastinfo6 && hasgmp5 -> ["tinfo6"]
+                            | hastinfo5 && hasgmp5 -> []
                             | hasncurses6 && hasgmp5 -> ["ncurses6"]
                             | hasgmp4 && hastinfo5 -> ["gmp4"]
                             | otherwise -> []


### PR DESCRIPTION
When both libtinfo 5 and 6 are installed on the same system, Stack currently defaults to 5. This breaks if nopie is also required, because the `no-pie` flags in [stack-setup-2.yaml](https://github.com/fpco/stackage-content/blob/master/stack/stack-setup-2.yaml) differ in case between `linux64-nopie` and `linux64-tinfo6-nopie`. In the long run it would probably make sense to simply infer the correct flags within Stack instead of hardcoding them in YAML, but that's a much more complex change.

Instead, this patch changes the order these flags are tested in, so that we default to the newer version if both are present.

I've tested it by running `stack setup` on the following distros (via Docker images):
* Sabayon / Hardened Gentoo - correctly uses tinfo6-nopie now
* Ubuntu Zesty - still uses `standard`
* Ubuntu Xenial - uses `standard`
* Fedora - uses tinfo6 before and after change
* Arch (dock0/arch) - uses ncurses6