### PR TITLE
Solver cabal install hint

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -55,6 +55,8 @@ Bug fixes:
 * When prompting users about saving their Hackage credentials on upload,
   flush to stdout before waiting for the response so the prompt actually
   displays. Also fixes a similar issue with ghci target selection prompt.
+* If `cabal` is not on PATH, running `stack solver` now prompts the user
+  to run `stack install cabal-install`
 
 
 ## v1.7.1

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -1353,7 +1353,7 @@ buildInGhcjsEnv envConfig boptsCli = do
 
 getCabalInstallVersion :: (HasProcessContext env, HasLogFunc env) => RIO env (Maybe Version)
 getCabalInstallVersion = do
-    ebs <- proc "cabal" ["--numeric-version"] $ tryAny . readProcessStdout_
+    ebs <- tryAny $ proc "cabal" ["--numeric-version"] readProcessStdout_
     case ebs of
         Left _ -> return Nothing
         Right bs -> Just <$> parseVersion (T.dropWhileEnd isSpace (T.decodeUtf8 (LBS.toStrict bs)))


### PR DESCRIPTION
Resolves #3841.

Recover from all errors on invoking `proc "cabal" --numeric-version`.

This reintroduces the helpful hint to `stack install cabal-install` if `stack solver` is run when `cabal` is not on PATH, instead of displaying the exception message propagated from RIO (thanks for the help, @mgsloan!).

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

* Ran `stack solver` on a project using an existing version of stack, with and without cabal on PATH
* Ran `stack solver` on the same project using the modified stack, with and without cabal on PATH. Verified that the helpful hint was displayed without cabal on PATH; verified that `stack solver` ran without issue with cabal on PATH