### PR TITLE
Update default generated stack.yaml to extensible snapshots

### DIFF
--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -239,7 +239,7 @@ renderStackYaml p ignoredPackages dupPackages =
         [ ("user-message"     , userMsgHelp)
         , ("resolver"         , resolverHelp)
         , ("packages"         , packageHelp)
-        , ("extra-deps"       , "# Dependency packages to be pulled from upstream that are not in the resolver\n# (e.g., acme-missiles-0.3)")
+        , ("extra-deps"       , "# Dependency packages to be pulled from upstream that are not in the resolver\n# using the same syntax as packages.\n# (e.g., acme-missiles-0.3)")
         , ("flags"            , "# Override default flag values for local packages and extra-deps")
         , ("extra-package-dbs", "# Extra package databases containing global packages")
         ]
@@ -262,9 +262,12 @@ renderStackYaml p ignoredPackages dupPackages =
         , "resolver: nightly-2015-09-21"
         , "resolver: ghc-7.10.2"
         , "resolver: ghcjs-0.1.0_ghc-7.10.2"
-        , "resolver:"
-        , " name: custom-snapshot"
-        , " location: \"./custom-snapshot.yaml\""
+        , ""
+        , "The location of a snapshot can be provided as a file or url. Stack assumes"
+        , "a snapshot provided as a file might change, whereas a url resource does not."
+        , ""
+        , "resolver: ./custom-snapshot.yaml"
+        , "resolver: https://example.com/snapshots/2018-01-01.yaml"
         ]
 
     userMsgHelp = commentHelp
@@ -281,14 +284,9 @@ renderStackYaml p ignoredPackages dupPackages =
         , "   git: https://github.com/commercialhaskell/stack.git"
         , "   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a"
         , "- location: https://github.com/commercialhaskell/stack/commit/e7b331f14bcffb8367cd58fbfc8b40ec7642100a"
-        , "  extra-dep: true"
         , " subdirs:"
         , " - auto-update"
         , " - wai"
-        , ""
-        , "A package marked 'extra-dep: true' will only be built if demanded by a"
-        , "non-dependency (i.e. a user package), and its test suites and benchmarks"
-        , "will not be run. This is useful for tweaking upstream packages."
         ]
 
     footerHelp =


### PR DESCRIPTION
Stack version
```
Version 1.6.1, Git revision f25811329bbc40b0c21053a8160c56f923e1201b (5435 commits) x86_64 hpack-0.20.0 
```
uses extensible snapshots, but the `stack.yaml` generated using `stack new` describes the old syntax. This PR corrects the errors and adds some description.

I think the update is correct, but I'm not sure how best to handle the `extra-deps` case — in any case, it seemed just as easy to open a PR as an issue about it.

---

Probably not relevant:
* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.