### PR TITLE
Print retry information if stack needs to retry network requests

### DIFF
--- a/src/Network/HTTP/Download.hs
+++ b/src/Network/HTTP/Download.hs
@@ -43,7 +43,7 @@ import           System.FilePath             (takeDirectory, (<.>))
 -- appropriate destination.
 --
 -- Throws an exception if things go wrong
-download :: (MonadIO m, MonadLogger m)
+download :: (MonadUnliftIO m, MonadLogger m)
          => Request
          -> Path Abs File -- ^ destination
          -> m Bool -- ^ Was a downloaded performed (True) or did the file already exist (False)?
@@ -60,7 +60,7 @@ download req destpath = do
 -- | Same as 'download', but will download a file a second time if it is already present.
 --
 -- Returns 'True' if the file was downloaded, 'False' otherwise
-redownload :: (MonadIO m, MonadLogger m)
+redownload :: (MonadUnliftIO m, MonadLogger m)
            => Request
            -> Path Abs File -- ^ destination
            -> m Bool
@@ -86,7 +86,7 @@ redownload req0 dest = do
                         [("If-None-Match", L.toStrict etag)]
                     }
         req2 = req1 { checkResponse = \_ _ -> return () }
-    liftIO $ recoveringHttp drRetryPolicyDefault $
+    recoveringHttp drRetryPolicyDefault $ liftIO $
       withResponse req2 $ \res -> case getResponseStatusCode res of
         200 -> do
           createDirectoryIfMissing True $ takeDirectory destFilePath

--- a/src/Network/HTTP/Download.hs
+++ b/src/Network/HTTP/Download.hs
@@ -21,6 +21,7 @@ module Network.HTTP.Download
     ) where
 
 import           Stack.Prelude
+import           Stack.Types.Runner
 import qualified Data.ByteString.Lazy        as L
 import           Data.Conduit                (yield)
 import           Data.Conduit.Binary         (sourceHandle)
@@ -43,7 +44,7 @@ import           System.FilePath             (takeDirectory, (<.>))
 -- appropriate destination.
 --
 -- Throws an exception if things go wrong
-download :: (MonadUnliftIO m, MonadLogger m)
+download :: (MonadUnliftIO m, MonadLogger m, HasRunner env, MonadReader env m)
          => Request
          -> Path Abs File -- ^ destination
          -> m Bool -- ^ Was a downloaded performed (True) or did the file already exist (False)?
@@ -60,7 +61,7 @@ download req destpath = do
 -- | Same as 'download', but will download a file a second time if it is already present.
 --
 -- Returns 'True' if the file was downloaded, 'False' otherwise
-redownload :: (MonadUnliftIO m, MonadLogger m)
+redownload :: (MonadUnliftIO m, MonadLogger m, HasRunner env, MonadReader env m)
            => Request
            -> Path Abs File -- ^ destination
            -> m Bool

--- a/src/Network/HTTP/Download/Verified.hs
+++ b/src/Network/HTTP/Download/Verified.hs
@@ -205,7 +205,7 @@ recoveringHttp retryPolicy =
           , "us"
           ]
         logWarn $ Text.unwords
-          [ "If you see this warning and stack fails,"
+          [ "If you see this warning and stack fails to download,"
           , "but running the command again solves the problem,"
           , "please report here: https://github.com/commercialhaskell/stack/issues/3510"
           ]

--- a/src/Network/HTTP/Download/Verified.hs
+++ b/src/Network/HTTP/Download/Verified.hs
@@ -197,7 +197,7 @@ recoveringHttp retryPolicy =
     handlers run = [Handler . alwaysRetryHttp (unliftIO run),const $ Handler retrySomeIO]
 
     alwaysRetryHttp :: (MonadLogger m', Monad m, HasRunner env, MonadReader env m') => (m' () -> m ()) -> RetryStatus -> HttpException -> m Bool
-    alwaysRetryHttp run rs e = do
+    alwaysRetryHttp run rs _ = do
       run $
         prettyWarn $ vcat
           [ flow $ unwords

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -59,6 +59,7 @@ import              Stack.Types.Config
 import              Stack.Types.PackageIdentifier
 import              Stack.Types.PackageIndex
 import              Stack.Types.PackageName
+import              Stack.Types.Runner
 import              Stack.Types.Version
 import qualified    System.FilePath as FP
 import              System.IO (hSeek, SeekMode (AbsoluteSeek))
@@ -505,7 +506,7 @@ fetchPackages' mdistDir toFetchAll = do
 
     liftIO $ readTVarIO outputVar
   where
-    go :: (MonadUnliftIO m,MonadThrow m,MonadLogger m)
+    go :: (MonadUnliftIO m,MonadThrow m,MonadLogger m,HasRunner env, MonadReader env m)
        => TVar (Map PackageIdentifier (Path Abs Dir))
        -> (m () -> IO ())
        -> (PackageIdentifier, ToFetch)

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -505,7 +505,7 @@ fetchPackages' mdistDir toFetchAll = do
 
     liftIO $ readTVarIO outputVar
   where
-    go :: (MonadIO m,MonadThrow m,MonadLogger m)
+    go :: (MonadUnliftIO m,MonadThrow m,MonadLogger m)
        => TVar (Map PackageIdentifier (Path Abs Dir))
        -> (m () -> IO ())
        -> (PackageIdentifier, ToFetch)

--- a/src/test/Network/HTTP/Download/VerifiedSpec.hs
+++ b/src/test/Network/HTTP/Download/VerifiedSpec.hs
@@ -9,6 +9,7 @@ import           Network.HTTP.Download.Verified
 import           Path
 import           Path.IO hiding (withSystemTempDir)
 import           Stack.Prelude
+import           Stack.Types.Runner
 import           System.IO (writeFile, readFile)
 import           Test.Hspec
 
@@ -66,20 +67,23 @@ spec = do
   let exampleProgressHook _ = return ()
 
   describe "verifiedDownload" $ do
+    let run func = runStdoutLoggingT
+                 $ withRunner LevelError True True ColorNever Nothing False
+                 $ \runner -> runRIO runner func
     -- Preconditions:
     -- * the exampleReq server is running
     -- * the test runner has working internet access to it
     it "downloads the file correctly" $ withTempDir' $ \dir -> do
       examplePath <- getExamplePath dir
       doesFileExist examplePath `shouldReturn` False
-      let go = runStdoutLoggingT $ verifiedDownload exampleReq examplePath exampleProgressHook
+      let go = run $ verifiedDownload exampleReq examplePath exampleProgressHook
       go `shouldReturn` True
       doesFileExist examplePath `shouldReturn` True
 
     it "is idempotent, and doesn't redownload unnecessarily" $ withTempDir' $ \dir -> do
       examplePath <- getExamplePath dir
       doesFileExist examplePath `shouldReturn` False
-      let go = runStdoutLoggingT $ verifiedDownload exampleReq examplePath exampleProgressHook
+      let go = run $ verifiedDownload exampleReq examplePath exampleProgressHook
       go `shouldReturn` True
       doesFileExist examplePath `shouldReturn` True
       go `shouldReturn` False
@@ -92,7 +96,7 @@ spec = do
       writeFile exampleFilePath exampleWrongContent
       doesFileExist examplePath `shouldReturn` True
       readFile exampleFilePath `shouldReturn` exampleWrongContent
-      let go = runStdoutLoggingT $ verifiedDownload exampleReq examplePath exampleProgressHook
+      let go = run $ verifiedDownload exampleReq examplePath exampleProgressHook
       go `shouldReturn` True
       doesFileExist examplePath `shouldReturn` True
       readFile exampleFilePath `shouldNotReturn` exampleWrongContent
@@ -102,7 +106,7 @@ spec = do
       let wrongContentLengthReq = exampleReq
             { drLengthCheck = Just exampleWrongContentLength
             }
-      let go = runStdoutLoggingT $ verifiedDownload wrongContentLengthReq examplePath exampleProgressHook
+      let go = run $ verifiedDownload wrongContentLengthReq examplePath exampleProgressHook
       go `shouldThrow` isWrongContentLength
       doesFileExist examplePath `shouldReturn` False
 
@@ -110,7 +114,7 @@ spec = do
       examplePath <- getExamplePath dir
       let wrongHashCheck = exampleHashCheck { hashCheckHexDigest = exampleWrongDigest }
       let wrongDigestReq = exampleReq { drHashChecks = [wrongHashCheck] }
-      let go = runStdoutLoggingT $ verifiedDownload wrongDigestReq examplePath exampleProgressHook
+      let go = run $ verifiedDownload wrongDigestReq examplePath exampleProgressHook
       go `shouldThrow` isWrongDigest
       doesFileExist examplePath `shouldReturn` False
 
@@ -124,7 +128,7 @@ spec = do
             , drLengthCheck = Nothing
             , drRetryPolicy = limitRetries 1
             }
-      let go = runStdoutLoggingT $ verifiedDownload dReq dest exampleProgressHook
+      let go = run $ verifiedDownload dReq dest exampleProgressHook
       doesFileExist dest `shouldReturn` False
       go `shouldReturn` True
       doesFileExist dest `shouldReturn` True


### PR DESCRIPTION
Tested this by adding `127.0.0.1       s3.amazonaws.com localhost` to my `/etc/hosts`, to make connections fail reliably (oh, the irony).

The output looks like this:

```
Retry number 0 after a total delay of 0 us
If you see this warning and stack fails, but running the command again solves the problem, please report here: https://github.com/commercialhaskell/stack/issues/3510
Progress: 4/6HttpExceptionRequest Request {
  host                 = "s3.amazonaws.com"
  port                 = 443
  secure               = True
  requestHeaders       = []
  path                 = "/hackage.fpcomplete.com/package/text-zipper-0.10.1.tar.gz"
  queryString          = ""
  method               = "GET"
  proxy                = Nothing
  rawBody              = False
  redirectCount        = 10
  responseTimeout      = ResponseTimeoutDefault
  requestVersion       = HTTP/1.1
}
 (InternalException (HostCannotConnect "s3.amazonaws.com" [Network.Socket.connect: <socket: 12>: does not exist (Connection refused)]))
```