### PR TITLE
More compat with buggy Cabal buildable deps #3631

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,7 @@ Bug fixes:
 
 * For versions of Cabal before 1.24, ensure that the dependencies of
   non-buildable components are part of the build plan to work around an old
-  Cabal bug.
+  Cabal bug. See [#3631](https://github.com/commercialhaskell/stack/issues/3631).
 * Run the Cabal file checking in the `sdist` command more reliably by
   allowing the Cabal library to flatten the
   `GenericPackageDescription` itself.

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -198,7 +198,7 @@ gpdPackageDeps
     -> Map FlagName Bool
     -> Map PackageName VersionRange
 gpdPackageDeps gpd cv platform flags =
-    Map.filterWithKey (const . (/= name)) (packageDependencies cv pkgDesc)
+    Map.filterWithKey (const . (/= name)) (packageDependencies pkgConfig pkgDesc)
     where
         name = gpdPackageName gpd
         -- Since tests and benchmarks are both enabled, doesn't matter

--- a/src/Stack/Snapshot.hs
+++ b/src/Stack/Snapshot.hs
@@ -769,7 +769,7 @@ calculate gpd platform compilerVersion loc flags hide options =
       , lpiGhcOptions = options
       , lpiPackageDeps = Map.map fromVersionRange
                        $ Map.filterWithKey (const . (/= name))
-                       $ packageDependencies compilerVersion pd
+                       $ packageDependencies pconfig pd
       , lpiProvidedExes =
             Set.fromList
           $ map (ExeName . T.pack . C.unUnqualComponentName . C.exeName)

--- a/test/integration/tests/3631-build-http2/Main.hs
+++ b/test/integration/tests/3631-build-http2/Main.hs
@@ -1,0 +1,6 @@
+import StackTest
+
+main :: IO ()
+main = do
+  stack ["build", "--resolver=lts-6.35", "--dry-run", "http2"]
+  stack ["build", "--resolver=lts-6.35", "http2"]


### PR DESCRIPTION
This is a direct continuation of my (now realized to be incorrect) patch
in 2a52ac28d28fda0b637cbb09c3c74d1de5605a1f. This ensures that tests and
benchmarks are only switched to `buildable = True` if we're enabling
them, otherwise we can end up with cyclic dependency errors.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
