### PR TITLE
Introduce `stack run` command line option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,6 +49,8 @@ Other enhancements:
   i.e. `stack build --keep-tmp-files --ghc-options=-keep-tmp-files`.
   See [#3857](https://github.com/commercialhaskell/stack/issues/3857)
 * Improved error messages for snapshot parse exceptions
+* A new sub command `run` has been introduced to run the first available
+  executable in the current stack project similar to `cabal run`.
 
 Bug fixes:
 

--- a/src/Stack/Options/ExecParser.hs
+++ b/src/Stack/Options/ExecParser.hs
@@ -22,6 +22,7 @@ execOptsParser mcmd =
         txt = case mcmd of
             Nothing -> normalTxt
             Just ExecCmd{} -> normalTxt
+            Just ExecRun -> "-- ARGS (e.g. stack run -- file.txt)"
             Just ExecGhc -> "-- ARGS (e.g. stack runghc -- X.hs -o x)"
             Just ExecRunGhc -> "-- ARGS (e.g. stack runghc -- X.hs)"
         normalTxt = "-- ARGS (e.g. stack exec -- ghc-pkg describe base)"

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -400,6 +400,7 @@ data ExecOpts = ExecOpts
 
 data SpecialExecCmd
     = ExecCmd String
+    | ExecRun
     | ExecGhc
     | ExecRunGhc
     deriving (Show, Eq)


### PR DESCRIPTION
This pull request introduces `stack run` which allows directly running the first available executable in the project similar to `cabal run`. This implements the whishlist issue: https://github.com/commercialhaskell/stack/issues/233

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

I have manually verified that it does indeed run the first available executable and have run the following manual tests:
* `stack exec stack run`
* `stack exec -- stack run help`
* `stack exec -- stack run -- help`

Any thoughts on the code? improvements? I'm pretty new to Haskell and stack.