### PR TITLE
fix hlint suggestions from hlint-2.0.13

### DIFF
--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -670,7 +670,7 @@ getLocalPackages = do
                               $ C.package
                               $ C.packageDescription gpd
                       in (name, (gpd, loc))
-            deps <- (map wrapGPD . concat)
+            deps <- map wrapGPD . concat
                 <$> mapM (parseMultiCabalFilesIndex root) (bcDependencies bc)
 
             checkDuplicateNames $

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -310,7 +310,7 @@ runContainerAndExit getCmdArgs
              (Files.createSymbolicLink
                  (toFilePathNoTrailingSep sshDir)
                  (toFilePathNoTrailingSep (sandboxHomeDir </> sshRelDir))))
-     containerID <- withWorkingDir projectRoot $ (trim . decodeUtf8) <$> readDockerProcess
+     containerID <- withWorkingDir projectRoot $ trim . decodeUtf8 <$> readDockerProcess
        (concat
          [["create"
           ,"--net=host"

--- a/src/Stack/Ghci/Script.hs
+++ b/src/Stack/Ghci/Script.hs
@@ -87,7 +87,7 @@ commandToBuilder (Module modules)
   | otherwise      =
        fromText ":module + "
     <> mconcat (intersperse (fromText " ")
-        $ (stringUtf8 . quoteFileName . mconcat . intersperse "." . components) <$> S.toAscList modules)
+        $ stringUtf8 . quoteFileName . mconcat . intersperse "." . components <$> S.toAscList modules)
     <> fromText "\n"
 
 -- | Make sure that a filename with spaces in it gets the proper quotes.

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -72,7 +72,7 @@ initProject whichCmd currDir initOpts mresolver = do
         find  = findCabalDirs (includeSubDirs initOpts)
         dirs' = if null dirs then [currDir] else dirs
     logInfo "Looking for .cabal or package.yaml files to use to init the project."
-    cabaldirs <- (Set.toList . Set.unions) <$> mapM find dirs'
+    cabaldirs <- Set.toList . Set.unions <$> mapM find dirs'
     (bundle, dupPkgs)  <- cabalPackagesCheck cabaldirs noPkgMsg Nothing
 
     (sd, flags, extraDeps, rbundle) <- getDefaultResolver whichCmd dest initOpts

--- a/src/Stack/Options/DockerParser.hs
+++ b/src/Stack/Options/DockerParser.hs
@@ -25,11 +25,11 @@ dockerOptsParser hide0 =
                        "using a Docker container. --docker implies 'system-ghc: true'"
                        hide
     <*> fmap First
-           ((Just . DockerMonoidRepo) <$> option str (long (dockerOptName dockerRepoArgName) <>
+           (Just . DockerMonoidRepo <$> option str (long (dockerOptName dockerRepoArgName) <>
                                                      hide <>
                                                      metavar "NAME" <>
                                                      help "Docker repository name") <|>
-             (Just . DockerMonoidImage) <$> option str (long (dockerOptName dockerImageArgName) <>
+             Just . DockerMonoidImage <$> option str (long (dockerOptName dockerImageArgName) <>
                                                       hide <>
                                                       metavar "IMAGE" <>
                                                       help "Exact Docker image ID (overrides docker-repo)") <|>

--- a/src/Stack/PackageLocation.hs
+++ b/src/Stack/PackageLocation.hs
@@ -279,7 +279,7 @@ parseMultiCabalFilesIndex
   -> PackageLocationIndex Subdirs
   -> RIO env [(GenericPackageDescription, PackageLocationIndex FilePath)]
 parseMultiCabalFilesIndex _root (PLIndex pir) =
-  (pure . (, PLIndex pir)) <$>
+  pure . (, PLIndex pir) <$>
   readPackageUnresolvedIndex pir
 parseMultiCabalFilesIndex root (PLOther loc0) =
   map (\lpv -> (lpvGPD lpv, PLOther $ lpvLoc lpv)) <$>

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -229,7 +229,7 @@ withMiniConfigAndLock
 withMiniConfigAndLock go@GlobalOpts{..} inner = withRunnerGlobal go $ \runner -> do
     miniConfig <-
         runRIO runner $
-        (loadMiniConfig . lcConfig) <$>
+        loadMiniConfig . lcConfig <$>
         loadConfigMaybeProject
           globalConfigMonoid
           globalResolver

--- a/src/Stack/Snapshot.hs
+++ b/src/Stack/Snapshot.hs
@@ -276,7 +276,7 @@ loadResolver (ResolverCustom url loc) = do
       mdir <-
         case loc of
           Left _ -> return Nothing
-          Right fp' -> (Just . parent) <$> liftIO (Dir.canonicalizePath fp' >>= parseAbsFile)
+          Right fp' -> Just . parent <$> liftIO (Dir.canonicalizePath fp' >>= parseAbsFile)
 
       -- Deal with the dual nature of the compiler key, which either
       -- means "use this compiler" or "override the compiler in the

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -503,7 +503,7 @@ findCabalDirs
   :: HasConfig env
   => Bool -> Path Abs Dir -> RIO env (Set (Path Abs Dir))
 findCabalDirs recurse dir =
-    (Set.fromList . map parent)
+    Set.fromList . map parent
     <$> liftIO (findFiles dir isHpackOrCabal subdirFilter)
   where
     subdirFilter subdir = recurse && not (isIgnored subdir)

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -229,7 +229,7 @@ instance subdirs ~ Subdirs => ToJSON (PackageLocation subdirs) where
 
 instance subdirs ~ Subdirs => FromJSON (WithJSONWarnings (PackageLocationIndex subdirs)) where
     parseJSON v
-        = ((noJSONWarnings . PLIndex) <$> parseJSON v)
+        = (noJSONWarnings . PLIndex <$> parseJSON v)
       <|> (fmap PLOther <$> parseJSON v)
 
 instance subdirs ~ Subdirs => FromJSON (WithJSONWarnings (PackageLocation subdirs)) where

--- a/src/Stack/Types/Docker.hs
+++ b/src/Stack/Types/Docker.hs
@@ -109,8 +109,8 @@ instance FromJSON (WithJSONWarnings DockerOptsMonoid) where
     (\o -> do dockerMonoidDefaultEnable    <- pure (Any True)
               dockerMonoidEnable           <- First <$> o ..:? dockerEnableArgName
               dockerMonoidRepoOrImage      <- First <$>
-                                              (((Just . DockerMonoidImage) <$> o ..: dockerImageArgName) <|>
-                                              ((Just . DockerMonoidRepo) <$> o ..: dockerRepoArgName) <|>
+                                              ((Just . DockerMonoidImage <$> o ..: dockerImageArgName) <|>
+                                              (Just . DockerMonoidRepo <$> o ..: dockerRepoArgName) <|>
                                               pure Nothing)
               dockerMonoidRegistryLogin    <- First <$> o ..:? dockerRegistryLoginArgName
               dockerMonoidRegistryUsername <- First <$> o ..:? dockerRegistryUsernameArgName


### PR DESCRIPTION
Looks like a new version of hlint has added some suggestions for our code, which is causing CI failures for PRs (eg #3763 and #3761)

This applies the changes hlint suggests.

They all appear to be   `(blah . foo) <$> something`  ====>  `blah . foo <$> something`

Can't say this seems like the most important suggestion ever, but it seems equally readable before and after, so this seems like the easiest way to shut hlint up unless someone has an objection.