### PR TITLE
Add stack install script ElementaryOS support

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -387,7 +387,7 @@ GETDISTRO
   fi
 
   case "$DISTRO" in
-    ubuntu|linuxmint)
+    ubuntu|linuxmint|elementary)
       do_ubuntu_install "$VERSION"
       ;;
     debian|kali|raspbian)


### PR DESCRIPTION
This small change allows the stack installer script to recognize ElementaryOS (https://elementary.io/) as a derivative of Ubuntu so that required dependency packages get installed.