### PR TITLE
Fix for #3992, for native terminals on Windows 10

### DIFF
--- a/src/Stack/Types/Runner.hs
+++ b/src/Stack/Types/Runner.hs
@@ -116,4 +116,4 @@ withRunner logLevel useTime terminal colorWhen widthOverride reExec inner = do
           | otherwise = w
 
 data ColorWhen = ColorNever | ColorAlways | ColorAuto
-    deriving (Show, Generic)
+    deriving (Eq, Show, Generic)

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -98,12 +98,14 @@ import           Stack.Types.Version
 import           Stack.Types.Config
 import           Stack.Types.Compiler
 import           Stack.Types.Nix
+import           Stack.Types.Runner
 import           Stack.Upgrade
 import qualified Stack.Upload as Upload
 import qualified System.Directory as D
 import           System.Environment (getProgName, getArgs, withArgs)
 import           System.Exit
 import           System.FilePath (isValid, pathSeparator)
+import           System.Console.ANSI (SGR (Reset), hSupportsANSI, setSGR)
 import           System.IO (stderr, stdin, stdout, BufferMode(..), hPutStrLn, hPrint, hGetEncoding, hSetEncoding)
 
 -- | Change the character encoding of the given Handle to transliterate
@@ -184,6 +186,15 @@ main = do
       throwIO exitCode
     Right (globalMonoid,run) -> do
       let global = globalOptsFromMonoid isTerminal globalMonoid
+      -- If stdout is (1) recognised as a terminal supporting ANSI (for the
+      -- purposes of the functions of the ansi-terminal package) and (2) a
+      -- native (ConHost) terminal on Windows 10, then the setSGR function will
+      -- enable the ANSI-capability for that terminal. Later uses of
+      -- hSupportsANSI with the functions of the RIO package that emit ANSI
+      -- codes will then have the intended outcome on native Windows 10
+      -- terminals.
+      when (globalColorWhen global /= ColorNever) $
+        hSupportsANSI stdout >>= flip when (setSGR [Reset])
       when (globalLogLevel global == LevelDebug) $ hPutStrLn stderr versionString'
       case globalReExecVersion global of
           Just expectVersion -> do


### PR DESCRIPTION
See #3992. This adds, to `main`, an initial output of an 'SGR Reset' ANSI code to `stdout`, if `stdout` is recognised as a supported terminal by `hSupportsANSI` (from the `ansi-terminal` package). For a native (ConHost) terminal on Windows 10, which is ANSI-capable, this will enable its capability to process the ANSI codes emitted by functions of the `RIO` package.

This will not fix #3992 for: (1) non-native ANSI-enabled terminals on Windows 10; or (2) terminals on legacy Windows. This is because (1) non-native ANSI-enabled terminals on Windows are not recognised as such by `hSupportsANSI` (used elsewhere by `stack`) and (2) native terminals on legacy Windows require an emulation layer to behave as if they were ANSI-enabled.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md. (None.)
* [x] The documentation has been updated, if necessary. (None necessary.)

Tested by building `stack` on Windows 10 and then using it successfully.