### PR TITLE
Ensure we build before ghci, due to #4148.

### DIFF
--- a/test/integration/tests/3926-ghci-with-sublibraries/Main.hs
+++ b/test/integration/tests/3926-ghci-with-sublibraries/Main.hs
@@ -9,6 +9,7 @@ main = do
   stack ["clean"] -- to make sure we can load the code even after a clean
   copy "src/Lib.v1" "src/Lib.hs"
   copy "src-internal/Internal.v1" "src-internal/Internal.hs"
+  stack ["build"] -- need a build before ghci at the moment, see #4148
   forkIO fileEditingThread
   replThread
 


### PR DESCRIPTION
Due to #4148, one of the integration tests fails (the second in #4142). This PR adds a build step before starting the repl process, punting the real work of making `stack ghci` work without a previous build step for later.
