### PR TITLE
Comment out instructions for Ubuntu package

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -102,6 +102,10 @@ If you are on OS X 10.12 ("Sierra") and encounter [GHC panic while building, see
 
 Use the [generic Linux option](#linux).
 
+There is also a
+[Ubuntu package](http://packages.ubuntu.com/search?keywords=haskell-stack&searchon=names&suite=all&section=all) for
+Ubuntu 16.10 and up, but the distribution's Stack version lags behind, so we recommend running `stack upgrade` or `stack upgrade --binary` after installing it. The version in Ubuntu 16.04 is too old to upgrade successfully.
+
 <!-- There is also
 a
 [Ubuntu package](http://packages.ubuntu.com/search?keywords=haskell-stack&searchon=names&suite=all&section=all) for
@@ -113,11 +117,9 @@ we recommend running `stack upgrade` (--binary?) after installing it.
 
 Use the [generic Linux option](#linux).
 
-There is also
-a
+There is also a
 [Debian package](https://packages.debian.org/search?keywords=haskell-stack&searchon=names&suite=all&section=all) for
-Stretch and up. Note that the distribution's Stack version lags behind, so
-we recommend running `stack upgrade` after installing it.
+Stretch and up, but the distribution's Stack version lags behind, so we recommend running `stack upgrade` or `stack upgrade --binary` after installing it.
 
 ## <a name="centos"></a>CentOS / Red Hat / Amazon Linux
 

--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -102,11 +102,12 @@ If you are on OS X 10.12 ("Sierra") and encounter [GHC panic while building, see
 
 Use the [generic Linux option](#linux).
 
-There is also
+<!-- There is also
 a
 [Ubuntu package](http://packages.ubuntu.com/search?keywords=haskell-stack&searchon=names&suite=all&section=all) for
-Ubuntu 16.04 and up. Note that the distribution's Stack version lags behind, so
-we recommend running `stack upgrade` after installing it.
+Ubuntu 16.10 and up. (Ubuntu 16.04's package cannot upgrade). Note that the distribution's Stack version lags behind, so
+we recommend running `stack upgrade` (--binary?) after installing it.
+-->
 
 ## Debian
 


### PR DESCRIPTION
I just confirmed that Ubuntu 16.04 cannot upgrade to latest stack (or do installations). The problem might extend to later Ubuntu/Debian releases, so maybe we should just drop mentions of the package for now? Adding a commit for Debian.
This PR is still for discussion on what to do in docs, feel free to take over or merge as-is. I can't look more closely at this now.

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
