### PR TITLE
Handle internal libs not listed as dependencies

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,11 @@ Bug fixes:
   load any module. This has been fixed now and changes to the code in the
   library and the sublibrary are properly tracked. See
   [#3926](https://github.com/commercialhaskell/stack/issues/3926).
+* For packages with internal libraries not depended upon, `stack build` used
+  to fail the build process since the internal library was not built but it
+  was tried to be registered. This is now fixed by always building internal
+  libraries. See
+  [#3996](https://github.com/commercialhaskell/stack/issues/3996).
 
 
 ## v1.7.1

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1899,7 +1899,7 @@ extraBuildOptions wc bopts = do
       else
         return [optsFlag, baseOpts]
 
--- Library and executable build components.
+-- Library, internal and foreign libraries and executable build components.
 primaryComponentOptions :: Map Text ExecutableBuildStatus -> LocalPackage -> [String]
 primaryComponentOptions executableBuildStatuses lp =
       -- TODO: get this information from target parsing instead,
@@ -1909,9 +1909,12 @@ primaryComponentOptions executableBuildStatuses lp =
          NoLibraries -> []
          HasLibraries names ->
              map T.unpack
-           $ T.append "lib:" (packageNameText (packageName (lpPackage lp)))
+           $ T.append "lib:" (packageNameText (packageName package))
            : map (T.append "flib:") (Set.toList names)) ++
+      (map (T.unpack . T.append "lib:") (Set.toList $ packageInternalLibraries package)) ++
       map (T.unpack . T.append "exe:") (Set.toList $ exesToBuild executableBuildStatuses lp)
+  where
+    package = lpPackage lp
 
 -- | History of this function:
 --

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1911,7 +1911,7 @@ primaryComponentOptions executableBuildStatuses lp =
              map T.unpack
            $ T.append "lib:" (packageNameText (packageName package))
            : map (T.append "flib:") (Set.toList names)) ++
-      (map (T.unpack . T.append "lib:") (Set.toList $ packageInternalLibraries package)) ++
+      map (T.unpack . T.append "lib:") (Set.toList $ packageInternalLibraries package) ++
       map (T.unpack . T.append "exe:") (Set.toList $ exesToBuild executableBuildStatuses lp)
   where
     package = lpPackage lp

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -16,7 +16,6 @@ import qualified Data.Conduit.List as CL
 import qualified Data.Foldable as F
 import qualified Data.HashSet as HashSet
 import           Data.List
-import qualified Data.Map.Strict as M
 import qualified Data.Map.Strict as Map
 import           Path
 import           Stack.Build.Cache
@@ -75,7 +74,7 @@ getInstalled opts sourceMap = do
         loadDatabase' (Just (InstalledTo Snap, snapDBPath)) installedLibs1
     (installedLibs3, localDumpPkgs) <-
         loadDatabase' (Just (InstalledTo Local, localDBPath)) installedLibs2
-    let installedLibs = M.fromList $ map lhPair installedLibs3
+    let installedLibs = Map.fromList $ map lhPair installedLibs3
 
     F.forM_ mcache $ \cache -> do
         icache <- configInstalledCache

--- a/test/integration/tests/3996-sublib-not-depended-upon/Main.hs
+++ b/test/integration/tests/3996-sublib-not-depended-upon/Main.hs
@@ -1,0 +1,8 @@
+import Control.Monad (unless)
+import Data.List (isInfixOf)
+import StackTest
+
+main :: IO ()
+main = do
+  stack ["clean"]
+  stack ["build"]

--- a/test/integration/tests/3996-sublib-not-depended-upon/files/Setup.hs
+++ b/test/integration/tests/3996-sublib-not-depended-upon/files/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/test/integration/tests/3996-sublib-not-depended-upon/files/files.cabal
+++ b/test/integration/tests/3996-sublib-not-depended-upon/files/files.cabal
@@ -1,0 +1,16 @@
+name:           files
+version:        0.1.0.0
+build-type:     Simple
+cabal-version:  >= 2.0
+
+library
+  hs-source-dirs:   src
+  exposed-modules:  Lib
+  build-depends:    base
+  default-language: Haskell2010
+
+library lib
+  hs-source-dirs:   src-internal
+  exposed-modules:  Internal
+  build-depends:    base
+  default-language: Haskell2010

--- a/test/integration/tests/3996-sublib-not-depended-upon/files/src-internal/Internal.hs
+++ b/test/integration/tests/3996-sublib-not-depended-upon/files/src-internal/Internal.hs
@@ -1,0 +1,4 @@
+module Internal where
+
+test :: Int
+test = 42

--- a/test/integration/tests/3996-sublib-not-depended-upon/files/src/Lib.hs
+++ b/test/integration/tests/3996-sublib-not-depended-upon/files/src/Lib.hs
@@ -1,0 +1,4 @@
+module Lib where
+
+testLib :: Int
+testLib = 42

--- a/test/integration/tests/3996-sublib-not-depended-upon/files/stack.yaml
+++ b/test/integration/tests/3996-sublib-not-depended-upon/files/stack.yaml
@@ -1,0 +1,4 @@
+resolver: ghc-8.2.2
+extra-deps:
+- stm-2.4.4.1
+- mtl-2.2.1


### PR DESCRIPTION
Solves #3996 by making sure `Cabal build` is called with libraries, *internal libraries*, foreign libraries and executables names (adds *internal libraries* to the list).

Otherwise, if the internal library is not listed as dependency of the main library, `Cabal configure` ignores it, `Cabal build` doesn't build it but `Cabal copy` and `Cabal register` are still looking for it. This causes the build to error, #3996.

Checklist:
* [x] fix bug
* [x] add tests
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
