### PR TITLE
Fixes #3843, by bump to LTS 10.5

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.14
+resolver: lts-10.5
 packages:
 - .
 - subs/rio
@@ -19,22 +19,6 @@ flags:
   stack:
     hide-dependency-versions: true
     supported-build: true
-  mintty:
-    win32-2-5: false
 extra-deps:
-- Cabal-2.0.1.0
-- mintty-0.1.1
-- bindings-uname-0.1
-- path-0.6.1
-- path-io-1.3.3
-- extra-1.6
-- hsc2hs-0.68.2
-- hpack-0.20.0
-- unliftio-0.2.1.0
-- smallcheck-1.1.3
-- conduit-extra-1.2.3.1
-- typed-process-0.2.1.0
-
 # https://github.com/commercialhaskell/stack/issues/3785
 - ansi-terminal-0.8.0.1
-- ansi-wl-pprint-0.6.8.2


### PR DESCRIPTION
The content of `stack.yaml` is as suggested by `stack solver`, after changing the resolver.

`stack install` works after making this change, building `Version 1.7.0, Git revision 5286a22129ced71aa50b5177ead3180c6ad34c5c (5657 commits) x86_64 hpack-0.21.2`