### PR TITLE
ResolverSnapshot becomes ResolverStackage.

### DIFF
--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -430,7 +430,7 @@ selectBestSnapshot root gpds snaps = do
     logInfo $ "Selecting the best among "
                <> T.pack (show (NonEmpty.length snaps))
                <> " snapshots...\n"
-    F.foldr1 go (NonEmpty.map (getResult <=< loadResolver . ResolverSnapshot) snaps)
+    F.foldr1 go (NonEmpty.map (getResult <=< loadResolver . ResolverStackage) snaps)
     where
         go mold mnew = do
             old@(_snap, bpc) <- mold
@@ -440,7 +440,7 @@ selectBestSnapshot root gpds snaps = do
 
         getResult snap = do
             result <- checkSnapBuildPlan root gpds Nothing snap
-              -- We know that we're only dealing with ResolverSnapshot
+              -- We know that we're only dealing with ResolverStackage
               -- here, where we can rely on the global package hints.
               -- Therefore, we don't use an actual compiler. For more
               -- info, see comments on

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -180,16 +180,16 @@ makeConcreteResolver root ar = do
                 ProjectAndConfigMonoid project _ <-
                     loadConfigYaml (parseProjectAndConfigMonoid (parent fp)) fp
                 return $ projectResolver project
-            ARLatestNightly -> return $ ResolverSnapshot $ Nightly $ snapshotsNightly snapshots
+            ARLatestNightly -> return $ ResolverStackage $ Nightly $ snapshotsNightly snapshots
             ARLatestLTSMajor x ->
                 case IntMap.lookup x $ snapshotsLts snapshots of
                     Nothing -> throwString $ "No LTS release found with major version " ++ show x
-                    Just y -> return $ ResolverSnapshot $ LTS x y
+                    Just y -> return $ ResolverStackage $ LTS x y
             ARLatestLTS
                 | IntMap.null $ snapshotsLts snapshots -> throwString "No LTS releases found"
                 | otherwise ->
                     let (x, y) = IntMap.findMax $ snapshotsLts snapshots
-                     in return $ ResolverSnapshot $ LTS x y
+                     in return $ ResolverStackage $ LTS x y
     logInfo $ "Selected resolver: " <> resolverRawName r
     return r
 
@@ -201,7 +201,7 @@ getLatestResolver = do
             (x,y) <- listToMaybe (reverse (IntMap.toList (snapshotsLts snapshots)))
             return (LTS x y)
         snap = fromMaybe (Nightly (snapshotsNightly snapshots)) mlts
-    return (ResolverSnapshot snap)
+    return (ResolverStackage snap)
 
 -- | Create a 'Config' value when we're not using any local
 -- configuration files (e.g., the script command)
@@ -281,7 +281,7 @@ configFromConfigMonoid
          configExtraLibDirs = configMonoidExtraLibDirs
          configOverrideGccPath = getFirst configMonoidOverrideGccPath
          configOverrideHpack = maybe HpackBundled HpackCommand $ getFirst configMonoidOverrideHpack
-         
+
          -- Only place in the codebase where platform is hard-coded. In theory
          -- in the future, allow it to be configured.
          (Platform defArch defOS) = buildPlatform

--- a/src/Stack/Config/Docker.hs
+++ b/src/Stack/Config/Docker.hs
@@ -41,7 +41,7 @@ dockerOptsFromMonoid mproject stackRoot maresolver DockerOptsMonoid{..} = do
                         Nothing -> ""
                         Just resolver ->
                             case resolver of
-                                ResolverSnapshot n@(LTS _ _) ->
+                                ResolverStackage n@(LTS _ _) ->
                                     ":" ++ T.unpack (renderSnapName n)
                                 _ ->
                                     impureThrow

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -786,7 +786,7 @@ checkSnapBuildPlanActual root gpds flags sd = do
     let forNonSnapshot inner = setupCabalEnv (sdWantedCompilerVersion sd) (inner . Just)
         runner =
           case sdResolver sd of
-            ResolverSnapshot _ -> ($ Nothing)
+            ResolverStackage _ -> ($ Nothing)
             ResolverCompiler _ -> forNonSnapshot
             ResolverCustom _ _ -> forNonSnapshot
 

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -102,7 +102,7 @@ instance Store SnapshotDef
 instance NFData SnapshotDef
 
 snapshotDefVC :: VersionConfig SnapshotDef
-snapshotDefVC = storeVersionConfig "sd-v1" "tnwWSSLerZ2XeR6XpVwj5Uh0eF4="
+snapshotDefVC = storeVersionConfig "sd-v1" "CKo7nln8EXkw07Gq-4ATxszNZiE="
 
 -- | A relative file path including a unique string for the given
 -- snapshot.
@@ -110,7 +110,7 @@ sdRawPathName :: SnapshotDef -> String
 sdRawPathName sd =
     T.unpack $ go $ sdResolver sd
   where
-    go (ResolverSnapshot name) = renderSnapName name
+    go (ResolverStackage name) = renderSnapName name
     go (ResolverCompiler version) = compilerVersionText version
     go (ResolverCustom _ hash) = "custom-" <> sdResolverName sd <> "-" <> trimmedSnapshotHash hash
 


### PR DESCRIPTION
* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.
---

Following [this comment](https://github.com/commercialhaskell/stack/compare/master...lwm:rename-resolver-snapshot?expand=1#diff-44f21bb6d216d7afb930c705712b837eL71).