### PR TITLE
Put file arguments first when stack is run as script interpreter #3658

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,10 @@ Bug fixes:
 * Run the Cabal file checking in the `sdist` command more reliably by
   allowing the Cabal library to flatten the
   `GenericPackageDescription` itself.
+* The script interpreter's implicit file arguments are now passed before other
+  arguments. See [#3658](https://github.com/commercialhaskell/stack/issues/3658).
+  In particular, this makes it possible to pass `-- +RTS ... -RTS` to specify
+  RTS arguments used when running the script.
 
 ## v1.6.1
 

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -563,8 +563,12 @@ interpreterHandler currentDir args f = do
       progName <- getProgName
       iargs <- getInterpreterArgs path
       let parseCmdLine = commandLineHandler currentDir progName True
-          separator = if "--" `elem` iargs then [] else ["--"]
-          cmdArgs = stackArgs ++ iargs ++ separator ++ path : fileArgs
+          -- Implicit file arguments are put before other arguments that
+          -- occur after "--". See #3658
+          cmdArgs = stackArgs ++ case break (== "--") iargs of
+            (beforeSep, []) -> beforeSep ++ ["--"] ++ [path] ++ fileArgs
+            (beforeSep, optSep : afterSep) ->
+              beforeSep ++ [optSep] ++ [path] ++ fileArgs ++ afterSep
        -- TODO show the command in verbose mode
        -- hPutStrLn stderr $ unwords $
        --   ["Running", "[" ++ progName, unwords cmdArgs ++ "]"]


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Tested via #3658 and tested that a few misc other uses of stack as an interpreter still work.  Seems to be fine, but this is potentially a change in behavior.  I think it's a positive change, though, I know of cases that it fixes, and don't know of any cases that it breaks.