### PR TITLE
Avoid stdout redirection in script --compile

### DIFF
--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -421,9 +421,7 @@ addUnlistedToBuildCache preBuildTime pkg cabalFP nonLibComponents buildCaches = 
             Nothing -> return Map.empty
             Just modTime' ->
                 if modTime' < preBuildTime
-                    then do
-                        newFci <- calcFci modTime' fp
-                        return (Map.singleton fp newFci)
+                    then Map.singleton fp <$> calcFci modTime' fp
                     else return Map.empty
 
 -- | Gets list of Paths for files relevant to a set of components in a package.

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -340,9 +340,8 @@ resolveRawTarget globals snap deps locals (ri, rt) =
               , rrPackageType = Dependency
               }
       where
-        getLatestVersion pn = do
-            vs <- getPackageVersions pn
-            return (fmap fst (Set.maxView vs))
+        getLatestVersion pn =
+            fmap fst . Set.maxView <$> getPackageVersions pn
 
     go (RTPackageIdentifier ident@(PackageIdentifier name version))
       | Map.member name locals = return $ Left $ T.concat

--- a/src/Stack/Docker/GlobalDB.hs
+++ b/src/Stack/Docker/GlobalDB.hs
@@ -59,10 +59,13 @@ updateDockerImageLastUsed config imageId projectPath =
 -- | Get a list of Docker image hashes and when they were last used.
 getDockerImagesLastUsed :: Config -> IO [DockerImageLastUsed]
 getDockerImagesLastUsed config =
-  do imageProjects <- withGlobalDB config (selectList [] [Asc DockerImageProjectLastUsedTime])
-     return (sortBy (flip sortImage)
-                    (Map.toDescList (Map.fromListWith (++)
-                                                      (map mapImageProject imageProjects))))
+      sortBy (flip sortImage)
+    . Map.toDescList
+    . Map.fromListWith (++)
+    . map mapImageProject
+  <$> withGlobalDB
+        config
+        (selectList [] [Asc DockerImageProjectLastUsedTime])
   where
     mapImageProject (Entity _ imageProject) =
       (dockerImageProjectImageHash imageProject
@@ -85,9 +88,9 @@ pruneDockerImagesLastUsed config existingHashes =
 -- | Get the record of whether an executable is compatible with a Docker image
 getDockerImageExe :: Config -> String -> FilePath -> UTCTime -> IO (Maybe Bool)
 getDockerImageExe config imageId exePath exeTimestamp =
-    withGlobalDB config $ do
-        mentity <- getBy (DockerImageExeUnique imageId exePath exeTimestamp)
-        return (fmap (dockerImageExeCompatible . entityVal) mentity)
+    withGlobalDB config $
+      fmap (dockerImageExeCompatible . entityVal) <$>
+      getBy (DockerImageExeUnique imageId exePath exeTimestamp)
 
 -- | Seet the record of whether an executable is compatible with a Docker image
 setDockerImageExe :: Config -> String -> FilePath -> UTCTime -> Bool -> IO ()

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -66,11 +66,12 @@ buildConfigCompleter inner = mkCompleter $ \inputRaw -> do
               runRIO envConfig (inner input)
 
 targetCompleter :: Completer
-targetCompleter = buildConfigCompleter $ \input -> do
-    lpvs <- fmap lpProject getLocalPackages
-    return $
-        filter (input `isPrefixOf`) $
-        concatMap allComponentNames (Map.toList lpvs)
+targetCompleter = buildConfigCompleter $ \input ->
+      filter (input `isPrefixOf`)
+    . concatMap allComponentNames
+    . Map.toList
+    . lpProject
+  <$> getLocalPackages
   where
     allComponentNames (name, lpv) =
         map (T.unpack . renderPkgComponent . (name,)) (Set.toList (lpvComponents lpv))
@@ -103,10 +104,14 @@ flagCompleter = buildConfigCompleter $ \input -> do
             _ -> normalFlags
 
 projectExeCompleter :: Completer
-projectExeCompleter = buildConfigCompleter $ \input -> do
-    lpvs <- fmap lpProject getLocalPackages
-    return $
-        filter (input `isPrefixOf`) $
-        nubOrd $
-        concatMap (\(_, lpv) -> map (C.unUnqualComponentName . fst) (C.condExecutables (lpvGPD lpv))) $
-        Map.toList lpvs
+projectExeCompleter = buildConfigCompleter $ \input ->
+      filter (input `isPrefixOf`)
+    . nubOrd
+    . concatMap
+        (\(_, lpv) -> map
+          (C.unUnqualComponentName . fst)
+          (C.condExecutables (lpvGPD lpv))
+        )
+    . Map.toList
+    . lpProject
+  <$> getLocalPackages

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -41,9 +41,8 @@ import           Lens.Micro
 loadCompilerVersion :: GlobalOpts
                     -> LoadConfig
                     -> IO (CompilerVersion 'CVWanted)
-loadCompilerVersion go lc = do
-    bconfig <- lcLoadBuildConfig lc (globalCompiler go)
-    return $ view wantedCompilerVersionL bconfig
+loadCompilerVersion go lc =
+    view wantedCompilerVersionL <$> lcLoadBuildConfig lc (globalCompiler go)
 
 -- | Enforce mutual exclusion of every action running via this
 -- function, on this path, on this users account.

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -105,12 +105,15 @@ scriptCmd opts go' = do
                 (ghcArgs ++ toFilePath file : soArgs opts)
           _ -> do
             let dir = parent file
-            -- use sinkProcessStdout to ensure a ProcessFailed
-            -- exception is generated for better error messages
-            withWorkingDir dir $ sinkProcessStdout
+            -- Use readProcessStdout_ so that (1) if GHC does send any output
+            -- to stdout, we capture it and stop it from being sent to our
+            -- stdout, which could break scripts, and (2) if there's an
+            -- exception, the standard output we did capture will be reported
+            -- to the user.
+            withWorkingDir dir $ withProc
               (compilerExeName wc)
               (ghcArgs ++ [toFilePath file])
-              CL.sinkNull
+              (void . readProcessStdout_)
             exec (toExeName $ toFilePath file) (soArgs opts)
   where
     toPackageName = reverse . drop 1 . dropWhile (/= '-') . reverse

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -663,12 +663,12 @@ solveExtraDeps modStackYaml = do
     resultSpecs <- case resolverResult of
         BuildPlanCheckOk flags ->
             return $ Just (mergeConstraints oldSrcs flags, Map.empty)
-        BuildPlanCheckPartial {} -> do
-            eres <- solveResolverSpec stackYaml cabalDirs
+        BuildPlanCheckPartial {} ->
+            either (const Nothing) Just <$>
+            solveResolverSpec stackYaml cabalDirs
                               (sd, srcConstraints, extraConstraints)
             -- TODO Solver should also use the init code to ignore incompatible
             -- packages
-            return $ either (const Nothing) Just eres
         BuildPlanCheckFail {} ->
             throwM $ ResolverMismatch IsSolverCmd (sdResolverName sd) (show resolverResult)
 

--- a/src/Stack/StaticBytes.hs
+++ b/src/Stack/StaticBytes.hs
@@ -114,9 +114,8 @@ instance word8 ~ Word8 => DynamicBytes (VP.Vector word8) where
   lengthD = VP.length
   fromWordsD len words0 = unsafePerformIO $ do
     ba <- BA.newByteArray len
-    let loop _ [] = do
-          ba' <- BA.unsafeFreezeByteArray ba
-          return $ VP.Vector 0 len ba'
+    let loop _ [] =
+          VP.Vector 0 len <$> BA.unsafeFreezeByteArray ba
         loop i (w:ws) = do
           BA.writeByteArray ba i w
           loop (i + 1) ws

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -826,9 +826,8 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
                   hPutStrLn stderr ("Could not find package id of package " ++ name)
                   exitFailure
 
-      getPkgOpts wc pkgs = do
-          ids <- mapM (getPkgId wc) pkgs
-          return $ map ("-package-id=" ++) ids
+      getPkgOpts wc pkgs =
+          map ("-package-id-" ++) <$> mapM (getPkgId wc) pkgs
 
       getGhcCmd prefix pkgs args = do
           wc <- view $ actualCompilerVersionL.whichCompilerL


### PR DESCRIPTION
Not only did this complicate the code and add overhead, but it seems to
have confused GHC into sending incorrectly encoded output. With this
approach, GHC gets to send its output directly to stderr.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
    * Left out, since this is a newly introduced regression with the refactoring of the output code
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
