### PR TITLE
Note that the 00-index.tar.gz file no longer works

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,9 @@ Behavior changes:
   `stack.yaml` will promote it to a local package, providing for more
   consistency with flags and better reproducibility. See:
   [#849](https://github.com/commercialhaskell/stack/issues/849)
+* The `package-indices` setting with Hackage no longer works with the
+  `00-index.tar.gz` tarball, but must use the `01-index.tar.gz` file
+  to allow revised packages to be found.
 * Options passsed via `--ghci-options` are now passed to the end of the
   invocation of ghci, instead of the middle.  This allows using `+RTS`
   without an accompanying `-RTS`.

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -374,7 +374,7 @@ package-indices:
   download-prefix: https://s3.amazonaws.com/hackage.fpcomplete.com/package/
 
   # HTTP location of the package index
-  http: https://s3.amazonaws.com/hackage.fpcomplete.com/00-index.tar.gz
+  http: https://s3.amazonaws.com/hackage.fpcomplete.com/01-index.tar.gz
 
   # Or, if using Hackage Security below, give the root URL:
   http: https://s3.amazonaws.com/hackage.fpcomplete.com/


### PR DESCRIPTION
As per #3527 and #3514, if you custom point at a 00 index file, you get errors. Important instead to point at the 01 version. Update the example in the user manual and put it in the changelog.