### PR TITLE
Use a fixed temp dir on AppVeyor

### DIFF
--- a/doc/appveyor.yml
+++ b/doc/appveyor.yml
@@ -12,6 +12,10 @@ environment:
   global:
     STACK_ROOT: "c:\\sr"
 
+    # Override the temp directory to avoid sed escaping issues
+    # See https://github.com/haskell/cabal/issues/5386
+    TMP: "c:\\tmp"
+
   matrix:
   - ARGS: ""
   #- ARGS: "--resolver lts-2"


### PR DESCRIPTION
This is a workaround for haskell/cabal#5386 and #3944