### PR TITLE
get-stack: check deps before sudo

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -561,7 +561,9 @@ try_install_pkgs() {
 
 # Install packages using apt-get
 apt_get_install_pkgs() {
-  if ! sudocmd apt-get install -y ${QUIET:+-qq} "$@"; then
+  if dpkg-query -W "$@" > /dev/null; then
+    info "Already installed!"
+  elif ! sudocmd apt-get install -y ${QUIET:+-qq} "$@"; then
     die "Installing apt packages failed.  Please run 'apt-get update' and try again."
   fi
 }


### PR DESCRIPTION
Don't need to invoke sudo if all deps are already installed.
Avoiding the sudo prompt where possible is going to be an improvement.

* [ :heavy_check_mark: ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ :heavy_check_mark: ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

I re-ran the script a few times, sometimes uninstalling libgmp-dev, and verified it skips `sudo apt install`
when appropriate.