### PR TITLE
Only tweak cabal file as necessary

### DIFF
--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -113,7 +113,7 @@ getSDistTarball
 getSDistTarball mpvpBounds pkgDir = do
     config <- view configL
     let PvpBounds pvpBounds asRevision = fromMaybe (configPvpBounds config) mpvpBounds
-        tweakCabal = True -- pvpBounds /= PvpBoundsNone
+        tweakCabal = pvpBounds /= PvpBoundsNone
         pkgFp = toFilePath pkgDir
     lp <- readLocalPackage pkgDir
     logInfo $ "Getting file list for " <> T.pack pkgFp


### PR DESCRIPTION
I think this was a mistaken change in
9f06ccfdb8fe6cc1156ce04c815731e63d3717d1. Perhaps ironically, without
this commit, we end up regularly triggering #3549 instead of only doing
so when using pvp-bounds.