### PR TITLE
Fix #4183 Make PrettyPrint styles background-agnostic

### DIFF
--- a/src/Stack/PrettyPrint.hs
+++ b/src/Stack/PrettyPrint.hs
@@ -154,31 +154,33 @@ debugBracket msg f = do
   output $ "Finished in" <+> displayMilliseconds diff <> ":" <+> msg
   return x
 
+--   The following syles do not affect the colour of the background.
+
 -- | Style an 'AnsiDoc' as an error. Should be used sparingly, not to style
 --   entire long messages. For example, it's used to style the "Error:"
 --   label for an error message, not the entire message.
 styleError :: AnsiDoc -> AnsiDoc
-styleError = dullred . ondullblack
+styleError = dullred
 
 -- | Style an 'AnsiDoc' as a warning. Should be used sparingly, not to style
 --   entire long messages. For example, it's used to style the "Warning:"
 --   label for an error message, not the entire message.
 styleWarning :: AnsiDoc -> AnsiDoc
-styleWarning = yellow . ondullblack
+styleWarning = dullyellow
 
 -- | Style an 'AnsiDoc' in a way to emphasize that it is a particularly good
 --   thing.
 styleGood :: AnsiDoc -> AnsiDoc
-styleGood = green . ondullblack
+styleGood = green
 
 -- | Style an 'AnsiDoc' as a shell command, i.e. when suggesting something
 --   to the user that should be typed in directly as written.
 styleShell :: AnsiDoc -> AnsiDoc
-styleShell = magenta . ondullblack
+styleShell = magenta
 
 -- | Style an 'AnsiDoc' as a filename. See 'styleDir' for directories.
 styleFile :: AnsiDoc -> AnsiDoc
-styleFile = bold . white . ondullblack
+styleFile = dullcyan
 
 -- | Style an 'AsciDoc' as a URL.  For now using the same style as files.
 styleUrl :: AnsiDoc -> AnsiDoc
@@ -186,25 +188,25 @@ styleUrl = styleFile
 
 -- | Style an 'AnsiDoc' as a directory name. See 'styleFile' for files.
 styleDir :: AnsiDoc -> AnsiDoc
-styleDir = bold . blue . ondullblack
+styleDir = bold . blue
 
 -- | Style used to highlight part of a recommended course of action.
 styleRecommendation :: AnsiDoc -> AnsiDoc
-styleRecommendation = bold . green . ondullblack
+styleRecommendation = bold . green
 
 -- | Style an 'AnsiDoc' in a way that emphasizes that it is related to
 --   a current thing. For example, could be used when talking about the
 --   current package we're processing when outputting the name of it.
 styleCurrent :: AnsiDoc -> AnsiDoc
-styleCurrent = yellow . ondullblack
+styleCurrent = dullyellow
 
 -- TODO: figure out how to describe this
 styleTarget :: AnsiDoc -> AnsiDoc
-styleTarget = cyan . ondullblack
+styleTarget = cyan
 
 -- | Style an 'AnsiDoc' as a module name
 styleModule :: AnsiDoc -> AnsiDoc
-styleModule = magenta . ondullblack -- TODO: what color should this be?
+styleModule = magenta -- TODO: what color should this be?
 
 instance Display PackageName where
     display = fromString . packageNameString


### PR DESCRIPTION
In order to ensure sufficient contrast on both black (dull black) and white (vivid white) terminals, also changes foreground text `bold . white` to `dullcyan` (affecting `styleFile` and `styleUrl`) and `yellow` to `dullyellow` (affecting `styleWarning` and `styleCurrent`).

`dullcyan` is used in preference to `black` (vivid black) because the latter is problematic with the popular 'solarized dark' theme.

See also issue #4047 and (reverted) #4814.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md _Not ChangeLog worthy_
* [x] The documentation has been updated, if necessary. N/A

Please also shortly describe how you tested your change. Bonus points for added tests!

See #4183 for screen shots of stack operating after this pull request is implemented.
