### PR TITLE
Add support for smallcheck 1.1.3

### DIFF
--- a/src/test/Stack/StoreSpec.hs
+++ b/src/test/Stack/StoreSpec.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 module Stack.StoreSpec where
 
 import qualified Data.ByteString as BS
@@ -51,7 +52,11 @@ addMinAndMaxBounds xs =
     (if (minBound :: a) `notElem` xs then [minBound] else []) ++
     (if (maxBound :: a) `notElem` xs && (maxBound :: a) /= minBound then maxBound : xs else xs)
 
+#if MIN_VERSION_smallcheck(1,1,3)
+$(do let ns = [ ''Int64, ''Word64, ''Word8
+#else
 $(do let ns = [ ''Int64, ''Word64, ''Word, ''Word8
+#endif
               ]
          f n = [d| instance Monad m => Serial m $(conT n) where
                       series = generate (\_ -> addMinAndMaxBounds [0, 1]) |]


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Upgrading smallcheck from 1.1.2 to 1.1.3 introduces the following build error:
```
[15 of 18] Compiling Stack.StoreSpec  ( src/test/Stack/StoreSpec.hs, dist/build/stack-test/stack-test-tmp/Stack/StoreSpec.dyn_o )

src/test/Stack/StoreSpec.hs:54:3: error:
    Duplicate instance declarations:
      instance Monad m => Serial m Word
        -- Defined at src/test/Stack/StoreSpec.hs:54:3
      instance [overlap ok] Monad m => Serial m Word
        -- Defined in ‘Test.SmallCheck.Series’
   |
54 | $(do let ns = [ ''Int64, ''Word64, ''Word, ''Word8
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```

This small change fixes this and should work with older versions. The test suite passes here with smallcheck 1.1.3 after the change.