### PR TITLE
Document that `stack ghci` works best only after `stack build`.

### DIFF
--- a/doc/ghci.md
+++ b/doc/ghci.md
@@ -75,3 +75,10 @@ For doing experiments which just involve packages installed in your databases,
 it may be useful to run ghci plainly like `stack exec ghci`. This will run a
 plain `ghci` in an environment which includes `GHC_PACKAGE_PATH`, and so will
 have access to your databases.
+
+*Note*: Running `stack ghci` on a pristine copy of the code doesn't currently
+build libraries
+([#2790](https://github.com/commercialhaskell/stack/issues/2790)) or internal
+libraries ([#4148](https://github.com/commercialhaskell/stack/issues/4148)).
+It is recommended to always run a `stack build` before running `stack ghci`,
+until these two issues are closed.


### PR DESCRIPTION
This documents the #2790 and #4148 bugs as we decided in #4177 to only
document this behavior for 1.8.1 release and solve them later.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
