### PR TITLE
Check for ncurses6 before checking for tinfo6

### DIFF
--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -585,15 +585,15 @@ getGhcBuild menv = do
                 logDebug $ if noPie
                                then "PIE disabled"
                                else "PIE enabled"
+                hasncurses6 <- checkLib $(mkRelFile "libncursesw.so.6")
                 hastinfo5 <- checkLib $(mkRelFile "libtinfo.so.5")
                 hastinfo6 <- checkLib $(mkRelFile "libtinfo.so.6")
-                hasncurses6 <- checkLib $(mkRelFile "libncursesw.so.6")
                 hasgmp5 <- checkLib $(mkRelFile "libgmp.so.10")
                 hasgmp4 <- checkLib $(mkRelFile "libgmp.so.3")
                 let libComponents =
-                        if  | hastinfo6 && hasgmp5 -> ["tinfo6"]
+                        if  | hasncurses6 && hasgmp5 -> ["ncurses6"]
+                            | hastinfo6 && hasgmp5 -> ["tinfo6"]
                             | hastinfo5 && hasgmp5 -> []
-                            | hasncurses6 && hasgmp5 -> ["ncurses6"]
                             | hasgmp4 && hastinfo5 -> ["gmp4"]
                             | otherwise -> []
                     pieComponents =


### PR DESCRIPTION
On Arch Linux which has both libraries, the *tinfo6* distribution will be picked, which doesn't work.

I'm not sure how to test if this is breaking anything, so I'll gladly accept some guidance.

Please include the following checklist in your PR:
- [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
- [ ] The documentation has been updated, if necessary.