### PR TITLE
upload integration test: Fix invocation to getAddrInfo

### DIFF
--- a/test/integration/tests/upload/files/FakeHackage.hs
+++ b/test/integration/tests/upload/files/FakeHackage.hs
@@ -18,7 +18,7 @@ main =
 serve :: IO ()
 serve = do
     let hints = defaultHints {addrFlags = [AI_PASSIVE], addrSocketType = Stream}
-    (addr:_) <- getAddrInfo Nothing Nothing (Just "12415")
+    (addr:_) <- getAddrInfo (Just hints) Nothing (Just "12415")
     sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
     setSocketOption sock ReuseAddr 1
     bind sock (addrAddress addr)


### PR DESCRIPTION
This seems the intended behavior and improves behavior on Mac.

The testing is what's described on https://github.com/commercialhaskell/stack/issues/4191#issuecomment-408705732, I'm fixing my GPG setup and rerunning integration tests.