### PR TITLE
Do correct path checking in precompiled cache.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -148,6 +148,8 @@ Bug fixes:
 * `stack build --only-dependencies` no longer builds local project packages
   that are depended on. See
   [#3476](https://github.com/commercialhaskell/stack/issues/3476).
+* Properly handle relative paths stored in the precompiled cache files. See
+  [#3431](https://github.com/commercialhaskell/stack/issues/3431).
 
 
 ## 1.5.1

--- a/test/integration/tests/3431-precompiled-works/Main.hs
+++ b/test/integration/tests/3431-precompiled-works/Main.hs
@@ -1,0 +1,9 @@
+import StackTest
+import Control.Monad
+import Data.List
+
+main :: IO ()
+main = do
+    stack ["build", "stm", "--stack-yaml", "custom1/stack.yaml"]
+    stackCheckStderr ["build", "stm", "--stack-yaml", "custom2/stack.yaml"] $ \out ->
+      unless ("precompiled" `isInfixOf` out) $ error "Didn't use precompiled!"

--- a/test/integration/tests/3431-precompiled-works/files/custom1/custom1.yaml
+++ b/test/integration/tests/3431-precompiled-works/files/custom1/custom1.yaml
@@ -1,0 +1,5 @@
+resolver: ghc-8.2.1
+name: custom1
+packages:
+- stm-2.4.4.1
+- acme-missiles-0.3

--- a/test/integration/tests/3431-precompiled-works/files/custom1/stack.yaml
+++ b/test/integration/tests/3431-precompiled-works/files/custom1/stack.yaml
@@ -1,0 +1,2 @@
+resolver: custom1.yaml
+packages: []

--- a/test/integration/tests/3431-precompiled-works/files/custom2/custom2.yaml
+++ b/test/integration/tests/3431-precompiled-works/files/custom2/custom2.yaml
@@ -1,0 +1,5 @@
+resolver: ghc-8.2.1
+name: custom2
+packages:
+- stm-2.4.4.1
+- acme-missiles-0.2

--- a/test/integration/tests/3431-precompiled-works/files/custom2/stack.yaml
+++ b/test/integration/tests/3431-precompiled-works/files/custom2/stack.yaml
@@ -1,0 +1,2 @@
+resolver: custom2.yaml
+packages: []


### PR DESCRIPTION
The commit ed9ccc08f327bad68dd2d09a1851ce0d055c0422 changed the behavior
of the precompiled cache to store relative instead of absolute paths.
That seems to have broken the ability to properly check if a library
exists, thereby defeating precompiled caching.

The issue that discovered this is #3431, and ascribed this to extensible
snapshots. I _think_, though I'm not 100% certain, that this bug reaches
much farther than extensible snapshots, and in fact breaks all
precompiled caches.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
