### PR TITLE
Add hpack command line option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -51,6 +51,9 @@ Behavior changes:
 
 Other enhancements:
 
+* The `with-hpack` configuration option specifies an Hpack executable to use
+  instead of the Hpack bundled with Stack. Please
+  see [#3179](https://github.com/commercialhaskell/stack/issues/3179).
 * It's now possible to skip tests and benchmarks using `--skip`
   flag
 * `GitSHA1` is now `StaticSHA256` and is implemented using the `StaticSize 64 ByteString` for improved performance.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -528,3 +528,4 @@ Yes:
 
 * If a package directory contains an Hpack `package.yaml` file, then Stack will use it to generate a `.cabal` file when building the package.
 * You can run `stack init` to initialize a `stack.yaml` file regardless of whether your packages are declared with `.cabal` files or with Hpack `package.yaml` files.
+* You can use the `with-hpack` configuration option to specify an Hpack executable to use instead of the Hpack bundled with Stack.

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -460,6 +460,14 @@ Specify a path to gcc explicitly, rather than relying on the normal path resolut
 with-gcc: /usr/local/bin/gcc-5
 ```
 
+### with-hpack
+
+Use an Hpack executable, rather than using the bundled Hpack.
+
+```yaml
+with-hpack: /usr/local/bin/hpack
+```
+
 ### compiler-check
 
 (Since 0.1.4)

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -283,7 +283,8 @@ configFromConfigMonoid
          configExtraIncludeDirs = configMonoidExtraIncludeDirs
          configExtraLibDirs = configMonoidExtraLibDirs
          configOverrideGccPath = getFirst configMonoidOverrideGccPath
-
+         configOverrideHpack = maybe HpackBundled HpackCommand $ getFirst configMonoidOverrideHpack
+         
          -- Only place in the codebase where platform is hard-coded. In theory
          -- in the future, allow it to be configured.
          (Platform defArch defOS) = buildPlatform

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -20,7 +20,7 @@ import qualified System.FilePath as FilePath
 -- | Command-line arguments parser for configuration.
 configOptsParser :: FilePath -> GlobalOptsContext -> Parser ConfigMonoid
 configOptsParser currentDir hide0 =
-    (\stackRoot workDir buildOpts dockerOpts nixOpts systemGHC installGHC arch ghcVariant ghcBuild jobs includes libs overrideGccPath skipGHCCheck skipMsys localBin modifyCodePage allowDifferentUser dumpLogs -> mempty
+    (\stackRoot workDir buildOpts dockerOpts nixOpts systemGHC installGHC arch ghcVariant ghcBuild jobs includes libs overrideGccPath overrideHpack skipGHCCheck skipMsys localBin modifyCodePage allowDifferentUser dumpLogs -> mempty
         { configMonoidStackRoot = stackRoot
         , configMonoidWorkDir = workDir
         , configMonoidBuildOpts = buildOpts
@@ -36,6 +36,7 @@ configOptsParser currentDir hide0 =
         , configMonoidExtraIncludeDirs = includes
         , configMonoidExtraLibDirs = libs
         , configMonoidOverrideGccPath = overrideGccPath
+        , configMonoidOverrideHpack = overrideHpack
         , configMonoidSkipMsys = skipMsys
         , configMonoidLocalBinPath = localBin
         , configMonoidModifyCodePage = modifyCodePage
@@ -101,6 +102,12 @@ configOptsParser currentDir hide0 =
              ( long "with-gcc"
             <> metavar "PATH-TO-GCC"
             <> help "Use gcc found at PATH-TO-GCC"
+            <> hide
+             ))
+    <*> optionalFirst (strOption
+             ( long "with-hpack"
+            <> metavar "HPACK"
+            <> help "Use HPACK executable (overrides bundled Hpack)"
             <> hide
              ))
     <*> firstBoolFlags

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -99,6 +99,7 @@ import qualified System.Directory as D
 import           System.FilePath (splitExtensions, replaceExtension)
 import qualified System.FilePath as FilePath
 import           System.IO.Error
+import           System.Process.Run (runCmd, Cmd(..))
 
 data Ctx = Ctx { ctxFile :: !(Path Abs File)
                , ctxDir :: !(Path Abs Dir)
@@ -171,7 +172,7 @@ readPackageBS packageConfig loc bs =
 -- | Get 'GenericPackageDescription' and 'PackageDescription' reading info
 -- from given directory.
 readPackageDescriptionDir
-  :: (MonadLogger m, MonadIO m, MonadThrow m, HasRunner env,
+  :: (MonadLogger m, MonadIO m, MonadUnliftIO m, MonadThrow m, HasRunner env, HasConfig env,
       MonadReader env m)
   => PackageConfig
   -> Path Abs Dir
@@ -1280,7 +1281,7 @@ logPossibilities dirs mn = do
 -- generate a .cabal file from it.
 findOrGenerateCabalFile
     :: forall m env.
-          (MonadIO m, MonadLogger m, HasRunner env, MonadReader env m)
+          (MonadIO m, MonadUnliftIO m, MonadLogger m, HasRunner env, HasConfig env, MonadReader env m)
     => Path Abs Dir -- ^ package directory
     -> m (Path Abs File)
 findOrGenerateCabalFile pkgDir = do
@@ -1309,30 +1310,38 @@ findOrGenerateCabalFile pkgDir = do
       where hasExtension fp x = FilePath.takeExtension fp == "." ++ x
 
 -- | Generate .cabal file from package.yaml, if necessary.
-hpack :: (MonadIO m, MonadLogger m, HasRunner env, MonadReader env m)
+hpack :: (MonadIO m, MonadUnliftIO m, MonadLogger m, HasRunner env, HasConfig env, MonadReader env m)
       => Path Abs Dir -> m ()
 hpack pkgDir = do
     let hpackFile = pkgDir </> $(mkRelFile Hpack.packageConfig)
     exists <- liftIO $ doesFileExist hpackFile
     when exists $ do
         prettyDebugL [flow "Running hpack on", display hpackFile]
+
+        config <- view configL
+        case configOverrideHpack config of
+            HpackBundled -> do
 #if MIN_VERSION_hpack(0,18,0)
-        r <- liftIO $ Hpack.hpackResult (Just $ toFilePath pkgDir)
+                r <- liftIO $ Hpack.hpackResult (Just $ toFilePath pkgDir)
 #else
-        r <- liftIO $ Hpack.hpackResult (toFilePath pkgDir)
+                r <- liftIO $ Hpack.hpackResult (toFilePath pkgDir)
 #endif
-        forM_ (Hpack.resultWarnings r) prettyWarnS
-        let cabalFile = styleFile . fromString . Hpack.resultCabalFile $ r
-        case Hpack.resultStatus r of
-            Hpack.Generated -> prettyDebugL
-                [flow "hpack generated a modified version of", cabalFile]
-            Hpack.OutputUnchanged -> prettyDebugL
-                [flow "hpack output unchanged in", cabalFile]
-            Hpack.AlreadyGeneratedByNewerHpack -> prettyWarnL
-                [ cabalFile
-                , flow "was generated with a newer version of hpack,"
-                , flow "please upgrade and try again."
-                ]
+                forM_ (Hpack.resultWarnings r) prettyWarnS
+                let cabalFile = styleFile . fromString . Hpack.resultCabalFile $ r
+                case Hpack.resultStatus r of
+                    Hpack.Generated -> prettyDebugL
+                        [flow "hpack generated a modified version of", cabalFile]
+                    Hpack.OutputUnchanged -> prettyDebugL
+                        [flow "hpack output unchanged in", cabalFile]
+                    Hpack.AlreadyGeneratedByNewerHpack -> prettyWarnL
+                        [ cabalFile
+                        , flow "was generated with a newer version of hpack,"
+                        , flow "please upgrade and try again."
+                        ]
+            HpackCommand command -> do
+                envOverride <- getMinimalEnvOverride
+                let cmd = Cmd (Just pkgDir) command envOverride []
+                runCmd cmd Nothing
 
 -- | Path for the package's build log.
 buildLogPath :: (MonadReader env m, HasBuildConfig env, MonadThrow m)

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -490,7 +490,7 @@ getResolverConstraints menv mcompilerVersion stackYaml sd = do
 -- file.
 -- Subdirectories can be included depending on the @recurse@ parameter.
 findCabalFiles
-  :: (MonadIO m, MonadLogger m, HasRunner env, MonadReader env m)
+  :: (MonadIO m, MonadUnliftIO m, MonadLogger m, HasRunner env, MonadReader env m, HasConfig env)
   => Bool -> Path Abs Dir -> m [Path Abs File]
 findCabalFiles recurse dir = do
     liftIO (findFiles dir isHpack subdirFilter) >>= mapM_ (hpack . parent)
@@ -586,8 +586,8 @@ formatGroup :: [String] -> String
 formatGroup = concatMap (\path -> "- " <> path <> "\n")
 
 reportMissingCabalFiles
-  :: (MonadIO m, MonadThrow m, MonadLogger m,
-      HasRunner env, MonadReader env m)
+  :: (MonadIO m, MonadUnliftIO m, MonadThrow m, MonadLogger m,
+      HasRunner env, MonadReader env m, HasConfig env)
   => [Path Abs File]   -- ^ Directories to scan
   -> Bool              -- ^ Whether to scan sub-directories
   -> m ()

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -565,6 +565,7 @@ configureOptsNoDir econfig bco deps isLocal package = concat
     , map ("--extra-include-dirs=" ++) (Set.toList (configExtraIncludeDirs config))
     , map ("--extra-lib-dirs=" ++) (Set.toList (configExtraLibDirs config))
     , maybe [] (\customGcc -> ["--with-gcc=" ++ toFilePath customGcc]) (configOverrideGccPath config)
+    , hpackOptions (configOverrideHpack config)
     , ["--ghcjs" | wc == Ghcjs]
     , ["--exact-configuration" | useExactConf]
     ]
@@ -588,6 +589,9 @@ configureOptsNoDir econfig bco deps isLocal package = concat
     depOptions = map (uncurry toDepOption) $ Map.toList deps
       where
         toDepOption = if newerCabal then toDepOption1_22 else toDepOption1_18
+
+    hpackOptions HpackBundled = []
+    hpackOptions (HpackCommand cmd) = ["--with-hpack=" ++ cmd]
 
     toDepOption1_22 ident gid = concat
         [ "--dependency="

--- a/src/test/Stack/ConfigSpec.hs
+++ b/src/test/Stack/ConfigSpec.hs
@@ -48,6 +48,12 @@ buildOptsConfig =
   "  reconfigure: true\n" ++
   "  cabal-verbose: true\n"
 
+hpackConfig :: String
+hpackConfig =
+  "resolver: lts-2.10\n" ++
+  "with-hpack: /usr/local/bin/hpack\n" ++
+  "packages: ['.']\n"
+
 stackDotYaml :: Path Rel File
 stackDotYaml = $(mkRelFile "stack.yaml")
 
@@ -87,6 +93,18 @@ spec = beforeAll setup $ do
       writeFile (toFilePath stackDotYaml) ""
       -- TODO(danburton): more specific test for exception
       loadConfig' (const (return ())) `shouldThrow` anyException
+
+    it "parses config option with-hpack" $ inTempDir $ do
+      writeFile (toFilePath stackDotYaml) hpackConfig
+      loadConfig' $ \lc -> do
+        let Config{..} = lcConfig lc
+        configOverrideHpack `shouldBe` HpackCommand "/usr/local/bin/hpack"
+
+    it "parses config bundled hpack" $ inTempDir $ do
+      writeFile (toFilePath stackDotYaml) sampleConfig
+      loadConfig' $ \lc -> do
+        let Config{..} = lcConfig lc
+        configOverrideHpack `shouldBe` HpackBundled
 
     it "parses build config options" $ inTempDir $ do
      writeFile (toFilePath stackDotYaml) buildOptsConfig


### PR DESCRIPTION
Resolves #3179.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I tested it with the `--with-hpack` option and without, and it works as I intended. I couldn't think of a good way to test this in code, so I did not add any tests to the test suite.

### Details
The core change is pretty basic.
* I added an `HpackExecutable` type with two cases--one for the bundled hpack, and one with the hpack command.
* I added `HpackExecutable` as a field to the `GlobalOpts` and `BuildConfig` types.
* I used `runCmd` to execute the command, which requires an `EnvOverride` to create a `Cmd` value.
* Then the remaining effort was in propagating the necessary information to the `hpack` function. 
  * When `HasEnvConfig` was available, I used the `hpackExecutableL` lens to retrieve the `HpackExecutable`
  * Else I passed `HpackExecutable` and `EnvOverride` as needed as function arguments.

