### PR TITLE
Fix inheritance of category ghc-options from config.yaml #3753

### DIFF
--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -828,17 +828,16 @@ parseConfigMonoidObject rootDir obj = do
     optionsEverything <-
       case (Map.lookup GOKOldEverything options, Map.lookup GOKEverything options) of
         (Just _, Just _) -> fail "Cannot specify both `*` and `$everything` GHC options"
-        (Nothing, Just x) -> return x
+        (Nothing, Just x) -> return (Just x)
         (Just x, Nothing) -> do
           tell "The `*` ghc-options key is not recommended. Consider using $locals, or if really needed, $everything"
-          return x
-        (Nothing, Nothing) -> return []
+          return (Just x)
+        (Nothing, Nothing) -> return Nothing
 
-    let configMonoidGhcOptionsByCat = Map.fromList
-          [ (AGOEverything, optionsEverything)
-          , (AGOLocals, Map.findWithDefault [] GOKLocals options)
-          , (AGOTargets, Map.findWithDefault [] GOKTargets options)
-          ]
+    let configMonoidGhcOptionsByCat = Map.fromList $
+          maybeToList (fmap (AGOEverything,) optionsEverything) ++
+          maybeToList (fmap (AGOLocals,) (Map.lookup GOKLocals options)) ++
+          maybeToList (fmap (AGOTargets,) (Map.lookup GOKTargets options))
 
         configMonoidGhcOptionsByName = Map.fromList
             [(name, opts) | (GOKPackage name, opts) <- Map.toList options]


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Tried the repro in #3753 and it works.

NOTE: Needs a changelog!  Haven't written one yet, since the desired semantics for ghc-options isn't yet clear to me.  It's either "shadowing" or "extending" prior ghc-options settings.  Previous semantics were "shadowing".