### PR TITLE
Explicitly install happy for style builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,10 @@ install:
    set -ex
    case "$BUILD" in
      style)
+       # This should be resolved (and removed) by Stack 1.6
+       # Follows from https://github.com/commercialhaskell/stack/issues/3178
+       stack --system-ghc --no-terminal install happy
+
        stack --system-ghc --no-terminal install hlint
        ;;
      stack)


### PR DESCRIPTION
Attempt to solve build failure (seen [on master](https://travis-ci.org/commercialhaskell/stack/jobs/266365181#L670) and also reported [over here](https://github.com/commercialhaskell/stack/pull/2812#issuecomment-323574408)).

This failure is a result of #3314 and was seen also in build failures in #2812.