### PR TITLE
Don't parse cabal files twice

### DIFF
--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -44,7 +44,7 @@ import           Stack.Build.Source
 import           Stack.Build.Target
 import           Stack.Fetch as Fetch
 import           Stack.Package
-import           Stack.PackageLocation (loadSingleRawCabalFile)
+import           Stack.PackageLocation (parseSingleCabalFileIndex)
 import           Stack.Types.Build
 import           Stack.Types.BuildPlan
 import           Stack.Types.Config
@@ -281,17 +281,10 @@ withLoadPackage inner = do
     root <- view projectRootL
     run <- askRunInIO
     withCabalLoader $ \loadFromIndex ->
-        inner $ \loc flags ghcOptions ->
-            run $ readPackageBS
+        inner $ \loc flags ghcOptions -> run $
+            resolvePackage
               (depPackageConfig econfig flags ghcOptions)
-              loc
-
-              -- Intentionally ignore warnings, as it's not really
-              -- appropriate to print a bunch of warnings out while
-              -- resolving the package index.
-              CWNoPrint
-
-              (loadSingleRawCabalFile loadFromIndex root loc)
+              <$> parseSingleCabalFileIndex loadFromIndex root loc
   where
     -- | Package config to be used for dependencies
     depPackageConfig :: EnvConfig -> Map FlagName Bool -> [Text] -> PackageConfig

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -281,17 +281,17 @@ withLoadPackage inner = do
     root <- view projectRootL
     run <- askRunInIO
     withCabalLoader $ \loadFromIndex ->
-        inner $ \loc flags ghcOptions -> do
-            bs <- run $ loadSingleRawCabalFile loadFromIndex root loc
-
-            -- Intentionally ignore warnings, as it's not really
-            -- appropriate to print a bunch of warnings out while
-            -- resolving the package index.
-            (_warnings,pkg) <- readPackageBS
+        inner $ \loc flags ghcOptions ->
+            run $ readPackageBS
               (depPackageConfig econfig flags ghcOptions)
               loc
-              bs
-            return pkg
+
+              -- Intentionally ignore warnings, as it's not really
+              -- appropriate to print a bunch of warnings out while
+              -- resolving the package index.
+              CWNoPrint
+
+              (loadSingleRawCabalFile loadFromIndex root loc)
   where
     -- | Package config to be used for dependencies
     depPackageConfig :: EnvConfig -> Map FlagName Bool -> [Text] -> PackageConfig

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -30,7 +30,7 @@ import qualified    Data.Map.Strict as M
 import qualified    Data.Set as Set
 import              Stack.Build.Cache
 import              Stack.Build.Target
-import              Stack.Config (getLocalPackages, getNamedComponents)
+import              Stack.Config (getLocalPackages)
 import              Stack.Constants (wiredInPackages)
 import              Stack.Package
 import              Stack.PackageLocation
@@ -94,25 +94,9 @@ loadSourceMapFull needTargets boptsCli = do
             -- NOTE: configOpts includes lpiGhcOptions for now, this may get refactored soon
             PLIndex pir -> return $ PSIndex loc (lpiFlags lpi) configOpts pir
             PLOther pl -> do
-              -- FIXME lots of code duplication with getLocalPackages
               root <- view projectRootL
-              dir <- resolveSinglePackageLocation root pl
-              cabalfp <- findOrGenerateCabalFile dir
-              eres <- cachedCabalFileParse
-                (PLOther pl)
-                (CWPrint (toFilePath cabalfp))
-                (liftIO (S.readFile (toFilePath cabalfp)))
-              gpd <-
-                case eres of
-                  Left e -> throwM $ InvalidCabalFileInLocal (Left cabalfp) e
-                  Right x -> return x
-              lp' <- loadLocalPackage False boptsCli targets (n, LocalPackageView
-                { lpvVersion = lpiVersion lpi
-                , lpvCabalFP = cabalfp
-                , lpvComponents = getNamedComponents gpd
-                , lpvGPD = gpd
-                , lpvLoc = pl
-                })
+              lpv <- parseSingleCabalFile root True pl
+              lp' <- loadLocalPackage False boptsCli targets (n, lpv)
               return $ PSFiles lp' loc
     sourceMap' <- Map.unions <$> sequence
       [ return $ Map.fromList $ map (\lp' -> (packageName $ lpPackage lp', PSFiles lp' Local)) locals

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -80,7 +80,6 @@ import           Path.Extra (rejectMissingDir)
 import           Path.IO
 import           Stack.Config (getLocalPackages)
 import           Stack.Fetch (withCabalLoader)
-import           Stack.Package
 import           Stack.PackageIndex
 import           Stack.PackageLocation
 import           Stack.Snapshot (calculatePackagePromotion)
@@ -512,13 +511,8 @@ parseTargets needTargets boptscli = do
 
   (globals', snapshots, locals') <- withCabalLoader $ \loadFromIndex -> do
     addedDeps' <- fmap Map.fromList $ forM (Map.toList addedDeps) $ \(name, loc) -> do
-      eres <- cachedCabalFileParse
-        loc
-        CWNoPrint
-        (loadSingleRawCabalFile loadFromIndex root loc)
-      case eres of
-        Left e -> throwIO $ InvalidCabalFileInLocal (Right loc) e
-        Right gpd -> return (name, (gpd, loc, Nothing))
+      gpd <- parseSingleCabalFileIndex loadFromIndex root loc
+      return (name, (gpd, loc, Nothing))
 
     -- Calculate a list of all of the locals, based on the project
     -- packages, local dependencies, and added deps found from the

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -18,7 +18,6 @@ module Stack.BuildPlan
     , DepErrors
     , gpdPackageDeps
     , gpdPackages
-    , gpdPackageName
     , removeSrcPkgDefaultFlags
     , selectBestSnapshot
     , getToolMap
@@ -191,12 +190,6 @@ gpdPackages gpds = Map.fromList $
     where
         fromCabalIdent (C.PackageIdentifier name version) =
             (fromCabalPackageName name, fromCabalVersion version)
-
-gpdPackageName :: GenericPackageDescription -> PackageName
-gpdPackageName = fromCabalPackageName
-    . C.pkgName
-    . C.package
-    . C.packageDescription
 
 gpdPackageDeps
     :: GenericPackageDescription

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -661,8 +661,8 @@ getLocalPackages = do
                               $ C.package
                               $ C.packageDescription gpd
                       in (name, (gpd, loc))
-            deps <- fmap (map wrapGPD . concat)
-                  $ mapM (parseMultiCabalFilesIndex loadFromIndex root) (bcDependencies bc)
+            deps <- (map wrapGPD . concat)
+                <$> mapM (parseMultiCabalFilesIndex loadFromIndex root) (bcDependencies bc)
 
             checkDuplicateNames $
               map (second (PLOther . lpvLoc)) packages ++

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -45,7 +45,6 @@ module Stack.Config
   ,defaultConfigYaml
   ,getProjectConfig
   ,LocalConfigStatus(..)
-  ,getNamedComponents
   ) where
 
 import           Control.Monad.Extra (firstJustM)
@@ -54,12 +53,10 @@ import           Data.Aeson.Extended
 import qualified Data.ByteString as S
 import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8)
 import qualified Data.Yaml as Yaml
 import qualified Distribution.PackageDescription as C
-import qualified Distribution.Types.UnqualComponentName as C
 import           Distribution.System (OS (..), Platform (..), buildPlatform, Arch(OtherArch))
 import qualified Distribution.Text
 import           Distribution.Version (simplifyVersionRange, mkVersion')
@@ -80,7 +77,6 @@ import           Stack.Config.Urls
 import           Stack.Constants
 import           Stack.Fetch
 import qualified Stack.Image as Image
-import           Stack.Package
 import           Stack.PackageLocation
 import           Stack.Snapshot
 import           Stack.Types.BuildPlan
@@ -656,42 +652,17 @@ getLocalPackages = do
             bc <- view buildConfigL
 
             packages <- do
-              bss <- concat <$> mapM (loadMultiRawCabalFiles root) (bcPackages bc)
-              forM bss $ \(cabalfp, loc) -> do
-                eres <- cachedCabalFileParse
-                  (PLOther loc)
-                  (CWPrint (toFilePath cabalfp))
-                  (liftIO (S.readFile (toFilePath cabalfp)))
-                gpd <-
-                  case eres of
-                    Left e -> throwM $ InvalidCabalFileInLocal (Left cabalfp) e
-                    Right x -> return x
-                let PackageIdentifier name version =
-                           fromCabalPackageIdentifier
-                         $ C.package
-                         $ C.packageDescription gpd
-                checkCabalFileName name cabalfp
-                let lpv = LocalPackageView
-                      { lpvVersion = version
-                      , lpvCabalFP = cabalfp
-                      , lpvComponents = getNamedComponents gpd
-                      , lpvGPD = gpd
-                      , lpvLoc = loc
-                      }
-                return (name, lpv)
+              let withName lpv = (lpvName lpv, lpv)
+              map withName . concat <$> mapM (parseMultiCabalFiles root True) (bcPackages bc)
 
-            deps <- mapM (loadMultiRawCabalFilesIndex loadFromIndex root) (bcDependencies bc)
-                >>= mapM (\(bs, loc :: PackageLocationIndex FilePath) -> do
-                     eres <- cachedCabalFileParse loc CWNoPrint (return bs)
-                     gpd <- do
-                       case eres of
-                         Left e -> throwM $ InvalidCabalFileInLocal (Right loc) e
-                         Right x -> return x
+            let wrapGPD (gpd, loc) =
                      let PackageIdentifier name _version =
                                 fromCabalPackageIdentifier
                               $ C.package
                               $ C.packageDescription gpd
-                     return (name, (gpd, loc))) . concat
+                      in (name, (gpd, loc))
+            deps <- fmap (map wrapGPD . concat)
+                  $ mapM (parseMultiCabalFilesIndex loadFromIndex root) (bcDependencies bc)
 
             checkDuplicateNames $
               map (second (PLOther . lpvLoc)) packages ++
@@ -701,19 +672,6 @@ getLocalPackages = do
               { lpProject = Map.fromList packages
               , lpDependencies = Map.fromList deps
               }
-
-getNamedComponents :: C.GenericPackageDescription -> Set NamedComponent
-getNamedComponents gpkg = Set.fromList $ concat
-    [ maybe []  (const [CLib]) (C.condLibrary gpkg)
-    , go CExe   (map fst . C.condExecutables)
-    , go CTest  (map fst . C.condTestSuites)
-    , go CBench (map fst . C.condBenchmarks)
-    ]
-  where
-    go :: (T.Text -> NamedComponent)
-       -> (C.GenericPackageDescription -> [C.UnqualComponentName])
-       -> [NamedComponent]
-    go wrapper f = map (wrapper . T.pack . C.unUnqualComponentName) $ f gpkg
 
 -- | Check if there are any duplicate package names and, if so, throw an
 -- exception.

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -566,7 +566,11 @@ makeGhciPkgInfo buildOptsCLI sourceMap installedMap locals addPkgs mfileTargets 
             , packageConfigCompilerVersion = compilerVersion
             , packageConfigPlatform = view platformL econfig
             }
-    gpkgdesc <- readPackageUnresolved cabalfp True
+    -- TODO we've already parsed this information, otherwise we
+    -- wouldn't have figured out the cabalfp already. In the future:
+    -- retain that GenericPackageDescription in the relevant data
+    -- structures to avoid reparsing.
+    (gpkgdesc, _cabalfp) <- readPackageUnresolvedDir (parent cabalfp) True
 
     -- Source the package's *.buildinfo file created by configure if any. See
     -- https://www.haskell.org/cabal/users-guide/developing-packages.html#system-dependent-parameters

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -566,7 +566,7 @@ makeGhciPkgInfo buildOptsCLI sourceMap installedMap locals addPkgs mfileTargets 
             , packageConfigCompilerVersion = compilerVersion
             , packageConfigPlatform = view platformL econfig
             }
-    (warnings,gpkgdesc) <- readPackageUnresolved cabalfp
+    gpkgdesc <- readPackageUnresolved cabalfp True
 
     -- Source the package's *.buildinfo file created by configure if any. See
     -- https://www.haskell.org/cabal/users-guide/developing-packages.html#system-dependent-parameters
@@ -588,7 +588,6 @@ makeGhciPkgInfo buildOptsCLI sourceMap installedMap locals addPkgs mfileTargets 
                     (C.updatePackageDescription bi y))
               mbuildinfo
 
-    mapM_ (printCabalFileWarning cabalfp) warnings
     (mods,files,opts) <- getPackageOpts (packageOpts pkg) sourceMap installedMap locals addPkgs cabalfp
     let filteredOpts = filterWanted opts
         filterWanted = M.filterWithKey (\k _ -> k `S.member` allWanted)

--- a/src/Stack/IDE.hs
+++ b/src/Stack/IDE.hs
@@ -14,7 +14,7 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import           Stack.Config (getLocalPackages)
-import           Stack.Package (findOrGenerateCabalFile)
+import           Stack.Package (readPackageUnresolvedDir, gpdPackageName)
 import           Stack.Prelude
 import           Stack.Types.Config
 import           Stack.Types.Package
@@ -28,9 +28,8 @@ listPackages = do
     -- the directory.
     packageDirs <- liftM (map lpvRoot . Map.elems . lpProject) getLocalPackages
     forM_ packageDirs $ \dir -> do
-        cabalfp <- findOrGenerateCabalFile dir
-        pkgName <- parsePackageNameFromFilePath cabalfp
-        (logInfo . packageNameText) pkgName
+        (gpd, _) <- readPackageUnresolvedDir dir False
+        (logInfo . packageNameText) (gpdPackageName gpd)
 
 -- | List the targets in the current project.
 listTargets :: HasEnvConfig env => RIO env ()

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -19,7 +19,8 @@ import           Data.List                       (intercalate, intersect,
                                                   maximumBy)
 import           Data.List.NonEmpty              (NonEmpty (..))
 import qualified Data.List.NonEmpty              as NonEmpty
-import qualified Data.Map                        as Map
+import qualified Data.Map.Strict                 as Map
+import qualified Data.Set                        as Set
 import qualified Data.Text                       as T
 import qualified Data.Yaml                       as Yaml
 import qualified Distribution.PackageDescription as C
@@ -68,11 +69,11 @@ initProject whichCmd currDir initOpts mresolver = do
     dirs <- mapM (resolveDir' . T.unpack) (searchDirs initOpts)
     let noPkgMsg =  "In order to init, you should have an existing .cabal \
                     \file. Please try \"stack new\" instead."
-        find  = findCabalFiles (includeSubDirs initOpts)
+        find  = findCabalDirs (includeSubDirs initOpts)
         dirs' = if null dirs then [currDir] else dirs
     logInfo "Looking for .cabal or package.yaml files to use to init the project."
-    cabalfps <- liftM concat $ mapM find dirs'
-    (bundle, dupPkgs)  <- cabalPackagesCheck cabalfps noPkgMsg Nothing
+    cabaldirs <- (Set.toList . Set.unions) <$> mapM find dirs'
+    (bundle, dupPkgs)  <- cabalPackagesCheck cabaldirs noPkgMsg Nothing
 
     (sd, flags, extraDeps, rbundle) <- getDefaultResolver whichCmd dest initOpts
                                                           mresolver bundle

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -208,7 +208,7 @@ readPackageUnresolvedFromIndex loadFromIndex pir@(PackageIdentifierRevision pi' 
           fromCabalPackageIdentifier
         $ D.package
         $ D.packageDescription gpd
-  unless (pi' == foundPI) $ error $ "Mismatched package identifiers found: " ++ show (pi', foundPI) -- FIXME better error message
+  unless (pi' == foundPI) $ throwM $ MismatchedCabalIdentifier pir foundPI
   return gpd
 
 -- | Reads and exposes the package information

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -171,7 +171,7 @@ getCabalLbs :: HasEnvConfig env
             -> RIO env (PackageIdentifier, L.ByteString)
 getCabalLbs pvpBounds mrev fp = do
     path <- liftIO $ resolveFile' fp
-    (_warnings, gpd) <- readPackageUnresolved path
+    gpd <- readPackageUnresolved path False
     (_, sourceMap) <- loadSourceMap AllowNoTargets defaultBuildOptsCLI
     menv <- getMinimalEnvOverride
     (installedMap, _, _, _) <- getInstalled menv GetInstalledOpts
@@ -296,8 +296,7 @@ readLocalPackage :: HasEnvConfig env => Path Abs Dir -> RIO env LocalPackage
 readLocalPackage pkgDir = do
     cabalfp <- findOrGenerateCabalFile pkgDir
     config  <- getDefaultPackageConfig
-    (warnings,package) <- readPackage config cabalfp
-    mapM_ (printCabalFileWarning cabalfp) warnings
+    package <- readPackage config cabalfp True
     return LocalPackage
         { lpPackage = package
         , lpWanted = False -- HACK: makes it so that sdist output goes to a log instead of a file.
@@ -405,7 +404,7 @@ checkPackageInExtractedTarball pkgDir = do
     cabalfp <- findOrGenerateCabalFile pkgDir
     name    <- parsePackageNameFromFilePath cabalfp
     config  <- getDefaultPackageConfig
-    (gdesc, PackageDescriptionPair pkgDesc _) <- readPackageDescriptionDir config pkgDir
+    (gdesc, PackageDescriptionPair pkgDesc _) <- readPackageDescriptionDir config pkgDir False
     logInfo $
         "Checking package '" <> packageNameText name <> "' for common mistakes"
     let pkgChecks = Check.checkPackage gdesc (Just pkgDesc)

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 module Stack.Solver
     ( cabalPackagesCheck
-    , findCabalFiles
+    , findCabalDirs
     , getResolverConstraints
     , mergeConstraints
     , solveExtraDeps
@@ -48,7 +48,7 @@ import           Stack.Build.Target (gpdVersion)
 import           Stack.BuildPlan
 import           Stack.Config (getLocalPackages, loadConfigYaml)
 import           Stack.Constants (stackDotYaml, wiredInPackages)
-import           Stack.Package               (hpack, readPackageUnresolved)
+import           Stack.Package               (readPackageUnresolvedDir, gpdPackageName)
 import           Stack.PrettyPrint
 import           Stack.Setup
 import           Stack.Setup.Installed
@@ -497,20 +497,20 @@ getResolverConstraints mcompilerVersion stackYaml sd = do
       (Map.map lpiConstraints (lsPackages ls))
       (Map.map lpiConstraints (lsGlobals ls))
 
--- | Finds all files with a .cabal extension under a given directory. If
--- a `hpack` `package.yaml` file exists, this will be used to generate a cabal
--- file.
--- Subdirectories can be included depending on the @recurse@ parameter.
-findCabalFiles
+-- | Finds all directories with a .cabal file or an hpack
+-- package.yaml.  Subdirectories can be included depending on the
+-- @recurse@ parameter.
+findCabalDirs
   :: (MonadIO m, MonadUnliftIO m, MonadLogger m, HasRunner env, MonadReader env m, HasConfig env)
-  => Bool -> Path Abs Dir -> m [Path Abs File]
-findCabalFiles recurse dir = do
-    liftIO (findFiles dir isHpack subdirFilter) >>= mapM_ (hpack . parent)
-    liftIO (findFiles dir isCabal subdirFilter)
+  => Bool -> Path Abs Dir -> m (Set (Path Abs Dir))
+findCabalDirs recurse dir =
+    (Set.fromList . map parent)
+    <$> liftIO (findFiles dir isHpackOrCabal subdirFilter)
   where
     subdirFilter subdir = recurse && not (isIgnored subdir)
     isHpack = (== "package.yaml")     . toFilePath . filename
     isCabal = (".cabal" `isSuffixOf`) . toFilePath
+    isHpackOrCabal x = isHpack x || isCabal x
 
     isIgnored path = "." `isPrefixOf` dirName || dirName `Set.member` ignoredDirs
       where
@@ -531,29 +531,30 @@ ignoredDirs = Set.fromList
 -- pairs.
 cabalPackagesCheck
     :: (HasConfig env, HasGHCVariant env)
-     => [Path Abs File]
+     => [Path Abs Dir]
      -> String
      -> Maybe String
      -> RIO env
           ( Map PackageName (Path Abs File, C.GenericPackageDescription)
           , [Path Abs File])
-cabalPackagesCheck cabalfps noPkgMsg dupErrMsg = do
-    when (null cabalfps) $
+cabalPackagesCheck cabaldirs noPkgMsg dupErrMsg = do
+    when (null cabaldirs) $
         error noPkgMsg
 
-    relpaths <- mapM prettyPath cabalfps
+    relpaths <- mapM prettyPath cabaldirs
     logInfo "Using cabal packages:"
     logInfo $ T.pack (formatGroup relpaths)
 
-    gpds <- mapM (flip readPackageUnresolved True) cabalfps
+    packages <- map (\(x, y) -> (y, x)) <$>
+                mapM (flip readPackageUnresolvedDir True)
+                cabaldirs
 
     -- package name cannot be empty or missing otherwise
     -- it will result in cabal solver failure.
     -- stack requires packages name to match the cabal file name
     -- Just the latter check is enough to cover both the cases
 
-    let packages  = zip cabalfps gpds
-        normalizeString = T.unpack . T.normalize T.NFC . T.pack
+    let normalizeString = T.unpack . T.normalize T.NFC . T.pack
         getNameMismatchPkg (fp, gpd)
             | (normalizeString . show . gpdPackageName) gpd /= (normalizeString . FP.takeBaseName . toFilePath) fp
                 = Just fp
@@ -603,9 +604,11 @@ reportMissingCabalFiles
   -> Bool              -- ^ Whether to scan sub-directories
   -> m ()
 reportMissingCabalFiles cabalfps includeSubdirs = do
-    allCabalfps <- findCabalFiles includeSubdirs =<< getCurrentDir
+    allCabalDirs <- findCabalDirs includeSubdirs =<< getCurrentDir
 
-    relpaths <- mapM prettyPath (allCabalfps \\ cabalfps)
+    relpaths <- mapM prettyPath
+              $ Set.toList
+              $ allCabalDirs `Set.difference` Set.fromList (map parent cabalfps)
     unless (null relpaths) $ do
         logWarn "The following packages are missing from the config:"
         logWarn $ T.pack (formatGroup relpaths)
@@ -644,7 +647,7 @@ solveExtraDeps modStackYaml = do
     -- TODO when solver supports --ignore-subdirs option pass that as the
     -- second argument here.
     reportMissingCabalFiles cabalfps True
-    (bundle, _) <- cabalPackagesCheck cabalfps noPkgMsg (Just dupPkgFooter)
+    (bundle, _) <- cabalPackagesCheck cabalDirs noPkgMsg (Just dupPkgFooter)
 
     let gpds              = Map.elems $ fmap snd bundle
         oldFlags          = bcFlags bconfig

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -19,7 +19,6 @@ module Stack.Solver
     , parseCabalOutputLine
     ) where
 
-import           Control.Monad (mapAndUnzipM)
 import           Stack.Prelude
 import           Data.Aeson.Extended         (object, (.=), toJSON)
 import qualified Data.ByteString as S
@@ -49,9 +48,7 @@ import           Stack.Build.Target (gpdVersion)
 import           Stack.BuildPlan
 import           Stack.Config (getLocalPackages, loadConfigYaml)
 import           Stack.Constants (stackDotYaml, wiredInPackages)
-import           Stack.Package               (printCabalFileWarning
-                                             , hpack
-                                             , readPackageUnresolved)
+import           Stack.Package               (hpack, readPackageUnresolved)
 import           Stack.PrettyPrint
 import           Stack.Setup
 import           Stack.Setup.Installed
@@ -548,8 +545,7 @@ cabalPackagesCheck cabalfps noPkgMsg dupErrMsg = do
     logInfo "Using cabal packages:"
     logInfo $ T.pack (formatGroup relpaths)
 
-    (warnings, gpds) <- mapAndUnzipM readPackageUnresolved cabalfps
-    zipWithM_ (mapM_ . printCabalFileWarning) cabalfps warnings
+    gpds <- mapM (flip readPackageUnresolved True) cabalfps
 
     -- package name cannot be empty or missing otherwise
     -- it will result in cabal solver failure.

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -142,7 +142,7 @@ data PackageLocation subdirs
   | PLArchive !(Archive subdirs)
   | PLRepo !(Repo subdirs)
   -- ^ Stored in a source control repository
-    deriving (Generic, Show, Eq, Data, Typeable, Functor)
+    deriving (Generic, Show, Eq, Ord, Data, Typeable, Functor)
 instance (Store a) => Store (PackageLocation a)
 instance (NFData a) => NFData (PackageLocation a)
 
@@ -156,7 +156,7 @@ data PackageLocationIndex subdirs
     -- version and (optional) cabal file info to specify the correct
     -- revision.
   | PLOther !(PackageLocation subdirs)
-    deriving (Generic, Show, Eq, Data, Typeable, Functor)
+    deriving (Generic, Show, Eq, Ord, Data, Typeable, Functor)
 instance (Store a) => Store (PackageLocationIndex a)
 instance (NFData a) => NFData (PackageLocationIndex a)
 
@@ -168,13 +168,13 @@ data Archive subdirs = Archive
   , archiveSubdirs :: !subdirs
   , archiveHash :: !(Maybe StaticSHA256)
   }
-    deriving (Generic, Show, Eq, Data, Typeable, Functor)
+    deriving (Generic, Show, Eq, Ord, Data, Typeable, Functor)
 instance Store a => Store (Archive a)
 instance NFData a => NFData (Archive a)
 
 -- | The type of a source control repository.
 data RepoType = RepoGit | RepoHg
-    deriving (Generic, Show, Eq, Data, Typeable)
+    deriving (Generic, Show, Eq, Ord, Data, Typeable)
 instance Store RepoType
 instance NFData RepoType
 
@@ -194,7 +194,7 @@ data Repo subdirs = Repo
     , repoType :: !RepoType
     , repoSubdirs :: !subdirs
     }
-    deriving (Generic, Show, Eq, Data, Typeable, Functor)
+    deriving (Generic, Show, Eq, Ord, Data, Typeable, Functor)
 instance Store a => Store (Repo a)
 instance NFData a => NFData (Repo a)
 

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -35,7 +35,7 @@ import           Stack.Types.Version
 
 -- | All exceptions thrown by the library.
 data PackageException
-  = PackageInvalidCabalFile (PackageLocationIndex FilePath) PError
+  = PackageInvalidCabalFile (Either PackageIdentifierRevision (Path Abs File)) PError
   | PackageNoCabalFileFound (Path Abs Dir)
   | PackageMultipleCabalFilesFound (Path Abs Dir) [Path Abs File]
   | MismatchedCabalName (Path Abs File) PackageName
@@ -43,8 +43,10 @@ data PackageException
 instance Exception PackageException
 instance Show PackageException where
     show (PackageInvalidCabalFile loc err) = concat
-        [ "Unable to parse cabal file for "
-        , show loc
+        [ "Unable to parse cabal file "
+        , case loc of
+            Left pir -> "for " ++ packageIdentifierRevisionString pir
+            Right fp -> toFilePath fp
         , ": "
         , show err
         ]

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -39,6 +39,7 @@ data PackageException
   | PackageNoCabalFileFound (Path Abs Dir)
   | PackageMultipleCabalFilesFound (Path Abs Dir) [Path Abs File]
   | MismatchedCabalName (Path Abs File) PackageName
+  | MismatchedCabalIdentifier !PackageIdentifierRevision !PackageIdentifier
   deriving Typeable
 instance Exception PackageException
 instance Show PackageException where
@@ -69,6 +70,13 @@ instance Show PackageException where
         , packageNameString name
         , ".cabal\n"
         , "For more information, see: https://github.com/commercialhaskell/stack/issues/317"
+        ]
+    show (MismatchedCabalIdentifier pir ident) = concat
+        [ "Mismatched package identifier."
+        , "\nFound:    "
+        , packageIdentifierString ident
+        , "\nExpected: "
+        , packageIdentifierRevisionString pir
         ]
 
 -- | Libraries in a package. Since Cabal 2.0, internal libraries are a

--- a/src/Stack/Types/PackageIdentifier.hs
+++ b/src/Stack/Types/PackageIdentifier.hs
@@ -94,7 +94,7 @@ instance FromJSON PackageIdentifier where
 data PackageIdentifierRevision = PackageIdentifierRevision
   { pirIdent :: !PackageIdentifier
   , pirRevision :: !CabalFileInfo
-  } deriving (Eq,Generic,Data,Typeable)
+  } deriving (Eq,Ord,Generic,Data,Typeable)
 
 instance NFData PackageIdentifierRevision where
   rnf (PackageIdentifierRevision !i !c) =
@@ -189,7 +189,7 @@ data CabalFileInfo
   | CFIRevision !Word
   -- ^ Identify by revision number, with 0 being the original and
   -- counting upward.
-    deriving (Generic, Show, Eq, Data, Typeable)
+    deriving (Generic, Show, Eq, Ord, Data, Typeable)
 instance Store CabalFileInfo
 instance NFData CabalFileInfo
 instance Hashable CabalFileInfo

--- a/src/Stack/Types/Runner.hs
+++ b/src/Stack/Types/Runner.hs
@@ -37,14 +37,13 @@ import qualified Data.Text.Encoding.Error   as T
 import qualified Data.Text.IO               as T
 import           Data.Time
 import           Distribution.PackageDescription (GenericPackageDescription)
-import           Distribution.ParseUtils         (PError)
 import           GHC.Foreign                (peekCString, withCString)
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Syntax (lift)
 import           Lens.Micro
 import           Stack.Prelude              hiding (lift)
 import           Stack.Constants
-import           Stack.Types.BuildPlan      (PackageLocationIndex)
+import           Stack.Types.PackageIdentifier (PackageIdentifierRevision)
 import           System.Console.ANSI
 import           System.FilePath
 import           System.IO
@@ -57,7 +56,7 @@ data Runner = Runner
   , runnerLogOptions :: !LogOptions
   , runnerTerminal   :: !Bool
   , runnerSticky     :: !Sticky
-  , runnerParsedCabalFiles :: !(IORef (Map (PackageLocationIndex FilePath) (Either PError GenericPackageDescription)))
+  , runnerParsedCabalFiles :: !(IORef (Map (Either PackageIdentifierRevision (Path Abs File)) GenericPackageDescription))
   -- ^ Cache of previously parsed cabal files.
   --
   -- TODO: This is really an ugly hack to avoid spamming the user with

--- a/test/integration/lib/StackTest.hs
+++ b/test/integration/lib/StackTest.hs
@@ -198,6 +198,9 @@ getIsAlpine = doesFileExist "/etc/alpine-release"
 isARM :: Bool
 isARM = arch == "arm"
 
+-- | Is the OS Mac OS X?
+isMacOSX = os == "darwin"
+
 -- | To avoid problems with GHC version mismatch when a new LTS major
 -- version is released, pass this argument to @stack@ when running in
 -- a global context. The LTS major version here should match that of

--- a/test/integration/tests/1336-1337-new-package-names/Main.hs
+++ b/test/integration/tests/1336-1337-new-package-names/Main.hs
@@ -1,4 +1,5 @@
 import StackTest
+import Control.Monad
 import System.Directory
 import System.FilePath
 
@@ -17,7 +18,7 @@ main =
             stackErr ["new", "44444444444444"]
             stackErr ["new", "abc-1"]
             stackErr ["new", "444-ば日本-4本"]
-            stack ["new", "ば日本-4本"]
+            unless isMacOSX $ stack ["new", "ば日本-4本"]
             stack ["new", "אבהץש"]
             stack ["new", "ΔΘΩϬ"]
             doesExist "./ΔΘΩϬ/stack.yaml"


### PR DESCRIPTION
This improves on the previous warning hack to keep a cache of parsed
GenericPackageDescriptions, and avoid rerunning hpack.

There are some TODOs added in this commit. One further point of concern:
should we opt-out of caching the results of parsing index files? I'm
imagining that when loading a snapshot, this may result in a lot of
memory usage. (Then again, this may already be the case, see #3586.)

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
