### PR TITLE
Avoid MAX_PATH for precompiled cache #3649

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,9 @@ Behaviour changes:
 Other enhancements:
 
 Bug fixes:
+* 1.6.1 introduced a change that made some precompiled cache files use
+  longer paths, sometimes causing builds to fail on windows. This has been
+  fixed. See [#3649](https://github.com/commercialhaskell/stack/issues/3649)
 
 
 ## v1.6.3

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -1,6 +1,7 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- | Constants used throughout the project.
 
@@ -32,6 +33,7 @@ module Stack.Constants
     ,minTerminalWidth
     ,maxTerminalWidth
     ,defaultTerminalWidth
+    ,maxPathLength
     )
     where
 
@@ -241,3 +243,12 @@ maxTerminalWidth = 200
 -- automatically detect it and when the user doesn't supply one.
 defaultTerminalWidth :: Int
 defaultTerminalWidth = 100
+
+-- | Maximum length to use in paths. Is only a 'Just' value on windows,
+-- corresponding to MAX_PATH.
+maxPathLength :: Maybe Int
+#ifdef mings32_HOST_OS
+maxPathLength = Just 260
+#else
+maxPathLength = Nothing
+#endif


### PR DESCRIPTION
Regression was in 99911566a0ac41203d8130bc3ae5fa724dd32128

I have not tested this change, since I do not currently have easy access to windows.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.