### PR TITLE
Fix off-by-one and char encoding issue #3649 #3702

### DIFF
--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -32,7 +33,6 @@ module Stack.Build.Cache
     , BuildCache(..)
     ) where
 
-import           Stack.Constants
 import           Stack.Prelude
 import           Crypto.Hash (hashWith, SHA256(..))
 import           Control.Monad.Trans.Maybe
@@ -40,6 +40,9 @@ import qualified Data.ByteArray as Mem (convert)
 import qualified Data.ByteString.Base64.URL as B64URL
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as S8
+#ifdef mingw32_HOST_OS
+import           Data.Char (ord)
+#endif
 import qualified Data.Map as M
 import qualified Data.Set as Set
 import qualified Data.Store as Store
@@ -287,14 +290,12 @@ precompiledCacheFile loc copts installedPackageIDs = do
     -- See #3649 - shorten the paths on windows if MAX_PATH will be
     -- violated. Doing this only when necessary allows use of existing
     -- precompiled packages.
-    case maxPathLength of
-      Nothing -> return longPath
-      Just maxPath
-        | length (toFilePath longPath) > maxPath -> do
-            shortPkg <- shaPath pkg
-            shortHash <- shaPath hashPath
-            return $ precompiledDir </> shortPkg </> shortHash
-        | otherwise -> return longPath
+    if pathTooLong (toFilePath longPath) then do
+        shortPkg <- shaPath pkg
+        shortHash <- shaPath hashPath
+        return $ precompiledDir </> shortPkg </> shortHash
+    else
+        return longPath
 
 -- | Write out information about a newly built package
 writePrecompiledCache :: (MonadThrow m, MonadReader env m, HasEnvConfig env, MonadIO m, MonadLogger m)
@@ -353,3 +354,20 @@ readPrecompiledCache loc copts depIDs = runMaybeT $
         { pcLibrary = mkAbs' <$> pcLibrary pc0
         , pcExes = mkAbs' <$> pcExes pc0
         }
+
+-- | Check if a filesystem path is too long.
+pathTooLong :: FilePath -> Bool
+#ifdef mingw32_HOST_OS
+pathTooLong path = utf16StringLength path >= win32MaxPath
+  where
+    win32MaxPath = 260
+    -- Calculate the length of a string in 16-bit units
+    -- if it were converted to utf-16.
+    utf16StringLength :: String -> Integer
+    utf16StringLength = sum . map utf16CharLength
+      where
+        utf16CharLength c | ord c < 0x10000 = 1
+                          | otherwise       = 2
+#else
+pathTooLong _ = False
+#endif

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -33,7 +32,6 @@ module Stack.Constants
     ,minTerminalWidth
     ,maxTerminalWidth
     ,defaultTerminalWidth
-    ,maxPathLength
     )
     where
 
@@ -243,12 +241,3 @@ maxTerminalWidth = 200
 -- automatically detect it and when the user doesn't supply one.
 defaultTerminalWidth :: Int
 defaultTerminalWidth = 100
-
--- | Maximum length to use in paths. Is only a 'Just' value on windows,
--- corresponding to MAX_PATH.
-maxPathLength :: Maybe Int
-#ifdef mingw32_HOST_OS
-maxPathLength = Just 260
-#else
-maxPathLength = Nothing
-#endif


### PR DESCRIPTION
As described in #3649, stack fails on Windows when building project dependencies because the paths it generates for cached files are too long.  #3702 and 36c1226d19e31cc8049eadc880d0f0c773f6d9ae are fixes to this but contain an off-by-one error so builds still fail when a cache path is exactly 260 characters long.  This patch fixes the off-by-one error.

Additionally, the Windows 260 character path limit is counted in 16-bit utf-16 code units, not unicode characters.  This patch also addresses this.

This is only tested on Windows, but the non-Windows functionality should not have changed.

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

To test this I rebuilt stack and a simple yesod app and all their dependencies using this modified stack.  This had previously failed.  I also edited the CPP constant to ensure the non-Windows branch of the code compiles without error.

  