### PR TITLE
mkdocs.yml: fix 'edit on github' link (fixes #4098)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,8 @@
 site_name: The Haskell Tool Stack
 site_description: The Haskell Tool Stack
 site_author: Stack contributors
-repo_url: https://github.com/commercialhaskell/stack/tree/master/doc
+repo_url: https://github.com/commercialhaskell/stack/
+edit_uri: edit/master/doc/
 copyright: Copyright (c) 2015-2018, Stack contributors
 docs_dir: doc
 site_dir: _site


### PR DESCRIPTION
I tested this locally using `mkdocs build`, and also enabled this branch on RTFD.  If you go to https://docs.haskellstack.org/en/fix-rtfd-edit-link/README/, the __Edit on Github__ link seems to be correct now (and same for other pages).