### PR TITLE
Add hlint rules to prevent regression of #3628

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -44,3 +44,13 @@
 - error: {lhs: "fromString . toFilePath", rhs: "display"}
 - ignore: {name: "Use display", within: "warnMultiple"}
 - ignore: {name: "Use display", within: "Stack.PrettyPrint"}
+
+- error: {lhs: "Network.HTTP.Simple.httpJSON", rhs: "Network.HTTP.StackClient.httpJSON"}
+- error: {lhs: "Network.HTTP.Simple.httpLbs", rhs: "Network.HTTP.StackClient.httpLbs"}
+- error: {lhs: "Network.HTTP.Simple.httpLBS", rhs: "Network.HTTP.StackClient.httpLBS"}
+- error: {lhs: "Network.HTTP.Simple.httpSink", rhs: "Network.HTTP.StackClient.httpSink"}
+- error: {lhs: "Network.HTTP.Simple.httpNoBody", rhs: "Network.HTTP.StackClient.httpNoBody"}
+- error: {lhs: "Network.HTTP.Simple.withResponse", rhs: "Network.HTTP.StackClient.withResponse"}
+- error: {lhs: "Network.HTTP.Client.withResponse", rhs: "Network.HTTP.StackClient.withResponseByManager"}
+- ignore: {name: "Use alternative", within: "Network.HTTP.StackClient"}
+- ignore: {name: "Use withResponseByManager", within: "Network.HTTP.StackClient"}


### PR DESCRIPTION
Related: https://github.com/commercialhaskell/stack/issues/3700

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

# Testing the change

I confirmed this change works with these tests:

- command:  `hlint -- src/Network/HTTP/StackClient.hs`
  result: doesn't reports error.
- command:  `hlint src/Stack/New.hs` without any modification
  result: doesn't reports error.
- command: `hlint src/Stack/New.hs` after modifying like (1).
  result: exit with the message (2)

(1)
```diff
diff --git a/src/Stack/New.hs b/src/Stack/New.hs
index fcffc1cc..fa57755b 100644
--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -38,8 +38,8 @@ import qualified Data.Text.Lazy as LT
 import           Data.Time.Calendar
 import           Data.Time.Clock
 import qualified Data.Yaml as Yaml
-import           Network.HTTP.Download
-import           Network.HTTP.Simple (Request, HttpException, getResponseStatusCode, getResponseBody)
+import           Network.HTTP.Download hiding (httpJSON)
+import           Network.HTTP.Simple (Request, HttpException, httpJSON, getResponseStatusCode, getResponseBody)
 import           Path
 import           Path.IO
 import           Stack.Constants
```

(2)
```
src/Stack/New.hs:287:20: Error: Use alternative
Found:
  httpJSON
Why not:
  Network.HTTP.StackClient.httpJSON

1 hint
```