### PR TITLE
Fix parallel invocation of `stack --docker` (#3400)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -120,6 +120,8 @@ Bug fixes:
   See [#3378](https://github.com/commercialhaskell/stack/issues/3378).
 * Previously, if you delete a yaml file from ~/.stack/build-plan, it would
   trust the etag and not re-download.  Fixed in this version.
+* Invoking `stack --docker` in parallel now correctly locks the sqlite database.
+  See [#3400](https://github.com/commercialhaskell/stack/issues/3400).
 
 ## 1.5.1
 


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

See issue #3400 for background.

Thanks to @mgsloan for your help on how to go about this! Turned out the fix was actually quite trivial.

A patched `stack` is already live in our CI. I will report findings here later.