### PR TITLE
fixed: terminating is newline

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ Other enhancements:
 
 Bug fixes:
 
+* `~/.stack/config.yaml` and `stack.yaml` terminating by newline
 
 ## v1.7.0.3 (release candidate)
 

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -964,4 +964,5 @@ defaultConfigYaml = S.intercalate "\n"
      , "#    author-email:"
      , "#    copyright:"
      , "#    github-username:"
+     , ""
      ]

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -185,6 +185,7 @@ renderStackYaml p ignoredPackages dupPackages =
         <> F.foldMap (goComment o) comments
         <> goOthers (o `HM.difference` HM.fromList comments)
         <> B.byteString footerHelp
+        <> "\n"
 
     goComment o (name, comment) =
         case (convert <$> HM.lookup name o) <|> nonPresentValue name of


### PR DESCRIPTION
`~/.stack/config.yaml` and `stack.yaml` is not terminating by newline.
It is not compliance POSIX.
[Definitions](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206)
I can not fix last template file do not terminate by newline.
This is project-templates bug.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
