### PR TITLE
Update the solution to the `-fPIC` problem.

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -434,13 +434,7 @@ such hardening flags by default which may be the cause of some instances of the
 problem. Therefore, a possible workaround might be to turn off PIE related
 flags.
 
-In Arch Linux, the support for this is provided by the `hardening-wrapper`
-package. Some possible workarounds:
-
-* Selectively disabling its PIE forcing by setting `HARDENING_PIE=0` in `/etc/hardening-wrapper.conf`.
-* Uninstalling the `hardening-wrapper` package and logging out then into your account again.
-
-If you manage to work around this in other distributions, please include instructions here.
+In Arch Linux, install the package `ncurses5-compat-libs` from AUR resolves this issue [see issue](https://github.com/commercialhaskell/stack/issues/2712).
 
 ## Where does the output from `--ghc-options=-ddump-splices` (and other `-ddump*` options) go?
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -434,7 +434,7 @@ such hardening flags by default which may be the cause of some instances of the
 problem. Therefore, a possible workaround might be to turn off PIE related
 flags.
 
-In Arch Linux, install the package `ncurses5-compat-libs` from AUR resolves this issue [see issue](https://github.com/commercialhaskell/stack/issues/2712).
+On Arch Linux, install the package `ncurses5-compat-libs` from AUR to resolve [this issue](https://github.com/commercialhaskell/stack/issues/2712).
 
 ## Where does the output from `--ghc-options=-ddump-splices` (and other `-ddump*` options) go?
 


### PR DESCRIPTION
The information was outdated. `hardening-wrapper` has been removed from ArchLinux for a while now.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
