### PR TITLE
Improve docker related documentation

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1678,7 +1678,7 @@ docker:
 ```
 
 You can find more details about the first integration
-method [here](./docker_integration.md).
+method [in the Docker integration documentation](./docker_integration.md).
 
 ### Nix
 

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1677,8 +1677,10 @@ docker:
     enable: true
 ```
 
-You can find more details about the first integration
-method [in the Docker integration documentation](./docker_integration.md).
+Alternatively, instead of the above configuration, you can use the
+`--docker` option to achieve the same.  You can find more details
+about the first integration method [in the Docker integration
+documentation](./docker_integration.md).
 
 ### Nix
 

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1604,21 +1604,19 @@ page](https://docs.haskellstack.org/en/stable/shell_autocompletion)
 
 ### Docker
 
-stack provides two built-in Docker integrations. Firstly, you can build your
-code inside a Docker image, which means:
+stack provides two built-in Docker integrations. The first way is to
+build your code inside a Docker image, which means:
 
 * even more reproducibility to your builds, since you and the rest of your team
   will always have the same system libraries
 * the Docker images ship with entire precompiled snapshots. That means you have
   a large initial download, but much faster builds
 
-For more information, see
-[the Docker-integration documentation](docker_integration.md).
-
-stack can also generate Docker images for you containing your built executables.
-This feature is great for automating deployments from CI. This feature is not
-yet well-documented, but the basics are to add a section like the following
-to stack.yaml:
+The second way is to generate Docker images for you containing your
+built executables (the executable is built in your local machine and
+copied into the image) .  This feature is great for automating
+deployments from CI. This feature is not yet well-documented, but the
+basics are to add a section like the following to stack.yaml:
 
 ```yaml
 image:
@@ -1654,9 +1652,7 @@ the images.
 
 Note that the executable will be built in the development environment
 and copied to the container, so the dev OS must match that of the
-container OS. This is easily accomplished using [Docker integration](docker_integration.md),
-under which the exe emitted by `stack build` will be built on the
-Docker container, not the local OS.
+container OS.
 
 The executable will be stored under `/usr/local/bin/<your-project>-exe`
 in the running container.
@@ -1668,6 +1664,21 @@ then set an entrypoint as follows:
 entrypoints:
     - <your-project>-exe
 ```
+
+The difference between the first and second integration methods is
+that in the first one your Haskell code is actually built in the
+container whereas in the second one the executable built in your host
+machine is copied to the container. The presence of the following
+configuration in `stack.yaml` informs stack to switch to the first
+integration method:
+
+```yaml
+docker:
+    enable: true
+```
+
+You can find more details about the first integration
+method [here](./docker_integration.md).
 
 ### Nix
 

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1652,7 +1652,10 @@ the images.
 
 Note that the executable will be built in the development environment
 and copied to the container, so the dev OS must match that of the
-container OS.
+container OS. Note that you can use the `--docker` option to build
+your code inside the Docker container in case you have a different
+development environment or if you specifically want to build on the
+container.
 
 The executable will be stored under `/usr/local/bin/<your-project>-exe`
 in the running container.


### PR DESCRIPTION
Brief history: Two days ago I deployed a Yesod application via Docker
and found the current documentation quite confusing. I had to use
`stack -v image container` to figure out what is being done and
understand things. One of the major thing I didn't understand was how
the presence of

```
docker:
  enable: true
```

will affect things as the `stack image container` was working with and
without it. I'm changing the documentation based on my experience. But
yeah, I'm open to changes and feedback if you think this can be
improved further!

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
