### PR TITLE
get-stack: allow users to use sudo carefully

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -127,8 +127,15 @@ print_bindist_notice() {
 
 # Adds a 'sudo' prefix if sudo is available to execute the given command
 # If not, the given command is run as is
+# When requesting root permission, always show the command and never re-use cached credentials.
 sudocmd() {
-  $(command -v sudo) "$@"
+  if command -v sudo >/dev/null; then
+    echo "sudo $@"
+    # -k: Always prompt.
+    sudo -k "$@"
+  else
+    "$@"
+  fi
 }
 
 # Install dependencies for distros that use Apt
@@ -159,7 +166,8 @@ do_ubuntu_install() {
     install_aarch64_binary
   elif is_64_bit ; then
     install_dependencies
-    print_bindist_notice
+
+print_bindist_notice
     install_64bit_standard_binary
   else
     install_dependencies

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -166,8 +166,7 @@ do_ubuntu_install() {
     install_aarch64_binary
   elif is_64_bit ; then
     install_dependencies
-
-print_bindist_notice
+    print_bindist_notice
     install_64bit_standard_binary
   else
     install_dependencies

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -131,7 +131,7 @@ print_bindist_notice() {
 sudocmd() {
   if command -v sudo >/dev/null; then
     echo "sudo $@"
-    # -k: Always prompt.
+    # -k: Disable cached credentials.
     sudo -k "$@"
   else
     "$@"


### PR DESCRIPTION
When requesting root permission, always show the command and never re-use cached credentials.

* [ :heavy_check_mark: ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ :heavy_check_mark: ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!


Note that the second sudo invocation doesn't prompt for password: (This also has #4074 applied.)
```
$ sudo apt remove libgmp-dev                          
[sudo] password for buck: 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages will be REMOVED:
  libgmp-dev
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 1,612 kB disk space will be freed.
Do you want to continue? [Y/n] 
(Reading database ... 295761 files and directories currently installed.)
Removing libgmp-dev:amd64 (2:6.1.2+dfsg-1) ...

$ sudo whoami
root

$ cat get.haskellstack.org | sh
Detected Linux distribution: ubuntu

Installing dependencies...

dpkg-query: no packages found matching libgmp-dev
sudo apt-get install -y g++ gcc libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev git gnupg
[sudo] password for buck: 
```