### PR TITLE
Fix use of and document year template parameter

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,9 @@ Bug fixes:
   arguments. See [#3658](https://github.com/commercialhaskell/stack/issues/3658).
   In particular, this makes it possible to pass `-- +RTS ... -RTS` to specify
   RTS arguments used when running the script.
+* Don't ignore the template `year` parameter in config files, and clarify the
+  surrounding documentation. See
+  [#2275](https://github.com/commercialhaskell/stack/issues/2275).
 
 ## v1.6.1
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -799,9 +799,10 @@ dump-logs: all       # dump all logs for local non-dependency packages
 
 Templates used with `stack new` have a number of parameters that affect the
 generated code. These can be set for all new projects you create. The result of
-them can be observed in the generated LICENSE and cabal files.
+them can be observed in the generated LICENSE and cabal files. The value for all
+of these parameters must be strings.
 
-The 5 parameters are: `author-email`, `author-name`, `category`, `copyright` and `github-username`.
+The parameters are: `author-email`, `author-name`, `category`, `copyright`, `year` and `github-username`.
 
 * _author-email_ - sets the `maintainer` property in cabal
 * _author-name_ - sets the `author` property in cabal and the name used in
@@ -815,6 +816,9 @@ The 5 parameters are: `author-email`, `author-name`, `category`, `copyright` and
 * _copyright_ - sets the `copyright` property in cabal. It is typically the
   name of the holder of the copyright on the package and the year(s) from which
   copyright is claimed. For example: `Copyright (c) 2006-2007 Joe Bloggs`
+* _year_ - if `copyright` is not specified, `year` and `author-name` are used
+  to generate the copyright property in cabal. If `year` is not specified, it
+  defaults to the current year.
 * _github-username_ - used to generate `homepage` and `source-repository` in
   cabal. For instance `github-username: myusername` and `stack new my-project new-template`
   would result:

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -176,17 +176,17 @@ applyTemplate project template nonceParams dir templateText = do
     config <- view configL
     currentYear <- do
       now <- liftIO getCurrentTime
-      (year, _, _) <- return $ toGregorian . utctDay $ now
+      let (year, _, _) = toGregorian (utctDay now)
       return $ T.pack . show $ year
-    let context = M.union (M.union nonceParams extraParams) configParams
+    let context = M.unions [nonceParams, nameParams, configParams, yearParam]
           where
             nameAsVarId = T.replace "-" "_" $ packageNameText project
             nameAsModule = T.filter (/= '-') $ T.toTitle $ packageNameText project
-            extraParams = M.fromList [ ("name", packageNameText project)
-                                     , ("name-as-varid", nameAsVarId)
-                                     , ("name-as-module", nameAsModule)
-                                     , ("year", currentYear) ]
+            nameParams = M.fromList [ ("name", packageNameText project)
+                                    , ("name-as-varid", nameAsVarId)
+                                    , ("name-as-module", nameAsModule) ]
             configParams = configTemplateParams config
+            yearParam = M.singleton "year" currentYear
     (applied,missingKeys) <-
         runWriterT
             (hastacheStr


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested by running `stack new` with combinations of year param specified or not in config file and on the command line.
