### PR TITLE
4039 namespaced templates

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,9 @@ Other enhancements:
   `extra-deps` of `stack.yaml`
 * `stack build` suggests trying another GHC version should the build
   plan end up requiring unattainable `base` version.
+* `stack new` now allows template names of the form `username/foo` to download
+  from a user other than `commercialstack` on Github, and can be prefixed with
+  the service `github:`, `gitlab:`, or `bitbucket:`.
 
 Bug fixes:
 

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -141,6 +141,15 @@ loadTemplate name logIt = do
                                                      (templateDir </> relFile)
                         Nothing -> throwM e
                 )
+        RepoPath (RepoTemplatePath service user name) ->
+            case service of
+                "github" -> do
+                    let url = T.concat ["https://raw.githubusercontent.com", "/", user, "/stack-templates/", name]
+                    let s = T.unpack url
+                    req <- parseRequest s
+                    let rel = fromMaybe backupUrlRelPath (parseRelFile s)
+                    downloadTemplate req (templateDir </> rel)
+                            
   where
     loadLocalFile :: Path b File -> RIO env Text
     loadLocalFile path = do

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -341,6 +341,10 @@ parseTemplateSet a = do
 defaultTemplateName :: TemplateName
 defaultTemplateName = $(mkTemplateName "new-template")
 
+-- | The default service to use to download templates.
+defaultRepoService :: RepoService
+defaultRepoService = Github
+
 -- | Default web URL to get a yaml file containing template metadata.
 defaultTemplateInfoUrl :: String
 defaultTemplateInfoUrl =

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -153,9 +153,9 @@ loadTemplate name logIt = do
             else throwM (FailedToLoadTemplate name (toFilePath path))
     relRequest :: MonadThrow n => Path Rel File -> n Request
     relRequest rel = do
-        rtp <- case parseRepoPathWithDefaultService (toFilePath rel) of
-                Just rtp -> return rtp
-                Nothing -> throwM (FailedToLoadTemplate name (toFilePath rel))
+        rtp <- case parseRepoPathWithService defaultRepoService (toFilePath rel) of
+            Just rtp -> return rtp
+            Nothing -> throwM (FailedToLoadTemplate name (toFilePath rel)) -- TODO: Is this the right error?
         let url = urlFromRepoTemplatePath rtp
         parseRequest (T.unpack url)
     downloadFromUrl :: String -> Path Abs Dir -> RIO env Text
@@ -338,6 +338,10 @@ parseTemplateSet a = do
 -- | The default template name you can use if you don't have one.
 defaultTemplateName :: TemplateName
 defaultTemplateName = $(mkTemplateName "new-template")
+
+-- | The default service to use to download templates.
+defaultRepoService :: RepoService
+defaultRepoService = Github
 
 -- | Default web URL to get a yaml file containing template metadata.
 defaultTemplateInfoUrl :: String

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -153,7 +153,7 @@ loadTemplate name logIt = do
             else throwM (FailedToLoadTemplate name (toFilePath path))
     relRequest :: Path Rel File -> Maybe Request
     relRequest rel = do
-        rtp <- parseRepoPathWithService defaultRepoService (toFilePath rel)
+        rtp <- parseRepoPathWithService defaultRepoService (T.pack (toFilePath rel))
         let url = urlFromRepoTemplatePath rtp
         parseRequest (T.unpack url)
     downloadFromUrl :: String -> Path Abs Dir -> RIO env Text
@@ -175,6 +175,10 @@ loadTemplate name logIt = do
 urlFromRepoTemplatePath :: RepoTemplatePath -> Text
 urlFromRepoTemplatePath (RepoTemplatePath Github user name) =
     T.concat ["https://raw.githubusercontent.com", "/", user, "/stack-templates/master/", name]
+urlFromRepoTemplatePath (RepoTemplatePath Gitlab user name) =
+    T.concat ["https://gitlab.com",                "/", user, "/stack-templates/raw/master/", name]
+urlFromRepoTemplatePath (RepoTemplatePath Bitbucket user name) =
+    T.concat ["https://bitbucket.org",             "/", user, "/stack-templates/raw/master/", name]
 
 -- | Apply and unpack a template into a directory.
 applyTemplate
@@ -336,10 +340,6 @@ parseTemplateSet a = do
 -- | The default template name you can use if you don't have one.
 defaultTemplateName :: TemplateName
 defaultTemplateName = $(mkTemplateName "new-template")
-
--- | The default service to use to download templates.
-defaultRepoService :: RepoService
-defaultRepoService = Github
 
 -- | Default web URL to get a yaml file containing template metadata.
 defaultTemplateInfoUrl :: String

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -151,11 +151,9 @@ loadTemplate name logIt = do
         if exists
             then liftIO (fmap (T.decodeUtf8With T.lenientDecode) (SB.readFile (toFilePath path)))
             else throwM (FailedToLoadTemplate name (toFilePath path))
-    relRequest :: MonadThrow n => Path Rel File -> n Request
+    relRequest :: Path Rel File -> Maybe Request
     relRequest rel = do
-        rtp <- case parseRepoPathWithService defaultRepoService (toFilePath rel) of
-            Just rtp -> return rtp
-            Nothing -> throwM (FailedToLoadTemplate name (toFilePath rel)) -- TODO: Is this the right error?
+        rtp <- parseRepoPathWithService defaultRepoService (toFilePath rel)
         let url = urlFromRepoTemplatePath rtp
         parseRequest (T.unpack url)
     downloadFromUrl :: String -> Path Abs Dir -> RIO env Text

--- a/src/Stack/Options/NewParser.hs
+++ b/src/Stack/Options/NewParser.hs
@@ -24,7 +24,8 @@ newOptsParser = (,) <$> newOpts <*> initOptsParser
         optional (templateNameArgument
             (metavar "TEMPLATE_NAME" <>
              help "Name of a template - can take the form\
-                \ [github:][username/]template with optional service name\
+                \ [service:][username/]template with optional service name\
+                \ (github, gitlab, or bitbucket) \
                 \ and username for the service; or, a local filename such as\
                 \ foo.hsfiles or ~/foo; or, a full URL such as\
                 \ https://example.com/foo.hsfiles.")) <*>

--- a/src/Stack/Options/NewParser.hs
+++ b/src/Stack/Options/NewParser.hs
@@ -23,9 +23,11 @@ newOptsParser = (,) <$> newOpts <*> initOptsParser
              help "Do not create a subdirectory for the project") <*>
         optional (templateNameArgument
             (metavar "TEMPLATE_NAME" <>
-             help "Name of a template or a local template in a file or a URL.\
-                  \ For example: foo or foo.hsfiles or ~/foo or\
-                  \ https://example.com/foo.hsfiles")) <*>
+             help "Name of a template - can take the form\
+                \ [github:][username/]template with optional service name\
+                \ and username for the service; or, a local filename such as\
+                \ foo.hsfiles or ~/foo; or, a full URL such as\
+                \ https://example.com/foo.hsfiles.")) <*>
         fmap
             M.fromList
             (many

--- a/src/Stack/Types/TemplateName.hs
+++ b/src/Stack/Types/TemplateName.hs
@@ -126,10 +126,6 @@ templateName (TemplateName prefix _) = prefix
 templatePath :: TemplateName -> TemplatePath
 templatePath (TemplateName _ fp) = fp
 
--- | The default service to use to download templates.
-defaultRepoService :: RepoService
-defaultRepoService = Github
-
 defaultRepoUser :: Text
 defaultRepoUser = "commercialhaskell"
 
@@ -140,7 +136,6 @@ parseRepoPath s =
     ["github"    , rest] -> parseRepoPathWithService Github rest
     ["gitlab"    , rest] -> parseRepoPathWithService Gitlab rest
     ["bitbucket" , rest] -> parseRepoPathWithService Bitbucket rest
-    [rest]               -> parseRepoPathWithService defaultRepoService rest
     _                    -> Nothing
 
 -- | Parses a template path of the form @user/template@, assuming the default service.

--- a/src/Stack/Types/TemplateName.hs
+++ b/src/Stack/Types/TemplateName.hs
@@ -124,9 +124,6 @@ templateName (TemplateName prefix _) = prefix
 templatePath :: TemplateName -> TemplatePath
 templatePath (TemplateName _ fp) = fp
 
-defaultRepoService :: RepoService
-defaultRepoService = Github
-
 defaultRepoUser :: Text
 defaultRepoUser = "commercialhaskell"
 
@@ -135,20 +132,20 @@ parseRepoPath :: FilePath -> Maybe RepoTemplatePath
 parseRepoPath path =
     case T.stripPrefix "github:" (T.pack path) of
         Just strippedPath ->
-            parseRepoPathWithDefaultService (T.unpack strippedPath)
+            parseRepoPathWithService Github (T.unpack strippedPath)
         _ -> Nothing
 
 -- | Parses a template path of the form @user/template@, assuming the default service.
-parseRepoPathWithDefaultService :: FilePath -> Maybe RepoTemplatePath
-parseRepoPathWithDefaultService path =
+parseRepoPathWithService :: RepoService -> FilePath -> Maybe RepoTemplatePath
+parseRepoPathWithService service path =
     case T.split (== '/') (T.pack path) of
         [tname] -> Just $ RepoTemplatePath
-            { rtpService = Github
+            { rtpService = service
             , rtpUser = defaultRepoUser
             , rtpTemplate = tname
             }
         [user, tname] -> Just $ RepoTemplatePath
-            { rtpService = Github
+            { rtpService = service
             , rtpUser = user
             , rtpTemplate = tname
             }

--- a/src/Stack/Types/TemplateName.hs
+++ b/src/Stack/Types/TemplateName.hs
@@ -128,12 +128,12 @@ parseRepoPath path =
         Just strippedPath ->
             case T.split (== '/') strippedPath of
                 [tname] -> Just $ RepoTemplatePath
-                    { rtpService = defaultRepoService
+                    { rtpService = "github"
                     , rtpUser = defaultRepoUser
                     , rtpTemplate = tname
                     }
                 [user, tname] -> Just $ RepoTemplatePath
-                    { rtpService = defaultRepoService
+                    { rtpService = "github"
                     , rtpUser = user
                     , rtpTemplate = tname
                     }

--- a/src/Stack/Types/TemplateName.hs
+++ b/src/Stack/Types/TemplateName.hs
@@ -135,16 +135,21 @@ parseRepoPath :: FilePath -> Maybe RepoTemplatePath
 parseRepoPath path =
     case T.stripPrefix "github:" (T.pack path) of
         Just strippedPath ->
-            case T.split (== '/') strippedPath of
-                [tname] -> Just $ RepoTemplatePath
-                    { rtpService = Github
-                    , rtpUser = defaultRepoUser
-                    , rtpTemplate = tname
-                    }
-                [user, tname] -> Just $ RepoTemplatePath
-                    { rtpService = Github
-                    , rtpUser = user
-                    , rtpTemplate = tname
-                    }
-                _ -> Nothing
+            parseRepoPathWithDefaultService (T.unpack strippedPath)
+        _ -> Nothing
+
+-- | Parses a template path of the form @user/template@, assuming the default service.
+parseRepoPathWithDefaultService :: FilePath -> Maybe RepoTemplatePath
+parseRepoPathWithDefaultService path =
+    case T.split (== '/') (T.pack path) of
+        [tname] -> Just $ RepoTemplatePath
+            { rtpService = Github
+            , rtpUser = defaultRepoUser
+            , rtpTemplate = tname
+            }
+        [user, tname] -> Just $ RepoTemplatePath
+            { rtpService = Github
+            , rtpUser = user
+            , rtpTemplate = tname
+            }
         _ -> Nothing


### PR DESCRIPTION
* `stack new` now allows template names of the form `username/foo` to download
  from a user other than `commercialstack` on Github, and can be prefixed with
  the service `github:`, `gitlab:`, or `bitbucket:`.
* Changelog.md has been updated
* Help text for `stack new` has been updated
* Tested this by temporarily adding a trace in the `downloadTemplate` function, to see the request it was using to download the template, and trying various new and old forms of the template name. Also created a local template and made sure that still took priority over a remote download.
* I would have liked to add an integration test, but it's hard to test things that download from remote URLs. There isn't currently a way to stub that out.