### PR TITLE
Set cabal_macros.h work directory in stack ghci to something non-temporary

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,10 @@ Other enhancements:
 
 Bug fixes:
 
+* `stack ghci` now does not invalidate `.o` files on repeated runs,
+  meaning any modules compiled with `-fobject-code` will be cached
+  between ghci runs. See
+  [#4038](https://github.com/commercialhaskell/stack/pull/4038).
 * `~/.stack/config.yaml` and `stack.yaml` terminating by newline
 * The previous released caused a regression where some `stderr` from the
   `ghc-pkg` command showed up in the terminal. This output is now silenced.

--- a/src/Stack/Constants/Config.hs
+++ b/src/Stack/Constants/Config.hs
@@ -15,6 +15,7 @@ module Stack.Constants.Config
   , hpcRelativeDir
   , hpcDirFromDir
   , objectInterfaceDirL
+  , ghciDirL
   , templatesDir
   ) where
 
@@ -32,11 +33,18 @@ objectInterfaceDirL = to $ \env -> -- FIXME is this idomatic lens code?
       root = view projectRootL env
    in root </> workDir </> $(mkRelDir "odir/")
 
+-- | GHCi files directory.
+ghciDirL :: HasBuildConfig env => Getting r env (Path Abs Dir)
+ghciDirL = to $ \env -> -- FIXME is this idomatic lens code?
+  let workDir = view workDirL env
+      root = view projectRootL env
+   in root </> workDir </> $(mkRelDir "ghci/")
+
 -- | The directory containing the files used for dirtiness check of source files.
 buildCachesDir :: (MonadThrow m, MonadReader env m, HasEnvConfig env)
                => Path Abs Dir      -- ^ Package directory.
                -> m (Path Abs Dir)
-buildCachesDir dir = 
+buildCachesDir dir =
     liftM
         (</> $(mkRelDir "stack-build-caches"))
         (distDirFromDir dir)

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -398,8 +398,10 @@ runGhci GhciOpts{..} targets mainIsTargets pkgs extraFiles exposePackages = do
     tmpDirectory <-
         (</> $(mkRelDir "haskell-stack-ghci")) <$>
         (parseAbsDir =<< liftIO getCanonicalTemporaryDirectory)
+    ghciDir <- view ghciDirL
+    ensureDir ghciDir
     ensureDir tmpDirectory
-    macrosOptions <- writeMacrosFile tmpDirectory pkgs
+    macrosOptions <- writeMacrosFile ghciDir pkgs
     if ghciNoLoadModules
         then execGhci macrosOptions
         else do


### PR DESCRIPTION
Use the `ghciDirL` for `cabal_macros.h` in `stack ghci` command.

Example:
```
bash-3.2$ stack exec -- stack ghci -v 2>/dev/stdout | egrep '\-optP.*?cabal_macros.*? ' -o
-optP-include -optP/Users/chris/Work/stack/.stack-work/ghci/cb285e1e/cabal_macros.h
bash-3.2$ stack exec -- stack ghci -v 2>/dev/stdout | egrep '\-optP.*?cabal_macros.*? ' -o
-optP-include -optP/Users/chris/Work/stack/.stack-work/ghci/cb285e1e/cabal_macros.h
```
Here are two runs of `stack ghci` on the stack codebase. The first
compiles everything, the second loads the cached object files:

https://gist.github.com/chrisdone/7468e27683a5f202b6a5f4e146b2fb8e#file-ghci-output-txt-L146-L164

Ping @mgsloan @bitemyapp 