### PR TITLE
Typo in cabal option --with-hc-pkg

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -843,8 +843,8 @@ ensureConfig newConfigCache pkgDir ExecuteEnv {..} announce cabal cabalfp task =
         menv <- view envOverrideL
         let programNames =
                 if eeCabalPkgVer < $(mkVersion "1.22")
-                    then ["ghc", "ghc-pkg"]
-                    else ["ghc", "ghc-pkg", "ghcjs", "ghcjs-pkg"]
+                    then ["ghc", "hc-pkg"]
+                    else ["ghc", "hc-pkg", "ghcjs", "ghcjs-pkg"]
         exes <- forM programNames $ \name -> do
             mpath <- findExecutable menv name
             return $ case mpath of


### PR DESCRIPTION
Cabal has no option --with-ghc-pkg
Probably intended was:  --with-hc-pkg
Check here: https://www.haskell.org/cabal/users-guide/search.html?q=with-hc-pkg&check_keywords=yes&area=default#
Or am I wrong? Why did it work so far?