### PR TITLE
detect terminal width and use it for pretty-printed output

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,12 @@ Behavior changes:
 * Addition of `stack build --copy-compiler-tool`, to allow tools like
   intero to be installed globally for a particular compiler.
   [#2643](https://github.com/commercialhaskell/stack/issues/2643)
+* Stack will now try to detect the width of the running terminal
+  (only on POSIX for the moment) and use that to better display
+  output messages. Work is ongoing, so some messages will not
+  be optimal yet. The terminal width can be overriden with the
+  new `--terminal-width` command-line option (this works even on
+  non-POSIX).
 
 Other enhancements:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,4 +20,5 @@ test_script:
 - stack setup > nul
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
+- stack install hsc2hs
 - echo "" | stack --no-terminal test --jobs 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,5 +20,4 @@ test_script:
 - stack setup > nul
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
-- stack install hsc2hs
 - echo "" | stack --no-terminal test --jobs 1

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -28,6 +28,8 @@ module Stack.Constants
     ,platformVariantEnvVar
     ,compilerOptionsCabalFlag
     ,ghcColorForceFlag
+    ,minTerminalWidth
+    ,defaultTerminalWidth
     )
     where
 
@@ -216,3 +218,9 @@ compilerOptionsCabalFlag Ghcjs = "--ghcjs-options"
 
 ghcColorForceFlag :: String
 ghcColorForceFlag = "-fdiagnostics-color=always"
+
+minTerminalWidth :: Int
+minTerminalWidth = 20
+
+defaultTerminalWidth :: Int
+defaultTerminalWidth = 100

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -221,7 +221,7 @@ ghcColorForceFlag :: String
 ghcColorForceFlag = "-fdiagnostics-color=always"
 
 minTerminalWidth :: Int
-minTerminalWidth = 20
+minTerminalWidth = 40
 
 maxTerminalWidth :: Int
 maxTerminalWidth = 200

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -29,6 +29,7 @@ module Stack.Constants
     ,compilerOptionsCabalFlag
     ,ghcColorForceFlag
     ,minTerminalWidth
+    ,maxTerminalWidth
     ,defaultTerminalWidth
     )
     where
@@ -221,6 +222,9 @@ ghcColorForceFlag = "-fdiagnostics-color=always"
 
 minTerminalWidth :: Int
 minTerminalWidth = 20
+
+maxTerminalWidth :: Int
+maxTerminalWidth = 200
 
 defaultTerminalWidth :: Int
 defaultTerminalWidth = 100

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -217,14 +217,20 @@ compilerOptionsCabalFlag :: WhichCompiler -> String
 compilerOptionsCabalFlag Ghc = "--ghc-options"
 compilerOptionsCabalFlag Ghcjs = "--ghcjs-options"
 
+-- | The flag to pass to GHC when we want to force its output to be
+-- colorized.
 ghcColorForceFlag :: String
 ghcColorForceFlag = "-fdiagnostics-color=always"
 
+-- | The minimum allowed terminal width. Used for pretty-printing.
 minTerminalWidth :: Int
 minTerminalWidth = 40
 
+-- | The maximum allowed terminal width. Used for pretty-printing.
 maxTerminalWidth :: Int
 maxTerminalWidth = 200
 
+-- | The default terminal width. Used for pretty-printing when we can't
+-- automatically detect it and when the user doesn't supply one.
 defaultTerminalWidth :: Int
 defaultTerminalWidth = 100

--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -40,6 +40,10 @@ globalOptsParser currentDir kind defLogLevel =
          completeWith ["always", "never", "auto"] <>
          help "Specify when to use color in output; WHEN is 'always', 'never', or 'auto'" <>
          hide)) <*>
+    optionalFirst (option auto
+        (long "terminal-width" <>
+         metavar "INT" <>
+         help "Specify the width of the terminal, used for pretty-print messages")) <*>
     optionalFirst
         (strOption
             (long "stack-yaml" <>
@@ -64,6 +68,7 @@ globalOptsFromMonoid defaultTerminal GlobalOptsMonoid{..} = GlobalOpts
     , globalCompiler = getFirst globalMonoidCompiler
     , globalTerminal = fromFirst defaultTerminal globalMonoidTerminal
     , globalColorWhen = fromFirst ColorAuto globalMonoidColorWhen
+    , globalTermWidth = getFirst globalMonoidTermWidth
     , globalStackYaml = maybe SYLDefault SYLOverride $ getFirst globalMonoidStackYaml }
 
 initOptsParser :: Parser InitOpts

--- a/src/Stack/PrettyPrint.hs
+++ b/src/Stack/PrettyPrint.hs
@@ -51,7 +51,7 @@ displayWithColor
     => a -> m T.Text
 displayWithColor x = do
     useAnsi <- liftM logUseColor $ view logOptionsL
-    return $ if useAnsi then displayAnsi x else displayPlain x
+    return $ (if useAnsi then displayAnsi else displayPlain) 120 x
 
 -- TODO: switch to using implicit callstacks once 7.8 support is dropped
 

--- a/src/Stack/PrettyPrint.hs
+++ b/src/Stack/PrettyPrint.hs
@@ -51,7 +51,8 @@ displayWithColor
     => a -> m T.Text
 displayWithColor x = do
     useAnsi <- liftM logUseColor $ view logOptionsL
-    return $ (if useAnsi then displayAnsi else displayPlain) 120 x
+    termWidth <- liftM logTermWidth $ view logOptionsL
+    return $ (if useAnsi then displayAnsi else displayPlain) termWidth x
 
 -- TODO: switch to using implicit callstacks once 7.8 support is dropped
 

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -214,6 +214,7 @@ withRunnerGlobal GlobalOpts{..} = withRunner
   globalTimeInLog
   globalTerminal
   globalColorWhen
+  globalTermWidth
   (isJust globalReExecVersion)
 
 withMiniConfigAndLock

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -442,6 +442,7 @@ data GlobalOpts = GlobalOpts
     , globalCompiler     :: !(Maybe (CompilerVersion 'CVWanted)) -- ^ Compiler override
     , globalTerminal     :: !Bool -- ^ We're in a terminal?
     , globalColorWhen    :: !ColorWhen -- ^ When to use ansi terminal colors
+    , globalTermWidth    :: !(Maybe Int) -- ^ Terminal width override
     , globalStackYaml    :: !(StackYamlLoc FilePath) -- ^ Override project stack.yaml
     } deriving (Show)
 
@@ -465,6 +466,7 @@ data GlobalOptsMonoid = GlobalOptsMonoid
     , globalMonoidCompiler     :: !(First (CompilerVersion 'CVWanted)) -- ^ Compiler override
     , globalMonoidTerminal     :: !(First Bool) -- ^ We're in a terminal?
     , globalMonoidColorWhen    :: !(First ColorWhen) -- ^ When to use ansi colors
+    , globalMonoidTermWidth    :: !(First Int) -- ^ Terminal width override
     , globalMonoidStackYaml    :: !(First FilePath) -- ^ Override project stack.yaml
     } deriving (Show, Generic)
 

--- a/src/Stack/Types/Runner.hs
+++ b/src/Stack/Types/Runner.hs
@@ -41,6 +41,7 @@ import           Language.Haskell.TH
 import           Language.Haskell.TH.Syntax (lift)
 import           Lens.Micro
 import           Stack.Prelude              hiding (lift)
+import           Stack.Constants
 import           System.Console.ANSI
 import           System.FilePath
 import           System.IO
@@ -255,7 +256,7 @@ withRunner logLevel useTime terminal colorWhen widthOverride reExec inner = do
     ColorAlways -> return True
     ColorAuto -> liftIO $ hSupportsANSI stderr
   termWidth <- case widthOverride >>= checkWidth of
-      Nothing -> fromMaybe 100 <$> liftIO getTerminalWidth
+      Nothing -> fromMaybe defaultTerminalWidth <$> liftIO getTerminalWidth
       Just w -> return w
   canUseUnicode <- liftIO getCanUseUnicode
   withSticky terminal $ \sticky -> inner Runner
@@ -272,7 +273,7 @@ withRunner logLevel useTime terminal colorWhen widthOverride reExec inner = do
     , runnerSticky = sticky
     }
   where checkWidth w
-          | w < 20 = Nothing
+          | w < minTerminalWidth = Nothing
           | otherwise = Just w
 
 -- | Taken from GHC: determine if we should use Unicode syntax

--- a/src/Stack/Types/Runner.hs
+++ b/src/Stack/Types/Runner.hs
@@ -46,7 +46,9 @@ import           System.Console.ANSI
 import           System.FilePath
 import           System.IO
 import           System.Log.FastLogger
+#ifndef WINDOWS
 import           System.Terminal
+#endif
 
 -- | Monadic environment.
 data Runner = Runner
@@ -276,6 +278,9 @@ withRunner logLevel useTime terminal colorWhen widthOverride reExec inner = do
           | w < minTerminalWidth = minTerminalWidth
           | w > maxTerminalWidth = maxTerminalWidth
           | otherwise = w
+#ifdef WINDOWS
+        getTerminalWidth = pure Nothing
+#endif
 
 -- | Taken from GHC: determine if we should use Unicode syntax
 getCanUseUnicode :: IO Bool

--- a/src/System/Terminal.hsc
+++ b/src/System/Terminal.hsc
@@ -7,6 +7,22 @@ module System.Terminal
 ( getTerminalWidth
 ) where
 
+import           Foreign
+import           Foreign.C.Types
+
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+newtype WindowWidth = WindowWidth CUShort
+    deriving (Eq, Ord, Show)
+
+instance Storable WindowWidth where
+  sizeOf _ = (#size struct winsize)
+  alignment _ = (#alignment struct winsize)
+  peek p = WindowWidth <$> (#peek struct winsize, ws_col) p
+  poke p (WindowWidth w) = do
+    (#poke struct winsize, ws_col) p w
+
 -- | Get the width, in columns, of the terminal if we can.
 getTerminalWidth :: IO (Maybe Int)
 #ifndef WINDOWS

--- a/src/System/Terminal.hsc
+++ b/src/System/Terminal.hsc
@@ -7,6 +7,7 @@ module System.Terminal
 ( getTerminalWidth
 ) where
 
+#ifndef WINDOWS
 import           Foreign
 import           Foreign.C.Types
 
@@ -25,6 +26,7 @@ instance Storable WindowWidth where
 
 foreign import ccall "sys/ioctl.h ioctl"
   ioctl :: CInt -> CInt -> Ptr WindowWidth -> IO CInt
+#endif
 
 -- | Get the width, in columns, of the terminal if we can.
 getTerminalWidth :: IO (Maybe Int)

--- a/src/System/Terminal.hsc
+++ b/src/System/Terminal.hsc
@@ -1,4 +1,7 @@
+{-# LANGUAGE CPP #-}
+#ifndef WINDOWS
 {-# LANGUAGE ForeignFunctionInterface #-}
+#endif
 
 module System.Terminal
 ( getTerminalWidth
@@ -6,4 +9,8 @@ module System.Terminal
 
 -- | Get the width, in columns, of the terminal if we can.
 getTerminalWidth :: IO (Maybe Int)
+#ifndef WINDOWS
 getTerminalWidth = pure Nothing
+#else
+getTerminalWidth = pure Nothing
+#endif

--- a/src/System/Terminal.hsc
+++ b/src/System/Terminal.hsc
@@ -1,13 +1,9 @@
-{-# LANGUAGE CPP #-}
-#ifndef WINDOWS
 {-# LANGUAGE ForeignFunctionInterface #-}
-#endif
 
 module System.Terminal
 ( getTerminalWidth
 ) where
 
-#ifndef WINDOWS
 import           Foreign
 import           Foreign.C.Types
 
@@ -26,11 +22,9 @@ instance Storable WindowWidth where
 
 foreign import ccall "sys/ioctl.h ioctl"
   ioctl :: CInt -> CInt -> Ptr WindowWidth -> IO CInt
-#endif
 
 -- | Get the width, in columns, of the terminal if we can.
 getTerminalWidth :: IO (Maybe Int)
-#ifndef WINDOWS
 getTerminalWidth =
   alloca $ \p -> do
     errno <- ioctl (#const STDOUT_FILENO) (#const TIOCGWINSZ) p
@@ -39,6 +33,3 @@ getTerminalWidth =
       else do
         WindowWidth w <- peek p
         return . Just . fromIntegral $ w
-#else
-getTerminalWidth = pure Nothing
-#endif

--- a/src/System/Terminal.hsc
+++ b/src/System/Terminal.hsc
@@ -1,0 +1,9 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module System.Terminal
+( getTerminalWidth
+) where
+
+-- | Get the width, in columns, of the terminal if we can.
+getTerminalWidth :: IO (Maybe Int)
+getTerminalWidth = pure Nothing

--- a/src/Text/PrettyPrint/Leijen/Extended.hs
+++ b/src/Text/PrettyPrint/Leijen/Extended.hs
@@ -176,24 +176,24 @@ instance HasAnsiAnn AnsiAnn where
 instance HasAnsiAnn () where
     getAnsiAnn _ = mempty
 
-displayPlain :: Display a => a -> T.Text
-displayPlain = LT.toStrict . displayAnsiSimple . renderDefault . fmap (const mempty) . display
+displayPlain :: Display a => Int -> a -> T.Text
+displayPlain w = LT.toStrict . displayAnsiSimple . renderDefault w . fmap (const mempty) . display
 
 -- TODO: tweak these settings more?
 -- TODO: options for settings if this is released as a lib
 
-renderDefault :: Doc a -> SimpleDoc a
-renderDefault = renderPretty 1 120
+renderDefault :: Int -> Doc a -> SimpleDoc a
+renderDefault = renderPretty 1
 
-displayAnsi :: (Display a, HasAnsiAnn (Ann a)) => a -> T.Text
-displayAnsi = LT.toStrict . displayAnsiSimple . renderDefault . toAnsiDoc . display
+displayAnsi :: (Display a, HasAnsiAnn (Ann a)) => Int -> a -> T.Text
+displayAnsi w = LT.toStrict . displayAnsiSimple . renderDefault w . toAnsiDoc . display
 
 hDisplayAnsi
     :: (Display a, HasAnsiAnn (Ann a), MonadIO m)
-    => Handle -> a -> m ()
-hDisplayAnsi h x = liftIO $ do
+    => Handle -> Int -> a -> m ()
+hDisplayAnsi h w x = liftIO $ do
     useAnsi <- hSupportsANSI h
-    T.hPutStr h $ if useAnsi then displayAnsi x else displayPlain x
+    T.hPutStr h $ if useAnsi then displayAnsi w x else displayPlain w x
 
 displayAnsiSimple :: SimpleDoc AnsiAnn -> LT.Text
 displayAnsiSimple doc =

--- a/src/test/Stack/ConfigSpec.hs
+++ b/src/test/Stack/ConfigSpec.hs
@@ -76,7 +76,7 @@ spec = beforeAll setup $ do
 
   describe "loadConfig" $ do
     let loadConfig' inner =
-          withRunner logLevel True False ColorAuto False $ \runner -> do
+          withRunner logLevel True False ColorAuto Nothing False $ \runner -> do
             lc <- runRIO runner $ loadConfig mempty Nothing SYLDefault
             inner lc
     -- TODO(danburton): make sure parent dirs also don't have config file

--- a/src/test/Stack/NixSpec.hs
+++ b/src/test/Stack/NixSpec.hs
@@ -46,7 +46,7 @@ setup = unsetEnv "STACK_YAML"
 spec :: Spec
 spec = beforeAll setup $ do
   let loadConfig' cmdLineArgs =
-        withRunner LevelDebug True False ColorAuto False $ \runner ->
+        withRunner LevelDebug True False ColorAuto Nothing False $ \runner ->
         runRIO runner $ loadConfig cmdLineArgs Nothing SYLDefault
       inTempDir test = do
         currentDirectory <- getCurrentDirectory

--- a/stack.cabal
+++ b/stack.cabal
@@ -268,6 +268,7 @@ library
                    , store-core >= 0.4 && < 0.5
                    , annotated-wl-pprint
                    , file-embed >= 0.0.10
+  build-tools:       hsc2hs >= 0.68
   if os(windows)
     cpp-options:     -DWINDOWS
     build-depends:   Win32

--- a/stack.cabal
+++ b/stack.cabal
@@ -187,7 +187,6 @@ library
                      System.Process.PagerEditor
                      System.Process.Read
                      System.Process.Run
-                     System.Terminal
   other-modules:     Hackage.Security.Client.Repository.HttpLib.HttpClient
   build-depends:     Cabal >= 2.0 && < 2.1
                    , aeson (>= 1.0 && < 1.2)
@@ -268,7 +267,6 @@ library
                    , store-core >= 0.4 && < 0.5
                    , annotated-wl-pprint
                    , file-embed >= 0.0.10
-  build-tools:       hsc2hs >= 0.68
   if os(windows)
     cpp-options:     -DWINDOWS
     build-depends:   Win32
@@ -276,6 +274,8 @@ library
     build-depends:   unix >= 2.7.0.1
                    , pid1 >= 0.1 && < 0.2
                    , bindings-uname >= 0.1
+    build-tools:     hsc2hs >= 0.68
+    exposed-modules: System.Terminal
   default-language:  Haskell2010
 
 executable stack

--- a/stack.cabal
+++ b/stack.cabal
@@ -187,6 +187,7 @@ library
                      System.Process.PagerEditor
                      System.Process.Read
                      System.Process.Run
+                     System.Terminal
   other-modules:     Hackage.Security.Client.Repository.HttpLib.HttpClient
   build-depends:     Cabal >= 2.0 && < 2.1
                    , aeson (>= 1.0 && < 1.2)

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,3 +24,4 @@ extra-deps:
 - path-io-1.3.3
 - extra-1.6
 - monad-logger-0.3.25
+- hsc2hs-0.68.2


### PR DESCRIPTION
Related to #2650, detect the width of the terminal and use it for proper output.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated
* [x] Test terminal detection more, ideally on several OSes
* [x] Use detected width when pretty-printing
* [x] Allow user configuration of widths (hardcode a width, set min and max?, disable detection?)
* [x] Make sure this doesn't screw up log files too badly
* [x] Figure out why hsc2hs isn't available on appveyor, or if that's just a CI problem

Note: this current implementation is only ever going to work on POSIX. I don't currently have ability to dev/test on windows, though it appears that there *are* APIs that could give this info if anyone else wants to sub that in.

**Testing:** It seems to work fine on all of the OSes I have. Unfortunately, that's a pretty unrepresentative set of OSes. I mostly have linux variants and one BSD I tried on and it worked fine. I don't have access to OSX or Windows really.

If anyone can, testing on other OSes would really be good. Windows won't do any terminal detection, but the command-line option should work.

Log output doesn't seem to be messed up by this. If anyone can verify that'd be nice though. I don't use logs really ever, so I'm hoping I looked the right places.

**Docs:** I couldn't find any places the docs actually need to be updated. The ```stack --help``` output is correct already obviously.