### PR TITLE
No blob key check as archive could contain outdated cabal file

### DIFF
--- a/subs/pantry/src/Pantry/Hackage.hs
+++ b/subs/pantry/src/Pantry/Hackage.hs
@@ -393,7 +393,7 @@ getHackageTarball pir@(PackageIdentifierRevision name ver _cfi) mtreeKey = check
       PackageMetadata
         { pmName = Just name
         , pmVersion = Just ver
-        , pmTree = mtreeKey -- can probably leave this off, we do the testing here
+        , pmTree = Nothing -- with a revision cabal file will differ giving a different tree
         , pmCabal = Nothing -- cabal file in the tarball may be different!
         , pmSubdir = T.empty -- no subdirs on Hackage
         }


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

With this `stack build` seems to work for `xlsx`
