### PR TITLE
Improved default .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
         - $HOME/.ghc
         - $HOME/.cabal
         - $HOME/.stack
+        - $TRAVIS_BUILD_DIR/.stack-work
 
 matrix:
   fast_finish: true

--- a/doc/travis-complex.yml
+++ b/doc/travis-complex.yml
@@ -20,6 +20,7 @@ cache:
   - $HOME/.ghc
   - $HOME/.cabal
   - $HOME/.stack
+  - $TRAVIS_BUILD_DIR/.stack-work
 
 # The different configurations we want to test. We have BUILD=cabal which uses
 # cabal-install, and BUILD=stack which uses Stack. More documentation on each
@@ -216,7 +217,11 @@ script:
         cd "$PKGVER"
         cabal configure --enable-tests --ghc-options -O0
         cabal build
-        cabal test
+        if [ "$CABALVER" = "1.16" ] || [ "$CABALVER" = "1.18" ]; then
+          cabal test
+        else
+          cabal test --show-details=streaming --log=/dev/stdout
+        fi
         cd $ORIGDIR
       done
       ;;

--- a/doc/travis-complex.yml
+++ b/doc/travis-complex.yml
@@ -163,10 +163,6 @@ before_install:
   echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
   echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
 
-  if [ "$CABALVER" != "1.16" ]
-  then
-    echo 'jobs: $ncpus' >> $HOME/.cabal/config
-  fi
 
 install:
 - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"


### PR DESCRIPTION
This PR includes speedups to default `.travis.yml` that is listed in the documentation as well as one that is used for stack. All of the changes where proven to be much better experimentally. Improvements:

* despite that there are some folders that are already being cached during Travis builds, unless `.stack-work` directory is cached the whole package will be recompiled from scratch again, as well as the dependencies.
* `ncpus` setting for cabal will parallelize compilation, but since Travis already runs multiple jobs on the same machine, that setting instead of speeding up, really slows down every build. By "really" I mean as much as factor of 10. Therefore it is removed
* by default `cabal test` will not print anything to `stdout`, therefore a long running test suite can cause a build to be killed by travis prematurely due to no output. Fixed by using `streaming` output.

In case an example of these changes in action is desired, here is a sample run that uses similar settings: https://travis-ci.org/snoyberg/tar-conduit/builds/337788675

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
