### PR TITLE
Add --to option to the unpack command to specify destination

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -65,6 +65,8 @@ Other enhancements:
   i.e. `stack build --keep-tmp-files --ghc-options=-keep-tmp-files`.
   See [#3857](https://github.com/commercialhaskell/stack/issues/3857)
 * Improved error messages for snapshot parse exceptions
+* `stack unpack` now supports a `--to /target/directory` option to
+  specify where to unpack the package into
 
 Bug fixes:
 

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -517,6 +517,13 @@ Unpacked yackage-0.8.0 to /var/home/harendra/yackage-0.8.0/
 cueball:~$ cd yackage-0.8.0/
 ```
 
+Note that you can also unpack to the directory of your liking instead of
+the current one by issueing:
+
+```
+cueball:~$ stack unpack yackage-0.8.0 --to ~/work
+```
+
 ### stack init
 This new directory does not have a `stack.yaml` file, so we need to make one
 first. We could do it by hand, but let's be lazy instead with the `stack init`
@@ -1715,7 +1722,8 @@ users. Here's a quick rundown:
   upstream packages available).
 * `stack unpack` is a command we've already used quite a bit for examples, but
   most users won't use it regularly. It does what you'd expect: downloads a
-  tarball and unpacks it.
+  tarball and unpacks it. It accept optional `--to` argument to specify
+  the destination directory.
 * `stack sdist` generates an uploading tarball containing your package code
 * `stack upload` uploads an sdist to Hackage. As of
   version [1.1.0](https://docs.haskellstack.org/en/v1.1.0/ChangeLog/) stack

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -305,9 +305,9 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
         addCommand' "unpack"
                     "Unpack one or more packages locally"
                     unpackCmd
-                    ((,) <$> (some $ strArgument $ metavar "PACKAGE")
-                         <*> (optional $ textOption $ long "to" <>
-                                help "Optional path to unpack the package into"))
+                    ((,) <$> some (strArgument $ metavar "PACKAGE")
+                         <*> optional (textOption $ long "to" <>
+                                         help "Optional path to unpack the package into"))
         addCommand' "update"
                     "Update the package index"
                     updateCmd


### PR DESCRIPTION
This PR introduces support for `stack unpack pkgname --to /dest/dir` option to unpack pkgname into the specified directory as per #3904.

Here's what I did:

- [x] ~Added the corresponding option and its handling~
- [x] ~Introduced a record in the ChangeLog.md file for the changes~
- [x] ~Updated the docs where deemed necessary~

`--to` option is optional (pun intended), the default behaviour without it remains unchanged compared to the previous Stack versions.

The following manual tests have been conducted:
- Omitting `--to`
- Specifying `--to .`
- Specifying `--to /tmp`
- Specifying `--to /directory/i/have/no/write/access/to`
- Using Unicode as a directory name `--to "असतोमा सद्गमय ।"` (who doesn't use Sanskrit to name directories these days, right?)