### PR TITLE
Do not hardcode GHC versions for Nixpkgs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -84,6 +84,8 @@ Other enhancements:
 * It is possible to specify the Hackage base URL to upload packages to, instead
   of the default of `https://hackage.haskell.org/`, by using `hackage-base-url`
   configuration option.
+* When using Nix, if a specific minor version of GHC is not requested, the
+  latest minor version in the given major branch will be used automatically.
 
 Bug fixes:
 


### PR DESCRIPTION
Hardcoding GHC versions for Nixpkgs makes assumptions which are frequently
violated: that the user has the latest Nixpkgs and that the user is using the
latest Stack. Instead of hardcoding the latest minor version in each major
branch, the latest minor version in the user's Nixpkgs is selected for the
wanted regular branch.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I tested this change against the test suite and by running `stack ghc -- --version` both inside and outside a project, against GHC versions that are and are not in my local copy of Nixpkgs.
