### PR TITLE
With ghci, allow multiple packages to use the same module #3776

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -65,6 +65,9 @@ Bug fixes:
   this bug, you will likely need to delete the binary build cache
   associated with the relevant custom snapshot. See
   [#3714](https://github.com/commercialhaskell/stack/issues/3714).
+* `stack ghci` now allows loading multiple packages with the same
+  module name, as long as they are the same filepath. See
+  [#3776](https://github.com/commercialhaskell/stack/pull/3776).
 
 ## v1.6.3
 

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -26,7 +26,6 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Distribution.PackageDescription as C
-import qualified Distribution.Text as C
 import           Path
 import           Path.Extra (toFilePathNoTrailingSep)
 import           Path.IO hiding (withSystemTempDir)
@@ -77,13 +76,21 @@ data GhciPkgInfo = GhciPkgInfo
     { ghciPkgName :: !PackageName
     , ghciPkgOpts :: ![(NamedComponent, BuildInfoOpts)]
     , ghciPkgDir :: !(Path Abs Dir)
-    , ghciPkgModules :: !(Set ModuleName)
-    , ghciPkgModFiles :: !(Set (Path Abs File)) -- ^ Module file paths.
+    , ghciPkgModules :: !ModuleMap
     , ghciPkgCFiles :: !(Set (Path Abs File)) -- ^ C files.
     , ghciPkgMainIs :: !(Map NamedComponent (Set (Path Abs File)))
     , ghciPkgTargetFiles :: !(Maybe (Set (Path Abs File)))
     , ghciPkgPackage :: !Package
     } deriving Show
+
+-- Mapping from a module name to a map with all of the paths that use
+-- that name. Each of those paths is associated with a set of components
+-- that contain it. Purpose of this complex structure is for use in
+-- 'checkForDuplicateModules'.
+type ModuleMap = Map ModuleName (Map (Path Abs File) (Set (PackageName, NamedComponent)))
+
+unionModuleMaps :: [ModuleMap] -> ModuleMap
+unionModuleMaps = M.unionsWith (M.unionWith S.union)
 
 data GhciException
     = InvalidPackageOption String
@@ -418,7 +425,7 @@ renderScript isIntero pkgs mainFile onlyMain extraFiles = do
             Just path -> [Right path]
             _ -> []
         modulePhase = cmdModule $ S.fromList allModules
-        allModules = concatMap (S.toList . ghciPkgModules) pkgs
+        allModules = nubOrd $ concatMap (M.keys . ghciPkgModules) pkgs
     case getFileTargets pkgs <> extraFiles of
         [] ->
           if onlyMain
@@ -602,8 +609,9 @@ makeGhciPkgInfo buildOptsCLI sourceMap installedMap locals addPkgs mfileTargets 
         { ghciPkgName = packageName pkg
         , ghciPkgOpts = M.toList filteredOpts
         , ghciPkgDir = parent cabalfp
-        , ghciPkgModules = mconcat (M.elems (filterWanted mods))
-        , ghciPkgModFiles = mconcat (M.elems (filterWanted (M.map (setMapMaybe dotCabalModulePath) files)))
+        , ghciPkgModules = unionModuleMaps $
+          map (\(comp, mp) -> M.map (\fp -> M.singleton fp (S.singleton (packageName pkg, comp))) mp)
+              (M.toList (filterWanted mods))
         , ghciPkgMainIs = M.map (setMapMaybe dotCabalMainPath) files
         , ghciPkgCFiles = mconcat (M.elems (filterWanted (M.map (setMapMaybe dotCabalCFilePath) files)))
         , ghciPkgTargetFiles = mfileTargets >>= M.lookup name
@@ -696,20 +704,28 @@ borderedWarning f = do
     logWarn ""
     return x
 
-checkForDuplicateModules :: HasLogFunc env => [GhciPkgInfo] -> RIO env ()
+-- TODO: Should this also tell the user the filepaths, not just the
+-- module name?
+checkForDuplicateModules :: HasRunner env => [GhciPkgInfo] -> RIO env ()
 checkForDuplicateModules pkgs = do
     unless (null duplicates) $ do
         borderedWarning $ do
-            logWarn "The following modules are present in multiple packages:"
-            forM_ duplicates $ \(mn, pns) -> do
-                logWarn (" * " <> T.pack mn <> " (in " <> T.intercalate ", " (map packageNameText pns) <> ")")
+            prettyError $ "Multiple files use the same module name:" <>
+              line <> bulletedList (map prettyDuplicate duplicates)
         throwM LoadingDuplicateModules
   where
-    duplicates, allModules :: [(String, [PackageName])]
-    duplicates = filter (not . null . tail . snd) allModules
-    allModules =
-        M.toList $ M.fromListWith (++) $
-        concatMap (\pkg -> map ((, [ghciPkgName pkg]) . C.display) (S.toList (ghciPkgModules pkg))) pkgs
+    duplicates :: [(ModuleName, Map (Path Abs File) (Set (PackageName, NamedComponent)))]
+    duplicates =
+      filter (\(_, mp) -> M.size mp > 1) $
+      M.toList $
+      unionModuleMaps (map ghciPkgModules pkgs)
+    prettyDuplicate :: (ModuleName, Map (Path Abs File) (Set (PackageName, NamedComponent))) -> AnsiDoc
+    prettyDuplicate (mn, mp) =
+      styleError (display mn) <+> "found at the following paths" <> line <>
+      bulletedList (map fileDuplicate (M.toList mp))
+    fileDuplicate :: (Path Abs File, Set (PackageName, NamedComponent)) -> AnsiDoc
+    fileDuplicate (fp, comps) =
+      display fp <+> parens (fillSep (punctuate "," (map display (S.toList comps))))
 
 targetWarnings
   :: HasRunner env

--- a/src/Stack/PrettyPrint.hs
+++ b/src/Stack/PrettyPrint.hs
@@ -37,6 +37,8 @@ module Stack.PrettyPrint
 import           Stack.Prelude
 import           Data.List (intersperse)
 import qualified Data.Text as T
+import qualified Distribution.ModuleName as C (ModuleName)
+import qualified Distribution.Text as C (display)
 import           Stack.Types.NamedComponent
 import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageName
@@ -210,6 +212,9 @@ instance Display (Path b Dir) where
 
 instance Display (PackageName, NamedComponent) where
     display = cyan . fromString . T.unpack . renderPkgComponent
+
+instance Display C.ModuleName where
+    display = fromString . C.display
 
 -- Display milliseconds.
 displayMilliseconds :: Clock.TimeSpec -> AnsiDoc

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -126,7 +126,7 @@ newtype GetPackageOpts = GetPackageOpts
                      -> [PackageName]
                      -> Path Abs File
                      -> RIO env
-                          (Map NamedComponent (Set ModuleName)
+                          (Map NamedComponent (Map ModuleName (Path Abs File))
                           ,Map NamedComponent (Set DotCabalPath)
                           ,Map NamedComponent BuildInfoOpts)
     }
@@ -155,7 +155,7 @@ newtype GetPackageFiles = GetPackageFiles
     { getPackageFiles :: forall env. HasEnvConfig env
                       => Path Abs File
                       -> RIO env
-                           (Map NamedComponent (Set ModuleName)
+                           (Map NamedComponent (Map ModuleName (Path Abs File))
                            ,Map NamedComponent (Set DotCabalPath)
                            ,Set (Path Abs File)
                            ,[PackageWarning])


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Tested by running against a repro with a duplicate module, got expected error.  Tested running against the stack repo (where the rio package shares a module), and no longer get an error (the issue described in #3776)