### PR TITLE
Install zlib development package

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -188,7 +188,7 @@ do_debian_install() {
 # and install the necessary dependencies explicitly.
 do_fedora_install() {
   install_dependencies() {
-    dnf_install_pkgs perl make automake gcc gmp-devel libffi zlib xz tar
+    dnf_install_pkgs perl make automake gcc gmp-devel libffi zlib-devel xz tar
   }
 
   if is_64_bit ; then


### PR DESCRIPTION
When building programs on Fedora Linux, you'll run into needing to build the **zlib** Haskell package in all likelihood, and that requires the **zlib-devel** Fedora package. 

The `get-stack.sh` script makes sure **gmp-devel** is present (that's the other one new users always seem to be missing). The script installs **zlib** but not **zlib-devel**. This patch changes that package set to include the latter.

AfC