### PR TITLE
Add rio package as a dep of stack

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -92,6 +92,7 @@ dependencies:
 - regex-applicative-text
 - resourcet
 - retry
+- rio
 - semigroups
 - split
 - stm
@@ -132,7 +133,6 @@ when:
 library:
   source-dirs:
   - src/
-  - subs/rio/src/
   ghc-options:
   - -fwarn-identities
   exposed-modules:
@@ -150,12 +150,8 @@ library:
   - Options.Applicative.Builder.Extra
   - Options.Applicative.Complicated
   - Path.CheckInstall
-  - Path.Extra
   - Path.Find
   - Paths_stack
-  - RIO
-  - RIO.Logger
-  - RIO.Process
   - Stack.Build
   - Stack.Build.Cache
   - Stack.Build.ConstructPlan


### PR DESCRIPTION
Otherwise, "stack ghci" fails to run due to

> The following modules are present in multiple packages:
>  * Path.Extra (in stack, rio)
>  * RIO (in stack, rio)
>  * RIO.Logger (in stack, rio)
>  * RIO.Prelude (in stack, rio)
>  * RIO.Process (in stack, rio)
