### PR TITLE
Include patched hackage-security for #3073

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,6 +34,12 @@ Bug fixes:
   we were forgetting to record the result, which meant that all tests
   always ran even if they had already passed before. See
   [#3770](https://github.com/commercialhaskell/stack/pull/3770).
+* Includes a patched version of `hackage-security` which fixes both
+  some issues around asynchronous exception handling, and moves from
+  directory locking to file locking, making the update mechanism
+  resilient against SIGKILL and machine failure. See
+  [hackage-security #187](https://github.com/haskell/hackage-security/issues/187)
+  and [#3073](https://github.com/commercialhaskell/stack/issues/3073).
 
 ## v1.6.3
 

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -7,3 +7,6 @@ nix:
     - http-client-tls-0.3.4
 extra-deps:
 - hpack-0.26.0
+- archive: https://github.com/haskell/hackage-security/archive/3297b0f3f4285cb30321baaa7b54e3d22e1f6bd7.tar.gz
+  subdirs:
+  - hackage-security

--- a/stack.yaml
+++ b/stack.yaml
@@ -30,3 +30,6 @@ extra-deps:
 - ansi-terminal-0.7.1.1
 - ansi-wl-pprint-0.6.8.1
 - smallcheck-1.1.3
+- archive: https://github.com/haskell/hackage-security/archive/3297b0f3f4285cb30321baaa7b54e3d22e1f6bd7.tar.gz
+  subdirs:
+  - hackage-security


### PR DESCRIPTION
NOTE: This is included via an extra-dep, which would constitute the
first time Stack would include a patched version of an upstream library.
This is due to the fact that
https://github.com/haskell/hackage-security/pull/203 is likely not going
to be merged, despite fixing issues affecting Stack. This leaves us with
(AFAICT) 4 choices at the Stack level:

1. Continue using the officially released upstream version of
   hackage-security, bugs and all
2. Fork hackage-security on Hackage, and depend on the fork
3. Inline the code from hackage-security into Stack itself, and drop the
   explicit dependency on hackage-security
4. Include hackage-security via an `extra-dep` pointing at a Git commit.
   Our official builds will use the patched version of hackage-security,
   and anyone building from Hackage will end up with the unpatched version

This PR represents approach (4). If and when the PR is merged and
released to Hackage, this becomes a non-issue. But generally speaking,
we should have a policy in Stack for handling these kinds of upstream
issues cases.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
