### PR TITLE
Strip trailing CR for file list

### DIFF
--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -119,7 +119,7 @@ getSDistTarball mpvpBounds pkgDir = do
     logInfo $ "Getting file list for " <> T.pack pkgFp
     (fileList, cabalfp) <-  getSDistFileList lp
     logInfo $ "Building sdist tarball for " <> T.pack pkgFp
-    files <- normalizeTarballPaths (lines fileList)
+    files <- normalizeTarballPaths (map (T.unpack . stripCR . T.pack) (lines fileList))
 
     -- We're going to loop below and eventually find the cabal
     -- file. When we do, we'll upload this reference, if the


### PR DESCRIPTION
Not listing in the ChangeLog, since this is a regression with the Cabal
2 upgrade.