### PR TITLE
Bump extra-deps to ansi-terminal-0.8.0.2

### DIFF
--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -11,7 +11,7 @@ nix:
     - http-client-tls-0.3.4
 extra-deps:
 # https://github.com/commercialhaskell/stack/issues/3785
-- ansi-terminal-0.8.0.1
+- ansi-terminal-0.8.0.2
 - archive: https://github.com/haskell/hackage-security/archive/3297b0f3f4285cb30321baaa7b54e3d22e1f6bd7.tar.gz
   subdirs:
   - hackage-security

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@ flags:
     supported-build: true
 extra-deps:
 # https://github.com/commercialhaskell/stack/issues/3785
-- ansi-terminal-0.8.0.1
+- ansi-terminal-0.8.0.2
 - archive: https://github.com/haskell/hackage-security/archive/3297b0f3f4285cb30321baaa7b54e3d22e1f6bd7.tar.gz
   subdirs:
   - hackage-security


### PR DESCRIPTION
The `ansi-terminal` package is now at `0.8.0.2` on Hackage.