### PR TITLE
Fix --no-rerun-tests

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,10 @@ Bug fixes:
   this bug, you will likely need to delete the binary build cache
   associated with the relevant custom snapshot. See
   [#3714](https://github.com/commercialhaskell/stack/issues/3714).
+* `--no-rerun-tests` has been fixed. Previously, after running a test
+  we were forgetting to record the result, which meant that all tests
+  always ran even if they had already passed before. See
+  [#3770](https://github.com/commercialhaskell/stack/pull/3770).
 
 ## v1.6.3
 

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1735,6 +1735,8 @@ singleTest runInBase topts testsToRun ac ee task installedMap = do
                 (fmap fst mlogFile)
                 bs
 
+            setTestSuccess pkgDir
+
 -- | Implements running a package's benchmarks.
 singleBench :: HasEnvConfig env
             => (RIO env () -> IO ())

--- a/test/integration/tests/no-rerun-tests/Main.hs
+++ b/test/integration/tests/no-rerun-tests/Main.hs
@@ -1,0 +1,13 @@
+import StackTest
+import System.Directory
+import Control.Monad
+
+main :: IO ()
+main = do
+  stack ["test"]
+  exists1 <- doesFileExist "foo"
+  unless exists1 $ error "exists1 should be True"
+  removeFile "foo"
+  stack ["test", "--no-rerun-tests"]
+  exists2 <- doesFileExist "foo"
+  when exists2 $ error "exists2 should be False"

--- a/test/integration/tests/no-rerun-tests/files/.gitignore
+++ b/test/integration/tests/no-rerun-tests/files/.gitignore
@@ -1,0 +1,4 @@
+.stack-work/
+files.cabal
+*~
+foo

--- a/test/integration/tests/no-rerun-tests/files/package.yaml
+++ b/test/integration/tests/no-rerun-tests/files/package.yaml
@@ -1,0 +1,12 @@
+name:                files
+
+dependencies:
+- base >= 4.7 && < 5
+
+library:
+  source-dirs: src
+
+tests:
+  test:
+    main:                Spec.hs
+    source-dirs:         test

--- a/test/integration/tests/no-rerun-tests/files/stack.yaml
+++ b/test/integration/tests/no-rerun-tests/files/stack.yaml
@@ -1,0 +1,1 @@
+resolver: ghc-8.2.2

--- a/test/integration/tests/no-rerun-tests/files/test/Spec.hs
+++ b/test/integration/tests/no-rerun-tests/files/test/Spec.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = writeFile "foo" ""


### PR DESCRIPTION
Demonstrates that --no-rerun-tests does not work, and tests are in fact
still rerun.

__NOTE__ DO NOT MERGE yet. We still need to fix this, the test case just fails for now.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
