### PR TITLE
Don't recompile in presence of sublibraries

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -52,7 +52,9 @@ Other enhancements:
 
 Bug fixes:
 
-
+* When a package contained sublibraries, stack was always recompiling the
+  package. This has been fixed now, no recompilation is being done because of
+  sublibraries. See [#3899](https://github.com/commercialhaskell/stack/issues/3899).
 
 ## v1.6.5
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,9 @@ Behavior changes:
 Other enhancements:
 
 Bug fixes:
+* When a package contained sublibraries, stack was always recompiling the
+  package. This has been fixed now, no recompilation is being done because of
+  sublibraries. See [#3899](https://github.com/commercialhaskell/stack/issues/3899).
 
 
 ## v1.7.0.1 (releases candidate)
@@ -64,16 +67,7 @@ Other enhancements:
 * Improved error messages for snapshot parse exceptions
 
 Bug fixes:
-* When a package contained sublibraries, stack was always recompiling the
-  package. This has been fixed now, no recompilation is being done because of
-  sublibraries. See [#3899](https://github.com/commercialhaskell/stack/issues/3899).
 
-## v1.6.5
-
-Bug fixes:
-* 1.6.1 introduced a change that made some precompiled cache files use
-  longer paths, sometimes causing builds to fail on windows. This has been
-  fixed. See [#3649](https://github.com/commercialhaskell/stack/issues/3649)
 * The script interpreter's implicit file arguments are now passed before other
   arguments. See [#3658](https://github.com/commercialhaskell/stack/issues/3658).
   In particular, this makes it possible to pass `-- +RTS ... -RTS` to specify

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -120,6 +120,7 @@ buildCacheFile dir component = do
     let nonLibComponent prefix name = prefix <> "-" <> T.unpack name
     cacheFileName <- parseRelFile $ case component of
         CLib -> "lib"
+        CInternalLib name -> nonLibComponent "internal-lib" name
         CExe name -> nonLibComponent "exe" name
         CTest name -> nonLibComponent "test" name
         CBench name -> nonLibComponent "bench" name

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -239,16 +239,18 @@ isAllowed opts mcache sourceMap mloc dp
                     -- See:
                     -- https://github.com/commercialhaskell/stack/issues/292
                     Just _ -> UnknownPkg
-            Just pii
-                | not (checkLocation (piiLocation pii)) -> WrongLocation mloc (piiLocation pii)
-                | version /= piiVersion pii -> WrongVersion version (piiVersion pii)
-                | otherwise -> Allowed
+            Just pii -> checkFound pii
   where
     PackageIdentifier name version = dpPackageIdent dp
     -- Ensure that the installed location matches where the sourceMap says it
     -- should be installed
     checkLocation Snap = mloc /= Just (InstalledTo Local) -- we can allow either global or snap
     checkLocation Local = mloc == Just (InstalledTo Local) || mloc == Just ExtraGlobal -- 'locally' installed snapshot packages can come from extra dbs
+    -- Check if a package is allowed if it is found in the sourceMap
+    checkFound pii
+      | not (checkLocation (piiLocation pii)) = WrongLocation mloc (piiLocation pii)
+      | version /= piiVersion pii = WrongVersion version (piiVersion pii)
+      | otherwise = Allowed
 
 data LoadHelper = LoadHelper
     { lhId   :: !GhcPkgId

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -167,6 +167,7 @@ splitComponents =
   where
     go a b c [] = (Set.fromList $ a [], Set.fromList $ b [], Set.fromList $ c [])
     go a b c (CLib:xs) = go a b c xs
+    go a b c (CInternalLib x:xs) = go (a . (x:)) b c xs
     go a b c (CExe x:xs) = go (a . (x:)) b c xs
     go a b c (CTest x:xs) = go a (b . (x:)) c xs
     go a b c (CBench x:xs) = go a b (c . (x:)) xs

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -435,9 +435,9 @@ getPackageFilesForTargets
     -> Set NamedComponent
     -> RIO env (Map NamedComponent (Set (Path Abs File)), [PackageWarning])
 getPackageFilesForTargets pkg cabalFP nonLibComponents = do
-    (_,compFiles,otherFiles,warnings) <-
+    (components',compFiles,otherFiles,warnings) <-
         getPackageFiles (packageFiles pkg) cabalFP
-    let components = Set.insert CLib nonLibComponents
+    let components = M.keysSet components' `Set.union` nonLibComponents
         componentsFiles =
             M.map (\files -> Set.union otherFiles (Set.map dotCabalGetPath files)) $
                 M.filterWithKey (\component _ -> component `Set.member` components) compFiles

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -230,6 +230,7 @@ resolveRawTarget globals snap deps locals (ri, rt) =
     -- Helper function: check if a 'NamedComponent' matches the given 'ComponentName'
     isCompNamed :: ComponentName -> NamedComponent -> Bool
     isCompNamed _ CLib = False
+    isCompNamed t1 (CInternalLib t2) = t1 == t2
     isCompNamed t1 (CExe t2) = t1 == t2
     isCompNamed t1 (CTest t2) = t1 == t2
     isCompNamed t1 (CBench t2) = t1 == t2

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -520,6 +520,7 @@ figureOutMainFile bopts mainIsTargets targets0 packages = do
     renderComp c =
         case c of
             CLib -> "lib"
+            CInternalLib name -> "internal-lib:" <> name
             CExe name -> "exe:" <> name
             CTest name -> "test:" <> name
             CBench name -> "bench:" <> name

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -42,7 +42,7 @@ module Stack.Package
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as C8
 import           Data.List (isSuffixOf, isPrefixOf)
-import           Data.Maybe (fromJust)
+import           Data.Maybe (maybe)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -736,7 +736,7 @@ packageDescModulesAndFiles pkg = do
     return (modules, files, dfiles, warnings)
   where
     libComponent = const CLib
-    internalLibComponent = CInternalLib . T.pack . Cabal.unUnqualComponentName . fromJust . libName
+    internalLibComponent = CInternalLib . T.pack . maybe "" Cabal.unUnqualComponentName . libName
     exeComponent = CExe . T.pack . Cabal.unUnqualComponentName . exeName
     testComponent = CTest . T.pack . Cabal.unUnqualComponentName . testName
     benchComponent = CBench . T.pack . Cabal.unUnqualComponentName . benchmarkName

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -710,11 +710,11 @@ packageDescModulesAndFiles pkg = do
     dfiles <- resolveGlobFiles
                     (extraSrcFiles pkg
                         ++ map (dataDir pkg FilePath.</>) (dataFiles pkg))
-    let modules = libraryMods <> executableMods <> testMods <> benchModules
+    let modules = libraryMods <> subLibrariesMods <> executableMods <> testMods <> benchModules
         files =
-            libDotCabalFiles <> exeDotCabalFiles <> testDotCabalFiles <>
+            libDotCabalFiles <> subLibDotCabalFiles <> exeDotCabalFiles <> testDotCabalFiles <>
             benchDotCabalPaths
-        warnings = libWarnings <> exeWarnings <> testWarnings <> benchWarnings
+        warnings = libWarnings <> subLibWarnings <> exeWarnings <> testWarnings <> benchWarnings
     return (modules, files, dfiles, warnings)
   where
     libComponent = const CLib

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -590,6 +590,7 @@ componentBuildDir cabalVer component distDir
     | otherwise =
         case component of
             CLib -> buildDir distDir
+            CInternalLib name -> buildDir distDir </> componentNameToDir name
             CExe name -> buildDir distDir </> componentNameToDir name
             CTest name -> buildDir distDir </> componentNameToDir name
             CBench name -> buildDir distDir </> componentNameToDir name

--- a/src/Stack/Types/NamedComponent.hs
+++ b/src/Stack/Types/NamedComponent.hs
@@ -24,6 +24,7 @@ import Data.Text.Encoding (encodeUtf8, decodeUtf8)
 -- | A single, fully resolved component of a package
 data NamedComponent
     = CLib
+    | CInternalLib !Text
     | CExe !Text
     | CTest !Text
     | CBench !Text
@@ -31,6 +32,7 @@ data NamedComponent
 
 renderComponent :: NamedComponent -> ByteString
 renderComponent CLib = "lib"
+renderComponent (CInternalLib x) = "internal-lib:" <> encodeUtf8 x
 renderComponent (CExe x) = "exe:" <> encodeUtf8 x
 renderComponent (CTest x) = "test:" <> encodeUtf8 x
 renderComponent (CBench x) = "bench:" <> encodeUtf8 x

--- a/src/test/Stack/PackageDumpSpec.hs
+++ b/src/test/Stack/PackageDumpSpec.hs
@@ -81,6 +81,7 @@ spec = do
             haskell2010 { dpExposedModules = [] } `shouldBe` DumpPackage
                 { dpGhcPkgId = ghcPkgId
                 , dpPackageIdent = packageIdent
+                , dpParentLibIdent = Nothing
                 , dpLicense = Just BSD3
                 , dpLibDirs = ["/opt/ghc/7.8.4/lib/ghc-7.8.4/haskell2010-1.1.2.0"]
                 , dpDepends = depends
@@ -124,6 +125,7 @@ spec = do
             haskell2010 { dpExposedModules = [] } `shouldBe` DumpPackage
                 { dpGhcPkgId = ghcPkgId
                 , dpPackageIdent = pkgIdent
+                , dpParentLibIdent = Nothing
                 , dpLicense = Just BSD3
                 , dpLibDirs = ["/opt/ghc/7.10.1/lib/ghc-7.10.1/ghc_EMlWrQ42XY0BNVbSrKixqY"]
                 , dpHaddockInterfaces = ["/opt/ghc/7.10.1/share/doc/ghc/html/libraries/ghc-7.10.1/ghc.haddock"]
@@ -160,6 +162,7 @@ spec = do
             hmatrix `shouldBe` DumpPackage
                 { dpGhcPkgId = ghcPkgId
                 , dpPackageIdent = pkgId
+                , dpParentLibIdent = Nothing
                 , dpLicense = Just BSD3
                 , dpLibDirs =
                       [ "/Users/alexbiehl/.stack/snapshots/x86_64-osx/lts-2.13/7.8.4/lib/x86_64-osx-ghc-7.8.4/hmatrix-0.16.1.5"
@@ -197,6 +200,7 @@ spec = do
           ghcBoot `shouldBe` DumpPackage
             { dpGhcPkgId = ghcPkgId
             , dpPackageIdent = pkgId
+            , dpParentLibIdent = Nothing
             , dpLicense = Just BSD3
             , dpLibDirs =
                   ["/opt/ghc/head/lib/ghc-7.11.20151213/ghc-boot-0.0.0.0"]

--- a/test/integration/tests/3899-dont-rebuild-sublibraries/Main.hs
+++ b/test/integration/tests/3899-dont-rebuild-sublibraries/Main.hs
@@ -1,0 +1,14 @@
+import Control.Monad (unless)
+import Data.List (isInfixOf)
+import StackTest
+
+main :: IO ()
+main = do
+  stack ["clean"]
+  stack ["build"]
+  res <- compilingModulesLines . snd <$> stackStderr ["build"]
+  unless (null res) $ fail "Stack recompiled code"
+
+-- Returns the lines where a module is compiled
+compilingModulesLines :: String -> [String]
+compilingModulesLines = filter (isInfixOf " Compiling ") . lines

--- a/test/integration/tests/3899-dont-rebuild-sublibraries/files/Setup.hs
+++ b/test/integration/tests/3899-dont-rebuild-sublibraries/files/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/test/integration/tests/3899-dont-rebuild-sublibraries/files/files.cabal
+++ b/test/integration/tests/3899-dont-rebuild-sublibraries/files/files.cabal
@@ -1,0 +1,22 @@
+name:           files
+version:        0.1.0.0
+build-type:     Simple
+cabal-version:  >= 2.0
+
+library
+  hs-source-dirs:   src
+  exposed-modules:  Lib
+  build-depends:    base, lib
+  default-language: Haskell2010
+
+library lib
+  hs-source-dirs:   src-internal
+  exposed-modules:  Internal
+  build-depends:    base
+  default-language: Haskell2010
+
+executable exe
+  hs-source-dirs:   src-exe
+  main-is:          Main.hs
+  build-depends:    base, files
+  default-language: Haskell2010

--- a/test/integration/tests/3899-dont-rebuild-sublibraries/files/src-exe/Main.hs
+++ b/test/integration/tests/3899-dont-rebuild-sublibraries/files/src-exe/Main.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import Lib
+
+main :: IO ()
+main = do
+  putStrLn "hello world"

--- a/test/integration/tests/3899-dont-rebuild-sublibraries/files/src-internal/Internal.hs
+++ b/test/integration/tests/3899-dont-rebuild-sublibraries/files/src-internal/Internal.hs
@@ -1,0 +1,1 @@
+module Internal where

--- a/test/integration/tests/3899-dont-rebuild-sublibraries/files/src/Lib.hs
+++ b/test/integration/tests/3899-dont-rebuild-sublibraries/files/src/Lib.hs
@@ -1,0 +1,3 @@
+module Lib where
+
+import Internal

--- a/test/integration/tests/3899-dont-rebuild-sublibraries/files/stack.yaml
+++ b/test/integration/tests/3899-dont-rebuild-sublibraries/files/stack.yaml
@@ -1,0 +1,4 @@
+resolver: ghc-8.2.2
+extra-deps:
+- stm-2.4.4.1
+- mtl-2.2.1


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

------

Tested first with the `internal-libraries` package mentioned in https://github.com/commercialhaskell/stack/issues/3899#issuecomment-375935325 and made Stack not ignore the internal library in this case.

Furthermore, tested against my own `hakyll`-based repo, to reproduce #3899.