### PR TITLE
fixed: missing flush before getLine

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,7 +42,7 @@ Bug fixes:
   was tried to be registered. This is now fixed by always building internal
   libraries. See
   [#3996](https://github.com/commercialhaskell/stack/issues/3996).
-
+* missing of flush before upload prompt. See [#4069](https://github.com/commercialhaskell/stack/pull/4069)
 
 ## v1.7.1
 

--- a/src/Stack/Upload.hs
+++ b/src/Stack/Upload.hs
@@ -114,6 +114,7 @@ loadCreds config = do
 
     loopPrompt :: String -> IO String
     loopPrompt p = do
+      hFlush stdout
       input <- TIO.getLine
       case input of
         "y" -> return "y"


### PR DESCRIPTION
I found bug of prompt.

~~~
2018-06-08T19:33:51 ncaq@karen/pts/0(130) ~/Desktop/debug-trace-var
% stack upload .
Getting file list for /home/ncaq/Desktop/debug-trace-var/
Building sdist tarball for /home/ncaq/Desktop/debug-trace-var/
Checking package 'debug-trace-var' for common mistakes
Hackage username: ncaq
Hackage password:

y
Save hackage credentials to file at /home/ncaq/.stack/upload/credentials.json [y/n]? Save hackage credentials to file at /home/ncaq/.stack/upload/credentials.json [y/n]? NOTE: Avoid this prompt in the future by using: save-hackage-creds: false
Saved!
Uploading debug-trace-var-0.1.0.tar.gz... done!
~~~

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
