### PR TITLE
'stack ghci' now asks which main module to load before building

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -62,6 +62,8 @@ Other enhancements:
 * [#3685](https://github.com/commercialhaskell/stack/issues/3685)
   Suggestion to add `'allow-newer': true` now shows path to user config
   file where this flag should be put into
+* `stack ghci` now asks which main target to load before doing the build,
+  rather than after
 
 Bug fixes:
 


### PR DESCRIPTION
Before this change, 'stack ghci' would ask the user a question after doing a
build which may take a long time. The reason it was this way is that the
question required resolution of package files, and package file resolution
needed to come after the build due to #1180.

The solution here is to resolve the package files twice - once before the build, 
and once after. This isn't the most efficient solution possible, but it is a
much better user experience to ask the main target question before building
rather than after.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Tested this by running on a large project and observing that ghci functions properly, and that the main target question is asked before the build.