### PR TITLE
Introduce Hoogle server command line option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,6 +49,9 @@ Other enhancements:
   i.e. `stack build --keep-tmp-files --ghc-options=-keep-tmp-files`.
   See [#3857](https://github.com/commercialhaskell/stack/issues/3857)
 * Improved error messages for snapshot parse exceptions
+* `stack hoogle` now supports a new flag `--server` that launches local
+  Hoogle server on port 8080. See
+  [#2310](https://github.com/commercialhaskell/stack/issues/2310)
 
 Bug fixes:
 

--- a/src/Stack/Hoogle.hs
+++ b/src/Stack/Hoogle.hs
@@ -27,12 +27,17 @@ import           System.Exit
 import           RIO.Process
 
 -- | Hoogle command.
-hoogleCmd :: ([String],Bool,Bool) -> GlobalOpts -> IO ()
-hoogleCmd (args,setup,rebuild) go = withBuildConfig go $ do
+hoogleCmd :: ([String],Bool,Bool,Bool) -> GlobalOpts -> IO ()
+hoogleCmd (args,setup,rebuild,startServer) go = withBuildConfig go $ do
     hooglePath <- ensureHoogleInPath
     generateDbIfNeeded hooglePath
-    runHoogle hooglePath args
+    runHoogle hooglePath args'
   where
+    args' :: [String]
+    args' = if startServer
+                 then ["server", "--local", "--port", "8080"]
+                 else []
+            ++ args
     generateDbIfNeeded :: Path Abs File -> RIO EnvConfig ()
     generateDbIfNeeded hooglePath = do
         databaseExists <- checkDatabaseExists

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -337,7 +337,7 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                     ("Run hoogle, the Haskell API search engine. Use 'stack exec' syntax " ++
                      "to pass Hoogle arguments, e.g. stack hoogle -- --count=20")
                     hoogleCmd
-                    ((,,) <$> many (strArgument (metavar "ARG"))
+                    ((,,,) <$> many (strArgument (metavar "ARG"))
                           <*> boolFlags
                                   True
                                   "setup"
@@ -345,7 +345,10 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                                   idm
                           <*> switch
                                   (long "rebuild" <>
-                                   help "Rebuild the hoogle database"))
+                                   help "Rebuild the hoogle database")
+                          <*> switch
+                                  (long "server" <>
+                                   help "Start local Hoogle server"))
         )
 
       -- These are the only commands allowed in interpreter mode as well


### PR DESCRIPTION
This PR introduces support for `stack hoogle --server` option to start local Hoogle server as per https://github.com/commercialhaskell/stack/issues/2310.

Here's what I did:
* [x] ~Added the corresponding option and its handling~
* [x] ~Introduced a record in the ChangeLog.md file for the changes~
* [x] ~I haven't found much info on Hoogle in the docs, so I figured no changes are necessary~

The testing was manual by issuing `stack hoogle --server` on the command line and making sure it works as expected.

As a side note: besides options mentioned in the issue I added `-p 8080` to start Hoogle on a non-privileged port. This is the default Hoogle behaviour since 5.0.13 (released on 2017-07-30), but I figured that there may be older versions in the wild. As there's no way to pass options directly to Hoogle via `stack hoogle` those older versions would try binding to 127.0.0.1:80 and fail without a real way to fix it apart from using `stack exec` to supply the `-p` option.
