### PR TITLE
Ensure updated EnvOverride when using stack init --solver

### DIFF
--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -278,12 +278,11 @@ withLoadPackage :: HasEnvConfig env
                 -> RIO env a
 withLoadPackage inner = do
     econfig <- view envConfigL
-    menv <- getMinimalEnvOverride
     root <- view projectRootL
     run <- askRunInIO
     withCabalLoader $ \loadFromIndex ->
         inner $ \loc flags ghcOptions -> do
-            bs <- run $ loadSingleRawCabalFile loadFromIndex menv root loc
+            bs <- run $ loadSingleRawCabalFile loadFromIndex root loc
 
             -- Intentionally ignore warnings, as it's not really
             -- appropriate to print a bunch of warnings out while

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -95,9 +95,8 @@ loadSourceMapFull needTargets boptsCli = do
             PLIndex pir -> return $ PSIndex loc (lpiFlags lpi) configOpts pir
             PLOther pl -> do
               -- FIXME lots of code duplication with getLocalPackages
-              menv <- getMinimalEnvOverride
               root <- view projectRootL
-              dir <- resolveSinglePackageLocation menv root pl
+              dir <- resolveSinglePackageLocation root pl
               cabalfp <- findOrGenerateCabalFile dir
               bs <- liftIO (S.readFile (toFilePath cabalfp))
               (warnings, gpd) <-

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -493,7 +493,6 @@ parseTargets needTargets boptscli = do
           ["The specified targets matched no packages"]
 
   root <- view projectRootL
-  menv <- getMinimalEnvOverride
 
   let dropMaybeKey (Nothing, _) = Map.empty
       dropMaybeKey (Just key, value) = Map.singleton key value
@@ -513,7 +512,7 @@ parseTargets needTargets boptscli = do
 
   (globals', snapshots, locals') <- withCabalLoader $ \loadFromIndex -> do
     addedDeps' <- fmap Map.fromList $ forM (Map.toList addedDeps) $ \(name, loc) -> do
-      bs <- loadSingleRawCabalFile loadFromIndex menv root loc
+      bs <- loadSingleRawCabalFile loadFromIndex root loc
       case rawParseGPD bs of
         Left e -> throwIO $ InvalidCabalFileInLocal loc e bs
         Right (_warnings, gpd) -> return (name, (gpd, loc, Nothing))
@@ -536,7 +535,7 @@ parseTargets needTargets boptscli = do
           ]
 
     calculatePackagePromotion
-      loadFromIndex menv root ls0 (Map.elems allLocals)
+      loadFromIndex root ls0 (Map.elems allLocals)
       flags hides options drops
 
   let ls = LoadedSnapshot

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -400,8 +400,7 @@ checkSnapBuildPlan
     -> RIO env BuildPlanCheck
 checkSnapBuildPlan root gpds flags snapshotDef mactualCompiler = do
     platform <- view platformL
-    menv <- getMinimalEnvOverride
-    rs <- loadSnapshot menv mactualCompiler root snapshotDef
+    rs <- loadSnapshot mactualCompiler root snapshotDef
 
     let
         compiler = lsCompilerVersion rs

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -652,12 +652,11 @@ getLocalPackages = do
     case mcached of
         Just cached -> return cached
         Nothing -> withCabalLoader $ \loadFromIndex -> do
-            menv <- getMinimalEnvOverride
             root <- view projectRootL
             bc <- view buildConfigL
 
             packages <- do
-              bss <- concat <$> mapM (loadMultiRawCabalFiles menv root) (bcPackages bc)
+              bss <- concat <$> mapM (loadMultiRawCabalFiles root) (bcPackages bc)
               forM bss $ \(bs, loc) -> do
                 (warnings, gpd) <-
                   case rawParseGPD bs of
@@ -667,7 +666,7 @@ getLocalPackages = do
                            fromCabalPackageIdentifier
                          $ C.package
                          $ C.packageDescription gpd
-                dir <- resolveSinglePackageLocation menv root loc
+                dir <- resolveSinglePackageLocation root loc
                 cabalfp <- findOrGenerateCabalFile dir
                 mapM_ (printCabalFileWarning cabalfp) warnings
                 checkCabalFileName name cabalfp
@@ -681,7 +680,7 @@ getLocalPackages = do
                       }
                 return (name, lpv)
 
-            deps <- mapM (loadMultiRawCabalFilesIndex loadFromIndex menv root) (bcDependencies bc)
+            deps <- mapM (loadMultiRawCabalFilesIndex loadFromIndex root) (bcDependencies bc)
                 >>= mapM (\(bs, loc :: PackageLocationIndex FilePath) -> do
                      (_warnings, gpd) <- do
                        case rawParseGPD bs of

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -490,8 +490,7 @@ checkBundleResolver whichCmd stackYaml initOpts bundle sd = do
       -- set of packages.
       findOneIndependent packages flags = do
           platform <- view platformL
-          menv <- getMinimalEnvOverride
-          (compiler, _) <- getResolverConstraints menv Nothing stackYaml sd
+          (compiler, _) <- getResolverConstraints Nothing stackYaml sd
           let getGpd pkg = snd (fromMaybe (error "findOneIndependent: getGpd") (Map.lookup pkg bundle))
               getFlags pkg = fromMaybe (error "fromOneIndependent: getFlags") (Map.lookup pkg flags)
               deps pkg = gpdPackageDeps (getGpd pkg) compiler platform

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -427,10 +427,9 @@ buildExtractedTarball :: HasEnvConfig env => Path Abs Dir -> RIO env ()
 buildExtractedTarball pkgDir = do
   projectRoot <- view projectRootL
   envConfig <- view envConfigL
-  menv <- getMinimalEnvOverride
   localPackageToBuild <- readLocalPackage pkgDir
   let packageEntries = bcPackages (envConfigBuildConfig envConfig)
-      getPaths = resolveMultiPackageLocation menv projectRoot
+      getPaths = resolveMultiPackageLocation projectRoot
   allPackagePaths <- fmap (map fst . mconcat) (mapM getPaths packageEntries)
   -- We remove the path based on the name of the package
   let isPathToRemove path = do

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -260,7 +260,6 @@ setupEnv mResolveMissingGHC = do
         bcPath = set envOverrideL (const (return menv)) bc
 
     ls <- runRIO bcPath $ loadSnapshot
-      menv
       (Just compilerVer)
       (view projectRootL bc)
       (bcSnapshotDef bc)

--- a/src/Stack/Snapshot.hs
+++ b/src/Stack/Snapshot.hs
@@ -63,7 +63,6 @@ import           Stack.Types.Urls
 import           Stack.Types.Compiler
 import           Stack.Types.Resolver
 import qualified System.Directory as Dir
-import           System.Process.Read (EnvOverride)
 
 type SinglePackageLocation = PackageLocationIndex FilePath
 
@@ -343,24 +342,22 @@ loadResolver (ResolverCustom url loc) = do
 loadSnapshot
   :: forall env.
      (HasConfig env, HasGHCVariant env)
-  => EnvOverride -- ^ used for running Git/Hg, and if relevant, getting global package info
-  -> Maybe (CompilerVersion 'CVActual) -- ^ installed GHC we should query; if none provided, use the global hints
+  => Maybe (CompilerVersion 'CVActual) -- ^ installed GHC we should query; if none provided, use the global hints
   -> Path Abs Dir -- ^ project root, used for checking out necessary files
   -> SnapshotDef
   -> RIO env LoadedSnapshot
-loadSnapshot menv mcompiler root sd = withCabalLoader $ \loader -> loadSnapshot' loader menv mcompiler root sd
+loadSnapshot mcompiler root sd = withCabalLoader $ \loader -> loadSnapshot' loader mcompiler root sd
 
 -- | Fully load up a 'SnapshotDef' into a 'LoadedSnapshot'
 loadSnapshot'
   :: forall env.
      (HasConfig env, HasGHCVariant env)
   => (PackageIdentifierRevision -> IO ByteString) -- ^ load a cabal file's contents from the index
-  -> EnvOverride -- ^ used for running Git/Hg, and if relevant, getting global package info
   -> Maybe (CompilerVersion 'CVActual) -- ^ installed GHC we should query; if none provided, use the global hints
   -> Path Abs Dir -- ^ project root, used for checking out necessary files
   -> SnapshotDef
   -> RIO env LoadedSnapshot
-loadSnapshot' loadFromIndex menv mcompiler root =
+loadSnapshot' loadFromIndex mcompiler root =
     start
   where
     start (snapshotDefFixes -> sd) = do
@@ -384,7 +381,7 @@ loadSnapshot' loadFromIndex menv mcompiler root =
           Right sd' -> start sd'
 
       gpds <- (concat <$> mapM
-        (loadMultiRawCabalFilesIndex loadFromIndex menv root >=> mapM parseGPD)
+        (loadMultiRawCabalFilesIndex loadFromIndex root >=> mapM parseGPD)
         (sdLocations sd)) `onException` do
           logError "Unable to load cabal files for snapshot"
           case sdResolver sd of
@@ -406,7 +403,7 @@ loadSnapshot' loadFromIndex menv mcompiler root =
             _ -> return ()
 
       (globals, snapshot, locals) <-
-        calculatePackagePromotion loadFromIndex menv root ls0
+        calculatePackagePromotion loadFromIndex root ls0
         (map (\(x, y) -> (x, y, ())) gpds)
         (sdFlags sd) (sdHidden sd) (sdGhcOptions sd) (sdDropPackages sd)
 
@@ -428,7 +425,6 @@ calculatePackagePromotion
   :: forall env localLocation.
      (HasConfig env, HasGHCVariant env)
   => (PackageIdentifierRevision -> IO ByteString) -- ^ load from index
-  -> EnvOverride
   -> Path Abs Dir -- ^ project root
   -> LoadedSnapshot
   -> [(GenericPackageDescription, SinglePackageLocation, localLocation)] -- ^ packages we want to add on top of this snapshot
@@ -442,7 +438,7 @@ calculatePackagePromotion
        , Map PackageName (LoadedPackageInfo (SinglePackageLocation, Maybe localLocation)) -- new locals
        )
 calculatePackagePromotion
-  loadFromIndex menv root (LoadedSnapshot compilerVersion globals0 parentPackages0)
+  loadFromIndex root (LoadedSnapshot compilerVersion globals0 parentPackages0)
   gpds flags0 hides0 options0 drops0 = do
 
       platform <- view platformL
@@ -504,7 +500,7 @@ calculatePackagePromotion
 
       -- ... so recalculate based on new values
       upgraded <- fmap Map.fromList
-                $ mapM (recalculate loadFromIndex menv root compilerVersion flags hide ghcOptions)
+                $ mapM (recalculate loadFromIndex root compilerVersion flags hide ghcOptions)
                 $ Map.toList allToUpgrade
 
       -- Could be nice to check snapshot early... but disabling
@@ -531,7 +527,6 @@ calculatePackagePromotion
 recalculate :: forall env.
                (HasConfig env, HasGHCVariant env)
             => (PackageIdentifierRevision -> IO ByteString)
-            -> EnvOverride
             -> Path Abs Dir -- ^ root
             -> CompilerVersion 'CVActual
             -> Map PackageName (Map FlagName Bool)
@@ -539,14 +534,14 @@ recalculate :: forall env.
             -> Map PackageName [Text] -- ^ GHC options
             -> (PackageName, LoadedPackageInfo SinglePackageLocation)
             -> RIO env (PackageName, LoadedPackageInfo SinglePackageLocation)
-recalculate loadFromIndex menv root compilerVersion allFlags allHide allOptions (name, lpi0) = do
+recalculate loadFromIndex root compilerVersion allFlags allHide allOptions (name, lpi0) = do
   let hide = fromMaybe (lpiHide lpi0) (Map.lookup name allHide)
       options = fromMaybe (lpiGhcOptions lpi0) (Map.lookup name allOptions)
   case Map.lookup name allFlags of
     Nothing -> return (name, lpi0 { lpiHide = hide, lpiGhcOptions = options }) -- optimization
     Just flags -> do
       let loc = lpiLocation lpi0
-      gpd <- loadSingleRawCabalFile loadFromIndex menv root loc >>= parseGPDSingle loc
+      gpd <- loadSingleRawCabalFile loadFromIndex root loc >>= parseGPDSingle loc
       platform <- view platformL
       let res@(name', lpi) = calculate gpd platform compilerVersion loc flags hide options
       unless (name == name' && lpiVersion lpi0 == lpiVersion lpi) $ error "recalculate invariant violated"

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -77,14 +77,13 @@ data ConstraintType = Constraint | Preference deriving (Eq)
 type ConstraintSpec = Map PackageName (Version, Map FlagName Bool)
 
 cabalSolver :: HasConfig env
-            => EnvOverride
-            -> [Path Abs Dir] -- ^ cabal files
+            => [Path Abs Dir] -- ^ cabal files
             -> ConstraintType
             -> ConstraintSpec -- ^ src constraints
             -> ConstraintSpec -- ^ dep constraints
             -> [String] -- ^ additional arguments
             -> RIO env (Either [PackageName] ConstraintSpec)
-cabalSolver menv cabalfps constraintType
+cabalSolver cabalfps constraintType
             srcConstraints depConstraints cabalArgs =
   withSystemTempDir "cabal-solver" $ \dir' -> do
 
@@ -115,6 +114,7 @@ cabalSolver menv cabalfps constraintType
                toConstraintArgs (flagConstraints constraintType) ++
                fmap toFilePath cabalfps
 
+    menv <- getMinimalEnvOverride
     catch (liftM Right (readProcessStdout (Just tmpdir) menv "cabal" args))
           (\ex -> case ex of
               ProcessFailed _ _ _ err -> return $ Left err
@@ -295,11 +295,14 @@ setupCompiler compiler = do
         }
     return dirs
 
+-- | Runs the given inner command with an updated configuration that
+-- has the desired GHC on the PATH.
 setupCabalEnv
     :: (HasConfig env, HasGHCVariant env)
     => CompilerVersion 'CVWanted
-    -> RIO env (EnvOverride, CompilerVersion 'CVActual)
-setupCabalEnv compiler = do
+    -> (CompilerVersion 'CVActual -> RIO env a)
+    -> RIO env a
+setupCabalEnv compiler inner = do
     mpaths <- setupCompiler compiler
     menv0 <- getMinimalEnvOverride
     envMap <- removeHaskellEnvVars
@@ -330,7 +333,9 @@ setupCabalEnv compiler = do
             return version
         Nothing -> error "Failed to determine compiler version. \
                          \This is most likely a bug."
-    return (menv, version)
+
+    env <- set envOverrideL (const (return menv)) <$> ask
+    runRIO env (inner version)
 
 -- | Merge two separate maps, one defining constraints on package versions and
 -- the other defining package flagmap, into a single map of version and flagmap
@@ -378,10 +383,8 @@ solveResolverSpec stackYaml cabalDirs
                   (sd, srcConstraints, extraConstraints) = do
   logInfo $ "Using resolver: " <> sdResolverName sd
   let wantedCompilerVersion = sdWantedCompilerVersion sd
-  (menv, compilerVersion) <- setupCabalEnv wantedCompilerVersion
-  env <- set envOverrideL (const (return menv)) <$> ask
-  runRIO env $ do
-    (compilerVer, snapConstraints) <- getResolverConstraints menv (Just compilerVersion) stackYaml sd
+  setupCabalEnv wantedCompilerVersion $ \compilerVersion -> do
+    (compilerVer, snapConstraints) <- getResolverConstraints (Just compilerVersion) stackYaml sd
 
     let -- Note - The order in Map.union below is important.
         -- We want to override snapshot with extra deps
@@ -391,7 +394,7 @@ solveResolverSpec stackYaml cabalDirs
         -- 1. We do not want snapshot versions to override the sources
         -- 2. Sources may have blank versions leading to bad cabal constraints
         depOnlyConstraints = Map.difference depConstraints srcConstraints
-        solver t = cabalSolver menv cabalDirs t srcConstraints depOnlyConstraints $
+        solver t = cabalSolver cabalDirs t srcConstraints depOnlyConstraints $
                      "-v" : -- TODO make it conditional on debug
                      ["--ghcjs" | whichCompiler compilerVer == Ghcjs]
 
@@ -482,15 +485,14 @@ solveResolverSpec stackYaml cabalDirs
 -- for that resolver.
 getResolverConstraints
     :: (HasConfig env, HasGHCVariant env)
-    => EnvOverride -- ^ for running Git/Hg clone commands
-    -> Maybe (CompilerVersion 'CVActual) -- ^ actually installed compiler
+    => Maybe (CompilerVersion 'CVActual) -- ^ actually installed compiler
     -> Path Abs File
     -> SnapshotDef
     -> RIO env
          (CompilerVersion 'CVActual,
           Map PackageName (Version, Map FlagName Bool))
-getResolverConstraints menv mcompilerVersion stackYaml sd = do
-    ls <- loadSnapshot menv mcompilerVersion (parent stackYaml) sd
+getResolverConstraints mcompilerVersion stackYaml sd = do
+    ls <- loadSnapshot mcompilerVersion (parent stackYaml) sd
     return (lsCompilerVersion ls, lsConstraints ls)
   where
     lpiConstraints lpi = (lpiVersion lpi, lpiFlags lpi)
@@ -782,20 +784,14 @@ checkSnapBuildPlanActual
     -> SnapshotDef
     -> RIO env BuildPlanCheck
 checkSnapBuildPlanActual root gpds flags sd = do
-    let forNonSnapshot = Just <$> setupCabalEnv (sdWantedCompilerVersion sd)
-    mactualCompiler <-
-      case sdResolver sd of
-        ResolverSnapshot _ -> return Nothing
-        ResolverCompiler _ -> forNonSnapshot
-        ResolverCustom _ _ -> forNonSnapshot
+    let forNonSnapshot inner = setupCabalEnv (sdWantedCompilerVersion sd) (inner . Just)
+        runner =
+          case sdResolver sd of
+            ResolverSnapshot _ -> ($ Nothing)
+            ResolverCompiler _ -> forNonSnapshot
+            ResolverCustom _ _ -> forNonSnapshot
 
-    let inner = checkSnapBuildPlan root gpds flags sd
-    case mactualCompiler of
-      Nothing -> inner Nothing
-      Just (modifiedPath, actualCompiler) -> do
-        env0 <- ask
-        let env = set envOverrideL (const $ return modifiedPath) env0
-        runRIO env $ inner (Just actualCompiler)
+    runner $ checkSnapBuildPlan root gpds flags sd
 
 prettyPath
     :: forall r t m. (MonadIO m, RelPath (Path r t) ~ Path Rel t, AnyPath (Path r t))

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -376,9 +376,11 @@ solveResolverSpec
 
 solveResolverSpec stackYaml cabalDirs
                   (sd, srcConstraints, extraConstraints) = do
-    logInfo $ "Using resolver: " <> sdResolverName sd
-    let wantedCompilerVersion = sdWantedCompilerVersion sd
-    (menv, compilerVersion) <- setupCabalEnv wantedCompilerVersion
+  logInfo $ "Using resolver: " <> sdResolverName sd
+  let wantedCompilerVersion = sdWantedCompilerVersion sd
+  (menv, compilerVersion) <- setupCabalEnv wantedCompilerVersion
+  env <- set envOverrideL (const (return menv)) <$> ask
+  runRIO env $ do
     (compilerVer, snapConstraints) <- getResolverConstraints menv (Just compilerVersion) stackYaml sd
 
     let -- Note - The order in Map.union below is important.

--- a/test/integration/tests/3607-stack-init-solver/Main.hs
+++ b/test/integration/tests/3607-stack-init-solver/Main.hs
@@ -1,0 +1,6 @@
+import StackTest
+
+main :: IO ()
+main = do
+  stack ["init", "--resolver", "nightly-2017-11-25", "--solver", "--force"]
+  stack ["build"]

--- a/test/integration/tests/3607-stack-init-solver/files/.gitignore
+++ b/test/integration/tests/3607-stack-init-solver/files/.gitignore
@@ -1,0 +1,4 @@
+.stack-work/
+foo.cabal
+*~
+stack.yaml

--- a/test/integration/tests/3607-stack-init-solver/files/package.yaml
+++ b/test/integration/tests/3607-stack-init-solver/files/package.yaml
@@ -1,0 +1,8 @@
+name:                foo
+version:             0.1.0.0
+
+dependencies:
+- base
+- acme-missiles
+
+library: {}


### PR DESCRIPTION
No ChangeLog updates, as this is a regression added since 1.5.1. New integration test case added as well.

Fixes #3607 