### PR TITLE
Fixes self-executing scripts not piping plan construction errors from runhaskell to terminal, issue #3942

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -88,6 +88,10 @@ Bug fixes:
   was a package with a sublibrary in the snapshot resulted in broken builds.
   This is now fixed, see
   [#4071](https://github.com/commercialhaskell/stack/issues/4071).
+* [#4114] Stack pretty prints error messages with proper `error` logging
+  level instead of `warning` now. This also fixes self-executing scripts
+  not piping plan construction errors from runhaskell to terminal (issue
+  #3942).
 
 
 ## v1.7.1

--- a/src/Stack/PrettyPrint.hs
+++ b/src/Stack/PrettyPrint.hs
@@ -83,7 +83,7 @@ prettyErrorWith f = prettyWith LevelError
                            indentAfterLabel . f)
 prettyWarnNoIndentWith f  = prettyWith LevelWarn
                                   ((line <>) . (styleWarning "Warning:" <+>) . f)
-prettyErrorNoIndentWith f = prettyWith LevelWarn
+prettyErrorNoIndentWith f = prettyWith LevelError
                                   ((line <>) . (styleError   "Error:" <+>) . f)
 
 prettyDebug, prettyInfo, prettyNote, prettyWarn, prettyError, prettyWarnNoIndent, prettyErrorNoIndent

--- a/test/integration/tests/3942-solver-error-output/Main.hs
+++ b/test/integration/tests/3942-solver-error-output/Main.hs
@@ -1,0 +1,16 @@
+import Control.Monad (unless)
+import Data.List (isInfixOf)
+import StackTest
+
+planFailure :: String
+planFailure =
+  "While constructing the build plan, the following exceptions were encountered:"
+
+main :: IO ()
+main = do
+  stackErrStderr ["./script.hs"] (expectMessage planFailure)
+
+expectMessage :: String -> String -> IO ()
+expectMessage msg stderr = do
+  unless (words msg `isInfixOf` words stderr)
+         (error $ "Expected a warning: \n" ++ show msg)

--- a/test/integration/tests/3942-solver-error-output/files/.gitignore
+++ b/test/integration/tests/3942-solver-error-output/files/.gitignore
@@ -1,0 +1,3 @@
+.stack-work/
+*.cabal
+stack.yaml

--- a/test/integration/tests/3942-solver-error-output/files/script.hs
+++ b/test/integration/tests/3942-solver-error-output/files/script.hs
@@ -1,0 +1,5 @@
+#!/usr/bin/env stack
+-- stack runhaskell --stack-yaml test-stack.yml --package cloud-seeder
+
+main :: IO ()
+main = putStrLn "yo"

--- a/test/integration/tests/3942-solver-error-output/files/test-stack.yml
+++ b/test/integration/tests/3942-solver-error-output/files/test-stack.yml
@@ -1,0 +1,11 @@
+resolver: lts-8.22
+
+packages:
+- location:
+    git: git@github.com:cjdev/cloudseeder.git
+    commit: c7068f25c41bcc0b4bdfc9b38ee5b05b5caefae5
+  extra-dep: true
+
+flags: {}
+
+extra-package-dbs: []


### PR DESCRIPTION
The issue seems to have been caused by improper logging level. Fixed that and added an integration test case.

* [x] ChangeLog.md has a relevant bugfix entry
* [x] No documentation updates are necessary, I reckon

I have tested the fix in accordance with the issue + added integration test cases.
