### PR TITLE
Warning about GHCJS use when constructing a build plan

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,16 +27,16 @@ manual_build:
   when: manual
   script: *build
 
-docker_image_lts-10:
-  stage: build
-  when: manual
-  script:
-    - docker login -u "$PROD_DOCKER_USERNAME" -p "$PROD_DOCKER_PASSWORD"
-    - etc/dockerfiles/stack-build/build.sh --push lts-10
-
 docker_image_lts-11:
   stage: build
   when: manual
   script:
     - docker login -u "$PROD_DOCKER_USERNAME" -p "$PROD_DOCKER_PASSWORD"
     - etc/dockerfiles/stack-build/build.sh --push lts-11
+
+docker_image_lts-12:
+  stage: build
+  when: manual
+  script:
+    - docker login -u "$PROD_DOCKER_USERNAME" -p "$PROD_DOCKER_PASSWORD"
+    - etc/dockerfiles/stack-build/build.sh --push lts-12

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@ Release notes:
 
 Major changes:
 
+* `GHCJS` support is being deprecated after the next major Stack release. At time of writing the upcoming release is 1.8. A warning notifying the user of the deprecation will be incorporated into 1.8.
+
 Behavior changes:
 
 * `ghc-options` from `stack.yaml` are now appended to `ghc-options` from

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -74,6 +74,7 @@ Other enhancements:
   file where this flag should be put into
 * `stack ghci` now asks which main target to load before doing the build,
   rather than after
+* Bump to hpack 0.29.0
 
 Bug fixes:
 

--- a/etc/dockerfiles/stack-build/lts-12.0/Dockerfile
+++ b/etc/dockerfiles/stack-build/lts-12.0/Dockerfile
@@ -1,0 +1,69 @@
+FROM ubuntu:16.04
+
+MAINTAINER Emanuel Borsboom <manny@fpcomplete.com>
+
+ARG GHC_VERSION=8.4.3
+ARG LTS_SLUG=lts-12.0
+ARG PID1_VERSION=0.1.2.0
+ARG STACK_VERSION=1.7.1
+ARG CUDA_VERSION=8.0
+ARG BOOTSTRAP_COMMIT=56c62ccbf31229ee2b09d3a0b4cd2ad94e7406a8
+ARG DEBIAN_FRONTEND=noninteractive
+
+#
+# Set encoding to UTF-8 and PATH to find GHC and cabal/stack-installed binaries.
+#
+
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PATH=/root/.cabal/bin:/root/.local/bin:/usr/local/cuda-$CUDA_VERSION/bin:/opt/ghc/$GHC_VERSION/bin:$PATH \
+    CUDA_PATH=/usr/local/cuda-$CUDA_VERSION \
+    LD_LIBRARY_PATH=/usr/local/cuda-$CUDA_VERSION/lib64:/usr/local/cuda-$CUDA_VERSION/nvvm/lib64
+#
+# Use Stackage's debian-bootstrap.sh script to install system libraries and
+# tools required to build any Stackage package.
+#
+
+RUN apt-get update && \
+    apt-get install -y wget && \
+    wget -qO- https://raw.githubusercontent.com/fpco/stackage/$BOOTSTRAP_COMMIT/debian-bootstrap.sh | bash && \
+    rm -rf /var/lib/apt/lists/*
+
+#
+# Create symlink to help tools find GHC documentation
+#
+
+RUN ln -s ghc /opt/ghc/$GHC_VERSION/share/doc/ghc-$GHC_VERSION
+
+#
+# Use 'stack' to install basic Haskell tools like alex, happy, and cpphs. We
+# remove most of the STACK_ROOT afterward to save space, but keep the 'share'
+# files that some of these tools require.
+#
+
+RUN stack --system-ghc --resolver=$LTS_SLUG --local-bin-path=/usr/local/bin install \
+        cabal-install happy alex cpphs gtk2hs-buildtools hscolour && \
+    cd $HOME/.stack && \
+    find . -type f -not -path './snapshots/*/share/*' -exec rm '{}' \; && \
+    find . -type d -print0 |sort -rz |xargs -0 rmdir 2>/dev/null || true
+
+#
+# Install 'pid1' init daemon
+#
+
+RUN wget -O- "https://github.com/fpco/pid1/releases/download/v$PID1_VERSION/pid1-$PID1_VERSION-linux-x86_64.tar.gz" | tar xzf - -C /usr/local && \
+    chown root:root /usr/local/sbin && \
+    chown root:root /usr/local/sbin/pid1
+
+#
+# Install Stack
+#
+
+RUN wget -qO- https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /usr/local/bin '*/stack'
+
+#
+# Set up pid1 entrypoint and default command
+#
+
+ENTRYPOINT ["/usr/local/sbin/pid1"]
+CMD ["bash"]

--- a/package.yaml
+++ b/package.yaml
@@ -61,7 +61,7 @@ dependencies:
 - generic-deriving
 - hackage-security
 - hashable
-- hpack
+- hpack >= 0.29
 - hpc
 - http-client
 - http-client-tls

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -704,7 +704,7 @@ addPackageDeps treatAsDep package = do
     -- make sure we consider internal libraries as libraries too
     packageHasLibrary :: Package -> Bool
     packageHasLibrary p =
-      Set.null (packageInternalLibraries p) ||
+      not (Set.null (packageInternalLibraries p)) ||
       case packageLibraries p of
         HasLibraries _ -> True
         NoLibraries -> False

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -262,7 +262,6 @@ renderStackYaml p ignoredPackages dupPackages =
         , "resolver: lts-3.5"
         , "resolver: nightly-2015-09-21"
         , "resolver: ghc-7.10.2"
-        , "resolver: ghcjs-0.1.0_ghc-7.10.2"
         , ""
         , "The location of a snapshot can be provided as a file or url. Stack assumes"
         , "a snapshot provided as a file might change, whereas a url resource does not."

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -88,6 +88,17 @@ listInstalled programsPath = do
         x <- T.stripSuffix ".installed" $ T.pack $ toFilePath $ filename fp
         parseToolText x
 
+-- | See https://github.com/commercialhaskell/stack/issues/4086.
+warnAboutGHCJS :: HasLogFunc env => RIO env ()
+warnAboutGHCJS =
+    logWarn $ "Building a GHCJS project. " <> fromString ghcjsWarning
+
+ghcjsWarning :: String
+ghcjsWarning = unwords
+     [ "Note that GHCJS support in Stack is DEPRECATED and it will be removed "
+     , "in a future release of Stack."
+     ]
+
 getCompilerVersion
   :: (HasProcessContext env, HasLogFunc env)
   => WhichCompiler
@@ -102,6 +113,7 @@ getCompilerVersion wc =
             logDebug $ "GHC version is: " <> display x
             return x
         Ghcjs -> do
+            warnAboutGHCJS
             logDebug "Asking GHCJS for its version"
             -- Output looks like
             --

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -830,8 +830,8 @@ execCmd ExecOpts {..} go@GlobalOpts{..} =
                     (ExecCmd cmd, args) -> return (cmd, args)
                     (ExecRun, args) -> getRunCmd args
                     (ExecGhc, args) -> getGhcCmd "" eoPackages args
-                    -- NOTE: this won't currently work for GHCJS, because it doesn't have
-                    -- a runghcjs binary. It probably will someday, though.
+                    -- NOTE: This doesn't work for GHCJS, because it doesn't have
+                    -- a runghcjs binary.
                     (ExecRunGhc, args) ->
                         getGhcCmd "run" eoPackages args
                 munlockFile lk -- Unlock before transferring control away.

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -20,6 +20,7 @@ extra-deps:
 - regex-applicative-text-0.1.0.1
 - unicode-transforms-0.3.4
 - githash-0.1.0.0@rev:0
+- hpack-0.29.0@rev:0
 
 ghc-options:
    "$locals": -fhide-source-paths

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,7 +19,7 @@ flags:
 extra-deps:
 - rio-0.1.1.0@rev:0
 - Cabal-2.2.0.1@rev:0
-- hpack-0.28.2
+- hpack-0.29.0@rev:0
 - http-api-data-0.3.8.1@rev:0
 - githash-0.1.0.0@rev:0
 

--- a/test/integration/tests/3926-ghci-with-sublibraries/Main.hs
+++ b/test/integration/tests/3926-ghci-with-sublibraries/Main.hs
@@ -9,6 +9,7 @@ main = do
   stack ["clean"] -- to make sure we can load the code even after a clean
   copy "src/Lib.v1" "src/Lib.hs"
   copy "src-internal/Internal.v1" "src-internal/Internal.hs"
+  stack ["build"] -- need a build before ghci at the moment, see #4148
   forkIO fileEditingThread
   replThread
 

--- a/test/integration/tests/3942-solver-error-output/files/test-stack.yml
+++ b/test/integration/tests/3942-solver-error-output/files/test-stack.yml
@@ -1,4 +1,4 @@
-resolver: lts-8.22
+resolver: lts-11.6
 
 packages:
 - location:


### PR DESCRIPTION
Fixes https://github.com/commercialhaskell/stack/issues/4086

I tested it (produced the output cited in the issue above) by building [miso](https://github.com/dmjio/miso).

Only issue with how it presently works is that people might miss the warning if it's at the start rather than the end. Do we have a means of registering warnings that should get emitted at the end by `main` or similar?