### PR TITLE
Remove psupstream

### DIFF
--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -86,7 +86,13 @@ build setLocalFiles mbuildLk boptsCli = fixCodePage $ do
     liftIO $ setLocalFiles
            $ Set.insert stackYaml
            $ Set.unions
-           $ map lpFiles locals
+             -- The `locals` value above only contains local project
+             -- packages, not local dependencies. This will get _all_
+             -- of the local files we're interested in
+             -- watching. Arguably, we should not bother watching repo
+             -- and archive files, since those shouldn't
+             -- change. That's a possible optimization to consider.
+             [lpFiles lp | PSFiles lp _ <- Map.elems sourceMap]
 
     (installedMap, globalDumpPkgs, snapshotDumpPkgs, localDumpPkgs) <-
         getInstalled menv
@@ -220,14 +226,9 @@ warnIfExecutablesWithSameNameCouldBeOverwritten locals plan = do
         collect
             [ (exe,pkgName)
             | (pkgName,task) <- Map.toList (planTasks plan)
-            , isLocal task
-            , exe <- (Set.toList . exeComponents . lpComponents . taskLP) task
+            , TTFiles lp _ <- [taskType task] -- FIXME analyze logic here, do we need to check for Local?
+            , exe <- (Set.toList . exeComponents . lpComponents) lp
             ]
-      where
-        isLocal Task{taskType = (TTLocal _)} = True
-        isLocal _ = False
-        taskLP Task{taskType = (TTLocal lp)} = lp
-        taskLP _ = error "warnIfExecutablesWithSameNameCouldBeOverwritten/taskLP: task isn't local"
     localExes :: Map Text (NonEmpty PackageName)
     localExes =
         collect

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -31,9 +31,10 @@ import qualified    Data.Map.Strict as M
 import qualified    Data.Set as Set
 import              Stack.Build.Cache
 import              Stack.Build.Target
-import              Stack.Config (getLocalPackages)
+import              Stack.Config (getLocalPackages, getNamedComponents)
 import              Stack.Constants (wiredInPackages)
 import              Stack.Package
+import              Stack.PackageLocation
 import              Stack.Types.Build
 import              Stack.Types.BuildPlan
 import              Stack.Types.Config
@@ -71,7 +72,7 @@ loadSourceMapFull :: HasEnvConfig env
                   -> RIO env
                        ( Map PackageName Target
                        , LoadedSnapshot
-                       , [LocalPackage]
+                       , [LocalPackage] -- FIXME do we really want this? it's in the SourceMap
                        , Set PackageName -- non-project targets
                        , SourceMap
                        )
@@ -88,17 +89,38 @@ loadSourceMapFull needTargets boptsCli = do
 
     -- Combine the local packages, extra-deps, and LoadedSnapshot into
     -- one unified source map.
-    let sourceMap = Map.unions
-            [ Map.fromList $ map (\lp' -> (packageName $ lpPackage lp', PSLocal lp')) locals
-            , flip Map.mapWithKey localDeps $ \n lpi ->
-                let configOpts = getGhcOptions bconfig boptsCli n False False
-                 -- NOTE: configOpts includes lpiGhcOptions for now, this may get refactored soon
-                 in PSUpstream (lpiVersion lpi) Local (lpiFlags lpi) configOpts (lpiLocation lpi)
-            , flip Map.mapWithKey (lsPackages ls) $ \n lpi ->
-                let configOpts = getGhcOptions bconfig boptsCli n False False
-                 -- NOTE: configOpts includes lpiGhcOptions for now, this may get refactored soon
-                 in PSUpstream (lpiVersion lpi) Snap (lpiFlags lpi) configOpts (lpiLocation lpi)
-            ]
+    let goLPI loc n lpi = do
+          let configOpts = getGhcOptions bconfig boptsCli n False False
+          case lpiLocation lpi of
+            -- NOTE: configOpts includes lpiGhcOptions for now, this may get refactored soon
+            PLIndex pir -> return $ PSIndex loc (lpiFlags lpi) configOpts pir
+            PLOther pl -> do
+              -- FIXME lots of code duplication with getLocalPackages
+              menv <- getMinimalEnvOverride
+              root <- view projectRootL
+              dir <- resolveSinglePackageLocation menv root pl
+              cabalfp <- findOrGenerateCabalFile dir
+              bs <- liftIO (S.readFile (toFilePath cabalfp))
+              (warnings, gpd) <-
+                case rawParseGPD bs of
+                  Left e -> throwM $ InvalidCabalFileInLocal (PLOther pl) e bs
+                  Right x -> return x
+              mapM_ (printCabalFileWarning cabalfp) warnings
+              lp' <- loadLocalPackage boptsCli targets (n, LocalPackageView
+                { lpvVersion = lpiVersion lpi
+                , lpvRoot = dir
+                , lpvCabalFP = cabalfp
+                , lpvComponents = getNamedComponents gpd
+                , lpvGPD = gpd
+                , lpvLoc = pl
+                })
+              return $ PSFiles lp' loc
+    sourceMap' <- Map.unions <$> sequence
+      [ return $ Map.fromList $ map (\lp' -> (packageName $ lpPackage lp', PSFiles lp' Local)) locals
+      , sequence $ Map.mapWithKey (goLPI Local) localDeps
+      , sequence $ Map.mapWithKey (goLPI Snap) (lsPackages ls)
+      ]
+    let sourceMap = sourceMap'
             `Map.difference` Map.fromList (map (, ()) (HashSet.toList wiredInPackages))
 
     return
@@ -286,6 +308,7 @@ loadLocalPackage boptsCli targets (name, lpv) = do
             (exes `Set.difference` packageExes pkg)
             (tests `Set.difference` Map.keysSet (packageTests pkg))
             (benches `Set.difference` packageBenchmarks pkg)
+        , lpLocation = lpvLoc lpv
         }
 
 -- | Ensure that the flags specified in the stack.yaml file and on the command

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -694,7 +694,7 @@ getExtraLoadDeps loadAllDeps sourceMap targets =
     getDeps :: PackageName -> [PackageName]
     getDeps name =
         case M.lookup name sourceMap of
-            Just (PSLocal lp) -> M.keys (packageDeps (lpPackage lp))
+            Just (PSFiles lp _) -> M.keys (packageDeps (lpPackage lp)) -- FIXME just Local?
             _ -> []
     go :: PackageName -> State (Map PackageName (Maybe (Path Abs File, Target))) Bool
     go name = do
@@ -702,7 +702,7 @@ getExtraLoadDeps loadAllDeps sourceMap targets =
         case (M.lookup name cache, M.lookup name sourceMap) of
             (Just (Just _), _) -> return True
             (Just Nothing, _) | not loadAllDeps -> return False
-            (_, Just (PSLocal lp)) -> do
+            (_, Just (PSFiles lp _)) -> do
                 let deps = M.keys (packageDeps (lpPackage lp))
                 shouldLoad <- liftM or $ mapM go deps
                 if shouldLoad
@@ -712,7 +712,7 @@ getExtraLoadDeps loadAllDeps sourceMap targets =
                     else do
                         modify (M.insert name Nothing)
                         return False
-            (_, Just PSUpstream{}) -> return loadAllDeps
+            (_, Just PSIndex{}) -> return loadAllDeps
             (_, _) -> return False
 
 preprocessCabalMacros :: MonadIO m => [GhciPkgInfo] -> Path Abs File -> m [String]

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -209,8 +209,7 @@ getCabalLbs pvpBounds mrev fp = do
       where
         lookupVersion name =
           case Map.lookup name sourceMap of
-              Just (PSLocal lp) -> Just $ packageVersion $ lpPackage lp
-              Just (PSUpstream version _ _ _ _) -> Just version
+              Just ps -> Just (piiVersion ps)
               Nothing ->
                   case Map.lookup name installedMap of
                       Just (_, installed) -> Just (installedVersion installed)
@@ -260,6 +259,7 @@ readLocalPackage pkgDir = do
         , lpFiles = Set.empty
         , lpComponents = Set.empty
         , lpUnbuildable = Set.empty
+        , lpLocation = PLFilePath $ toFilePath pkgDir
         }
 
 -- | Returns a newline-separate list of paths, and the absolute path to the .cabal file.
@@ -285,7 +285,7 @@ getSDistFileList lp =
     ac = ActionContext Set.empty []
     task = Task
         { taskProvides = PackageIdentifier (packageName package) (packageVersion package)
-        , taskType = TTLocal lp
+        , taskType = TTFiles lp Local
         , taskConfigOpts = TaskConfigOpts
             { tcoMissing = Set.empty
             , tcoOpts = \_ -> ConfigureOpts [] []

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -39,7 +39,7 @@ import qualified Data.Set as Set
 import           Data.Store.Version
 import           Data.Store.VersionTagged
 import qualified Data.Text as T
-import           Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import           Data.Text.Encoding (encodeUtf8)
 import qualified Distribution.ModuleName as C
 import qualified Distribution.Version as C
 import           Network.HTTP.Client (parseRequest)
@@ -106,7 +106,7 @@ sdRawPathName sd =
   where
     go (ResolverSnapshot name) = renderSnapName name
     go (ResolverCompiler version) = compilerVersionText version
-    go (ResolverCustom _ hash) = "custom-" <> sdResolverName sd <> "-" <> decodeUtf8 (trimmedSnapshotHash hash)
+    go (ResolverCustom _ hash) = "custom-" <> sdResolverName sd <> "-" <> trimmedSnapshotHash hash
 
 -- | Modify the wanted compiler version in this snapshot. This is used
 -- when overriding via the `compiler` value in a custom snapshot or

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -25,7 +25,7 @@ import           Distribution.Package hiding (Package,PackageName,packageName,pa
 import           Distribution.PackageDescription (TestSuiteInterface, BuildType)
 import           Distribution.System (Platform (..))
 import           Path as FL
-import           Stack.Types.BuildPlan (PackageLocationIndex)
+import           Stack.Types.BuildPlan (PackageLocation, PackageLocationIndex (..))
 import           Stack.Types.Compiler
 import           Stack.Types.Config
 import           Stack.Types.FlagName
@@ -184,19 +184,24 @@ type SourceMap = Map PackageName PackageSource
 
 -- | Where the package's source is located: local directory or package index
 data PackageSource
-    = PSLocal LocalPackage
-    | PSUpstream Version InstallLocation (Map FlagName Bool) [Text] (PackageLocationIndex FilePath) -- FIXME still seems like we could do better... Minimum: rename from Upstream to Dependency and Local to Project
-    -- ^ Upstream packages could be installed in either local or snapshot
-    -- databases; this is what 'InstallLocation' specifies.
+  = PSFiles LocalPackage InstallLocation
+  -- ^ Package which exist on the filesystem (as opposed to an index tarball)
+  | PSIndex InstallLocation (Map FlagName Bool) [Text] PackageIdentifierRevision
+  -- ^ Package which is in an index, and the files do not exist on the
+  -- filesystem yet.
     deriving Show
 
 piiVersion :: PackageSource -> Version
-piiVersion (PSLocal lp) = packageVersion $ lpPackage lp
-piiVersion (PSUpstream v _ _ _ _) = v
+piiVersion (PSFiles lp _) = packageVersion $ lpPackage lp
+piiVersion (PSIndex _ _ _ (PackageIdentifierRevision (PackageIdentifier _ v) _)) = v
 
 piiLocation :: PackageSource -> InstallLocation
-piiLocation (PSLocal _) = Local
-piiLocation (PSUpstream _ loc _ _ _) = loc
+piiLocation (PSFiles _ loc) = loc
+piiLocation (PSIndex loc _ _ _) = loc
+
+piiPackageLocation :: PackageSource -> PackageLocationIndex FilePath
+piiPackageLocation (PSFiles lp _) = PLOther (lpLocation lp)
+piiPackageLocation (PSIndex _ _ _ pir) = PLIndex pir
 
 -- | Information on a locally available package of source code
 data LocalPackage = LocalPackage
@@ -208,7 +213,7 @@ data LocalPackage = LocalPackage
     , lpUnbuildable   :: !(Set NamedComponent)
     -- ^ Components explicitly requested for build, that are marked
     -- "buildable: false".
-    , lpWanted        :: !Bool
+    , lpWanted        :: !Bool -- FIXME Should completely drop this "wanted" terminology, it's unclear
     -- ^ Whether this package is wanted as a target.
     , lpTestDeps      :: !(Map PackageName VersionRange)
     -- ^ Used for determining if we can use --enable-tests in a normal build.
@@ -231,6 +236,8 @@ data LocalPackage = LocalPackage
     -- ^ current state of the files
     , lpFiles         :: !(Set (Path Abs File))
     -- ^ all files used by this package
+    , lpLocation      :: !(PackageLocation FilePath)
+    -- ^ Where this source code came from
     }
     deriving Show
 


### PR DESCRIPTION
The concept of PSUpstream no longer makes sense: it's possible to have snapshot packages which don't come from the package index now that extensible snapshots exist. This is a tactical change to fix some broken assumptions.

Overall, the code and types could use a more significant cleanup to make things easier to follow and less error prone. I want to get this change in without getting held up further by a grander vision. I'll add comments on a separate issue explaining what I think can be improved in the future.