### PR TITLE
Pantry - package identifier parsing fix

### DIFF
--- a/src/Control/Concurrent/Execute.hs
+++ b/src/Control/Concurrent/Execute.hs
@@ -16,7 +16,6 @@ import           Control.Concurrent.STM   (retry)
 import           Stack.Prelude
 import           Data.List (sortBy)
 import qualified Data.Set                 as Set
-import           Stack.Types.PackageIdentifier
 
 data ActionType
     = ATBuild

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -36,7 +36,6 @@ import qualified Data.Text.IO as TIO
 import           Data.Text.Read (decimal)
 import qualified Data.Vector as V
 import qualified Data.Yaml as Yaml
-import           Pantry
 import           Path (parent)
 import           Stack.Build.ConstructPlan
 import           Stack.Build.Execute
@@ -46,13 +45,9 @@ import           Stack.Build.Source
 import           Stack.Build.Target
 import           Stack.Package
 import           Stack.Types.Build
-import           Stack.Types.BuildPlan
 import           Stack.Types.Config
-import           Stack.Types.FlagName
 import           Stack.Types.NamedComponent
 import           Stack.Types.Package
-import           Stack.Types.PackageIdentifier
-import           Stack.Types.PackageName
 import           Stack.Types.Version
 
 import           Stack.Types.Compiler (compilerVersionText

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -55,14 +55,11 @@ import           Path
 import           Path.IO
 import           Stack.Constants.Config
 import           Stack.Types.Build
-import           Stack.Types.BuildPlan
 import           Stack.Types.Compiler
 import           Stack.Types.Config
 import           Stack.Types.GhcPkgId
 import           Stack.Types.NamedComponent
 import           Stack.Types.Package
-import           Stack.Types.PackageIdentifier
-import           Stack.Types.Version
 import qualified System.FilePath as FP
 
 -- | Directory containing files to mark an executable as installed

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -85,7 +85,7 @@ getInstalledExes loc = do
         -- was fixed), then we don't know which is correct - ignore them.
         M.fromListWith (\_ _ -> []) $
         map (\x -> (pkgName x, [x])) $
-        mapMaybe (parsePackageIdentifierFromString . toFilePath . filename) files
+        mapMaybe (parsePackageIdentifier . toFilePath . filename) files
 
 -- | Mark the given executable as installed
 markExeInstalled :: (MonadReader env m, HasEnvConfig env, MonadIO m, MonadThrow m)

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -21,7 +21,6 @@ module Stack.Build.ConstructPlan
 import           Stack.Prelude hiding (Display (..))
 import           Control.Monad.RWS.Strict hiding ((<>))
 import           Control.Monad.State.Strict (execState)
-import qualified Data.HashSet as HashSet
 import           Data.List
 import qualified Data.Map.Strict as M
 import qualified Data.Map.Strict as Map
@@ -43,17 +42,14 @@ import           Stack.Build.Source
 import           Stack.Constants
 import           Stack.Package
 import           Stack.PackageDump
-import           Pantry
 import           Stack.PrettyPrint
 import           Stack.Types.Build
 import           Stack.Types.BuildPlan
 import           Stack.Types.Compiler
 import           Stack.Types.Config
-import           Stack.Types.FlagName
 import           Stack.Types.GhcPkgId
 import           Stack.Types.NamedComponent
 import           Stack.Types.Package
-import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageName
 import           Stack.Types.Runner
 import           Stack.Types.Version

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -71,7 +71,6 @@ import           Stack.Config
 import           Stack.Constants
 import           Stack.Constants.Config
 import           Stack.Coverage
-import           Pantry
 import           Stack.GhcPkg
 import           Stack.Package
 import           Stack.PackageDump
@@ -82,7 +81,6 @@ import           Stack.Types.Config
 import           Stack.Types.GhcPkgId
 import           Stack.Types.NamedComponent
 import           Stack.Types.Package
-import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageName
 import           Stack.Types.Runner
 import           Stack.Types.Version

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1553,7 +1553,7 @@ singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} installedMap
                   forM (Set.toList $ packageInternalLibraries package) $ \sublib -> do
                     -- z-haddock-library-z-attoparsec for internal lib attoparsec of haddock-library
                     let sublibName = T.concat ["z-", displayC $ packageName package, "-z-", sublib]
-                    case parsePackageName sublibName of
+                    case parsePackageName $ T.unpack sublibName of
                       Nothing -> return Nothing -- invalid lib, ignored
                       Just subLibName -> loadInstalledPkg wc [installedPkgDb] installedDumpPkgsTVar subLibName
 

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -22,13 +22,10 @@ import qualified    Data.ByteArray as Mem (convert)
 import qualified    Data.ByteString as S
 import              Data.Conduit (ZipSink (..))
 import qualified    Data.Conduit.List as CL
-import qualified    Data.HashSet as HashSet
 import              Data.List
 import qualified    Data.Map as Map
 import qualified    Data.Map.Strict as M
 import qualified    Data.Set as Set
-import              Pantry
-import              Path.IO (resolveDir)
 import              Stack.Build.Cache
 import              Stack.Build.Target
 import              Stack.Config (getLocalPackages)
@@ -37,10 +34,8 @@ import              Stack.Package
 import              Stack.Types.Build
 import              Stack.Types.BuildPlan
 import              Stack.Types.Config
-import              Stack.Types.FlagName
 import              Stack.Types.NamedComponent
 import              Stack.Types.Package
-import              Stack.Types.PackageName
 import qualified    System.Directory as D
 import              System.FilePath (takeFileName)
 import              System.IO.Error (isDoesNotExistError)

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -169,8 +169,8 @@ parseRawTargetDirs root locals ri =
 -- directory.
 parseRawTarget :: Text -> Maybe RawTarget
 parseRawTarget t =
-        (RTPackageIdentifier <$> parsePackageIdentifier t)
-    <|> (RTPackage <$> parsePackageNameFromString s)
+        (RTPackageIdentifier <$> parsePackageIdentifier s)
+    <|> (RTPackage <$> parsePackageName s)
     <|> (RTComponent <$> T.stripPrefix ":" t)
     <|> parsePackageComponent
   where
@@ -179,13 +179,13 @@ parseRawTarget t =
     parsePackageComponent =
         case T.splitOn ":" t of
             [pname, "lib"]
-                | Just pname' <- parsePackageNameFromString (T.unpack pname) ->
+                | Just pname' <- parsePackageName (T.unpack pname) ->
                     Just $ RTPackageComponent pname' $ ResolvedComponent CLib
             [pname, cname]
-                | Just pname' <- parsePackageNameFromString (T.unpack pname) ->
+                | Just pname' <- parsePackageName (T.unpack pname) ->
                     Just $ RTPackageComponent pname' $ UnresolvedComponent cname
             [pname, typ, cname]
-                | Just pname' <- parsePackageNameFromString (T.unpack pname)
+                | Just pname' <- parsePackageName (T.unpack pname)
                 , Just wrapper <- parseCompType typ ->
                     Just $ RTPackageComponent pname' $ ResolvedComponent $ wrapper cname
             _ -> Nothing

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -82,8 +82,6 @@ import           Stack.Config (getLocalPackages)
 import           Stack.Snapshot (calculatePackagePromotion)
 import           Stack.Types.Config
 import           Stack.Types.NamedComponent
-import           Stack.Types.PackageIdentifier
-import           Stack.Types.PackageName
 import           Stack.Types.Build
 import           Stack.Types.BuildPlan
 import           Stack.Types.GhcPkgId

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -30,7 +30,6 @@ import           Data.List (intercalate)
 import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Distribution.Package as C
 import           Distribution.PackageDescription (GenericPackageDescription,
@@ -45,9 +44,6 @@ import           Stack.Constants
 import           Stack.Package
 import           Stack.Snapshot
 import           Stack.Types.BuildPlan
-import           Stack.Types.FlagName
-import           Stack.Types.PackageIdentifier
-import           Stack.Types.PackageName
 import           Stack.Types.Version
 import           Stack.Types.Config
 import           Stack.Types.Compiler

--- a/src/Stack/Clean.hs
+++ b/src/Stack/Clean.hs
@@ -17,7 +17,6 @@ import qualified Data.Map.Strict as Map
 import           Path.IO (ignoringAbsence, removeDirRecur)
 import           Stack.Config (getLocalPackages)
 import           Stack.Constants.Config (distDirFromDir, workDirFromDir)
-import           Stack.Types.PackageName
 import           Stack.Types.Config
 import           System.Exit (exitFailure)
 

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -88,7 +88,6 @@ import           Stack.Types.Config
 import           Stack.Types.Docker
 import           Stack.Types.Nix
 import           Stack.Types.PackageName (PackageName)
-import           Stack.Types.PackageIdentifier
 import           Stack.Types.Resolver
 import           Stack.Types.Runner
 import           Stack.Types.Urls

--- a/src/Stack/Constants/Config.hs
+++ b/src/Stack/Constants/Config.hs
@@ -23,7 +23,6 @@ import Stack.Prelude
 import Stack.Constants
 import Stack.Types.Compiler
 import Stack.Types.Config
-import Stack.Types.PackageIdentifier
 import Path
 
 -- | Output .o/.hi directory.

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -41,8 +41,6 @@ import           Stack.Types.Compiler
 import           Stack.Types.Config
 import           Stack.Types.NamedComponent
 import           Stack.Types.Package
-import           Stack.Types.PackageIdentifier
-import           Stack.Types.PackageName
 import           Stack.Types.Runner
 import           Stack.Types.Version
 import           System.FilePath (isPathSeparator)

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -697,7 +697,7 @@ checkDockerVersion docker =
      dockerVersionOut <- readDockerProcess ["--version"]
      case words (decodeUtf8 dockerVersionOut) of
        (_:_:v:_) ->
-         case parseVersionFromString (stripVersion v) of
+         case parseVersion (stripVersion v) of
            Just v'
              | v' < minimumDockerVersion ->
                throwIO (DockerTooOldException minimumDockerVersion v')

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -42,7 +42,6 @@ import qualified Data.Text.Encoding as T
 import           Data.Time (UTCTime,LocalTime(..),diffDays,utcToLocalTime,getZonedTime,ZonedTime(..))
 import           Data.Version (showVersion)
 import           GHC.Exts (sortWith)
-import           Lens.Micro (set)
 import           Path
 import           Path.Extra (toFilePathNoTrailingSep)
 import           Path.IO hiding (canonicalizePath)
@@ -51,8 +50,6 @@ import           Stack.Config (getInContainer)
 import           Stack.Constants
 import           Stack.Constants.Config
 import           Stack.Docker.GlobalDB
-import           Pantry
-import           Stack.Types.PackageIndex
 import           Stack.Types.Runner
 import           Stack.Types.Version
 import           Stack.Types.Config

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -18,7 +18,6 @@ module Stack.Dot (dot
 import qualified Data.Foldable as F
 import qualified Data.Set as Set
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import qualified Data.Traversable as T
@@ -37,12 +36,9 @@ import           Stack.PackageDump (DumpPackage(..))
 import           Stack.Prelude hiding (Display (..))
 import           Stack.Types.Build
 import           Stack.Types.Config
-import           Stack.Types.FlagName
 import           Stack.Types.GhcPkgId
 import           Stack.Types.Package
-import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageName
-import           Stack.Types.Version
 
 -- | Options record for @stack dot@
 data DotOpts = DotOpts

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -150,7 +150,7 @@ findGhcPkgVersion :: (HasProcessContext env, HasLogFunc env)
 findGhcPkgVersion wc pkgDbs name = do
     mv <- findGhcPkgField wc pkgDbs (displayC name) "version"
     case mv of
-        Just !v -> return (parseVersion v)
+        Just !v -> return (parseVersion $ T.unpack v)
         _ -> return Nothing
 
 unregisterGhcPkgId :: (HasProcessContext env, HasLogFunc env)

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -33,9 +33,7 @@ import           Path.IO
 import           Stack.Constants
 import           Stack.Types.Build
 import           Stack.Types.GhcPkgId
-import           Stack.Types.PackageIdentifier
 import           Stack.Types.Compiler
-import           Stack.Types.PackageName
 import           Stack.Types.Version
 import           System.FilePath (searchPathSeparator)
 import           RIO.Process

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -45,10 +45,8 @@ import           Stack.PrettyPrint
 import           Stack.Types.Build
 import           Stack.Types.Compiler
 import           Stack.Types.Config
-import           Stack.Types.FlagName
 import           Stack.Types.NamedComponent
 import           Stack.Types.Package
-import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageName
 import           Stack.Types.Runner
 import           System.IO (putStrLn)

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -336,8 +336,8 @@ buildDepsAndInitialSteps GhciOpts{..} targets0 = do
 
 checkAdditionalPackages :: MonadThrow m => [String] -> m [PackageName]
 checkAdditionalPackages pkgs = forM pkgs $ \name -> do
-    let mres = (pkgName <$> parsePackageIdentifierFromString name)
-            <|> parsePackageNameFromString name
+    let mres = (pkgName <$> parsePackageIdentifier name)
+            <|> parsePackageNameThrowing name
     maybe (throwM $ InvalidPackageOption name) return mres
 
 runGhci

--- a/src/Stack/Hoogle.hs
+++ b/src/Stack/Hoogle.hs
@@ -159,7 +159,7 @@ hoogleCmd (args,setup,rebuild,startServer) go = withBuildConfig go $ do
                         ]
                 return $ case result of
                     Left err -> unexpectedResult $ T.pack (show err)
-                    Right bs -> case parseVersionFromString (takeWhile (not . isSpace) (BL8.unpack bs)) of
+                    Right bs -> case parseVersion (takeWhile (not . isSpace) (BL8.unpack bs)) of
                         Nothing -> unexpectedResult $ T.pack (BL8.unpack bs)
                         Just ver
                             | ver >= hoogleMinVersion -> Right hooglePath

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -26,7 +26,6 @@ import qualified Data.Yaml                       as Yaml
 import qualified Distribution.PackageDescription as C
 import qualified Distribution.Text               as C
 import qualified Distribution.Version            as C
-import           Pantry
 import           Path
 import           Path.Extra                      (toFilePathNoTrailingSep)
 import           Path.IO
@@ -40,9 +39,6 @@ import           Stack.Solver
 import           Stack.Types.Build
 import           Stack.Types.BuildPlan
 import           Stack.Types.Config
-import           Stack.Types.FlagName
-import           Stack.Types.PackageIdentifier
-import           Stack.Types.PackageName
 import           Stack.Types.Resolver
 import           Stack.Types.Version
 import qualified System.FilePath                 as FP

--- a/src/Stack/Options/PackageParser.hs
+++ b/src/Stack/Options/PackageParser.hs
@@ -5,8 +5,6 @@ import qualified Data.Map                          as Map
 import           Options.Applicative
 import           Options.Applicative.Types         (readerAsk)
 import           Stack.Prelude
-import           Stack.Types.FlagName
-import           Stack.Types.PackageName
 
 -- | Parser for package:[-]flag
 readFlag :: ReadM (Map (Maybe PackageName) (Map FlagName Bool))

--- a/src/Stack/Options/PackageParser.hs
+++ b/src/Stack/Options/PackageParser.hs
@@ -15,7 +15,7 @@ readFlag = do
     case break (== ':') s of
         (pn, ':':mflag) -> do
             pn' <-
-                case parsePackageNameFromString pn of
+                case parsePackageName pn of
                     Nothing
                         | pn == "*" -> return Nothing
                         | otherwise -> readerError $ "Invalid package name: " ++ pn
@@ -25,7 +25,7 @@ readFlag = do
                         '-':x -> (False, x)
                         _ -> (True, mflag)
             flagN <-
-                case parseFlagNameFromString flagS of
+                case parseFlagName flagS of
                     Nothing -> readerError $ "Invalid flag name: " ++ flagS
                     Just x -> return x
             return $ Map.singleton pn' $ Map.singleton flagN b

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -296,8 +296,9 @@ packageFromPackageDescription packageConfig pkgFlags (PackageDescriptionPair pkg
       \sourceMap installedMap omitPkgs addPkgs cabalfp ->
            do (componentsModules,componentFiles,_,_) <- getPackageFiles pkgFiles cabalfp
               let internals = S.toList $ internalLibComponents $ M.keysSet componentsModules
-              excludedInternals <- mapM parsePackageName internals
-              mungedInternals <- mapM (parsePackageName . toInternalPackageMungedName) internals
+              excludedInternals <- mapM (parsePackageNameThrowing . T.unpack) internals
+              mungedInternals <- mapM (parsePackageNameThrowing . T.unpack .
+                                       toInternalPackageMungedName) internals
               componentsOpts <-
                   generatePkgDescOpts sourceMap installedMap
                   (excludedInternals ++ omitPkgs) (mungedInternals ++ addPkgs)

--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -342,8 +342,8 @@ conduitDumpPackage = (.| CL.catMaybes) $ eachSection $ do
     case Map.lookup "id" m of
         Just ["builtin_rts"] -> return Nothing
         _ -> do
-            name <- parseS "name" >>= parsePackageName
-            version <- parseS "version" >>= parseVersion
+            name <- parseS "name" >>= parsePackageNameThrowing . T.unpack
+            version <- parseS "version" >>= parseVersionThrowing . T.unpack
             ghcPkgId <- parseS "id" >>= parseGhcPkgId
 
             -- if a package has no modules, these won't exist
@@ -360,7 +360,8 @@ conduitDumpPackage = (.| CL.catMaybes) $ eachSection $ do
             -- Handle sublibs by recording the name of the parent library
             -- If name of parent library is missing, this is not a sublib.
             let mkParentLib n = PackageIdentifier n version
-                parentLib = mkParentLib <$> (parseS "package-name" >>= parsePackageName)
+                parentLib = mkParentLib <$> (parseS "package-name" >>=
+                                             parsePackageNameThrowing . T.unpack)
 
             let parseQuoted key =
                     case mapM (P.parseOnly (argsParser NoEscaping)) val of

--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -44,7 +44,6 @@ import           Stack.GhcPkg
 import           Stack.Types.Compiler
 import           Stack.Types.GhcPkgId
 import           Stack.Types.PackageDump
-import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageName
 import           Stack.Types.Version
 import           System.Directory (getDirectoryContents, doesFileExist)

--- a/src/Stack/PrettyPrint.hs
+++ b/src/Stack/PrettyPrint.hs
@@ -41,10 +41,7 @@ import qualified Data.Text as T
 import qualified Distribution.ModuleName as C (ModuleName)
 import qualified Distribution.Text as C (display)
 import           Stack.Types.NamedComponent
-import           Stack.Types.PackageIdentifier
-import           Stack.Types.PackageName
 import           Stack.Types.Runner
-import           Stack.Types.Version
 import           Text.PrettyPrint.Leijen.Extended
 
 displayWithColor

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -197,7 +197,7 @@ getCabalLbs pvpBounds mrev cabalfp = do
                   $ Cabal.packageDescription gpd'
                   }
               }
-    ident <- parsePackageIdentifierFromString $ Cabal.display $ Cabal.package $ Cabal.packageDescription gpd''
+    ident <- parsePackageIdentifierThrowing $ Cabal.display $ Cabal.package $ Cabal.packageDescription gpd''
     -- Sanity rendering and reparsing the input, to ensure there are no
     -- cabal bugs, since there have been bugs here before, and currently
     -- are at the time of writing:

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -48,7 +48,6 @@ import           Distribution.Version (simplifyVersionRange, orLaterVersion, ear
 import           Lens.Micro (set)
 import           Path
 import           Path.IO hiding (getModificationTime, getPermissions, withSystemTempDir)
-import qualified RIO
 import           Stack.Build (mkBaseConfigOpts, build)
 import           Stack.Build.Execute
 import           Stack.Build.Installed
@@ -61,7 +60,6 @@ import           Stack.Types.Build
 import           Stack.Types.Config
 import           Stack.Types.Package
 import           Stack.Types.PackageIdentifier
-import           Stack.Types.PackageName
 import           Stack.Types.Runner
 import           Stack.Types.Version
 import           System.Directory (getModificationTime, getPermissions)

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -64,7 +64,7 @@ scriptCmd opts go' = do
                     getPackagesFromModuleInfo moduleInfo (soFile opts)
                 packages -> do
                     let targets = concatMap wordsComma packages
-                    targets' <- mapM parsePackageNameFromString targets
+                    targets' <- mapM parsePackageNameThrowing targets
                     return $ Set.fromList targets'
 
         unless (Set.null targetsSet) $ do
@@ -242,7 +242,7 @@ parseImports =
             bs3 = fromMaybe bs2 $ stripPrefix "qualified " bs2
         case stripPrefix "\"" bs3 of
             Just bs4 -> do
-                pn <- parsePackageNameFromString $ S8.unpack $ S8.takeWhile (/= '"') bs4
+                pn <- parsePackageNameThrowing $ S8.unpack $ S8.takeWhile (/= '"') bs4
                 Just (Set.singleton pn, Set.empty)
             Nothing -> Just
                 ( Set.empty

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -55,7 +55,7 @@ toolNameString ToolGhcjs{} = "ghcjs"
 
 parseToolText :: Text -> Maybe Tool
 parseToolText (parseCompilerVersion -> Just cv@GhcjsVersion{}) = Just (ToolGhcjs cv)
-parseToolText (parsePackageIdentifierFromString . T.unpack -> Just pkgId) = Just (Tool pkgId)
+parseToolText (parsePackageIdentifier . T.unpack -> Just pkgId) = Just (Tool pkgId)
 parseToolText _ = Nothing
 
 markInstalled :: (MonadIO m, MonadThrow m)
@@ -97,7 +97,7 @@ getCompilerVersion wc =
             logDebug "Asking GHC for its version"
             bs <- fst <$> proc "ghc" ["--numeric-version"] readProcess_
             let (_, ghcVersion) = versionFromEnd $ BL.toStrict bs
-            x <- GhcVersion <$> parseVersion (T.decodeUtf8 ghcVersion)
+            x <- GhcVersion <$> parseVersionThrowing (T.unpack $ T.decodeUtf8 ghcVersion)
             logDebug $ "GHC version is: " <> display x
             return x
         Ghcjs -> do
@@ -106,9 +106,9 @@ getCompilerVersion wc =
             --
             -- The Glorious Glasgow Haskell Compilation System for JavaScript, version 0.1.0 (GHC 7.10.2)
             bs <- fst <$> proc "ghcjs" ["--version"] readProcess_
-            let (rest, ghcVersion) = T.decodeUtf8 <$> versionFromEnd (BL.toStrict bs)
-                (_, ghcjsVersion) = T.decodeUtf8 <$> versionFromEnd rest
-            GhcjsVersion <$> parseVersion ghcjsVersion <*> parseVersion ghcVersion
+            let (rest, ghcVersion) = T.unpack . T.decodeUtf8 <$> versionFromEnd (BL.toStrict bs)
+                (_, ghcjsVersion) = T.unpack . T.decodeUtf8 <$> versionFromEnd rest
+            GhcjsVersion <$> parseVersionThrowing ghcjsVersion <*> parseVersionThrowing ghcVersion
   where
     versionFromEnd = S8.spanEnd isValid . fst . S8.breakEnd isValid
     isValid c = c == '.' || ('0' <= c && c <= '9')

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -37,7 +37,6 @@ import           Path
 import           Path.IO
 import           Stack.Types.Compiler
 import           Stack.Types.Config
-import           Stack.Types.PackageIdentifier
 import           Stack.Types.Version
 import           RIO.Process
 

--- a/src/Stack/SetupCmd.hs
+++ b/src/Stack/SetupCmd.hs
@@ -54,7 +54,7 @@ cabalUpgradeParser = Specific <$> version' <|> latestParser
     where
         versionReader = do
             s <- OA.readerAsk
-            case parseVersion (T.pack s) of
+            case parseVersion s of
                 Nothing -> OA.readerError $ "Invalid version: " ++ s
                 Just v  -> return v
         version' = OA.option versionReader (

--- a/src/Stack/Sig/Sign.hs
+++ b/src/Stack/Sig/Sign.hs
@@ -26,7 +26,6 @@ import           Network.HTTP.StackClient (RequestBody (RequestBodyBS), setReque
 import           Path
 import           Stack.Package
 import           Stack.Sig.GPG
-import           Stack.Types.PackageIdentifier
 import           Stack.Types.Sig
 import qualified System.FilePath as FP
 

--- a/src/Stack/Snapshot.hs
+++ b/src/Stack/Snapshot.hs
@@ -46,7 +46,6 @@ import           Network.HTTP.StackClient (Request)
 import           Network.HTTP.Download
 import qualified RIO
 import           Network.URI (isURI)
-import           Pantry
 import           Pantry.StaticSHA256
 import           Path
 import           Path.IO
@@ -56,9 +55,7 @@ import           Stack.PackageDump
 import           Stack.Types.BuildPlan
 import           Stack.Types.FlagName
 import           Stack.Types.GhcPkgId
-import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageName
-import           Stack.Types.Version
 import           Stack.Types.VersionIntervals
 import           Stack.Types.Config
 import           Stack.Types.Urls

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -211,8 +211,8 @@ parseCabalOutputLine t0 = maybe (Left t0) Right . join .  match re $ t0
     mk :: String -> [Maybe (Bool, String)] -> Maybe (PackageName, (Version, Map FlagName Bool))
     mk ident fl = do
         PackageIdentifier name version <-
-            parsePackageIdentifierFromString ident
-        fl' <- (traverse . traverse) parseFlagNameFromString $ catMaybes fl
+            parsePackageIdentifierThrowing ident
+        fl' <- (traverse . traverse) parseFlagNameThrowing $ catMaybes fl
         return (name, (version, Map.fromList $ map swap fl'))
 
     lexeme r = some (psym isSpace) *> r

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -70,12 +70,9 @@ import           Stack.Constants
 import           Stack.Types.Compiler
 import           Stack.Types.CompilerBuild
 import           Stack.Types.Config
-import           Stack.Types.FlagName
 import           Stack.Types.GhcPkgId
 import           Stack.Types.NamedComponent
 import           Stack.Types.Package
-import           Stack.Types.PackageIdentifier
-import           Stack.Types.PackageName
 import           Stack.Types.Version
 import           System.Exit                     (ExitCode (ExitFailure))
 import           System.FilePath                 (pathSeparator)

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -29,8 +29,6 @@ module Stack.Types.BuildPlan
     , sdWantedCompilerVersion
     ) where
 
-import           Data.Aeson (ToJSON (..), FromJSON (..), withText, object, (.=))
-import           Data.Aeson.Extended (WithJSONWarnings (..), (..:), (..:?), withObjectWarnings, noJSONWarnings, (..!=))
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import           Data.Store.Version
@@ -39,17 +37,11 @@ import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8)
 import qualified Distribution.ModuleName as C
 import qualified Distribution.Version as C
-import           Network.HTTP.StackClient (parseRequest)
 import           Pantry
-import           Pantry.StaticSHA256
 import           Stack.Prelude
 import           Stack.Types.Compiler
-import           Stack.Types.FlagName
 import           Stack.Types.GhcPkgId
-import           Stack.Types.PackageIdentifier
-import           Stack.Types.PackageName
 import           Stack.Types.Resolver
-import           Stack.Types.Version
 import           Stack.Types.VersionIntervals
 
 -- | A definition of a snapshot. This could be a Stackage snapshot or

--- a/src/Stack/Types/Compiler.hs
+++ b/src/Stack/Types/Compiler.hs
@@ -63,12 +63,12 @@ wantedToActual (GhcjsVersion x y) = GhcjsVersion x y
 parseCompilerVersion :: T.Text -> Maybe (CompilerVersion a)
 parseCompilerVersion t
     | Just t' <- T.stripPrefix "ghc-" t
-    , Just v <- parseVersionFromString $ T.unpack t'
+    , Just v <- parseVersion $ T.unpack t'
         = Just (GhcVersion v)
     | Just t' <- T.stripPrefix "ghcjs-" t
     , [tghcjs, tghc] <- T.splitOn "_ghc-" t'
-    , Just vghcjs <- parseVersionFromString $ T.unpack tghcjs
-    , Just vghc <- parseVersionFromString $ T.unpack tghc
+    , Just vghcjs <- parseVersion $ T.unpack tghcjs
+    , Just vghc <- parseVersion $ T.unpack tghc
         = Just (GhcjsVersion vghcjs vghc)
     | otherwise
         = Nothing

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -177,7 +177,7 @@ import           Crypto.Hash (hashWith, SHA1(..))
 import           Stack.Prelude
 import           Data.Aeson.Extended
                  (ToJSON, toJSON, FromJSON, FromJSONKey (..), parseJSON, withText, object,
-                  (.=), (..:), (..:?), (..!=), Value(Bool, String),
+                  (.=), (..:), (..:?), (..!=), Value(Bool),
                   withObjectWarnings, WarningParser, Object, jsonSubWarnings,
                   jsonSubWarningsT, jsonSubWarningsTT, WithJSONWarnings(..), noJSONWarnings,
                   FromJSONKeyFunction (FromJSONKeyTextParser))
@@ -209,18 +209,15 @@ import           Options.Applicative (ReadM)
 import qualified Options.Applicative as OA
 import qualified Options.Applicative.Types as OA
 import           Path
-import           Pantry
 import qualified Paths_stack as Meta
 import           Stack.Constants
 import           Stack.Types.BuildPlan
 import           Stack.Types.Compiler
 import           Stack.Types.CompilerBuild
 import           Stack.Types.Docker
-import           Stack.Types.FlagName
 import           Stack.Types.Image
 import           Stack.Types.NamedComponent
 import           Stack.Types.Nix
-import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageIndex
 import           Stack.Types.PackageName
 import           Stack.Types.Resolver

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -850,7 +850,7 @@ parseConfigMonoidObject rootDir obj = do
         name <-
             if name' == "*"
                 then return Nothing
-                else case parsePackageNameFromString $ T.unpack name' of
+                else case parsePackageNameThrowing $ T.unpack name' of
                         Left e -> fail $ show e
                         Right x -> return $ Just x
         return (name, b)
@@ -1730,7 +1730,7 @@ instance FromJSONKey GhcOptionKey where
       "$locals" -> return GOKLocals
       "$targets" -> return GOKTargets
       _ ->
-        case parsePackageName t of
+        case parsePackageNameThrowing $ T.unpack t of
           Left e -> fail $ show e
           Right x -> return $ GOKPackage x
   fromJSONKeyList = FromJSONKeyTextParser $ \_ -> fail "GhcOptionKey.fromJSONKeyList"

--- a/src/Stack/Types/Config/Build.hs
+++ b/src/Stack/Types/Config/Build.hs
@@ -32,8 +32,6 @@ import           Data.Aeson.Extended
 import qualified Data.Map.Strict as Map
 import           Generics.Deriving.Monoid (memptydefault, mappenddefault)
 import           Stack.Prelude
-import           Stack.Types.FlagName
-import           Stack.Types.PackageName
 
 -- | Build options that is interpreted by the build command.
 --   This is built up from BuildOptsCLI and BuildOptsMonoid

--- a/src/Stack/Types/FlagName.hs
+++ b/src/Stack/Types/FlagName.hs
@@ -18,15 +18,11 @@ module Stack.Types.FlagName
   where
 
 import           Stack.Prelude
-import           Data.Aeson.Extended
-import           Data.Attoparsec.Text as A
-import           Data.Char (isLetter, isDigit, toLower)
 import qualified Data.Text as T
 import qualified Distribution.PackageDescription as Cabal
 import           Distribution.PackageDescription (FlagName)
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Syntax
-import           Pantry
 
 -- | A parse fail.
 newtype FlagNameParseFail = FlagNameParseFail Text

--- a/src/Stack/Types/FlagName.hs
+++ b/src/Stack/Types/FlagName.hs
@@ -13,7 +13,7 @@ module Stack.Types.FlagName
   (FlagName
   ,FlagNameParseFail(..)
   ,parseFlagName
-  ,parseFlagNameFromString
+  ,parseFlagNameThrowing
   ,mkFlagName)
   where
 
@@ -52,17 +52,13 @@ instance FromJSONKey FlagName where
 -- | Make a flag name.
 mkFlagName :: String -> Q Exp
 mkFlagName s =
-  case parseFlagNameFromString s of
+  case parseFlagName s of
     Nothing -> qRunIO $ throwString ("Invalid flag name: " ++ show s)
     Just _ -> [|Cabal.mkFlagName s|]
 
--- | Convenient way to parse a flag name from a 'Text'.
-parseFlagName :: MonadThrow m => Text -> m FlagName
-parseFlagName = parseFlagNameFromString . T.unpack
-
 -- | Convenience function for parsing from a 'String'
-parseFlagNameFromString :: MonadThrow m => String -> m FlagName
-parseFlagNameFromString str =
-  case parseC str of
+parseFlagNameThrowing :: MonadThrow m => String -> m FlagName
+parseFlagNameThrowing str =
+  case parseFlagName str of
     Nothing -> throwM $ FlagNameParseFail $ T.pack str
     Just fn -> pure fn

--- a/src/Stack/Types/NamedComponent.hs
+++ b/src/Stack/Types/NamedComponent.hs
@@ -18,7 +18,6 @@ module Stack.Types.NamedComponent
 
 import Pantry
 import Stack.Prelude
-import Stack.Types.PackageName
 import qualified Data.Set as Set
 import qualified Data.Text as T
 

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -27,11 +27,8 @@ import           Path as FL
 import           Stack.Types.BuildPlan (ExeName)
 import           Stack.Types.Compiler
 import           Stack.Types.Config
-import           Stack.Types.FlagName
 import           Stack.Types.GhcPkgId
 import           Stack.Types.NamedComponent
-import           Stack.Types.PackageIdentifier
-import           Stack.Types.PackageName
 import           Stack.Types.Version
 
 -- | All exceptions thrown by the library.

--- a/src/Stack/Types/PackageIdentifier.hs
+++ b/src/Stack/Types/PackageIdentifier.hs
@@ -16,20 +16,7 @@ module Stack.Types.PackageIdentifier
   ) where
 
 import           Stack.Prelude
-import           Crypto.Hash.Conduit (hashFile)
-import           Crypto.Hash as Hash (hashlazy, Digest, SHA256)
-import           Data.Aeson.Extended
-import           Data.Attoparsec.Text as A
-import qualified Data.ByteArray
-import qualified Data.ByteArray.Encoding as Mem
-import qualified Data.ByteString.Lazy as L
 import qualified Data.Text as T
-import           Data.Text.Encoding (decodeUtf8, encodeUtf8)
-import qualified Distribution.Package as C
-import           Pantry
-import           Pantry.StaticSHA256
-import           Stack.Types.PackageName
-import           Stack.Types.Version
 
 -- | A parse fail.
 data PackageIdentifierParseFail

--- a/src/Stack/Types/PackageIdentifier.hs
+++ b/src/Stack/Types/PackageIdentifier.hs
@@ -12,7 +12,7 @@
 
 module Stack.Types.PackageIdentifier
   ( parsePackageIdentifier
-  , parsePackageIdentifierFromString
+  , parsePackageIdentifierThrowing
   ) where
 
 import           Stack.Prelude
@@ -57,13 +57,9 @@ instance FromJSON PackageIdentifierRevision where
       Right x -> return x
 -}
 
--- | Convenient way to parse a package identifier from a 'Text'.
-parsePackageIdentifier :: MonadThrow m => Text -> m PackageIdentifier
-parsePackageIdentifier = parsePackageIdentifierFromString . T.unpack
-
 -- | Convenience function for parsing from a 'String'.
-parsePackageIdentifierFromString :: MonadThrow m => String -> m PackageIdentifier
-parsePackageIdentifierFromString str =
-  case parseC str of
+parsePackageIdentifierThrowing :: MonadThrow m => String -> m PackageIdentifier
+parsePackageIdentifierThrowing str =
+  case parsePackageIdentifier str of
     Nothing -> throwM $ PackageIdentifierParseFail $ T.pack str
     Just ident -> pure ident

--- a/src/Stack/Types/PackageIndex.hs
+++ b/src/Stack/Types/PackageIndex.hs
@@ -19,18 +19,10 @@ module Stack.Types.PackageIndex
     ) where
 
 import           Data.Aeson.Extended
-import qualified Data.Foldable as F
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8, decodeUtf8)
 import           Path
-import           Pantry
 import           Stack.Prelude
-import           Stack.Types.PackageName
-import           Stack.Types.PackageIdentifier
-import           Stack.Types.Version
-import           Data.List.NonEmpty (NonEmpty)
 
 -- | offset in bytes into the 01-index.tar file for the .cabal file
 -- contents, and size in bytes of the .cabal file

--- a/src/Stack/Types/PackageName.hs
+++ b/src/Stack/Types/PackageName.hs
@@ -13,14 +13,14 @@ module Stack.Types.PackageName
   (PackageName
   ,PackageNameParseFail(..)
   ,parsePackageName
-  ,parsePackageNameFromString
+  ,parsePackageNameThrowing
   ,parsePackageNameFromFilePath
   ,mkPackageName
   ,packageNameArgument)
   where
 
 import           Stack.Prelude
-import           Pantry
+import           Pantry as P
 import           Data.Aeson.Extended
 import           Data.Attoparsec.Combinators
 import           Data.Attoparsec.Text
@@ -61,18 +61,14 @@ instance FromJSONKey PackageName where
 -- | Make a package name.
 mkPackageName :: String -> Q Exp
 mkPackageName s =
-  case parsePackageNameFromString s of
-    Left e -> qRunIO $ throwIO e
-    Right _ -> [|Cabal.mkPackageName s|]
-
--- | Parse a package name from a 'Text'.
-parsePackageName :: MonadThrow m => Text -> m PackageName
-parsePackageName = parsePackageNameFromString . T.unpack
+  case parsePackageName s of
+    Nothing -> qRunIO $ throwIO (PackageNameParseFail $ T.pack s)
+    Just _ -> [|Cabal.mkPackageName s|]
 
 -- | Parse a package name from a 'String'.
-parsePackageNameFromString :: MonadThrow m => String -> m PackageName
-parsePackageNameFromString str =
-  case parseC str of
+parsePackageNameThrowing :: MonadThrow m => String -> m PackageName
+parsePackageNameThrowing str =
+  case parsePackageName str of
     Nothing -> throwM $ PackageNameParseFail $ T.pack str
     Just pn -> pure pn
 
@@ -80,7 +76,7 @@ parsePackageNameFromString str =
 parsePackageNameFromFilePath :: MonadThrow m => Path a File -> m PackageName
 parsePackageNameFromFilePath fp = do
     base <- clean $ toFilePath $ filename fp
-    case parsePackageNameFromString base of
+    case parsePackageName base of
         Nothing -> throwM $ CabalFileNameInvalidPackageName $ toFilePath fp
         Just x -> return x
   where clean = liftM reverse . strip . reverse
@@ -97,7 +93,7 @@ packageNameArgument =
             either O.readerError return (p s))
   where
     p s =
-        case parsePackageNameFromString s of
+        case parsePackageName s of
             Just x -> Right x
             Nothing -> Left $ unlines
                 [ "Expected valid package name, but got: " ++ s

--- a/src/Stack/Types/PackageName.hs
+++ b/src/Stack/Types/PackageName.hs
@@ -20,11 +20,6 @@ module Stack.Types.PackageName
   where
 
 import           Stack.Prelude
-import           Pantry as P
-import           Data.Aeson.Extended
-import           Data.Attoparsec.Combinators
-import           Data.Attoparsec.Text
-import           Data.List (intercalate)
 import qualified Data.Text as T
 import qualified Distribution.Package as Cabal
 import           Language.Haskell.TH

--- a/src/Stack/Types/Resolver.hs
+++ b/src/Stack/Types/Resolver.hs
@@ -56,7 +56,6 @@ import           Pantry.StaticSHA256
 import           Path
 import           Stack.Prelude
 import           Stack.Types.Compiler
-import           Stack.Types.PackageIdentifier
 import qualified System.FilePath as FP
 
 data IsLoaded = Loaded | NotLoaded

--- a/src/Stack/Types/Sig.hs
+++ b/src/Stack/Types/Sig.hs
@@ -21,7 +21,6 @@ import           Data.Aeson (Value(..), ToJSON(..), FromJSON(..))
 import qualified Data.ByteString as SB
 import           Data.Char (isHexDigit)
 import qualified Data.Text as T
-import           Stack.Types.PackageName
 
 -- | A GPG signature.
 newtype Signature =

--- a/src/Stack/Types/Sig.hs
+++ b/src/Stack/Types/Sig.hs
@@ -63,7 +63,7 @@ instance FromJSON (Aeson PackageName) where
         s <- parseJSON j
         case parsePackageName s of
             Just name -> return (Aeson name)
-            Nothing -> fail ("Invalid package name: " <> T.unpack s)
+            Nothing -> fail ("Invalid package name: " <> s)
 
 -- | Handy wrapper for orphan instances.
 newtype Aeson a = Aeson

--- a/src/Stack/Types/Version.hs
+++ b/src/Stack/Types/Version.hs
@@ -32,21 +32,16 @@ module Stack.Types.Version
   where
 
 import           Stack.Prelude hiding (Vector)
-import           Pantry
 import           Data.Aeson.Extended
-import           Data.Hashable (Hashable (..))
 import           Data.List
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import           Data.Vector.Unboxed (Vector)
-import qualified Data.Vector.Unboxed as V
 import           Distribution.Text (disp)
 import qualified Distribution.Version as Cabal
 import           Distribution.Version (Version, versionNumbers, withinRange)
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Syntax
 import qualified Paths_stack as Meta
-import           Pantry
 import           Text.PrettyPrint (render)
 
 -- | A parse fail.

--- a/src/Stack/Unpack.hs
+++ b/src/Stack/Unpack.hs
@@ -6,13 +6,9 @@ module Stack.Unpack
 
 import Stack.Prelude
 import Stack.Types.BuildPlan
-import Stack.Types.PackageName
-import Stack.Types.PackageIdentifier
-import Stack.Types.Version
 import qualified RIO.Text as T
 import qualified RIO.Map as Map
 import qualified RIO.Set as Set
-import Pantry
 import RIO.Directory (doesDirectoryExist)
 import RIO.List (intercalate)
 import RIO.FilePath ((</>))

--- a/src/Stack/Unpack.hs
+++ b/src/Stack/Unpack.hs
@@ -100,9 +100,9 @@ unpackPackages mSnapshotDef dest input = do
 
     -- Possible future enhancement: parse names as name + version range
     parse s =
-        case parsePackageName t of
-            Right x -> Right $ Left x
-            Left _ ->
+        case parsePackageName (T.unpack t) of
+            Just x -> Right $ Left x
+            Nothing ->
                 case parsePackageIdentifierRevision t of
                     Right x -> Right $ Right x
                     Left _ -> Left s

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -193,7 +193,7 @@ main = do
       when (globalLogLevel global == LevelDebug) $ hPutStrLn stderr versionString'
       case globalReExecVersion global of
           Just expectVersion -> do
-              expectVersion' <- parseVersionFromString expectVersion
+              expectVersion' <- parseVersionThrowing expectVersion
               unless (checkVersion MatchMinor expectVersion' (mkVersion' Meta.version))
                   $ throwIO $ InvalidReExecVersion expectVersion (showVersion Meta.version)
           _ -> return ()

--- a/subs/pantry/src/Pantry.hs
+++ b/subs/pantry/src/Pantry.hs
@@ -32,7 +32,10 @@ module Pantry
   , completePackageLocation
 
     -- ** Cabal helpers
-  , parseC
+  , parsePackageIdentifier
+  , parsePackageName
+  , parseFlagName
+  , parseVersion
   , displayC
   , CabalString (..)
   , toCabalStringMap

--- a/subs/pantry/src/Pantry.hs
+++ b/subs/pantry/src/Pantry.hs
@@ -63,22 +63,13 @@ import RIO
 import RIO.FilePath ((</>))
 import qualified RIO.Map as Map
 import qualified Data.Map.Strict as Map (mapKeysMonotonic)
-import qualified RIO.Set as Set
-import qualified RIO.Text as T
 import Pantry.StaticSHA256
 import Pantry.Storage
 import Pantry.Tree
 import Pantry.Types
 import Pantry.Hackage
-import Data.Aeson (ToJSON (..), FromJSON (..), withText, ToJSONKey (..), FromJSONKey (..))
-import Data.Aeson.Types (ToJSONKey (..) ,toJSONKeyText)
-import qualified Distribution.Text
-import Data.List.NonEmpty (NonEmpty)
 import Distribution.PackageDescription (GenericPackageDescription, FlagName)
 import Distribution.PackageDescription.Parsec
-import qualified Distribution.PackageDescription.Parsec as D
-import qualified Data.List.NonEmpty as NE
-import Data.Coerce (coerce)
 
 withPantryConfig
   :: HasLogFunc env

--- a/subs/pantry/src/Pantry/Archive.hs
+++ b/subs/pantry/src/Pantry/Archive.hs
@@ -22,7 +22,6 @@ import Conduit
 import Crypto.Hash.Conduit
 import Data.Conduit.Zlib (ungzip)
 import qualified Data.Conduit.Tar as Tar
-import qualified Codec.Archive.Zip as Zip
 import Network.HTTP.Client (parseUrlThrow)
 import Network.HTTP.Simple (httpSink)
 

--- a/subs/pantry/src/Pantry/Storage.hs
+++ b/subs/pantry/src/Pantry/Storage.hs
@@ -52,7 +52,6 @@ import RIO.Orphans ()
 import Pantry.StaticSHA256
 import qualified RIO.Map as Map
 import RIO.Time (UTCTime, getCurrentTime)
-import qualified RIO.Text as T
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
 BlobTable sql=blob

--- a/subs/pantry/src/Pantry/Types.hs
+++ b/subs/pantry/src/Pantry/Types.hs
@@ -442,8 +442,9 @@ data PackageTarball = PackageTarball
   }
   deriving Show
 
--- | Modified version of Cabal's parser - we don't need null version
--- in package indentifiers
+-- | This is almost a copy of Cabal's parser for package identifiers,
+-- the main difference is in the fact that Stack requires version to be
+-- present while Cabal uses "null version" as a defaul value
 parsePackageIdentifier :: String -> Maybe PackageIdentifier
 parsePackageIdentifier str =
     case [p | (p, s) <- Parse.readP_to_S parser str, all isSpace s] of
@@ -452,6 +453,7 @@ parsePackageIdentifier str =
   where
     parser = do
         n <- Distribution.Text.parse
+        -- version is a required component of a package identifier for Stack
         v <- Parse.char '-' >> Distribution.Text.parse
         return (PackageIdentifier n v)
 

--- a/subs/pantry/src/Pantry/Types.hs
+++ b/subs/pantry/src/Pantry/Types.hs
@@ -37,7 +37,10 @@ module Pantry.Types
   , Archive (..)
   , Repo (..)
   , RepoType (..)
-  , parseC
+  , parsePackageIdentifier
+  , parsePackageName
+  , parseFlagName
+  , parseVersion
   , displayC
   , RawPackageLocation (..)
   , RawArchive (..)
@@ -52,6 +55,7 @@ import RIO
 import qualified RIO.Text as T
 import qualified RIO.ByteString as B
 import qualified RIO.ByteString.Lazy as BL
+import RIO.Char (isSpace)
 import qualified RIO.Map as Map
 import Data.Aeson (ToJSON (..), FromJSON (..), withText, FromJSONKey (..))
 import Data.Aeson.Types (ToJSONKey (..) ,toJSONKeyText)
@@ -61,6 +65,7 @@ import Data.Pool (Pool)
 import Database.Persist
 import Database.Persist.Sql
 import Pantry.StaticSHA256
+import qualified Distribution.Compat.ReadP as Parse
 import Distribution.Parsec.Common (PError (..), PWarning (..), showPos)
 import Distribution.Types.PackageName (PackageName)
 import Distribution.PackageDescription (FlagName)
@@ -259,7 +264,7 @@ instance FromJSON PackageIdentifierRevision where
 parsePackageIdentifierRevision :: MonadThrow m => Text -> m PackageIdentifierRevision
 parsePackageIdentifierRevision t = maybe (throwM $ PackageIdentifierRevisionParseFail t) pure $ do
   let (identT, cfiT) = T.break (== '@') t
-  PackageIdentifier name version <- parseC $ T.unpack identT
+  PackageIdentifier name version <- Distribution.Text.simpleParse $ T.unpack identT
   cfi <-
     case splitColon cfiT of
       Just ("@sha256", shaSizeT) -> do
@@ -438,9 +443,27 @@ data PackageTarball = PackageTarball
   }
   deriving Show
 
--- | Parse Cabal types using 'Distribution.Text.Text'.
-parseC :: Distribution.Text.Text a => String -> Maybe a
-parseC = Distribution.Text.simpleParse
+-- | Modified version of Cabal's parser - we don't need null version
+-- in package indentifiers
+parsePackageIdentifier :: String -> Maybe PackageIdentifier
+parsePackageIdentifier str =
+    case [p | (p, s) <- Parse.readP_to_S parser str, all isSpace s] of
+        [] -> Nothing
+        (p:_) -> Just p
+  where
+    parser = do
+        n <- Distribution.Text.parse
+        v <- Parse.char '-' >> Distribution.Text.parse
+        return (PackageIdentifier n v)
+
+parsePackageName :: String -> Maybe PackageName
+parsePackageName = Distribution.Text.simpleParse
+
+parseVersion :: String -> Maybe Version
+parseVersion = Distribution.Text.simpleParse
+
+parseFlagName :: String -> Maybe FlagName
+parseFlagName = Distribution.Text.simpleParse
 
 -- | Display Cabal types using 'Distribution.Text.Text'.
 displayC :: (IsString str, Distribution.Text.Text a) => a -> str
@@ -635,7 +658,7 @@ instance Store PackageName where
     case size of
       ConstSize x -> x
       VarSize f -> f (displayC name :: String)
-  peek = peek >>= maybe (fail "Invalid package name") pure . parseC
+  peek = peek >>= maybe (fail "Invalid package name") pure . parsePackageName
   poke name = poke (displayC name :: String)
 instance Store Version where
   size =
@@ -643,7 +666,7 @@ instance Store Version where
     case size of
       ConstSize x -> x
       VarSize f -> f (displayC version :: String)
-  peek = peek >>= maybe (fail "Invalid version") pure . parseC
+  peek = peek >>= maybe (fail "Invalid version") pure . parseVersion
   poke version = poke (displayC version :: String)
 instance Store FlagName where
   size =
@@ -651,7 +674,7 @@ instance Store FlagName where
     case size of
       ConstSize x -> x
       VarSize f -> f (displayC fname :: String)
-  peek = peek >>= maybe (fail "Invalid flag name") pure . parseC
+  peek = peek >>= maybe (fail "Invalid flag name") pure . parseFlagName
   poke fname = poke (displayC fname :: String)
 instance Store PackageIdentifierRevision where
   size =

--- a/subs/pantry/src/Pantry/Types.hs
+++ b/subs/pantry/src/Pantry/Types.hs
@@ -61,7 +61,6 @@ import Data.Aeson (ToJSON (..), FromJSON (..), withText, FromJSONKey (..))
 import Data.Aeson.Types (ToJSONKey (..) ,toJSONKeyText)
 import Data.Aeson.Extended
 import Data.ByteString.Builder (toLazyByteString, byteString, wordDec)
-import Data.Pool (Pool)
 import Database.Persist
 import Database.Persist.Sql
 import Pantry.StaticSHA256


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

`stack build` now stops at later `undefined`
