### PR TITLE
When using Nix, depend on gcc.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -93,6 +93,9 @@ Other enhancements:
   [#3360](https://github.com/commercialhaskell/stack/issues/3360)
 * Better descriptions are now available for `stack upgrade --help`. See:
   [#3070](https://github.com/commercialhaskell/stack/issues/3070)
+* When using Nix, nix-shell now depends always on gcc to prevent build errors
+  when using the FFI. As ghc depends on gcc anyway, this doesn't increase the
+  dependency footprint.
 
 Bug fixes:
 

--- a/src/Stack/Nix.hs
+++ b/src/Stack/Nix.hs
@@ -73,7 +73,7 @@ runShellAndExit mprojectRoot getCompilerVersion getCmdArgs = do
      inContainer <- getInContainer
      ghc <- either throwIO return $ nixCompiler compilerVersion
      let pkgsInConfig = nixPackages (configNix config)
-         pkgs = pkgsInConfig ++ [ghc, "git"]
+         pkgs = pkgsInConfig ++ [ghc, "git", "gcc"]
          pkgsStr = "[" <> T.intercalate " " pkgs <> "]"
          pureShell = nixPureShell (configNix config)
          addGCRoots = nixAddGCRoots (configNix config)


### PR DESCRIPTION
Fixes builds using the FFI, with no additional dependency footprint.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
