### PR TITLE
Changed the default retry strategy

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,9 @@ Other enhancements:
   `build.interleaved-output` config value which causes multiple concurrent
   builds to dump to stderr at the same time with a `packagename> ` prefix. See
   [#3225](https://github.com/commercialhaskell/stack/issues/3225).
+* The default retry strategy has changed to exponential backoff.
+  This should help with
+  [#3510](https://github.com/commercialhaskell/stack/issues/3510).
 
 Bug fixes:
 

--- a/src/Network/HTTP/Download/Verified.hs
+++ b/src/Network/HTTP/Download/Verified.hs
@@ -30,7 +30,7 @@ import qualified    Data.Text.Encoding as Text
 import              Control.Monad
 import              Control.Monad.Catch (Handler (..)) -- would be nice if retry exported this itself
 import              Stack.Prelude hiding (Handler (..))
-import              Control.Retry (recovering,limitRetries,RetryPolicy,constantDelay,RetryStatus(..))
+import              Control.Retry (recovering,limitRetries,RetryPolicy,exponentialBackoff,RetryStatus(..))
 import              Crypto.Hash
 import              Crypto.Hash.Conduit (sinkHash)
 import              Data.ByteArray as Mem (convert)
@@ -72,7 +72,7 @@ data DownloadRequest = DownloadRequest
 -- * 3.2s
 -- * 6.4s
 drRetryPolicyDefault :: RetryPolicy
-drRetryPolicyDefault = limitRetries 7 <> constantDelay onehundredMilliseconds
+drRetryPolicyDefault = limitRetries 7 <> exponentialBackoff onehundredMilliseconds
   where onehundredMilliseconds = 100000
 
 data HashCheck = forall a. (Show a, HashAlgorithm a) => HashCheck

--- a/src/Network/HTTP/Download/Verified.hs
+++ b/src/Network/HTTP/Download/Verified.hs
@@ -59,9 +59,20 @@ data DownloadRequest = DownloadRequest
     , drRetryPolicy :: RetryPolicy
     }
 
--- | Default to retrying thrice with a short constant delay.
+-- | Default to retrying seven times with exponential backoff starting from
+-- one hundred milliseconds.
+--
+-- This means the tries will occur after these delays if necessary:
+--
+-- * 0.1s
+-- * 0.2s
+-- * 0.4s
+-- * 0.8s
+-- * 1.6s
+-- * 3.2s
+-- * 6.4s
 drRetryPolicyDefault :: RetryPolicy
-drRetryPolicyDefault = limitRetries 3 <> constantDelay onehundredMilliseconds
+drRetryPolicyDefault = limitRetries 7 <> constantDelay onehundredMilliseconds
   where onehundredMilliseconds = 100000
 
 data HashCheck = forall a. (Show a, HashAlgorithm a) => HashCheck
@@ -210,6 +221,7 @@ recoveringHttp retryPolicy =
             [ "If you see this warning and stack fails to download,"
             , "but running the command again solves the problem,"
             , "please report here: https://github.com/commercialhaskell/stack/issues/3510"
+            , "Make sure to paste the output of 'stack --version'"
             ]
           ]
       return True


### PR DESCRIPTION
This changes makes the default retry strategy an exponential backoff
starting from 100 ms.
This should counteract the problem that is being tracked in #3510.
This new strategy means that it will take 12.7 seconds for stack to
fail entirely when the network cable is unplugged.

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

I did not add any tests, as discussed with @snoyberg.
