### PR TITLE
Allow Nix mode to be disabled under NixOS

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,7 @@ Bug fixes:
   was tried to be registered. This is now fixed by always building internal
   libraries. See
   [#3996](https://github.com/commercialhaskell/stack/issues/3996).
+* `--no-nix` was not respected under NixOS
 
 
 ## v1.7.1

--- a/doc/nix_integration.md
+++ b/doc/nix_integration.md
@@ -186,9 +186,10 @@ Here is a commented configuration file, showing the default values:
 ```yaml
 nix:
 
-  # false by default. Must be present and set to `true` to enable Nix.
-  # You can set set it in your `$HOME/.stack/config.yaml` to enable
-  # Nix for all your projects without having to repeat it
+  # false by default. Must be present and set to `true` to enable Nix, except on
+  # NixOS where it is enabled by default (see #3938).  You can set set it in your
+  # `$HOME/.stack/config.yaml` to enable Nix for all your projects without having
+  # to repeat it
   # enable: true
 
   # true by default. Tells Nix whether to run in a pure shell or not.

--- a/src/Stack/Config/Nix.hs
+++ b/src/Stack/Config/Nix.hs
@@ -27,8 +27,7 @@ nixOptsFromMonoid
     -> OS
     -> RIO env NixOpts
 nixOptsFromMonoid NixOptsMonoid{..} os = do
-    let nixEnable0 = fromFirst False nixMonoidEnable
-        defaultPure = case os of
+    let defaultPure = case os of
           OSX -> False
           _ -> True
         nixPureShell = fromFirst defaultPure nixMonoidPureShell
@@ -38,14 +37,14 @@ nixOptsFromMonoid NixOptsMonoid{..} os = do
                           ++ prefixAll (T.pack "-I") (fromFirst [] nixMonoidPath)
         nixAddGCRoots   = fromFirst False nixMonoidAddGCRoots
 
+    -- Enable Nix-mode by default on NixOS, unless Docker-mode was specified
     osIsNixOS <- isNixOS
+    let nixEnable0 = fromFirst osIsNixOS nixMonoidEnable
+
     nixEnable <- case () of _
                                 | nixEnable0 && osIsWindows -> do
                                       logInfo "Note: Disabling nix integration, since this is being run in Windows"
                                       return False
-                                | not nixEnable0 && osIsNixOS -> do
-                                      logInfo "Note: Enabling Nix integration, as it is required under NixOS"
-                                      return True
                                 | otherwise                 -> return nixEnable0
 
     when (not (null nixPackages) && isJust nixInitFile) $

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,6 @@ resolver: lts-11.6
 #       name: "fpco/stack-test"
 nix:
   # --nix on the command-line to enable.
-  enable: false
   packages:
     - zlib
     - unzip


### PR DESCRIPTION
This was introduced in #3938, but breaks Docker mode under NixOS.

This PR relaxes the logic to only change the default under NixOS, rather than force Nix mode to enabled.

Fixes #4002.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested under NixOS using the Stack project.