### PR TITLE
Cache snapshot def parsing

### DIFF
--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -6,6 +6,7 @@
 
 module Stack.Constants
     (buildPlanDir
+    ,buildPlanCacheDir
     ,haskellModuleExts
     ,stackDotYaml
     ,stackWorkEnvVar
@@ -205,6 +206,12 @@ defaultGlobalConfigPath = parseAbsFile "/etc/stack/config.yaml"
 buildPlanDir :: Path Abs Dir -- ^ Stack root
              -> Path Abs Dir
 buildPlanDir = (</> $(mkRelDir "build-plan"))
+
+-- | Path where binary caches of the build plans are stored.
+buildPlanCacheDir
+  :: Path Abs Dir -- ^ Stack root
+  -> Path Abs Dir
+buildPlanCacheDir = (</> $(mkRelDir "build-plan-cache"))
 
 -- | Environment variable that stores a variant to append to platform-specific directory
 -- names.  Used to ensure incompatible binaries aren't shared between Docker builds and host

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -13,6 +13,7 @@
 module Stack.Types.BuildPlan
     ( -- * Types
       SnapshotDef (..)
+    , snapshotDefVC
     , sdRawPathName
     , PackageLocation (..)
     , PackageLocationIndex (..)
@@ -96,7 +97,12 @@ data SnapshotDef = SnapshotDef
     -- of a snapshot with some codebase without installing GHC (e.g.,
     -- during stack init), we would use this field.
     }
-    deriving (Show, Eq)
+    deriving (Show, Eq, Data, Generic, Typeable)
+instance Store SnapshotDef
+instance NFData SnapshotDef
+
+snapshotDefVC :: VersionConfig SnapshotDef
+snapshotDefVC = storeVersionConfig "sd-v1" "tnwWSSLerZ2XeR6XpVwj5Uh0eF4="
 
 -- | A relative file path including a unique string for the given
 -- snapshot.


### PR DESCRIPTION
I believe this was a performance regression in the new extensible
snapshots code. In any event, this is a pretty straightforward
optimization: store a binary cache of the SnapshotDef to avoid reparsing
the large YAML files each time. In my testing, this sped up a previously
3 second `stack exec true` to about .2 seconds.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.