### PR TITLE
Fixes automatically shown versions for licenses #3432

### DIFF
--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -22,6 +22,7 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import qualified Data.Traversable as T
+import           Distribution.Text (display)
 import           Distribution.License (License(BSD3))
 import           Stack.Build (withLoadPackage)
 import           Stack.Build.Installed (getInstalled, GetInstalledOpts(..))
@@ -143,8 +144,8 @@ listDependencies opts = do
   void (Map.traverseWithKey go (snd <$> resultGraph))
     where go name payload =
             let payloadText =
-                    if listDepsLicense opts
-                      then maybe "<unknown>" (Text.pack . show) (payloadLicense payload)
+                  if listDepsLicense opts
+                      then maybe "<unknown>" (Text.pack . display) (payloadLicense payload)
                       else maybe "<unknown>" (Text.pack . show) (payloadVersion payload)
                 line = packageNameText name <> listDepsSep opts <> payloadText
             in  liftIO $ Text.putStrLn line


### PR DESCRIPTION
Cabal has a method to render this, so we'll just call it directly.

This was just tested manually by adding the package `machines-directory` and checking the output of `stack list-dependencies --license | grep machines`. This renders properly now.

I can some tests if people think it's a good idea, I haven't because it's really just a call to an upstream library, and the code itself lives in `IO` land (which means a refactor). 