### PR TITLE
Don't require yaml and persistent-sqlite in snapshots

### DIFF
--- a/src/Stack/Snapshot.hs
+++ b/src/Stack/Snapshot.hs
@@ -32,6 +32,7 @@ import qualified Data.Conduit.List as CL
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import           Data.Time (toGregorian)
 import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8)
 import           Data.Yaml (decodeFileEither, ParseException (AesonException))
@@ -686,10 +687,9 @@ findPackage platform compilerVersion (gpd, loc, localLoc) = do
   where
     PackageIdentifier name _version = fromCabalPackageIdentifier $ C.package $ C.packageDescription gpd
 
--- | Some hard-coded fixes for build plans, hopefully to be irrelevant over
--- time.
+-- | Some hard-coded fixes for build plans, only for hysterical raisins.
 snapshotDefFixes :: SnapshotDef -> SnapshotDef
-snapshotDefFixes sd | isStackage (sdResolver sd) = sd
+snapshotDefFixes sd | isOldStackage (sdResolver sd) = sd
     { sdFlags = Map.unionWith Map.union overrides $ sdFlags sd
     }
   where
@@ -698,8 +698,12 @@ snapshotDefFixes sd | isStackage (sdResolver sd) = sd
       , ($(mkPackageName "yaml"), Map.singleton $(mkFlagName "system-libyaml") False)
       ]
 
-    isStackage (ResolverSnapshot _) = True
-    isStackage _ = False
+    -- Only apply this hack to older Stackage snapshots. In
+    -- particular, nightly-2018-03-13 did not contain these two
+    -- packages.
+    isOldStackage (ResolverSnapshot (LTS major _)) = major < 11
+    isOldStackage (ResolverSnapshot (Nightly (toGregorian -> (year, _, _)))) = year < 2018
+    isOldStackage _ = False
 snapshotDefFixes sd = sd
 
 -- | Convert a global 'LoadedPackageInfo' to a snapshot one by


### PR DESCRIPTION
The recent nightly-2018-03-13 uncovered a bug in Stack: it assumes that
these two packages are present in all snapshots to apply a historical,
hacky fix. The hacky fix has not been required for quite some time, so
we simply gate on whether we're using an older snapshot or not.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
