### PR TITLE
Avoid withBinaryFile and runConduitRes

### DIFF
--- a/src/Network/HTTP/Download.hs
+++ b/src/Network/HTTP/Download.hs
@@ -24,7 +24,6 @@ import           Stack.Prelude
 import           Stack.Types.Runner
 import qualified Data.ByteString.Lazy        as L
 import           Data.Conduit                (yield)
-import           Data.Conduit.Binary         (sourceHandle)
 import qualified Data.Conduit.Binary         as CB
 import           Data.Text.Encoding.Error    (lenientDecode)
 import           Data.Text.Encoding          (decodeUtf8With)
@@ -75,8 +74,7 @@ redownload req0 dest = do
       if not exists
         then return Nothing
         else liftIO $ handleIO (const $ return Nothing) $ fmap Just $
-                 withBinaryFile etagFilePath ReadMode $ \h ->
-                     runConduit $ sourceHandle h .| CB.take 512
+                 withSourceFile etagFilePath $ \src -> runConduit $ src .| CB.take 512
 
     let req1 =
             case metag of

--- a/src/Network/HTTP/Download.hs
+++ b/src/Network/HTTP/Download.hs
@@ -95,10 +95,12 @@ redownload req0 dest = do
           -- force the download to happen again.
           handleIO (const $ return ()) $ removeFile etagFilePath
 
-          runConduitRes $ getResponseBody res .| CB.sinkFileCautious destFilePath
+          withSinkFileCautious destFilePath $ \sink ->
+            runConduit $ getResponseBody res .| sink
 
           forM_ (lookup "ETag" (getResponseHeaders res)) $ \e ->
-            runConduitRes $ yield e .| CB.sinkFileCautious etagFilePath
+            withSinkFileCautious etagFilePath $ \sink ->
+            runConduit $ yield e .| sink
 
           return True
         304 -> return False

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -20,8 +20,7 @@ import              Crypto.Hash (Digest, SHA256(..))
 import              Crypto.Hash.Conduit (sinkHash)
 import qualified    Data.ByteArray as Mem (convert)
 import qualified    Data.ByteString as S
-import              Data.Conduit (($$), ZipSink (..))
-import qualified    Data.Conduit.Binary as CB
+import              Data.Conduit (ZipSink (..))
 import qualified    Data.Conduit.List as CL
 import qualified    Data.HashSet as HashSet
 import              Data.List
@@ -447,8 +446,8 @@ getModTimeMaybe fp =
 -- | Create FileCacheInfo for a file.
 calcFci :: MonadIO m => ModTime -> FilePath -> m FileCacheInfo
 calcFci modTime' fp = liftIO $
-    withBinaryFile fp ReadMode $ \h -> do
-        (size, digest) <- CB.sourceHandle h $$ getZipSink
+    withSourceFile fp $ \src -> do
+        (size, digest) <- runConduit $ src .| getZipSink
             ((,)
                 <$> ZipSink (CL.fold
                     (\x y -> x + fromIntegral (S.length y))

--- a/src/Stack/Docker/GlobalDB.hs
+++ b/src/Stack/Docker/GlobalDB.hs
@@ -17,6 +17,7 @@ module Stack.Docker.GlobalDB
   where
 
 import           Control.Monad.Logger (NoLoggingT)
+import           Control.Monad.Trans.Resource (ResourceT)
 import           Stack.Prelude
 import           Data.List (sortBy, isInfixOf, stripPrefix)
 import           Data.List.Extra (stripSuffix)

--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -37,7 +37,6 @@ import              Control.Concurrent.STM
 import              Stack.Prelude
 import              Crypto.Hash (SHA256 (..))
 import qualified    Data.ByteString as S
-import qualified    Data.ByteString.Lazy as L
 import qualified    Data.Foldable as F
 import qualified    Data.HashMap.Strict as HashMap
 import qualified    Data.HashSet as HashSet
@@ -590,10 +589,7 @@ fetchPackages' mdistDir toFetchAll = do
 untar :: forall b1 b2. Path b1 File -> Path Rel Dir -> Path b2 Dir -> IO [(FilePath, T.Text)]
 untar tarPath expectedTarFolder destDirParent = do
   ensureDir destDirParent
-  withBinaryFile (toFilePath tarPath) ReadMode $ \h -> do
-                -- Avoid using L.readFile, which is more likely to leak
-                -- resources
-                lbs <- L.hGetContents h
+  withLazyFile (toFilePath tarPath) $ \lbs -> do
                 let rawEntries = fmap (either wrap wrap)
                             $ Tar.checkTarbomb (toFilePathNoTrailingSep expectedTarFolder)
                             $ Tar.read $ decompress lbs

--- a/src/Stack/PackageLocation.hs
+++ b/src/Stack/PackageLocation.hs
@@ -111,10 +111,8 @@ resolveSinglePackageLocation projRoot (PLArchive (Archive url subdir msha)) = do
 
         let tryTar = do
                 logDebug $ "Trying to untar " <> T.pack fp
-                liftIO $ withBinaryFile fp ReadMode $ \h -> do
-                    lbs <- L.hGetContents h
-                    let entries = Tar.read $ GZip.decompress lbs
-                    Tar.unpack (toFilePath dirTmp) entries
+                liftIO $ withLazyFile fp $
+                    Tar.unpack (toFilePath dirTmp) . Tar.read . GZip.decompress
             tryZip = do
                 logDebug $ "Trying to unzip " <> T.pack fp
                 archive <- fmap Zip.toArchive $ liftIO $ L.readFile fp

--- a/src/Stack/Prelude.hs
+++ b/src/Stack/Prelude.hs
@@ -3,10 +3,9 @@
 {-# LANGUAGE OverloadedStrings          #-}
 module Stack.Prelude
   ( mapLeft
-  , ResourceT
-  , runConduitRes
   , withSourceFile
   , withSinkFile
+  , withSinkFileCautious
   , withLazyFile
   , NoLogging (..)
   , withSystemTempDir
@@ -112,10 +111,13 @@ import           UnliftIO             as X
 import qualified Data.Text            as T
 import qualified Path.IO
 
-import qualified Control.Monad.Trans.Resource as Res (runResourceT, transResourceT)
-import           Control.Monad.Trans.Resource (ResourceT)
 import           Data.Conduit.Binary (sourceHandle, sinkHandle)
 import qualified Data.ByteString.Lazy as BL
+
+import qualified System.IO as IO
+import qualified System.Directory as Dir
+import qualified System.FilePath as FP
+import           System.IO.Error (isDoesNotExistError)
 
 mapLeft :: (a1 -> a2) -> Either a1 b -> Either a2 b
 mapLeft f (Left a1) = Left (f a1)
@@ -144,12 +146,6 @@ forMaybeM = flip mapMaybeM
 stripCR :: T.Text -> T.Text
 stripCR t = fromMaybe t (T.stripSuffix "\r" t)
 
-runConduitRes :: MonadUnliftIO m => ConduitM () Void (ResourceT m) r -> m r
-runConduitRes = runResourceT . runConduit
-
-runResourceT :: MonadUnliftIO m => ResourceT m a -> m a
-runResourceT r = withRunInIO $ \run -> Res.runResourceT (Res.transResourceT run r)
-
 -- | Get a source for a file. Unlike @sourceFile@, doesn't require
 -- @ResourceT@. Unlike explicit @withBinaryFile@ and @sourceHandle@
 -- usage, you can't accidentally use @WriteMode@ instead of
@@ -160,6 +156,25 @@ withSourceFile fp inner = withBinaryFile fp ReadMode $ inner . sourceHandle
 -- | Same idea as 'withSourceFile', see comments there.
 withSinkFile :: MonadUnliftIO m => FilePath -> (ConduitM ByteString o m () -> m a) -> m a
 withSinkFile fp inner = withBinaryFile fp WriteMode $ inner . sinkHandle
+
+-- | Like 'withSinkFile', but ensures that the file is atomically
+-- moved after all contents are written.
+withSinkFileCautious
+  :: MonadUnliftIO m
+  => FilePath
+  -> (ConduitM ByteString o m () -> m a)
+  -> m a
+withSinkFileCautious fp inner =
+    withRunInIO $ \run -> bracket acquire cleanup $ \(tmpFP, h) ->
+      run (inner $ sinkHandle h) <* (IO.hClose h *> Dir.renameFile tmpFP fp)
+  where
+    acquire = IO.openBinaryTempFile (FP.takeDirectory fp) (FP.takeFileName fp FP.<.> "tmp")
+    cleanup (tmpFP, h) = do
+        IO.hClose h
+        Dir.removeFile tmpFP `catch` \e ->
+            if isDoesNotExistError e
+                then return ()
+                else throwIO e
 
 -- | Lazily get the contents of a file. Unlike 'BL.readFile', this
 -- ensures that if an exception is thrown, the file handle is closed

--- a/src/test/Stack/PackageDumpSpec.hs
+++ b/src/test/Stack/PackageDumpSpec.hs
@@ -5,7 +5,6 @@
 module Stack.PackageDumpSpec where
 
 import           Data.Conduit
-import qualified Data.Conduit.Binary           as CB
 import qualified Data.Conduit.List             as CL
 import           Data.Conduit.Text             (decodeUtf8)
 import qualified Data.Map                      as Map
@@ -67,9 +66,9 @@ spec = do
     describe "conduitDumpPackage" $ do
         it "ghc 7.8" $ do
             haskell2010:_ <-
-                  withBinaryFile "test/package-dump/ghc-7.8.txt" ReadMode $ \h ->
+                  withSourceFile "test/package-dump/ghc-7.8.txt" $ \src ->
                   runConduit
-                $ CB.sourceHandle h
+                $ src
                .| decodeUtf8
                .| conduitDumpPackage
                .| CL.consume
@@ -99,9 +98,9 @@ spec = do
 
         it "ghc 7.10" $ do
             haskell2010:_ <-
-                  withBinaryFile "test/package-dump/ghc-7.10.txt" ReadMode $ \h ->
+                  withSourceFile "test/package-dump/ghc-7.10.txt" $ \src ->
                   runConduit
-                $ CB.sourceHandle h
+                $ src
                .| decodeUtf8
                .| conduitDumpPackage
                .| CL.consume
@@ -141,9 +140,9 @@ spec = do
                 }
         it "ghc 7.8.4 (osx)" $ do
             hmatrix:_ <-
-                  withBinaryFile "test/package-dump/ghc-7.8.4-osx.txt" ReadMode $ \h ->
+                  withSourceFile "test/package-dump/ghc-7.8.4-osx.txt" $ \src ->
                   runConduit
-                $ CB.sourceHandle h
+                $ src
                .| decodeUtf8
                .| conduitDumpPackage
                .| CL.consume
@@ -181,9 +180,9 @@ spec = do
                 }
         it "ghc HEAD" $ do
           ghcBoot:_ <-
-                withBinaryFile "test/package-dump/ghc-head.txt" ReadMode $ \h ->
+                withSourceFile "test/package-dump/ghc-head.txt" $ \src ->
                 runConduit
-              $ CB.sourceHandle h
+              $ src
              .| decodeUtf8
              .| conduitDumpPackage
              .| CL.consume


### PR DESCRIPTION
Motivation for the first: prevent bugs like that patched in 25dfaf17e0513267e605820c8ab6ab31941ab1b7 from occurring again. `Handle` doesn't indicate at the type level whether you can read or write, so reducing usage of explicit `Handle`s is a Good Thing.

Motivation for the second is less strong, but given how little we were using `runConduitRes`, and that it carries a (small) performance penalty, I thought standardizing the `with...File` usage throughout the codebase was good thing.

These new helper functions will eventually make it into conduit-extra itself and then we can drop the definitions in `Stack.Prelude`.