### PR TITLE
Fix references to non-existing GitHub issue labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,9 @@ discuss the change before plowing into writing code.
 
 If you'd like to help out but aren't sure what to work on, look for issues with
 the
-[awaiting pr](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3A%22awaiting+pr%22)
+[awaiting pull request](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3A%22awaiting+pull+request%22)
 label. Issues that are suitable for newcomers to the codebase have the
-[newcomer](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3A%22awaiting+pr%22+label%3Anewcomer)
+[newcomer friendly](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3A%22awaiting+pull+request%22+label%3a%22newcomer+friendly%22)
 label. Best to post a comment to the issue before you start work, in case anyone
 has already started.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -53,7 +53,7 @@ the needed files to start a project correctly.
 - The `stack build` command will build the minimal project.
 - `stack exec my-project-exe` will execute the command.
 - If you just want to install an executable using stack, then all you have to do
-is`stack install <package-name>`.
+is `stack install <package-name>`.
 
 If you want to launch a REPL:
 
@@ -116,7 +116,10 @@ installed.
 4. Once `stack` finishes building, check the stack version with
    `stack exec stack -- --version`. Make sure the version is the latest.
 5. Look for issues tagged with
-   [`newcomer` and `awaiting-pr` labels](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3Anewcomer+label%3A%22awaiting+pr%22).
+   [newcomer friendly](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3a%22newcomer+friendly%22)
+   and
+   [awaiting pull request](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3A%22awaiting+pull+request%22)
+   labels.
 
 Build from source as a one-liner:
 
@@ -173,4 +176,4 @@ commercial Haskell users, and has since become a thriving open source
 project meeting the needs of Haskell users of all stripes.
 
 If you'd like to get involved with Stack, check out the
-[newcomers label on the Github issue tracker](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3Anewcomer).
+[newcomer friendly](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3a%22newcomer+friendly%22) label on the Github issue tracker.


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.


I was looking for things I could help with and was a bit surprised there were no `newcomer` and `awaiting pr` issues. Turns out, they are actually called `newcomer friendly` and `awaiting pull request`.

I'm not sure whether to target `stable` or `master`, since it affects both documentation for https://docs.haskellstack.org/en/stable/ and `CONTRIBUTING.md`.
