### PR TITLE
Fix STACK_IN_NIX_SHELL environment variable name

### DIFF
--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -94,7 +94,7 @@ inContainerEnvVar = stackProgNameUpper ++ "_IN_CONTAINER"
 -- although we already have STACK_IN_NIX_EXTRA_ARGS that is set in the same conditions,
 -- it can happen that STACK_IN_NIX_EXTRA_ARGS is set to empty.
 inNixShellEnvVar :: String
-inNixShellEnvVar = map toUpper stackProgName ++ "_IN_NIXSHELL"
+inNixShellEnvVar = map toUpper stackProgName ++ "_IN_NIX_SHELL"
 
 -- See https://downloads.haskell.org/~ghc/7.10.1/docs/html/libraries/ghc/src/Module.html#integerPackageKey
 wiredInPackages :: HashSet PackageName


### PR DESCRIPTION
The correct name has one more '_':

https://github.com/NixOS/nixpkgs/blob/72f530ba3310b8304b148b74ece9e6e75309666b/pkgs/development/haskell-modules/generic-stack-builder.nix#L20

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
