### PR TITLE
Adjustments to plan construction error messages #3766

### DIFF
--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -957,29 +957,33 @@ pprintExceptions exceptions stackYaml parentMap wanted =
       , line <> line
       , mconcat (intersperse (line <> line) (mapMaybe pprintException exceptions'))
       , line <> line
-      , flow "Some potential ways to resolve this:"
+      , flow "Some different approaches to resolving this:"
+      , line <> line
+      ] ++
+      (if not onlyHasDependencyMismatches then [] else
+         [ "  *" <+> align (flow "Set 'allow-newer: true' to ignore all version constraints and build anyway.")
+         , line <> line
+         ]
+      ) ++
+      [ "  *" <+> align (flow "Consider trying 'stack solver', which uses the cabal-install solver to attempt to find some working build configuration. This can be convenient when dealing with many complicated constraint errors, but results may be unpredictable.")
       , line <> line
       ] ++
       (if Map.null extras then [] else
          [ "  *" <+> align
-           (flow "Recommended action: try adding the following to your extra-deps in" <+>
+           (styleRecommendation (flow "Recommended action:") <+>
+            flow "try adding the following to your extra-deps in" <+>
             toAnsiDoc (display stackYaml) <> ":")
          , line <> line
          , vsep (map pprintExtra (Map.toList extras))
-         , line <> line
+         , line
          ]
-      ) ++
-      [ "  *" <+> align (flow "Set 'allow-newer: true' to ignore all version constraints and build anyway.")
-      , line <> line
-      , "  *" <+> align (flow "You may also want to try using the 'stack solver' command.")
-      , line
-      ]
+      )
   where
     exceptions' = nubOrd exceptions
 
     extras = Map.unions $ map getExtras exceptions'
-    getExtras (DependencyCycleDetected _) = Map.empty
-    getExtras (UnknownPackage _) = Map.empty
+    getExtras DependencyCycleDetected{} = Map.empty
+    getExtras UnknownPackage{} = Map.empty
     getExtras (DependencyPlanFailures _ m) =
        Map.unions $ map go $ Map.toList m
      where
@@ -996,6 +1000,17 @@ pprintExceptions exceptions stackYaml parentMap wanted =
     toNotInBuildPlan (DependencyPlanFailures _ pDeps) =
       map fst $ filter (\(_, (_, _, badDep)) -> badDep == NotInBuildPlan) $ Map.toList pDeps
     toNotInBuildPlan _ = []
+
+    -- This checks if 'allow-newer: true' could resolve all issues.
+    onlyHasDependencyMismatches = all go exceptions'
+      where
+        go DependencyCycleDetected{} = False
+        go UnknownPackage{} = False
+        go (DependencyPlanFailures _ m) =
+          all (\(_, _, depErr) -> isMismatch depErr) (M.elems m)
+        isMismatch DependencyMismatch{} = True
+        isMismatch Couldn'tResolveItsDependencies{} = True
+        isMismatch _ = False
 
     pprintException (DependencyCycleDetected pNames) = Just $
         flow "Dependency cycle detected in packages:" <> line <>
@@ -1035,7 +1050,9 @@ pprintExceptions exceptions stackYaml parentMap wanted =
     pprintDep (name, (range, mlatestApplicable, badDep)) = case badDep of
         NotInBuildPlan -> Just $
             styleError (display name) <+>
-            align (flow "must match" <+> goodRange <> "," <> softline <>
+            align ((if range == Cabal.anyVersion
+                      then flow "needed"
+                      else flow "must match" <+> goodRange) <> "," <> softline <>
                    flow "but the stack configuration has no specified version" <>
                    latestApplicable Nothing)
         -- TODO: For local packages, suggest editing constraints

--- a/src/Stack/PrettyPrint.hs
+++ b/src/Stack/PrettyPrint.hs
@@ -18,6 +18,7 @@ module Stack.PrettyPrint
     , styleWarning, styleError, styleGood
     , styleShell, styleFile, styleUrl, styleDir, styleModule
     , styleCurrent, styleTarget
+    , styleRecommendation
     , displayMilliseconds
       -- * Formatting utils
     , bulletedList
@@ -178,6 +179,10 @@ styleUrl = styleFile
 -- | Style an 'AnsiDoc' as a directory name. See 'styleFile' for files.
 styleDir :: AnsiDoc -> AnsiDoc
 styleDir = bold . blue
+
+-- | Style used to highlight part of a recommended course of action.
+styleRecommendation :: AnsiDoc -> AnsiDoc
+styleRecommendation = bold . green
 
 -- | Style an 'AnsiDoc' in a way that emphasizes that it is related to
 --   a current thing. For example, could be used when talking about the


### PR DESCRIPTION
* Makes it so that it doesn't output '-any' to describe a version range.

* Doesn't suggest "allow-newer" if some errors aren't constraint mismatches.

* Reorders them so that the recommended action comes last.  This also looks
  better because it has a dedented listing of extra-deps.

* Gives a rough / brief reason why approaches other than 'stack solver' may be
  preferred.

New output:

![2018-01-15_1449x440_scrot](https://user-images.githubusercontent.com/22570/34936212-63c53f74-f995-11e7-87cb-96371e537ba0.png)
