### PR TITLE
Bump to hpack 0.29

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -74,6 +74,7 @@ Other enhancements:
   file where this flag should be put into
 * `stack ghci` now asks which main target to load before doing the build,
   rather than after
+* Bump to hpack 0.29.0
 
 Bug fixes:
 

--- a/package.yaml
+++ b/package.yaml
@@ -61,7 +61,7 @@ dependencies:
 - generic-deriving
 - hackage-security
 - hashable
-- hpack
+- hpack >= 0.29
 - hpc
 - http-client
 - http-client-tls

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -20,6 +20,7 @@ extra-deps:
 - regex-applicative-text-0.1.0.1
 - unicode-transforms-0.3.4
 - githash-0.1.0.0@rev:0
+- hpack-0.29.0@rev:0
 
 ghc-options:
    "$locals": -fhide-source-paths

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,7 +19,7 @@ flags:
 extra-deps:
 - rio-0.1.1.0@rev:0
 - Cabal-2.2.0.1@rev:0
-- hpack-0.28.2
+- hpack-0.29.0@rev:0
 - http-api-data-0.3.8.1@rev:0
 - githash-0.1.0.0@rev:0
 


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

CC @sol