### PR TITLE
Change parsers to use `flag'` instead of `switch`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,6 +38,8 @@ Bug fixes:
   was tried to be registered. This is now fixed by always building internal
   libraries. See
   [#3996](https://github.com/commercialhaskell/stack/issues/3996).
+* Order of commandline arguments does not matter anymore.
+  See [#3959](https://github.com/commercialhaskell/stack/issues/3959)
 
 
 ## v1.7.1

--- a/src/Stack/Options/BenchParser.hs
+++ b/src/Stack/Options/BenchParser.hs
@@ -19,7 +19,7 @@ benchOptsParser hide0 = BenchmarkOptsMonoid
                                  help ("Forward BENCH_ARGS to the benchmark suite. " <>
                                        "Supports templates from `cabal bench`") <>
                                  hide))
-        <*> optionalFirst (switch (long "no-run-benchmarks" <>
+        <*> optionalFirst (flag' True (long "no-run-benchmarks" <>
                           help "Disable running of benchmarks. (Benchmarks will still be built.)" <>
                              hide))
    where hide = hideMods hide0

--- a/src/Stack/Options/TestParser.hs
+++ b/src/Stack/Options/TestParser.hs
@@ -27,12 +27,12 @@ testOptsParser hide0 =
                          help "Arguments passed in to the test suite program" <>
                          hide)))
         <*> optionalFirst
-                (switch
+                (flag' True
                     (long "coverage" <>
                      help "Generate a code coverage report" <>
                      hide))
         <*> optionalFirst
-                (switch
+                (flag' True
                     (long "no-run-tests" <>
                      help "Disable running of tests. (Tests will still be built.)" <>
                      hide))

--- a/test/integration/tests/3959-order-of-flags/Main.hs
+++ b/test/integration/tests/3959-order-of-flags/Main.hs
@@ -1,0 +1,21 @@
+import StackTest
+
+import Control.Monad (unless)
+import Data.List (isInfixOf)
+
+-- Integration test for https://github.com/commercialhaskell/stack/issues/3959
+main :: IO ()
+main = do
+  checkFlagsBeforeCommand
+  checkFlagsAfterCommand
+
+checkFlagsBeforeCommand :: IO ()
+checkFlagsBeforeCommand = stackCheckStderr ["--test", "--no-run-tests", "build"] checker
+
+checkFlagsAfterCommand :: IO ()
+checkFlagsAfterCommand = stackCheckStderr ["build", "--test", "--no-run-tests"] checker
+
+checker :: String -> IO ()
+checker output = do
+  let testsAreDisabled = any (\ln -> "Test running disabled by" `isInfixOf` ln) (lines output)
+  unless testsAreDisabled $ fail "Tests should not be run"

--- a/test/integration/tests/3959-order-of-flags/files/package.yaml
+++ b/test/integration/tests/3959-order-of-flags/files/package.yaml
@@ -1,0 +1,10 @@
+name: issue3959
+version: 0.1.0.0
+
+dependencies:
+- base
+
+tests:
+  test:
+    main:                Spec.hs
+    source-dirs:         test

--- a/test/integration/tests/3959-order-of-flags/files/stack.yaml
+++ b/test/integration/tests/3959-order-of-flags/files/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-11.6

--- a/test/integration/tests/3959-order-of-flags/files/test/Spec.hs
+++ b/test/integration/tests/3959-order-of-flags/files/test/Spec.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = fail "this always fails for the test"


### PR DESCRIPTION
This fixes #3959.

The problem is that the [switch](https://hackage.haskell.org/package/optparse-applicative/docs/Options-Applicative-Builder.html#v:switch) function returns a `Just False` which gets wrapped into `First`.

This means that the value is *always* set to either `True` or `False`
and the `First` monoid means that during options parsing the order of
the flags suddenly matters as described in #3959, because `First (Just
False)` is chosen when `mappend`ing with `First (Just True)`.

The fix is to use the [flag](https://hackage.haskell.org/package/optparse-applicative-0.14.2.0/docs/Options-Applicative-Builder.html#v:flag-39-) function that does not set a default value, so we get a `First Nothing` instead.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
  there should be no user relevant changes
* [x] The documentation has been updated, if necessary.
  no relevant changes

Please also shortly describe how you tested your change. Bonus points for added tests!
There is a new integration test in the `3959-order-of-flags` folder that makes sure that the order does not matter.