### PR TITLE
Switch stack.yaml to old way of specifying extra-dep tarball #3903

### DIFF
--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,11 +1,15 @@
 resolver: nightly-2018-02-18
+packages:
+- .
+- location:
+    archive: https://github.com/haskell/hackage-security/archive/3297b0f3f4285cb30321baaa7b54e3d22e1f6bd7.tar.gz
+    subdirs:
+    - hackage-security
+  extra-dep: true
+
 nix:
   # --nix on the command-line to enable.
   enable: false
   packages:
     - zlib
     - http-client-tls-0.3.4
-extra-deps:
-- archive: https://github.com/haskell/hackage-security/archive/3297b0f3f4285cb30321baaa7b54e3d22e1f6bd7.tar.gz
-  subdirs:
-  - hackage-security

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,11 @@
 resolver: lts-9.14
+packages:
+- .
+- location:
+    archive: https://github.com/haskell/hackage-security/archive/3297b0f3f4285cb30321baaa7b54e3d22e1f6bd7.tar.gz
+    subdirs:
+    - hackage-security
+  extra-dep: true
 # docker:
 #   enable: true
 #   repo: fpco/stack-full
@@ -30,6 +37,3 @@ extra-deps:
 - ansi-terminal-0.7.1.1
 - ansi-wl-pprint-0.6.8.1
 - smallcheck-1.1.3
-- archive: https://github.com/haskell/hackage-security/archive/3297b0f3f4285cb30321baaa7b54e3d22e1f6bd7.tar.gz
-  subdirs:
-  - hackage-security


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
