### PR TITLE
Don't save Hackage credentials without asking first

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -45,6 +45,9 @@ Behavior changes:
   be optimal yet. The terminal width can be overriden with the
   new `--terminal-width` command-line option (this works even on
   non-POSIX).
+* Stack will ask before saving hackage credentials to file. This new
+  prompt can be avoided by using the `save-hackage-creds` setting. Please
+  see [#2159](https://github.com/commercialhaskell/stack/issues/2159).
 
 Other enhancements:
 

--- a/src/Options/Applicative/Builder/Extra.hs
+++ b/src/Options/Applicative/Builder/Extra.hs
@@ -247,9 +247,10 @@ unescapeBashArg :: String -> String
 unescapeBashArg ('\'' : rest) = rest
 unescapeBashArg ('\"' : rest) = go rest
   where
+    pattern = "$`\"\\\n" :: String
     go [] = []
     go ('\\' : x : xs)
-        | x `elem` "$`\"\\\n" = x : xs
+        | x `elem` pattern = x : xs
         | otherwise = '\\' : x : go xs
     go (x : xs) = x : go xs
 unescapeBashArg input = go input

--- a/src/Stack/Types/GhcPkgId.hs
+++ b/src/Stack/Types/GhcPkgId.hs
@@ -55,7 +55,8 @@ parseGhcPkgId x = go x
 -- | A parser for a package-version-hash pair.
 ghcPkgIdParser :: Parser GhcPkgId
 ghcPkgIdParser =
-    GhcPkgId . T.pack <$> many1 (choice [digit, letter, satisfy (`elem` "_.-")])
+    let elements =  "_.-" :: String in
+    GhcPkgId . T.pack <$> many1 (choice [digit, letter, satisfy (`elem` elements)])
 
 -- | Get a string representation of GHC package id.
 ghcPkgIdString :: GhcPkgId -> String


### PR DESCRIPTION
Something for https://github.com/commercialhaskell/stack/issues/2159.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Here's my manual test logs:

```bash
>> :main ["upload", "."]
Getting file list for /home/lwm/hacking/hobby/stack/

Warning: In getPackageArgs: custom-setup in use, but no dependency map present
Could not find custom-setup dep: Cabal
Could not find custom-setup dep: base
Could not find custom-setup dep: filepath
Building sdist tarball for /home/lwm/hacking/hobby/stack/
Checking package 'stack' for common mistakes
Hackage username: foobar
Hackage password: 
Save hackage credentials to file at /home/lwm/.stack/upload/credentials.json [y/n]? bad input
Save hackage credentials to file at /home/lwm/.stack/upload/credentials.json [y/n]? n
NOTE: Avoid this prompt in the future by using: save-hackage-creds: false
Uploading stack-1.5.1.tar.gz... authentication failure
Control.Exception.Safe.throwString called with:

Authentication failure uploading to server
Called from:
  throwString (/home/lwm/hacking/hobby/stack/src/Stack/Upload.hs:181:17 in main:Stack.Upload)

*** Exception: ExitFailure 1
```
