### PR TITLE
Fix typos

### DIFF
--- a/src/Stack/Fetch.hs
+++ b/src/Stack/Fetch.hs
@@ -351,8 +351,8 @@ withCabalLoader inner = do
                  -> IO ByteString
         doLookup ident = do
             bothCaches <- unliftIO u getPackageCaches
-            eres <- unliftIO u $ lookupPackageIdentifierExact ident bothCaches
-            case eres of
+            mres <- unliftIO u $ lookupPackageIdentifierExact ident bothCaches
+            case mres of
                 Just bs -> return bs
                 -- Update the cache and try again
                 Nothing -> do

--- a/src/Stack/Snapshot.hs
+++ b/src/Stack/Snapshot.hs
@@ -308,7 +308,7 @@ loadResolver (ResolverCustom url loc) = do
                   case sdResolver parent' of
                     ResolverStackage snapName -> snapNameToHash snapName
                     ResolverCustom _ parentHash -> parentHash
-                    ResolverCompiler _ -> error "loadResolver: Receieved ResolverCompiler in impossible location"
+                    ResolverCompiler _ -> error "loadResolver: Received ResolverCompiler in impossible location"
             return (Right parent', hash')
       return $ overrideCompiler sd0
         { sdParent = parent'


### PR DESCRIPTION
Two typos I came across while tweaking the code, nothing major

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
