### PR TITLE
Pass --quickjump to Haddock for GHC 8.4 and later

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -77,6 +77,7 @@ Other enhancements:
 * `stack ghci` now asks which main target to load before doing the build,
   rather than after
 * Bump to hpack 0.29.0
+* With GHC 8.4 and later, Haddock is given the `--quickjump` flag.
 
 Bug fixes:
 

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1496,12 +1496,22 @@ singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} installedMap
                             ("Warning: haddock not generating hyperlinked sources because 'HsColour' not\n" <>
                              "found on PATH (use 'stack install hscolour' to install).")
                         return ["--hyperlink-source" | hscolourExists]
+
+            -- For GHC 8.4 and later, provide the --quickjump option.
+            actualCompiler <- view actualCompilerVersionL
+            let quickjump =
+                  case actualCompiler of
+                    GhcVersion ghcVer
+                      | ghcVer >= $(mkVersion "8.4") -> ["--haddock-option=--quickjump"]
+                    _ -> []
+
             cabal KeepTHLoading $ concat
                 [ ["haddock", "--html", "--hoogle", "--html-location=../$pkg-$version/"]
                 , sourceFlag
                 , ["--internal" | boptsHaddockInternal eeBuildOpts]
                 , [ "--haddock-option=" <> opt
                   | opt <- hoAdditionalArgs (boptsHaddockOpts eeBuildOpts) ]
+                , quickjump
                 ]
 
         let hasLibrary =


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
