### PR TITLE
Issue #4039 - Spec for template name parsing in `stack new`

### DIFF
--- a/src/test/Stack/Types/TemplateNameSpec.hs
+++ b/src/test/Stack/Types/TemplateNameSpec.hs
@@ -4,6 +4,7 @@ module Stack.Types.TemplateNameSpec where
 
 import Stack.Types.TemplateName
 import Path.Internal
+import System.Info (os)
 import Test.Hspec
 
 spec :: Spec
@@ -19,16 +20,32 @@ spec =
 
         pathOf "http://www.com/file"  `shouldBe` (UrlPath "http://www.com/file")
         pathOf "https://www.com/file" `shouldBe` (UrlPath "https://www.com/file")
-        
-        pathOf "//home/file"          `shouldBe` (AbsPath $ Path "/home/file.hsfiles")
-        pathOf "/home/file"           `shouldBe` (AbsPath $ Path "/home/file.hsfiles")
-        pathOf "/home/file.hsfiles"   `shouldBe` (AbsPath $ Path "/home/file.hsfiles")
-        
-        pathOf "with/slash"           `shouldBe` (RelPath $ Path "with/slash.hsfiles")
-        pathOf "with:colon"           `shouldBe` (RelPath $ Path "with:colon.hsfiles")
+
         pathOf "name"                 `shouldBe` (RelPath $ Path "name.hsfiles")
         pathOf "name.hsfile"          `shouldBe` (RelPath $ Path "name.hsfile.hsfiles")
         pathOf "name.hsfiles"         `shouldBe` (RelPath $ Path "name.hsfiles")
-        pathOf "c:\\home\\file"       `shouldBe` (RelPath $ Path "c:\\home\\file.hsfiles")
         pathOf ""                     `shouldBe` (RelPath $ Path ".hsfiles")
+
+        if os == "mingw32"
+        then do
+          pathOf "//home/file"          `shouldBe` (AbsPath $ Path "\\\\home\\file.hsfiles")
+          pathOf "/home/file"           `shouldBe` (RelPath $ Path "\\home\\file.hsfiles")
+          pathOf "/home/file.hsfiles"   `shouldBe` (RelPath $ Path "\\home\\file.hsfiles")
+
+          pathOf "c:\\home\\file"       `shouldBe` (AbsPath $ Path "C:\\home\\file.hsfiles")
+          pathOf "with/slash"           `shouldBe` (RelPath $ Path "with\\slash.hsfiles")
+
+          let colonAction =
+                do
+                  return $! pathOf "with:colon"
+          colonAction `shouldThrow` anyErrorCall
+
+        else do
+          pathOf "//home/file"          `shouldBe` (AbsPath $ Path "/home/file.hsfiles")
+          pathOf "/home/file"           `shouldBe` (AbsPath $ Path "/home/file.hsfiles")
+          pathOf "/home/file.hsfiles"   `shouldBe` (AbsPath $ Path "/home/file.hsfiles")
+
+          pathOf "c:\\home\\file"       `shouldBe` (RelPath $ Path "c:\\home\\file.hsfiles")
+          pathOf "with/slash"           `shouldBe` (RelPath $ Path "with/slash.hsfiles")
+          pathOf "with:colon"           `shouldBe` (RelPath $ Path "with:colon.hsfiles")
 

--- a/src/test/Stack/Types/TemplateNameSpec.hs
+++ b/src/test/Stack/Types/TemplateNameSpec.hs
@@ -18,8 +18,8 @@ spec =
         pathOf "bitbucket:user/name"  `shouldBe` (RepoPath $ RepoTemplatePath Bitbucket "user" "name.hsfiles")
         pathOf "gitlab:user/name"     `shouldBe` (RepoPath $ RepoTemplatePath Gitlab    "user" "name.hsfiles")
 
-        pathOf "http://www.com/file"  `shouldBe` (UrlPath "http://www.com/file")
-        pathOf "https://www.com/file" `shouldBe` (UrlPath "https://www.com/file")
+        pathOf "http://www.com/file"  `shouldBe` UrlPath "http://www.com/file"
+        pathOf "https://www.com/file" `shouldBe` UrlPath "https://www.com/file"
 
         pathOf "name"                 `shouldBe` (RelPath $ Path "name.hsfiles")
         pathOf "name.hsfile"          `shouldBe` (RelPath $ Path "name.hsfile.hsfiles")

--- a/src/test/Stack/Types/TemplateNameSpec.hs
+++ b/src/test/Stack/Types/TemplateNameSpec.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Stack.Types.TemplateNameSpec where
+
+import Stack.Types.TemplateName
+import Path.Internal
+import Test.Hspec
+
+spec :: Spec
+spec =
+  describe "TemplateName" $ do
+    describe "parseTemplateNameFromString" $ do
+      let pathOf s = either error templatePath (parseTemplateNameFromString s)
+
+      it "parses out the TemplatePath" $ do
+        pathOf "github:user/name"     `shouldBe` (RepoPath $ RepoTemplatePath Github    "user" "name.hsfiles")
+        pathOf "bitbucket:user/name"  `shouldBe` (RepoPath $ RepoTemplatePath Bitbucket "user" "name.hsfiles")
+        pathOf "gitlab:user/name"     `shouldBe` (RepoPath $ RepoTemplatePath Gitlab    "user" "name.hsfiles")
+
+        pathOf "http://www.com/file"  `shouldBe` (UrlPath "http://www.com/file")
+        pathOf "https://www.com/file" `shouldBe` (UrlPath "https://www.com/file")
+        
+        pathOf "//home/file"          `shouldBe` (AbsPath $ Path "/home/file.hsfiles")
+        pathOf "/home/file"           `shouldBe` (AbsPath $ Path "/home/file.hsfiles")
+        pathOf "/home/file.hsfiles"   `shouldBe` (AbsPath $ Path "/home/file.hsfiles")
+        
+        pathOf "with/slash"           `shouldBe` (RelPath $ Path "with/slash.hsfiles")
+        pathOf "with:colon"           `shouldBe` (RelPath $ Path "with:colon.hsfiles")
+        pathOf "name"                 `shouldBe` (RelPath $ Path "name.hsfiles")
+        pathOf "name.hsfile"          `shouldBe` (RelPath $ Path "name.hsfile.hsfiles")
+        pathOf "name.hsfiles"         `shouldBe` (RelPath $ Path "name.hsfiles")
+        pathOf "c:\\home\\file"       `shouldBe` (RelPath $ Path "c:\\home\\file.hsfiles")
+        pathOf ""                     `shouldBe` (RelPath $ Path ".hsfiles")
+


### PR DESCRIPTION
This is a small spec to go along with https://github.com/commercialhaskell/stack/pull/4103.

This shows the behavior of template name parsing in the `stack new` command.  There are some significant differences when run on windows vs unix.

Please include the following checklist in your PR:

* [ x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

I did install Stack on windows to write this, and if there are any Stack devs that run windows I would appreciate if you can confirm it passes on your machine.