### PR TITLE
When a cabal file can't be found, warn that extra-deps could be the problem too

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,6 +32,8 @@ Other enhancements:
 * The build progress bar reports names of packages currently building.
 * `stack setup --verbose` causes verbose output of GHC configure process.
   See [#3716](https://github.com/commercialhaskell/stack/issues/3716)
+* Improve the error message when an `extra-dep` from a path or git reference can't be found
+  See [#3808](https://github.com/commercialhaskell/stack/pull/3808)
 
 Bug fixes:
 * 1.6.1 introduced a change that made some precompiled cache files use

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -52,9 +52,10 @@ instance Show PackageException where
         ]
     show (PackageNoCabalFileFound dir) = concat
         [ "Stack looks for packages in the directories configured in"
-        , " the 'packages' variable defined in your stack.yaml\n"
-        , "The current entry points to " ++ toFilePath dir ++
-          " but no .cabal file could be found there."
+        , " the 'packages' and 'extra-deps' fields defined in your stack.yaml\n"
+        , "The current entry points to "
+        , toFilePath dir
+        , " but no .cabal or package.yaml file could be found there."
         ]
     show (PackageMultipleCabalFilesFound dir files) =
         "Multiple .cabal files found in directory " ++


### PR DESCRIPTION
* Also: slight refactor to use only `concat` instead of ++ in the error message
* Also: mention that a package.yaml file would also be accepted
	* The code that throws this is only searching for a .cabal file, but it runs hpack on the directory immediately before that to generate a cabal file, so it's effectively looking for a package.yaml file as well

Closes #3806

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary. [Not necessary]

> Please also shortly describe how you tested your change. Bonus points for added tests!

I used `stack install` to install my changes, then ran that executable:

![image](https://user-images.githubusercontent.com/1274145/35401090-6f853812-01ad-11e8-8c02-622f9ea9c2da.png)
