### PR TITLE
Revert "Clean up --only-dependencies logic in ConstructPlan"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -142,6 +142,9 @@ Bug fixes:
   [#3376](https://github.com/commercialhaskell/stack/issues/3376).
 * `stack clean` now works with nix.  See
   [#3468](https://github.com/commercialhaskell/stack/issues/3376).
+* `stack build --only-dependencies` no longer builds local project packages
+  that are depended on. See
+  [#3476](https://github.com/commercialhaskell/stack/issues/3476).
 
 
 ## 1.5.1


### PR DESCRIPTION
This reverts commit d1e6c480cd46def34bfacd3aeaee953ba32c7758 and resolves #3476 

The problem is caused specifically in the `PSFiles -> Nothing` branch of `installPackages`.

As the flag was no longer being passed through, packages were not being checked for being in the wanted map. This led to the local packages being built as dependencies

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I tested this by running `stack --only-dependencies --dry-run` on our stack project with multiple packages. Setting the call to `resolveDepsAndInstall`'s `treatAsDep` value to `True` causes the problem and removing it removes the problem