### PR TITLE
Doc: suggest recommended installation target for Nixos

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -240,7 +240,7 @@ If you use the [ArchHaskell repository](https://wiki.archlinux.org/index.php/Arc
 
 Users who follow the `nixos-unstable` channel or the Nixpkgs `master` branch can install the latest `stack` release into their profile by running:
 
-    nix-env -f "<nixpkgs>" -iA haskellPackages.stack
+    nix-env -f "<nixpkgs>" -i stack
 
 Alternatively, the package can be built from source as follows.
 

--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -240,7 +240,7 @@ If you use the [ArchHaskell repository](https://wiki.archlinux.org/index.php/Arc
 
 Users who follow the `nixos-unstable` channel or the Nixpkgs `master` branch can install the latest `stack` release into their profile by running:
 
-    nix-env -f "<nixpkgs>" -i stack
+    nix-env -f "<nixpkgs>" -iA stack
 
 Alternatively, the package can be built from source as follows.
 


### PR DESCRIPTION
Stack is exported as a package `stack` which is more efficient than `haskellPackages.stack`

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.