### PR TITLE
Don't close stdin for subprocesses when running Setup

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1132,7 +1132,7 @@ withSingleContext ActionContext {..} ExecuteEnv {..} task@Task {..} mdeps msuffi
                         Just (_, h) ->
                             withProc (toFilePath exeName) fullArgs
                           $ runProcess_
-                          . setStdin closed
+                          . setStdin (byteStringInput "")
                           . setStdout (useHandleOpen h)
                           . setStderr (useHandleOpen h)
                         Nothing ->


### PR DESCRIPTION
Instead, provide an empty stream.  Otherwise, operations which try to
use their stdin (for example, network's configure script) will fail
with a "bad file descriptor" error when they try to do something with
fd 0.

It looks like this was introduced a few days ago, in 0d2943ad291f6350049bfdde45d99bc9dc4dbaf3

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
