### PR TITLE
Add more queries to `stack query`

### DIFF
--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -373,12 +373,14 @@ rawBuildInfo = do
     (locals, _sourceMap) <- loadSourceMap NeedTargets defaultBuildOptsCLI
     wantedCompiler <- view $ wantedCompilerVersionL.to compilerVersionText
     actualCompiler <- view $ actualCompilerVersionL.to compilerVersionText
+    globalHints <- view globalHintsL
     return $ object
         [ "locals" .= Object (HM.fromList $ map localToPair locals)
         , "compiler" .= object
             [ "wanted" .= wantedCompiler
             , "actual" .= actualCompiler
             ]
+        , "global-hints" .= globalHints
         ]
   where
     localToPair lp =

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -46,6 +46,7 @@ import           Stack.Package
 import           Stack.PackageLocation (parseSingleCabalFileIndex)
 import           Stack.Types.Build
 import           Stack.Types.BuildPlan
+import           Stack.Types.Compiler (compilerVersionText)
 import           Stack.Types.Config
 import           Stack.Types.FlagName
 import           Stack.Types.NamedComponent
@@ -55,7 +56,7 @@ import           Stack.Types.PackageName
 import           Stack.Types.Version
 
 #ifdef WINDOWS
-import           Stack.Types.Compiler
+import           Stack.Types.Compiler (getGhcVersion)
 #endif
 import           System.FileLock (FileLock, unlockFile)
 
@@ -370,8 +371,14 @@ queryBuildInfo selectors0 =
 rawBuildInfo :: HasEnvConfig env => RIO env Value
 rawBuildInfo = do
     (locals, _sourceMap) <- loadSourceMap NeedTargets defaultBuildOptsCLI
+    wantedCompiler <- view $ wantedCompilerVersionL.to compilerVersionText
+    actualCompiler <- view $ actualCompilerVersionL.to compilerVersionText
     return $ object
         [ "locals" .= Object (HM.fromList $ map localToPair locals)
+        , "compiler" .= object
+            [ "wanted" .= wantedCompiler
+            , "actual" .= actualCompiler
+            ]
         ]
   where
     localToPair lp =

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -161,6 +161,7 @@ module Stack.Types.Config
   ,whichCompilerL
   ,envOverrideSettingsL
   ,loadedSnapshotL
+  ,globalHintsL
   ,shouldForceGhcColorFlag
   ,appropriateGhcColorFlag
   -- * Lens reexport
@@ -2005,6 +2006,9 @@ envOverrideSettingsL :: HasConfig env => Lens' env (EnvSettings -> IO EnvOverrid
 envOverrideSettingsL = configL.lens
     configEnvOverrideSettings
     (\x y -> x { configEnvOverrideSettings = y })
+
+globalHintsL :: HasBuildConfig s => Getting r s (Map PackageName (Maybe Version))
+globalHintsL = snapshotDefL.to sdGlobalHints
 
 shouldForceGhcColorFlag :: (HasRunner env, HasEnvConfig env)
                         => RIO env Bool


### PR DESCRIPTION
While looking into input-output-hk/stack2nix#84 I added a couple of queries to `stack query`, so I thought I’d share them in case someone finds them useful.

The change is pretty trivial, but if I had access to a Windows machine, I would make sure it still compiles on Windows, just in case.