### PR TITLE
Never run benchmarks concurrently, always output to console #3663

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,13 +42,16 @@ Bug fixes:
   arguments. See [#3658](https://github.com/commercialhaskell/stack/issues/3658).
   In particular, this makes it possible to pass `-- +RTS ... -RTS` to specify
   RTS arguments used when running the script.
-
+* Benchmarks used to be run concurrently with other benchmarks
+  and build steps. This is non-ideal because CPU usage of other processes
+  may interfere with benchmarks. It also prevented benchmark output from
+  being displayed by default. This is now fixed. See
+  [#3663](https://github.com/commercialhaskell/stack/issues/3663).
 
 ## v1.6.1.1
 
 Hackage-only release with no user facing changes (updated to build with
 newer dependency versions).
-
 
 ## v1.6.1
 

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -17,7 +17,7 @@ import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Archive.Tar.Entry as Tar
 import qualified Codec.Compression.GZip as GZip
 import           Control.Applicative
-import           Control.Concurrent.Execute (ActionContext(..))
+import           Control.Concurrent.Execute (ActionContext(..), Concurrency(..))
 import           Stack.Prelude
 import           Control.Monad.Reader.Class (local)
 import qualified Data.ByteString as S
@@ -335,7 +335,7 @@ getSDistFileList lp =
                 return (T.unpack $ T.decodeUtf8With T.lenientDecode contents, cabalfp)
   where
     package = lpPackage lp
-    ac = ActionContext Set.empty []
+    ac = ActionContext Set.empty [] ConcurrencyAllowed
     task = Task
         { taskProvides = PackageIdentifier (packageName package) (packageVersion package)
         , taskType = TTFiles lp Local


### PR DESCRIPTION
Also generally cleans up code related to parallel execution of tasks. Instead of
locking happening among "final tasks" (tests and benchmark running), it's now
possible to mark some tasks as work that shouldn't be done in parallel with
anything else.  This is what makes sense for benchmark running - they shouldn't
be run concurrently with either building or running tests.

Previously benchmarks and tests shared the same final task. The mechanism to
execute one task exclusively is part of Control.Concurrent.Execute. If they were
kept in the same task, then if any benchmarks were enabled, then tests would be
run without any concurrency. In order to have as much concurrency as possible,
they are now split into two different "final" tasks.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Tested via the repro in #3663