### PR TITLE
Port `list-dependencies` under the new ls sub command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@ Other enhancements:
 * A new sub command `ls` has been introduced to stack to view
   local and remote snapshots present in the system. Use `stack ls
   snapshots --help` to get more details about it.
+* `list-dependencies` has been deprecated. The functionality has
+  to accessed through the new `ls dependencies` interface.
 * Specify User-Agent HTTP request header on every HTTP request.
   See [#3628](https://github.com/commercialhaskell/stack/issues/3628) for details.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,8 +13,10 @@ Other enhancements:
 * A new sub command `ls` has been introduced to stack to view
   local and remote snapshots present in the system. Use `stack ls
   snapshots --help` to get more details about it.
-* `list-dependencies` has been deprecated. The functionality has
-  to accessed through the new `ls dependencies` interface.
+*`list-dependencies` has been deprecated. The functionality has
+  to accessed through the new `ls dependencies` interface. See
+  [#3669](https://github.com/commercialhaskell/stack/issues/3669)
+  for details.
 * Specify User-Agent HTTP request header on every HTTP request.
   See [#3628](https://github.com/commercialhaskell/stack/issues/3628) for details.
 

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -2116,7 +2116,7 @@ users. Here's a quick rundown:
   default. You can also view the remote snapshots using `stack ls
   snapshots remote`. It also supports option for viewing only lts
   (`-l`) and nightly (`-n`) snapshots.
-* `stack list-dependencies` lists all of the packages and versions used for a
+* `stack ls dependencies` lists all of the packages and versions used for a
   project
 * `stack sig` subcommand can help you with GPG signing & verification
     * `sign` will sign an sdist tarball and submit the signature to

--- a/src/Stack/Ls.hs
+++ b/src/Stack/Ls.hs
@@ -12,6 +12,7 @@ import Control.Exception (Exception, throw)
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (MonadReader)
+import Control.Monad (when)
 import Data.Aeson
 import Stack.Types.Runner
 import qualified Data.Aeson.Types as A
@@ -36,6 +37,7 @@ import Stack.Dot
 import Stack.Options.DotParser (listDepsOptsParser)
 import System.Process.PagerEditor (pageText)
 import System.Directory (listDirectory)
+import System.IO (stderr, hPutStrLn)
 import Network.HTTP.Client.TLS (getGlobalManager)
 
 data LsView
@@ -239,11 +241,16 @@ lsCmd lsOpts go =
             case soptViewType of
                 Local -> withBuildConfig go (handleLocal lsOpts)
                 Remote -> withBuildConfig go (handleRemote lsOpts)
-        LsDependencies depOpts -> listDependenciesCmd depOpts go
+        LsDependencies depOpts -> listDependenciesCmd False depOpts go
 
 -- | List the dependencies
-listDependenciesCmd :: ListDepsOpts -> GlobalOpts -> IO ()
-listDependenciesCmd opts go =
+listDependenciesCmd :: Bool -> ListDepsOpts -> GlobalOpts -> IO ()
+listDependenciesCmd deprecated opts go = do
+    when
+        deprecated
+        (hPutStrLn
+             stderr
+             "DEPRECATED: Use ls dependencies instead. Will be removed in next major version.")
     withBuildConfigDot (listDepsDotOpts opts) go $ listDependencies opts
 
 lsViewLocalCmd :: OA.Mod OA.CommandFields LsView

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -385,8 +385,8 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                     cleanCmd
                     cleanOptsParser
         addCommand' "list-dependencies"
-                    "DEPRECATED: Use ls dependencies instead. Will be removed in next major version."
-                    listDependenciesCmd
+                    "List the dependencies"
+                    (listDependenciesCmd True)
                     listDepsOptsParser
         addCommand' "query"
                     "Query general build information (experimental)"

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -301,7 +301,7 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                     pathCmd
                     Stack.Path.pathParser
         addCommand' "ls"
-                    "List command. (Supports snapshots)"
+                    "List command. (Supports snapshots and dependencies)"
                     lsCmd
                     lsParser
         addCommand' "unpack"
@@ -385,7 +385,7 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                     cleanCmd
                     cleanOptsParser
         addCommand' "list-dependencies"
-                    "List the dependencies"
+                    "DEPRECATED: Use ls dependencies instead. Will be removed in next major version."
                     listDependenciesCmd
                     listDepsOptsParser
         addCommand' "query"
@@ -953,19 +953,6 @@ solverCmd fixStackYaml go =
 -- | Visualize dependencies
 dotCmd :: DotOpts -> GlobalOpts -> IO ()
 dotCmd dotOpts go = withBuildConfigDot dotOpts go $ dot dotOpts
-
--- | List the dependencies
-listDependenciesCmd :: ListDepsOpts -> GlobalOpts -> IO ()
-listDependenciesCmd opts go = withBuildConfigDot (listDepsDotOpts opts) go $ listDependencies opts
-
--- Plumbing for --test and --bench flags
-withBuildConfigDot :: DotOpts -> GlobalOpts -> RIO EnvConfig () -> IO ()
-withBuildConfigDot opts go f = withBuildConfig go' f
-  where
-    go' =
-        (if dotTestTargets opts then set (globalOptsBuildOptsMonoidL.buildOptsMonoidTestsL) (Just True) else id) $
-        (if dotBenchTargets opts then set (globalOptsBuildOptsMonoidL.buildOptsMonoidBenchmarksL) (Just True) else id)
-        go
 
 -- | Query build information
 queryCmd :: [String] -> GlobalOpts -> IO ()


### PR DESCRIPTION
This PR also deprecates the existing interface. Fixes #3669 

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
