### PR TITLE
Don't pass --with-hpack to Setup.hs configure #3696

### DIFF
--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -604,7 +604,6 @@ configureOptsNoDir econfig bco deps isLocal package = concat
     , map ("--extra-include-dirs=" ++) (Set.toList (configExtraIncludeDirs config))
     , map ("--extra-lib-dirs=" ++) (Set.toList (configExtraLibDirs config))
     , maybe [] (\customGcc -> ["--with-gcc=" ++ toFilePath customGcc]) (configOverrideGccPath config)
-    , hpackOptions (configOverrideHpack config)
     , ["--ghcjs" | wc == Ghcjs]
     , ["--exact-configuration" | useExactConf]
     ]
@@ -628,9 +627,6 @@ configureOptsNoDir econfig bco deps isLocal package = concat
     depOptions = map (uncurry toDepOption) $ Map.toList deps
       where
         toDepOption = if newerCabal then toDepOption1_22 else toDepOption1_18
-
-    hpackOptions HpackBundled = []
-    hpackOptions (HpackCommand cmd) = ["--with-hpack=" ++ cmd]
 
     toDepOption1_22 ident gid = concat
         [ "--dependency="


### PR DESCRIPTION
Pinging @scott-fleischman - any thoughts on why this worked with https://github.com/commercialhaskell/stack/pull/3443 ?  Maybe Cabal-1.24 was less strict about `--with-*` options?

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Tested by
```
stack new issue3696
cd issue3696
stack build hpack
stack build --with-hpack=hpack
```
(reproduced the issue)

After this fix, the issue no longer occurs.