### PR TITLE
Expand --help output of 'new' and 'templates' commands

### DIFF
--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -320,11 +320,7 @@ runGhci GhciOpts{..} targets mainIsTargets pkgs extraFiles exposePackages = do
     wc <- view $ actualCompilerVersionL.whichCompilerL
     let pkgopts = hidePkgOpts ++ genOpts ++ ghcOpts
         shouldHidePackages =
-          case ghciHidePackages of
-            -- Default to not hiding anything if there's nothing to
-            -- expose.
-            Nothing -> not (null pkgs && null exposePackages)
-            Just x -> x
+          fromMaybe (not (null pkgs && null exposePackages)) ghciHidePackages
         hidePkgOpts =
           if shouldHidePackages
             then "-hide-all-packages" : concatMap (\n -> ["-package", packageNameString n]) exposePackages

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -268,11 +268,20 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                          buildCmd
                          (buildOptsParser Haddock)
         addCommand' "new"
-                    "Create a new project from a template. Run `stack templates' to see available templates."
+         (unwords [ "Create a new project from a template."
+                  , "Run `stack templates' to see available templates."
+                  , "Note: you can also specify a local file or a"
+                  , "remote URL as a template."
+                  ] )
                     newCmd
                     newOptsParser
         addCommand' "templates"
-                    "List the templates available for `stack new'."
+         (unwords [ "List the templates available for `stack new'."
+                  , "Templates are drawn from"
+                  , "https://github.com/commercialhaskell/stack-templates"
+                  , "Note: `stack new' can also accept a template from a"
+                  , "local file or a remote URL."
+                  ] )
                     templatesCmd
                     (pure ())
         addCommand' "init"


### PR DESCRIPTION
closes #3584

Added a note to 'templates' mentioning where the templates list comes from. Also mentioned in both 'new' and 'templates' that you can specify a file or URL for a template. It was already mentioned in 'new', but only in the description of TEMPLATE_NAME, which was easy to miss.