### PR TITLE
Fix issues with stderr being inherited by child processes

### DIFF
--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -168,13 +168,13 @@ generateHpcReportInternal tixSrc reportDir report extraMarkupArgs extraReportArg
                     -- Look for index files in the correct dir (relative to each pkgdir).
                     ["--hpcdir", toFilePathNoTrailingSep hpcRelDir, "--reset-hpcdirs"]
             logInfo $ "Generating " <> RIO.display report
-            outputLines <- liftM (map (S8.filter (/= '\r')) . S8.lines . BL.toStrict) $
+            outputLines <- liftM (map (S8.filter (/= '\r')) . S8.lines . BL.toStrict . fst) $
                 proc "hpc"
                 ( "report"
                 : toFilePath tixSrc
                 : (args ++ extraReportArgs)
                 )
-                readProcessStdout_
+                readProcess_
             if all ("(0/0)" `S8.isSuffixOf`) outputLines
                 then do
                     let msg html =
@@ -202,7 +202,7 @@ generateHpcReportInternal tixSrc reportDir report extraMarkupArgs extraReportArg
                         : ("--destdir=" ++ toFilePathNoTrailingSep reportDir)
                         : (args ++ extraMarkupArgs)
                         )
-                        readProcessStdout_
+                        readProcess_
                     return (Just reportPath)
 
 data HpcReportOpts = HpcReportOpts

--- a/src/Stack/Hoogle.hs
+++ b/src/Stack/Hoogle.hs
@@ -164,7 +164,7 @@ hoogleCmd (args,setup,rebuild,startServer) go = withBuildConfig go $ do
             Right hooglePath -> do
                 result <- withProcessContext menv
                         $ proc hooglePath ["--numeric-version"]
-                        $ tryAny . readProcessStdout_
+                        $ tryAny . fmap fst . readProcess_
                 let unexpectedResult got = Left $ T.concat
                         [ "'"
                         , T.pack hooglePath

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -96,7 +96,7 @@ getCompilerVersion wc =
     case wc of
         Ghc -> do
             logDebug "Asking GHC for its version"
-            bs <- proc "ghc" ["--numeric-version"] readProcessStdout_
+            bs <- fst <$> proc "ghc" ["--numeric-version"] readProcess_
             let (_, ghcVersion) = versionFromEnd $ BL.toStrict bs
             x <- GhcVersion <$> parseVersion (T.decodeUtf8 ghcVersion)
             logDebug $ "GHC version is: " <> display x
@@ -106,7 +106,7 @@ getCompilerVersion wc =
             -- Output looks like
             --
             -- The Glorious Glasgow Haskell Compilation System for JavaScript, version 0.1.0 (GHC 7.10.2)
-            bs <- proc "ghcjs" ["--version"] readProcessStdout_
+            bs <- fst <$> proc "ghcjs" ["--version"] readProcess_
             let (rest, ghcVersion) = T.decodeUtf8 <$> versionFromEnd (BL.toStrict bs)
                 (_, ghcjsVersion) = T.decodeUtf8 <$> versionFromEnd rest
             GhcjsVersion <$> parseVersion ghcjsVersion <*> parseVersion ghcVersion

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -113,11 +113,11 @@ cabalSolver cabalfps constraintType
                fmap toFilePath cabalfps
 
     try ( withWorkingDir (toFilePath tmpdir)
-        $ proc "cabal" args readProcessStdout_
+        $ proc "cabal" args readProcess_
         )
         >>= either
           (parseCabalErrors . eceStderr)
-          (parseCabalOutput . BL.toStrict)
+          (parseCabalOutput . BL.toStrict . fst)
 
   where
     errCheck = T.isInfixOf "Could not resolve dependencies"


### PR DESCRIPTION
The only case where stdio should be inherited is when passing execution to
another process, so there should be no uses of runProcess

Most processes should also not inherit stdin, but I'm not sure if there are any
concrete issues with this in stack. I recall some prior issues where some
processes do not like being given a closed stdin, for example.

There is one remaining use of readProcessStdout_ in Stack.Docker which should
probably be fixed. However, I'm not sure what the correct implementation there
should be. The comment in the code makes it seem like it should log stderr while
reading stdout.

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
