### PR TITLE
Re #4091: Pre-Windows 10, default --color=never

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,8 @@ Behavior changes:
 
 Other enhancements:
 
+* On Windows before Windows 10, --color=never is the default on terminals that
+  can support ANSI color codes in output only by emulation
 * On Windows, recognise a 'mintty' (false) terminal as a terminal, by default
 * `stack build` issues a warning when `base` is explicitly listed in
   `extra-deps` of `stack.yaml`

--- a/package.yaml
+++ b/package.yaml
@@ -175,6 +175,7 @@ library:
   - Stack.Constants
   - Stack.Constants.Config
   - Stack.Coverage
+  - Stack.DefaultColorWhen
   - Stack.Docker
   - Stack.Docker.GlobalDB
   - Stack.Dot

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -21,6 +21,7 @@ import qualified Distribution.Types.UnqualComponentName as C
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
 import           Stack.Config (getLocalPackages)
+import           Stack.DefaultColorWhen (defaultColorWhen)
 import           Stack.Options.GlobalParser (globalOptsFromMonoid)
 import           Stack.Runners (loadConfigWithOpts)
 import           Stack.Prelude hiding (lift)
@@ -57,7 +58,8 @@ buildConfigCompleter inner = mkCompleter $ \inputRaw -> do
         -- If it looks like a flag, skip this more costly completion.
         ('-': _) -> return []
         _ -> do
-            let go = (globalOptsFromMonoid False mempty)
+            defColorWhen <- liftIO defaultColorWhen
+            let go = (globalOptsFromMonoid False defColorWhen mempty)
                     { globalLogLevel = LevelOther "silent" }
             loadConfigWithOpts go $ \lc -> do
               bconfig <- liftIO $ lcLoadBuildConfig lc (globalCompiler go)

--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -38,7 +38,10 @@ globalOptsParser currentDir kind defLogLevel =
         (long "color" <>
          metavar "WHEN" <>
          completeWith ["always", "never", "auto"] <>
-         help "Specify when to use color in output; WHEN is 'always', 'never', or 'auto'" <>
+         help "Specify when to use color in output; WHEN is 'always', 'never', \
+              \or 'auto'. On Windows versions before Windows 10, for terminals \
+              \that do not support color codes, the default is 'never'; color \
+              \may work on terminals that support color codes" <>
          hide)) <*>
     optionalFirst (option auto
         (long "terminal-width" <>
@@ -58,8 +61,8 @@ globalOptsParser currentDir kind defLogLevel =
     hide0 = kind /= OuterGlobalOpts
 
 -- | Create GlobalOpts from GlobalOptsMonoid.
-globalOptsFromMonoid :: Bool -> GlobalOptsMonoid -> GlobalOpts
-globalOptsFromMonoid defaultTerminal GlobalOptsMonoid{..} = GlobalOpts
+globalOptsFromMonoid :: Bool -> ColorWhen -> GlobalOptsMonoid -> GlobalOpts
+globalOptsFromMonoid defaultTerminal defaultColorWhen GlobalOptsMonoid{..} = GlobalOpts
     { globalReExecVersion = getFirst globalMonoidReExecVersion
     , globalDockerEntrypoint = getFirst globalMonoidDockerEntrypoint
     , globalLogLevel = fromFirst defaultLogLevel globalMonoidLogLevel
@@ -68,7 +71,7 @@ globalOptsFromMonoid defaultTerminal GlobalOptsMonoid{..} = GlobalOpts
     , globalResolver = getFirst globalMonoidResolver
     , globalCompiler = getFirst globalMonoidCompiler
     , globalTerminal = fromFirst defaultTerminal globalMonoidTerminal
-    , globalColorWhen = fromFirst ColorAuto globalMonoidColorWhen
+    , globalColorWhen = fromFirst defaultColorWhen globalMonoidColorWhen
     , globalTermWidth = getFirst globalMonoidTermWidth
     , globalStackYaml = maybe SYLDefault SYLOverride $ getFirst globalMonoidStackYaml }
 

--- a/src/unix/Stack/DefaultColorWhen.hs
+++ b/src/unix/Stack/DefaultColorWhen.hs
@@ -1,0 +1,11 @@
+{- | This version of the module is only for non-Windows (eg unix-like)
+operating systems.
+-}
+module Stack.DefaultColorWhen
+  ( defaultColorWhen
+  ) where
+
+import Stack.Types.Runner (ColorWhen (ColorAuto))
+
+defaultColorWhen :: IO ColorWhen
+defaultColorWhen = return ColorAuto

--- a/src/windows/Stack/DefaultColorWhen.hs
+++ b/src/windows/Stack/DefaultColorWhen.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE CPP #-}
+
+{- | This version of the module is only for Windows operating systems.
+-}
+module Stack.DefaultColorWhen
+  ( defaultColorWhen
+  ) where
+
+-- The Win32 package provides CPP macro WINDOWS_CCONV.
+#include "windows_cconv.h"
+
+import Stack.Prelude (stdout)
+import Stack.Types.Runner (ColorWhen (ColorAuto, ColorNever))
+
+import Data.Bits ((.|.), (.&.))
+import Foreign.Marshal (alloca)
+import Foreign.Ptr (Ptr)
+import Foreign.Storable (peek)
+import System.Win32.Types (BOOL, DWORD, HANDLE, iNVALID_HANDLE_VALUE,
+  nullHANDLE, withHandleToHANDLE)
+
+defaultColorWhen :: IO ColorWhen
+defaultColorWhen = withHandleToHANDLE stdout aNSISupport
+
+-- The following is based on extracts from the modules
+-- System.Console.ANSI.Windows.Foreign and System.Console.ANSI.Windows.Detect
+-- from the ansi-terminal package, simplified.
+
+-- | This function first checks if the Windows handle is valid and yields
+-- 'never' if it is not. It then tries to get a ConHost console mode for that
+-- handle. If it can not, it assumes that the handle is ANSI-enabled. If virtual
+-- termimal (VT) processing is already enabled, the handle supports 'auto'.
+-- Otherwise, it trys to enable processing. If it can, the handle supports
+-- 'auto'. If it can not, the function yields 'never'.
+aNSISupport :: HANDLE -> IO ColorWhen
+aNSISupport h =
+  if h == iNVALID_HANDLE_VALUE || h == nullHANDLE
+    then return ColorNever  -- Invalid handle or no handle
+    else do
+      tryMode <- getConsoleMode h
+      case tryMode of
+        Nothing     -> return ColorAuto  -- No ConHost mode
+        Just mode   -> if mode .&. eNABLE_VIRTUAL_TERMINAL_PROCESSING /= 0
+          then return ColorAuto  -- VT processing already enabled
+          else do
+            let mode' = mode .|. eNABLE_VIRTUAL_TERMINAL_PROCESSING
+            succeeded <- cSetConsoleMode h mode'
+            if succeeded
+              then return ColorAuto  -- VT processing enabled
+              else return ColorNever -- Can't enable VT processing
+ where
+  eNABLE_VIRTUAL_TERMINAL_PROCESSING = 4
+
+foreign import WINDOWS_CCONV unsafe "windows.h GetConsoleMode"
+  cGetConsoleMode :: HANDLE -> Ptr DWORD -> IO BOOL
+
+foreign import WINDOWS_CCONV unsafe "windows.h SetConsoleMode"
+  cSetConsoleMode :: HANDLE -> DWORD -> IO BOOL
+
+getConsoleMode :: HANDLE -> IO (Maybe DWORD)
+getConsoleMode handle = alloca $ \ptr_mode -> do
+  succeeded <- cGetConsoleMode handle ptr_mode
+  if succeeded
+    then Just <$> peek ptr_mode
+    else pure Nothing

--- a/stack.yaml
+++ b/stack.yaml
@@ -30,3 +30,6 @@ extra-deps:
 - resourcet-1.1.11@rev:0
 - conduit-1.2.13@rev:0
 - conduit-extra-1.2.3.2@rev:0
+
+# Not present until resolver lts-11.9
+- ansi-terminal-0.8.0.4


### PR DESCRIPTION
Implements `--color=never` as default on Windows before Windows 10, if emulation would be required to support ANSI colour codes.

Also bumps the lts-11 resolver in `stack.yaml` to lts-11.14, in order to benefit from `ansi-terminal-0.8.0.4`.

`defaultColorWhen`, exported by new module `Stack.DefaultColorWhen`, establishes the default. That module differs, pending on whether the operating system is Windows or non-Windows (see the conditional in `package.yaml`).

`globalOptsFromMonoid` in module `Stack.Options.GlobalParser` is modified so that the default is an argument rather than a given.

A beneficial side-effect of `defaultColorWhen` on Windows is that it enables ANSI on ANSI-capable native terminals. This allows some existing code in module `Main` to be removed.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Tested on Windows 10 and some limited testing on Windows 7.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
