### PR TITLE
Help users not to go down the road of base upgrade/downgrade, addresses #3940

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,10 @@ Behavior changes:
 Other enhancements:
 
 * On Windows, recognise a 'mintty' (false) terminal as a terminal, by default
+* `stack build` issues a warning when `base` is explicitly listed in
+  `extra-deps` of `stack.yaml`
+* `stack build` suggests trying another GHC version should the build
+  plan end up requiring unattainable `base` version.
 
 Bug fixes:
 

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -187,7 +187,7 @@ constructPlan ls0 baseConfigOpts0 locals extraToBuild0 localDumpPkgs loadPackage
 
     bconfig <- view buildConfigL
     when (hasBaseInDeps bconfig) $
-      prettyWarn $ flow "You are trying to upgrade/downgrade base, which is almost certainly not what you really want. Please, consider using another GHC version if you need a certain version of base, or removing base from extra-deps." <> line
+      prettyWarn $ flow "You are trying to upgrade/downgrade base, which is almost certainly not what you really want. Please, consider using another GHC version if you need a certain version of base, or removing base from extra-deps. See more at https://github.com/commercialhaskell/stack/issues/3940." <> line
 
     econfig <- view envConfigL
     let onWanted = void . addDep False . packageName . lpPackage

--- a/test/integration/tests/3940-base-upgrade-warning/Main.hs
+++ b/test/integration/tests/3940-base-upgrade-warning/Main.hs
@@ -1,0 +1,25 @@
+import Control.Monad (unless)
+import Data.List (isInfixOf)
+import StackTest
+
+unattainableBaseWarning :: String
+unattainableBaseWarning =
+  "Build requires unattainable version of base. Since base is a part of GHC, \
+  \you most likely need to use a different GHC version with the matching base."
+
+noBaseUpgradeWarning :: String
+noBaseUpgradeWarning =
+  "You are trying to upgrade/downgrade base, which is almost certainly \
+  \not what you really want. Please, consider using another GHC version \
+  \if you need a certain version of base, or removing base from extra-deps. \
+  \See more at https://github.com/commercialhaskell/stack/issues/3940."
+
+main :: IO ()
+main = do
+  stackErrStderr ["build", "--stack-yaml", "unattainable-base.yaml"] (expectMessage unattainableBaseWarning)
+  stackErrStderr ["build", "--stack-yaml", "no-base-upgrade.yaml"] (expectMessage noBaseUpgradeWarning)
+
+expectMessage :: String -> String -> IO ()
+expectMessage msg stderr =
+  unless ((words msg) `isInfixOf` (words stderr))
+         (error $ "Expected a warning: \n" ++ show msg)

--- a/test/integration/tests/3940-base-upgrade-warning/Main.hs
+++ b/test/integration/tests/3940-base-upgrade-warning/Main.hs
@@ -21,5 +21,5 @@ main = do
 
 expectMessage :: String -> String -> IO ()
 expectMessage msg stderr =
-  unless ((words msg) `isInfixOf` (words stderr))
+  unless (words msg `isInfixOf` words stderr)
          (error $ "Expected a warning: \n" ++ show msg)

--- a/test/integration/tests/3940-base-upgrade-warning/files/files.cabal
+++ b/test/integration/tests/3940-base-upgrade-warning/files/files.cabal
@@ -1,0 +1,10 @@
+name:                   files
+version:                0.0.1.0
+build-type:             Simple
+cabal-version:          >= 1.18
+
+library
+  hs-source-dirs:       src
+  exposed-modules:      Lib
+  build-depends:        base < 4.10 && >= 4.6.0.1
+  default-language:     Haskell2010

--- a/test/integration/tests/3940-base-upgrade-warning/files/no-base-upgrade.yaml
+++ b/test/integration/tests/3940-base-upgrade-warning/files/no-base-upgrade.yaml
@@ -1,0 +1,3 @@
+resolver: lts-11.4
+extra-deps:
+  - base-4.10.1.0

--- a/test/integration/tests/3940-base-upgrade-warning/files/unattainable-base.yaml
+++ b/test/integration/tests/3940-base-upgrade-warning/files/unattainable-base.yaml
@@ -1,0 +1,1 @@
+resolver: lts-11.4


### PR DESCRIPTION
Implements the following:

1. Emit a warning when someones tries to upgrade/downgrade base.
2. Show a specific message when build plan results in base upgrade/downgrade requirement.

Here's what I did or checked out:

* [x] Wrote the code
* [x] Added relevant ChangeLog.md entries
* [x] No documentation updates seemed necessary to me
* [x] Linted my changes
* [x] Did some manual tests

### Here's how I tested it (as per comments in #3940):

#### Test #1

- Created `stack.yaml` with the following contents:

      resolver: lts-11.6
      extra-deps: []

- Issued `stack build ghc-mod`
- Made sure I'm getting the right error message suggesting me to pick another GHC with the matching `base`.

#### Test #2

- Created `stack.yaml` with the following contents:

      resolver: lts-11.6
      extra-deps: ["base-4.9.1.0"]

- Issued `stack build ghc-mod`
- Made sure I'm getting the right warning suggesting me not to put `base` in `extra-deps`, and use another GHC version instead.
