### PR TITLE
Windows: use 'hIsTerminalDevice or isMinTTYHandle'

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@ Behavior changes:
 
 Other enhancements:
 
+* On Windows, recognise a 'mintty' (false) terminal as a terminal, by default
+
 Bug fixes:
 
 * `~/.stack/config.yaml` and `stack.yaml` terminating by newline

--- a/package.yaml
+++ b/package.yaml
@@ -121,7 +121,7 @@ when:
   then:
     cpp-options: -DWINDOWS
     dependencies:
-    - Win32
+    - Win32 >= 2.5.3.0
   else:
     build-tools:
     - hsc2hs

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -243,8 +243,8 @@ runContainerAndExit getCmdArgs
      (env,isStdinTerminal,isStderrTerminal,homeDir) <- liftIO $
        (,,,)
        <$> getEnvironment
-       <*> hIsTerminalDevice stdin
-       <*> hIsTerminalDevice stderr
+       <*> hIsTerminalDeviceOrMinTTY stdin
+       <*> hIsTerminalDeviceOrMinTTY stderr
        <*> (parseAbsDir =<< getHomeDirectory)
      isStdoutTerminal <- view terminalL
      let dockerHost = lookup "DOCKER_HOST" env

--- a/src/Stack/FileWatch.hs
+++ b/src/Stack/FileWatch.hs
@@ -35,7 +35,7 @@ fileWatchConf :: WatchConfig
               -> IO ()
 fileWatchConf cfg out inner = withManagerConf cfg $ \manager -> do
     let putLn = hPutStrLn out
-    outputIsTerminal <- hIsTerminalDevice out
+    outputIsTerminal <- hIsTerminalDeviceOrMinTTY out
     let withColor color str = putLn $ do
             if outputIsTerminal
             then concat [color, str, reset]

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -167,7 +167,7 @@ main = do
   hSetTranslit stderr
   args <- getArgs
   progName <- getProgName
-  isTerminal <- hIsTerminalDevice stdout
+  isTerminal <- hIsTerminalDeviceOrMinTTY stdout
   execExtraHelp args
                 Docker.dockerHelpOptName
                 (dockerOptsParser False)


### PR DESCRIPTION
`hIsTerminalDevice` does not recognise handles to 'mintty' terminals, but `isMinTTYHandle` does. Currently, `stack` relies on `hIsTerminalDevice` in three places to detect handles to terminals and does not use `isMinTTYHandle`. This proposal introduces 'isMinTTYHandle' in those three places.

`isMinTTYHandle` was first added to package `Win32-2.5.0.0` and then made robust to an upstream (ntdll-related) bug from `Win32-2.5.3.0`. The latter constraint is added to `package.yaml`.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary. (None necessary.)

This has been tested only by building `stack` on Windows 10 and using it in native and 'mintty' terminals - I do not know what significance the terminal device-checking has.