### PR TITLE
Report currently building packages along with "Progress:" label

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,7 @@ Other enhancements:
   relevant on Linux where different distributions may have different
   combinations of libtinfo 5/6, ncurses 5/6, and gmp 4/5, and will allow
   simpifying the setup-info metadata YAML for future GHC releases.
+* The build progress bar reports names of packages currently building.
 * `stack setup --verbose` causes verbose output of GHC configure process.
   See [#3716](https://github.com/commercialhaskell/stack/issues/3716)
 

--- a/src/Control/Concurrent/Execute.hs
+++ b/src/Control/Concurrent/Execute.hs
@@ -73,7 +73,7 @@ instance Show ExecuteException where
 runActions :: Int -- ^ threads
            -> Bool -- ^ keep going after one task has failed
            -> [Action]
-           -> (TVar Int -> IO ()) -- ^ progress updated
+           -> (TVar Int -> TVar (Set ActionId) -> IO ()) -- ^ progress updated
            -> IO [SomeException]
 runActions threads keepGoing actions0 withProgress = do
     es <- ExecuteState
@@ -82,7 +82,7 @@ runActions threads keepGoing actions0 withProgress = do
         <*> newTVarIO Set.empty
         <*> newTVarIO 0
         <*> pure keepGoing
-    _ <- async $ withProgress $ esCompleted es
+    _ <- async $ withProgress (esCompleted es) (esInAction es)
     if threads <= 1
         then runActions' es
         else replicateConcurrently_ threads $ runActions' es

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -637,10 +637,10 @@ executePlan' installedMap0 targets plan ee@ExecuteEnv {..} = do
                     inProgress <- readTVarIO actionsVar
                     let packageNames = map (\(ActionId pkgID _) -> packageIdentifierText pkgID) (toList inProgress)
                         nowBuilding []    = ""
-                        nowBuilding names = "; [" <> T.intercalate "|" names <> "]"
+                        nowBuilding names = ": " <> T.intercalate ", " names
                     when terminal $ run $
                         logSticky $
-                            "Progress: " <> T.pack (show prev) <> "/" <> T.pack (show total) <>
+                            "Progress " <> T.pack (show prev) <> "/" <> T.pack (show total) <>
                                 nowBuilding packageNames
                     done <- atomically $ do
                         done <- readTVar doneVar


### PR DESCRIPTION
Rationale: make user feel more "in control" when waiting for these tens to hundreds of packages to be built by providing information on what is building now.

Build progress line <details><summary>before</summary>`Progress: 3/74`</details> and <details><summary>after</summary>`Progress: 3/74; [Cabal-2.0.1.1|basement-0.0.4|old-time-1.1.0.3|simple-sendfile-0.2.26|stm-2.4.4.1|stringsearch-0.3.6.6]`</details> applying this change.

Limitations: `configure` and `copy/register` stages are not covered, would require refactoring. Since these are quite fast, covering them might not worth the effect.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
