### PR TITLE
Stack installer script is not detected latest `redhatenterpriseserver` linux version

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -396,7 +396,7 @@ GETDISTRO
     fedora)
       do_fedora_install "$VERSION"
       ;;
-    centos|rhel)
+    centos|rhel|redhatenterpriseserver)
       do_centos_install "$VERSION"
       ;;
     alpine)


### PR DESCRIPTION
The current install script at `https://get.haskellstack.org/` is attempting to detect for `rhel` when the latest RedHate Enterprise is detected as `redhatenterpriseserver`, thus the script is falling back to the `sloppy` install.

Adding `|redhatenterpriseserver` as an option after `rhel` fixes the issue and install fully completes properly and successfully with all dependent packages properly installed.