### PR TITLE
Use a hard-coded tool dependency map (fixes #4125)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,13 @@ Behavior changes:
   [help file](https://github.com/commercialhaskell/stack-templates/blob/master/STACK_HELP.md)
   with more information on how to discover templates. See:
   [#4039](https://github.com/commercialhaskell/stack/issues/4039)
+* Build tools are now handled in a similar way to `cabal-install`. In
+  particular, for legacy `build-tools` fields, we use a hard-coded
+  list of build tools in place of looking up build tool packages in a
+  tool map. This both brings Stack's behavior closer into line with
+  `cabal-install`, avoids some bugs, and opens up some possible
+  optimizations/laziness. See:
+  [#4125](https://github.com/commercialhaskell/stack/issues/4125).
 
 Other enhancements:
 

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -286,8 +286,8 @@ loadLocalPackage isLocal boptsCli targets (name, lpv) = do
 
     return LocalPackage
         { lpPackage = pkg
-        , lpTestDeps = packageDeps testpkg
-        , lpBenchDeps = packageDeps benchpkg
+        , lpTestDeps = dvVersionRange <$> packageDeps testpkg
+        , lpBenchDeps = dvVersionRange <$> packageDeps benchpkg
         , lpTestBench = btpkg
         , lpComponentFiles = componentFiles
         , lpForceDirty = boptsForceDirty bopts

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -733,6 +733,7 @@ hardCodedMap = M.fromList
   , ("c2hs", Distribution.Package.mkPackageName "c2hs")
   , ("hscolour", Distribution.Package.mkPackageName "hscolour")
   , ("hspec-discover", Distribution.Package.mkPackageName "hspec-discover")
+  , ("hsx2hs", Distribution.Package.mkPackageName "hsx2hs")
   , ("gtk2hsC2hs", Distribution.Package.mkPackageName "gtk2hs-buildtools")
   , ("gtk2hsHookGenerator", Distribution.Package.mkPackageName "gtk2hs-buildtools")
   , ("gtk2hsTypeGen", Distribution.Package.mkPackageName "gtk2hs-buildtools")

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -31,7 +31,6 @@ module Stack.Package
   ,buildLogPath
   ,PackageException (..)
   ,resolvePackageDescription
-  ,packageDescTools
   ,packageDependencies
   ,cabalFilePackageId
   ,gpdPackageIdentifier
@@ -41,7 +40,7 @@ module Stack.Package
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as CL8
-import           Data.List (isSuffixOf, isPrefixOf)
+import           Data.List (isSuffixOf, isPrefixOf, unzip)
 import           Data.Maybe (maybe)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -264,7 +263,7 @@ packageFromPackageDescription packageConfig pkgFlags (PackageDescriptionPair pkg
     , packageLicense = licenseRaw pkg
     , packageDeps = deps
     , packageFiles = pkgFiles
-    , packageTools = packageDescTools pkg
+    , packageUnknownTools = unknownTools
     , packageGhcOptions = packageConfigGhcOptions packageConfig
     , packageFlags = packageConfigFlags packageConfig
     , packageDefaultFlags = M.fromList
@@ -364,17 +363,27 @@ packageFromPackageDescription packageConfig pkgFlags (PackageDescriptionPair pkg
              return (componentModules, componentFiles, buildFiles <> dataFiles', warnings)
     pkgId = package pkg
     name = fromCabalPackageName (pkgName pkgId)
-    deps = M.filterWithKey (const . not . isMe) (M.union
-        (packageDependencies packageConfig pkg)
+
+    (unknownTools, knownTools) = packageDescTools pkg
+
+    deps = M.filterWithKey (const . not . isMe) (M.unionsWith (<>)
+        [ asLibrary <$> packageDependencies packageConfig pkg
         -- We include all custom-setup deps - if present - in the
         -- package deps themselves. Stack always works with the
         -- invariant that there will be a single installed package
         -- relating to a package name, and this applies at the setup
         -- dependency level as well.
-        (fromMaybe M.empty msetupDeps))
+        , asLibrary <$> fromMaybe M.empty msetupDeps
+        , knownTools
+        ])
     msetupDeps = fmap
         (M.fromList . map (depName &&& depRange) . setupDepends)
         (setupBuildInfo pkg)
+
+    asLibrary range = DepValue
+      { dvVersionRange = range
+      , dvType = AsLibrary
+      }
 
     -- Is the package dependency mentioned here me: either the package
     -- name itself, or the name of one of the sub libraries
@@ -678,17 +687,54 @@ packageDependencies pkgConfig pkg' =
 --
 -- This uses both the new 'buildToolDepends' and old 'buildTools'
 -- information.
-packageDescTools :: PackageDescription -> Map ExeName VersionRange
-packageDescTools =
-  M.fromList . concatMap tools . allBuildInfo'
+packageDescTools
+  :: PackageDescription
+  -> (Set ExeName, Map PackageName DepValue)
+packageDescTools pd =
+    (S.fromList $ concat unknowns, M.fromListWith (<>) $ concat knowns)
   where
-    tools bi = map go1 (buildTools bi) ++ map go2 (buildToolDepends bi)
+    (unknowns, knowns) = unzip $ map perBI $ allBuildInfo' pd
 
-    go1 :: Cabal.LegacyExeDependency -> (ExeName, VersionRange)
-    go1 (Cabal.LegacyExeDependency name range) = (ExeName $ T.pack name, range)
+    perBI :: BuildInfo -> ([ExeName], [(PackageName, DepValue)])
+    perBI bi =
+        (unknownTools, tools)
+      where
+        (unknownTools, knownTools) = partitionEithers $ map go1 (buildTools bi)
 
-    go2 :: Cabal.ExeDependency -> (ExeName, VersionRange)
-    go2 (Cabal.ExeDependency _pkg name range) = (ExeName $ T.pack $ Cabal.unUnqualComponentName name, range)
+        tools = map go2 (knownTools ++ buildToolDepends bi)
+
+        -- This is similar to desugarBuildTool from Cabal, however it
+        -- uses our own hard-coded map which drops tools shipped with
+        -- GHC (like hsc2hs), and includes some tools from Stackage.
+        go1 :: Cabal.LegacyExeDependency -> Either ExeName Cabal.ExeDependency
+        go1 (Cabal.LegacyExeDependency name range) =
+          case M.lookup name hardCodedMap of
+            Just pkgName -> Right $ Cabal.ExeDependency pkgName (Cabal.mkUnqualComponentName name) range
+            Nothing -> Left $ ExeName $ T.pack name
+
+        go2 :: Cabal.ExeDependency -> (PackageName, DepValue)
+        go2 (Cabal.ExeDependency pkg _name range) =
+          ( fromCabalPackageName pkg
+          , DepValue
+              { dvVersionRange = range
+              , dvType = AsBuildTool
+              }
+          )
+
+-- | A hard-coded map for tool dependencies
+hardCodedMap :: Map String D.PackageName
+hardCodedMap = M.fromList
+  [ ("alex", Distribution.Package.mkPackageName "alex")
+  , ("happy", Distribution.Package.mkPackageName "happy")
+  , ("cpphs", Distribution.Package.mkPackageName "cpphs")
+  , ("greencard", Distribution.Package.mkPackageName "greencard")
+  , ("c2hs", Distribution.Package.mkPackageName "c2hs")
+  , ("hscolour", Distribution.Package.mkPackageName "hscolour")
+  , ("hspec-discover", Distribution.Package.mkPackageName "hspec-discover")
+  , ("gtk2hsC2hs", Distribution.Package.mkPackageName "gtk2hs-buildtools")
+  , ("gtk2hsHookGenerator", Distribution.Package.mkPackageName "gtk2hs-buildtools")
+  , ("gtk2hsTypeGen", Distribution.Package.mkPackageName "gtk2hs-buildtools")
+  ]
 
 -- | Variant of 'allBuildInfo' from Cabal that, like versions before
 -- 2.2, only includes buildable components.

--- a/src/Stack/Snapshot.hs
+++ b/src/Stack/Snapshot.hs
@@ -39,7 +39,6 @@ import           Data.Yaml (decodeFileEither, ParseException (AesonException))
 import           Distribution.InstalledPackageInfo (PError)
 import           Distribution.PackageDescription (GenericPackageDescription)
 import qualified Distribution.PackageDescription as C
-import qualified Distribution.Types.UnqualComponentName as C
 import           Distribution.System (Platform)
 import           Distribution.Text (display)
 import qualified Distribution.Version as C
@@ -579,8 +578,6 @@ fromGlobalHints =
       , lpiFlags = Map.empty
       , lpiGhcOptions = []
       , lpiPackageDeps = Map.empty
-      , lpiProvidedExes = Set.empty
-      , lpiNeededExes = Map.empty
       , lpiExposedModules = Set.empty
       , lpiHide = False
       }
@@ -654,8 +651,6 @@ loadCompiler cv = do
                 , lpiFlags = Map.empty
                 , lpiGhcOptions = []
                 , lpiPackageDeps = Map.unions $ map goDep $ dpDepends dp
-                , lpiProvidedExes = Set.empty
-                , lpiNeededExes = Map.empty
                 , lpiExposedModules = Set.fromList $ map (ModuleName . encodeUtf8) $ dpExposedModules dp
                 , lpiHide = not $ dpIsExposed dp
                 }
@@ -819,12 +814,6 @@ calculate gpd platform compilerVersion loc flags hide options =
       , lpiPackageDeps = Map.map fromVersionRange
                        $ Map.filterWithKey (const . (/= name))
                        $ packageDependencies pconfig pd
-      , lpiProvidedExes =
-            Set.fromList
-          $ map (ExeName . T.pack . C.unUnqualComponentName . C.exeName)
-          $ C.executables pd
-      , lpiNeededExes = Map.map fromVersionRange
-                      $ packageDescTools pd
       , lpiExposedModules = maybe
           Set.empty
           (Set.fromList . map fromCabalModuleName . C.exposedModules)

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -310,7 +310,7 @@ instance Store LoadedSnapshot
 instance NFData LoadedSnapshot
 
 loadedSnapshotVC :: VersionConfig LoadedSnapshot
-loadedSnapshotVC = storeVersionConfig "ls-v4" "a_ljrJRo8hA_-gcIDP9c6NXJ2pE="
+loadedSnapshotVC = storeVersionConfig "ls-v5" "CeSRWh1VU8v0__kwA__msbe6WlU="
 
 -- | Information on a single package for the 'LoadedSnapshot' which
 -- can be installed.
@@ -340,11 +340,6 @@ data LoadedPackageInfo loc = LoadedPackageInfo
     , lpiPackageDeps :: !(Map PackageName VersionIntervals)
     -- ^ All packages which must be built/copied/registered before
     -- this package.
-    , lpiProvidedExes :: !(Set ExeName)
-    -- ^ The names of executables provided by this package, for
-    -- performing build tool lookups.
-    , lpiNeededExes :: !(Map ExeName VersionIntervals)
-    -- ^ Executables needed by this package.
     , lpiExposedModules :: !(Set ModuleName)
     -- ^ Modules exposed by this package's library
     , lpiHide :: !Bool


### PR DESCRIPTION
This is a fundamental change to how Stack discovers build tools, its inclusion should be discussed before we merge. We should also wait to see if it actually fixes #4125.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!