### PR TITLE
Fix readthedocs search (fixes #3376)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -122,6 +122,10 @@ Bug fixes:
   trust the etag and not re-download.  Fixed in this version.
 * Invoking `stack --docker` in parallel now correctly locks the sqlite database.
   See [#3400](https://github.com/commercialhaskell/stack/issues/3400).
+* docs.haskellstack.org RTD documentation search is replaced by the mkdocs
+  search. Please see
+  [#3376](https://github.com/commercialhaskell/stack/issues/3376).
+
 
 ## 1.5.1
 

--- a/doc/js/searchhack.js
+++ b/doc/js/searchhack.js
@@ -13,7 +13,7 @@
       observer.disconnect();
       var form = $('#rtd-search-form');
       form.empty();
-      form.attr('action', 'https://' + window.location.hostname + '/en/' + determineSelectedBranch() + '/search.html');
+      form.attr('action', 'https://' + window.location.hostname + '/' + window.location.pathname.split('/')[1] + '/' + window.location.pathname.split('/')[2] + '/search.html');
       $('<input>').attr({
         type: "text",
         name: "q",
@@ -21,7 +21,7 @@
       }).appendTo(form);
     });
 
-    if (window.location.origin.indexOf('readthedocs') > -1) {
+    if (window.location.origin.indexOf('readthedocs') > -1 || window.location.origin.indexOf('docs.haskellstack') > -1) {
       observer.observe(target, config);
     }
   }

--- a/etc/mkdocsjs/searchhack.js
+++ b/etc/mkdocsjs/searchhack.js
@@ -1,0 +1,29 @@
+// Please see https://github.com/commercialhaskell/stack/issues/3376
+
+(function () {
+  $(document).ready(function () {
+    fixSearch();
+  });
+
+  function fixSearch() {
+    var target = document.getElementById('rtd-search-form');
+    var config = {attributes: true, childList: true};
+
+    var observer = new MutationObserver(function(mutations) {
+      observer.disconnect();
+      var form = $('#rtd-search-form');
+      form.empty();
+      form.attr('action', 'https://' + window.location.hostname + '/en/' + determineSelectedBranch() + '/search.html');
+      $('<input>').attr({
+        type: "text",
+        name: "q",
+        placeholder: "Search docs"
+      }).appendTo(form);
+    });
+
+    if (window.location.origin.indexOf('readthedocs') > -1) {
+      observer.observe(target, config);
+    }
+  }
+
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,8 @@ site_dir: _site
 theme: readthedocs
 extra_css:
 - css/extra.css
+extra_javascript:
+- js/searchhack.js
 
 pages:
 - Home: README.md
@@ -38,6 +40,3 @@ pages:
 markdown_extensions:
 - toc:
     permalink: true
-
-extra_javascript:
-- etc/mkdocsjs/searchhack.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,3 +38,6 @@ pages:
 markdown_extensions:
 - toc:
     permalink: true
+
+extra_javascript:
+- etc/mkdocsjs/searchhack.js


### PR DESCRIPTION
* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Tested here, searching for 'yaml' returns appropriate results: https://docs.haskellstack.org/en/3376-fix-search/README/