### PR TITLE
Fix docker comment

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -90,6 +90,8 @@ Other enhancements:
 
 Bug fixes:
 
+* `stack --docker-help` is now clearer about --docker implying
+   system-ghc: true, rather than both --docker and --no-docker.
 * `stack haddock` now includes package names for all modules in the
    Haddock index page. See:
   [#2886](https://github.com/commercialhaskell/stack/issues/2886)

--- a/src/Stack/Options/DockerParser.hs
+++ b/src/Stack/Options/DockerParser.hs
@@ -22,7 +22,7 @@ dockerOptsParser hide0 =
     DockerOptsMonoid
     <$> pure (Any False)
     <*> firstBoolFlags dockerCmdName
-                       "using a Docker container. Implies 'system-ghc: true'"
+                       "using a Docker container. --docker implies 'system-ghc: true'"
                        hide
     <*> fmap First
            ((Just . DockerMonoidRepo) <$> option str (long (dockerOptName dockerRepoArgName) <>


### PR DESCRIPTION

So, previously, if you ran

```shell
stack --docker-help
```

you'd see this:

```
  --[no-]docker            Enable/disable using a Docker container. Implies
                           'system-ghc: true'
```

Well, that's not strictly true! --no-docker does not imply system-ghc: true. Only --docker does. 

Looking at the code, it's super-easy to see how this happened, but I'm inclined towards pedantry and I want my documentation to be super-clear. So, PR!

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [*] Any changes that could be relevant to users have been recorded in the ChangeLog.md
Done, in this PR
* [*] The documentation has been updated, if necessary.
This is a documentation update, of a sort. I don't know of any others that need to be polished. The --nix-help page in stack needs similar treatment, though.

Please also shortly describe how you tested your change. Bonus points for added tests!

I built it, cd'd to the dir, and ran ./stack --docker-help. It did what I expected.
