### PR TITLE
Adapt upload integration test for Windows

### DIFF
--- a/test/integration/tests/upload/Main.hs
+++ b/test/integration/tests/upload/Main.hs
@@ -42,4 +42,4 @@ withFakeHackage act = do
         threadDelay 2000000
         act
   where
-    withNetworkArgs = ["runghc", "--package", "network-simple"]
+    withNetworkArgs = ["runghc", "--package", "network"]

--- a/test/integration/tests/upload/files/FakeHackage.hs
+++ b/test/integration/tests/upload/files/FakeHackage.hs
@@ -1,8 +1,32 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-import Network.Simple.TCP
+import Control.Concurrent
+import Control.Monad
+import Network.Socket hiding (recv)
+import Network.Socket.ByteString (recv, sendAll)
+import System.Exit
+import System.IO
 
 -- | Fake server that always responds with HTTP OK
 main =
-    serve (Host "127.0.0.1") "12415" $ \(socket, _) ->
-        send socket "HTTP/1.1 200 OK\r\n\r\n"
+    withSocketsDo $ do
+        _ <- forkIO serve
+        -- Exit after a delay to ensure the process doesn't linger around
+        threadDelay 10000000
+        exitSuccess
+
+serve :: IO ()
+serve = do
+    let hints = defaultHints {addrFlags = [AI_PASSIVE], addrSocketType = Stream}
+    (addr:_) <- getAddrInfo Nothing Nothing (Just "12415")
+    sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+    setSocketOption sock ReuseAddr 1
+    bind sock (addrAddress addr)
+    listen sock 10
+    forever $ do
+        (conn, _) <- accept sock
+        _ <- recv conn 1024
+        sendAll
+            conn
+            "HTTP/1.1 200 OK\r\nContent-Length: 1\r\nContent-Type: text/plain\r\n\r\na"
+        shutdown conn ShutdownSend

--- a/test/integration/tests/upload/files/gpg-disabled/gpg.bat
+++ b/test/integration/tests/upload/files/gpg-disabled/gpg.bat
@@ -1,0 +1,2 @@
+@echo off
+exit 1

--- a/test/integration/tests/upload/files/gpg-disabled/gpg2.bat
+++ b/test/integration/tests/upload/files/gpg-disabled/gpg2.bat
@@ -1,0 +1,2 @@
+@echo off
+exit 1


### PR DESCRIPTION
See #4167 for context. This is an attempt to fix the upload integration test on Windows; currently I'm still getting a hanging process when running the real test, but not via a manual `stack runghc`.