### PR TITLE
'stack setup' can install GHC on linux-aarch64

### DIFF
--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -296,6 +296,7 @@ configFromConfigMonoid
          configCompilerCheck = fromFirst MatchMinor configMonoidCompilerCheck
 
      case arch of
+         OtherArch "aarch64" -> return ()
          OtherArch unk -> logWarn $ "Warning: Unknown value for architecture setting: " <> T.pack (show unk)
          _ -> return ()
 

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -930,17 +930,18 @@ getOSKey :: (MonadThrow m)
          => Platform -> m Text
 getOSKey platform =
     case platform of
-        Platform I386   Cabal.Linux   -> return "linux32"
-        Platform X86_64 Cabal.Linux   -> return "linux64"
-        Platform I386   Cabal.OSX     -> return "macosx"
-        Platform X86_64 Cabal.OSX     -> return "macosx"
-        Platform I386   Cabal.FreeBSD -> return "freebsd32"
-        Platform X86_64 Cabal.FreeBSD -> return "freebsd64"
-        Platform I386   Cabal.OpenBSD -> return "openbsd32"
-        Platform X86_64 Cabal.OpenBSD -> return "openbsd64"
-        Platform I386   Cabal.Windows -> return "windows32"
-        Platform X86_64 Cabal.Windows -> return "windows64"
-        Platform Arm    Cabal.Linux   -> return "linux-armv7"
+        Platform I386                  Cabal.Linux   -> return "linux32"
+        Platform X86_64                Cabal.Linux   -> return "linux64"
+        Platform I386                  Cabal.OSX     -> return "macosx"
+        Platform X86_64                Cabal.OSX     -> return "macosx"
+        Platform I386                  Cabal.FreeBSD -> return "freebsd32"
+        Platform X86_64                Cabal.FreeBSD -> return "freebsd64"
+        Platform I386                  Cabal.OpenBSD -> return "openbsd32"
+        Platform X86_64                Cabal.OpenBSD -> return "openbsd64"
+        Platform I386                  Cabal.Windows -> return "windows32"
+        Platform X86_64                Cabal.Windows -> return "windows64"
+        Platform Arm                   Cabal.Linux   -> return "linux-armv7"
+        Platform (OtherArch "aarch64") Cabal.Linux   -> return "linux-aarch64"
         Platform arch os -> throwM $ UnsupportedSetupCombo os arch
 
 downloadFromInfo


### PR DESCRIPTION
GHC release team has provided linux-aarch64 bindists since GHC 8.2.1.  This adds support by `stack setup` to install them.  Note, however, that manual installation of the correct LLVM version is still required.
