### PR TITLE
Make etc/scripts/get-stack.sh respect the -d argument

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -102,6 +102,8 @@ Bug fixes:
   downloaded index.  Fixes potential issue if stack was interrupted when
   updating index.
   See [#3033](https://github.com/commercialhaskell/stack/issues/3033)
+* The Stack install script now respects the `-d` option.
+  See [#3366](https://github.com/commercialhaskell/stack/pull/3366).
 
 ## 1.5.1
 

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -655,7 +655,7 @@ check_home_local_bin_on_path() {
   fi
 }
 
-# Check whether /usr/local/bin is on the PATH, and print a warning if not.
+# Check whether $DEST is on the PATH, and print a warning if not.
 check_dest_on_path() {
   if ! on_path "$(dirname $DEST)" ; then
     info "WARNING: '$(dirname $DEST)' is not on your PATH."

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -577,7 +577,11 @@ stack_location() {
 
 # Check whether 'stack' command exists
 has_stack() {
-  has_cmd stack
+  if [ "$DEST" != "" ] ; then
+    has_cmd "$DEST"
+  else
+    has_cmd stack
+  fi
 }
 
 # Check whether 'wget' command exists
@@ -674,8 +678,9 @@ check_stack_installed() {
       else
         get="wget -qO-"
       fi
+      [ "$DEST" != "" ] && location=$(realpath "$DEST") || location=$(stack_location)
       die "Stack $(stack_version) already appears to be installed at:
-  $(stack_location)
+  $location
 Use 'stack upgrade' or your OS's package manager to upgrade,
 or pass '-f' to this script to over-write the existing binary, e.g.:
   $get https://get.haskellstack.org/ | sh -s - -f"


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

---

This change now makes the install script use the `-d {path}` value when checking for existing stack executables. Should close off https://github.com/commercialhaskell/stack/issues/3350. Arguably, we should also use `realpath` for the 'Installing Stack to: ...' message, no?

Here's my test logs (click dropdown):

<details>
<summary>Before</summary>

``` bash
λ ~/hobby/stack/ master mkdir foobar
λ ~/hobby/stack/ master cd foobar     
λ ~/hobby/stack/foobar/ master less ../etc/scripts/get-stack.sh | sh -s - -d .    
Stack Version 1.5.1 already appears to be installed at:
  /home/lwm/.local/bin/stack
Use 'stack upgrade' or your OS's package manager to upgrade,
or pass '-f' to this script to over-write the existing binary, e.g.:
  curl -sSL https://get.haskellstack.org/ | sh -s - -f
```

</details>

<details>
<summary>After</summary>

``` bash
λ ~/hobby/stack/ fixup-3350 mkdir foobar
λ ~/hobby/stack/ fixup-3350 cd foobar                                              
λ ~/hobby/stack/foobar/ fixup-3350 less ../etc/scripts/get-stack.sh | sh -s - -d .
... (regular install logs)
λ ~/hobby/stack/foobar/ fixup-3350* less ../etc/scripts/get-stack.sh | sh -s - -d .
Stack Version 1.5.1 already appears to be installed at:
  /home/lwm/hobby/stack/foobar/stack
Use 'stack upgrade' or your OS's package manager to upgrade,
or pass '-f' to this script to over-write the existing binary, e.g.:
  curl -sSL https://get.haskellstack.org/ | sh -s - -f
λ ~/hobby/stack/foobar/ fixup-3350* less ../etc/scripts/get-stack.sh | sh -s - -d . -f
... (regular install logs)
Installing Stack to: ./stack...

-------------------------------------------------------------------------------

Stack has been installed to: ./stack

WARNING: '.' is not on your PATH.
```

</details>