### PR TITLE
Fix integration test 3942-solver-error-output

### DIFF
--- a/test/integration/tests/3942-solver-error-output/files/no-deps/package.yaml
+++ b/test/integration/tests/3942-solver-error-output/files/no-deps/package.yaml
@@ -1,0 +1,15 @@
+name: no-deps
+version: 0.1.0.0
+synopsis: A package with no dependencies, other than base
+license: BSD3
+author: David Baynard
+copyright: 2018 David Baynard
+category: Development
+extra-source-files: []
+
+dependencies:
+  - base
+
+library:
+  source-dirs: '.'
+  exposed-modules: []

--- a/test/integration/tests/3942-solver-error-output/files/one-deps/package.yaml
+++ b/test/integration/tests/3942-solver-error-output/files/one-deps/package.yaml
@@ -1,0 +1,17 @@
+name: one-deps
+version: 0.1.0.0
+synopsis: A package with one dependency (no-deps) other than base
+license: BSD3
+author: David Baynard
+copyright: 2018 David Baynard
+category: Development
+extra-source-files: []
+
+dependencies:
+  - base
+  - no-deps
+
+library:
+  source-dirs: '.'
+  exposed-modules: []
+

--- a/test/integration/tests/3942-solver-error-output/files/script.hs
+++ b/test/integration/tests/3942-solver-error-output/files/script.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack runhaskell --stack-yaml test-stack.yml --package cloud-seeder
+-- stack runhaskell --stack-yaml test-stack.yml --package one-deps
 
 main :: IO ()
 main = putStrLn "yo"

--- a/test/integration/tests/3942-solver-error-output/files/test-stack.yml
+++ b/test/integration/tests/3942-solver-error-output/files/test-stack.yml
@@ -1,10 +1,10 @@
 resolver: lts-11.6
 
 packages:
-- location:
-    git: https://github.com/cjdev/cloudseeder.git
-    commit: c7068f25c41bcc0b4bdfc9b38ee5b05b5caefae5
+- location: ./one-deps
   extra-dep: true
+
+extra-deps: []
 
 flags: {}
 


### PR DESCRIPTION
Fixes #4178.

This creates two fake packages, rather than using a real one which might be included in stackage (as broke this test).

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.