### PR TITLE
Initialize a new project only when no stack.yaml

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,9 @@ Behavior changes:
   this itself since ghc-8.0.2, and Stack's attempted workaround for older
   versions caused more problems than it solved.
 
+* `stack new` no longer initializes a project if the project template contain
+   a stack.yaml file.
+
 Other enhancements:
 
 * A new sub command `ls` has been introduced to stack to view

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -935,7 +935,9 @@ newCmd :: (NewOpts,InitOpts) -> GlobalOpts -> IO ()
 newCmd (newOpts,initOpts) go@GlobalOpts{..} =
     withMiniConfigAndLock go $ do
         dir <- new newOpts (forceOverwrite initOpts)
-        initProject IsNewCmd dir initOpts globalResolver
+        exists <- doesFileExist $ dir </> stackDotYaml
+        when (forceOverwrite initOpts || not exists) $
+            initProject IsNewCmd dir initOpts globalResolver
 
 -- | List the available templates.
 templatesCmd :: () -> GlobalOpts -> IO ()


### PR DESCRIPTION
* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

`stack new` unpacks the project template and then initializes the unpacked project.   When a project template contains a stack.yaml, initializing the project fails due to the presence of the stack.yaml files.  Skip the initialization if the project template contains a stack.yaml.

The change was tested by using project templates that contain stack.yaml files.

