### PR TITLE
Point to user's config.yaml when advising 'allow-newer: true'

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -51,6 +51,9 @@ Other enhancements:
 * [#4039] `stack new` now allows template names of the form `username/foo` to
   download from a user other than `commercialstack` on Github, and can be prefixed
   with the service `github:`, `gitlab:`, or `bitbucket:`.
+* [#3685](https://github.com/commercialhaskell/stack/issues/3685)
+  Suggestion to add `'allow-newer': true` now shows path to user config
+  file where this flag should be put into
 
 Bug fixes:
 

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -229,7 +229,8 @@ constructPlan ls0 baseConfigOpts0 locals extraToBuild0 localDumpPkgs loadPackage
         else do
             planDebug $ show errs
             stackYaml <- view stackYamlL
-            prettyErrorNoIndent $ pprintExceptions errs stackYaml parents (wanted ctx)
+            stackRoot <- view stackRootL
+            prettyErrorNoIndent $ pprintExceptions errs stackYaml stackRoot parents (wanted ctx)
             throwM $ ConstructPlanFailed "Plan construction failed."
   where
     hasBaseInDeps bconfig =
@@ -967,10 +968,11 @@ data BadDependency
 pprintExceptions
     :: [ConstructPlanException]
     -> Path Abs File
+    -> Path Abs Dir
     -> ParentMap
     -> Set PackageName
     -> AnsiDoc
-pprintExceptions exceptions stackYaml parentMap wanted =
+pprintExceptions exceptions stackYaml stackRoot parentMap wanted =
     mconcat $
       [ flow "While constructing the build plan, the following exceptions were encountered:"
       , line <> line
@@ -980,7 +982,7 @@ pprintExceptions exceptions stackYaml parentMap wanted =
       , line <> line
       ] ++
       (if not onlyHasDependencyMismatches then [] else
-         [ "  *" <+> align (flow "Set 'allow-newer: true' to ignore all version constraints and build anyway.")
+         [ "  *" <+> align (flow "Set 'allow-newer: true' in " <+> toAnsiDoc (display (defaultUserConfigPath stackRoot)) <+> "to ignore all version constraints and build anyway.")
          , line <> line
          ]
       ) ++

--- a/test/integration/tests/3685-config-yaml-for-allow-newer/Main.hs
+++ b/test/integration/tests/3685-config-yaml-for-allow-newer/Main.hs
@@ -1,0 +1,23 @@
+import Control.Monad (unless)
+import Data.List (isInfixOf)
+import StackTest
+import System.Directory
+
+main :: IO ()
+main = do
+  stack ["init", defaultResolverArg]
+  (_, stdErr) <- stackStderr ["install", "intero-0.1.23"]
+  -- here we check stderr for 'allow-newer: true' and
+  -- config.yaml sitting either on the same line or on
+  -- two consecutive lines
+  let errLines = lines stdErr
+      hasNewer l = "'allow-newer: true'" `isInfixOf` l
+      withNewer = map hasNewer errLines
+      userConfig = "config.yaml"
+      hasConfigForAllowNewer prevNewer l =
+         (prevNewer || hasNewer l) &&
+        userConfig `isInfixOf` l
+      hasProperLines =
+        or $ zipWith hasConfigForAllowNewer (False:withNewer) errLines
+  unless hasProperLines $
+    error $ "Not stderr lines with 'allow-newer: true' and " ++ userConfig

--- a/test/integration/tests/3685-config-yaml-for-allow-newer/files/files.cabal
+++ b/test/integration/tests/3685-config-yaml-for-allow-newer/files/files.cabal
@@ -1,0 +1,10 @@
+name:           files
+version:        0.1.0.0
+build-type:     Simple
+cabal-version:  >= 2.0
+
+library
+  exposed-modules: Src
+  hs-source-dirs: src
+  build-depends: base
+  default-language: Haskell2010

--- a/test/integration/tests/3685-config-yaml-for-allow-newer/files/src/Src.hs
+++ b/test/integration/tests/3685-config-yaml-for-allow-newer/files/src/Src.hs
@@ -1,0 +1,5 @@
+module Src where
+
+-- | A function of the main library
+funMainLib :: Int -> Int
+funMainLib = succ


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Tested using `stack exec -- stack install intero-0.1.23` from the stack's work directory

Fixes #3685 

