### PR TITLE
init: Load snapshots on demand during resolver selection

### DIFF
--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -431,13 +431,13 @@ selectBestSnapshot
     :: (HasConfig env, HasGHCVariant env)
     => Path Abs Dir -- ^ project root, used for checking out necessary files
     -> [GenericPackageDescription]
-    -> NonEmpty SnapshotDef
+    -> NonEmpty SnapName
     -> RIO env (SnapshotDef, BuildPlanCheck)
 selectBestSnapshot root gpds snaps = do
     logInfo $ "Selecting the best among "
                <> T.pack (show (NonEmpty.length snaps))
                <> " snapshots...\n"
-    F.foldr1 go (NonEmpty.map getResult snaps)
+    F.foldr1 go (NonEmpty.map (getResult <=< loadResolver . ResolverSnapshot) snaps)
     where
         go mold mnew = do
             old@(_snap, bpc) <- mold

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -360,8 +360,7 @@ getDefaultResolver whichCmd stackYaml initOpts mresolver bundle = do
         selectSnapResolver = do
             let gpds = Map.elems (fmap snd bundle)
             snaps <- fmap getRecommendedSnapshots getSnapshots'
-            sds <- mapM (loadResolver . ResolverSnapshot) snaps
-            (s, r) <- selectBestSnapshot (parent stackYaml) gpds sds
+            (s, r) <- selectBestSnapshot (parent stackYaml) gpds snaps
             case r of
                 BuildPlanCheckFail {} | not (omitPackages initOpts)
                         -> throwM (NoMatchingSnapshot whichCmd snaps)


### PR DESCRIPTION
This fixes a regression from 6047a31594367ed222c6f5cc9dc3ccfe9ea77efc that
caused _all_ the recommended snapshots to be loaded upfront.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Tested manually:

master:

```
➤ stack new bla -v
...
2017-10-06 23:07:29.736790: [debug] Decoding build plan from: /home/simon/.stack/build-plan/lts-9.6.yaml
@(Stack/Snapshot.hs:151:5)
2017-10-06 23:07:31.580566: [debug] Decoding build plan from: /home/simon/.stack/build-plan/nightly-2017-10-06.yaml
@(Stack/Snapshot.hs:151:5)
2017-10-06 23:07:33.238201: [debug] Decoding build plan from: /home/simon/.stack/build-plan/lts-8.24.yaml
@(Stack/Snapshot.hs:151:5)
2017-10-06 23:07:34.852551: [debug] Decoding build plan from: /home/simon/.stack/build-plan/lts-7.24.yaml
@(Stack/Snapshot.hs:151:5)
2017-10-06 23:07:36.510772: [debug] Decoding build plan from: /home/simon/.stack/build-plan/lts-6.35.yaml
@(Stack/Snapshot.hs:151:5)
2017-10-06 23:07:37.966521: [debug] Decoding build plan from: /home/simon/.stack/build-plan/lts-5.18.yaml
@(Stack/Snapshot.hs:151:5)
2017-10-06 23:07:39.118522: [debug] Decoding build plan from: /home/simon/.stack/build-plan/lts-4.2.yaml
@(Stack/Snapshot.hs:151:5)
2017-10-06 23:07:39.996415: [debug] Decoding build plan from: /home/simon/.stack/build-plan/lts-3.22.yaml
@(Stack/Snapshot.hs:151:5)
2017-10-06 23:07:40.675626: [debug] Decoding build plan from: /home/simon/.stack/build-plan/lts-2.22.yaml
@(Stack/Snapshot.hs:151:5)
2017-10-06 23:07:41.206140: [debug] Decoding build plan from: /home/simon/.stack/build-plan/lts-1.15.yaml
@(Stack/Snapshot.hs:151:5)
2017-10-06 23:07:41.696462: [debug] Decoding build plan from: /home/simon/.stack/build-plan/lts-0.7.yaml
@(Stack/Snapshot.hs:151:5)
2017-10-06 23:07:42.156137: [info] Selecting the best among 11 snapshots...

@(Stack/BuildPlan.hs:437:5)
2017-10-06 23:07:42.163070: [debug] Trying to decode /home/simon/.stack/loaded-snapshot-cache/x86_64-linux/__snapshot_hints__/lts-9.6.cache
@(Data/Store/VersionTagged.hs:66:5)
2017-10-06 23:07:42.224834: [debug] Success decoding /home/simon/.stack/loaded-snapshot-cache/x86_64-linux/__snapshot_hints__/lts-9.6.cache
@(Data/Store/VersionTagged.hs:70:13)
2017-10-06 23:07:42.225689: [info] * Matches lts-9.6
@(Stack/BuildPlan.hs:458:13)
...
```

This branch:
```
➤ stack exec -- stack new -v bla
...
2017-10-06 23:09:24.338878: [info] Selecting the best among 11 snapshots...

@(Stack/BuildPlan.hs:437:5)
2017-10-06 23:09:24.339269: [debug] Decoding build plan from: /home/simon/.stack/build-plan/lts-9.6.yaml
@(Stack/Snapshot.hs:151:5)
2017-10-06 23:09:26.241434: [debug] Trying to decode /home/simon/.stack/loaded-snapshot-cache/x86_64-linux/__snapshot_hints__/lts-9.6.cache
@(Data/Store/VersionTagged.hs:66:5)
2017-10-06 23:09:26.283036: [debug] Success decoding /home/simon/.stack/loaded-snapshot-cache/x86_64-linux/__snapshot_hints__/lts-9.6.cache
@(Data/Store/VersionTagged.hs:70:13)
2017-10-06 23:09:26.284101: [info] * Matches lts-9.6
@(Stack/BuildPlan.hs:458:13)
...
```