### PR TITLE
Fix #4205 (Step 0): Annotate with Style, not [SGR]

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ dependencies:
 - aeson
 - annotated-wl-pprint
 - ansi-terminal
+- array
 - async
 - attoparsec
 - base >=4.10 && < 5
@@ -176,6 +177,7 @@ library:
   - Stack.Constants.Config
   - Stack.Coverage
   - Stack.DefaultColorWhen
+  - Stack.DefaultStyles
   - Stack.Docker
   - Stack.Docker.GlobalDB
   - Stack.Dot
@@ -253,6 +255,7 @@ library:
   - Stack.Types.PackageIdentifier
   - Stack.Types.PackageIndex
   - Stack.Types.PackageName
+  - Stack.Types.PrettyPrint
   - Stack.Types.Resolver
   - Stack.Types.Runner
   - Stack.Types.Sig

--- a/src/Path/CheckInstall.hs
+++ b/src/Path/CheckInstall.hs
@@ -29,25 +29,25 @@ warnInstallSearchPathIssues destDir installed = do
                     unless (exeDir `FP.equalFilePath` destDir) $ do
                         prettyWarnL
                           [ flow "The"
-                          , styleFile . fromString . T.unpack $ exe
+                          , style File . fromString . T.unpack $ exe
                           , flow "executable found on the PATH environment variable is"
-                          , styleFile . fromString $ exePath
+                          , style File . fromString $ exePath
                           , flow "and not the version that was just installed."
                           , flow "This means that"
-                          , styleFile . fromString . T.unpack $ exe
+                          , style File . fromString . T.unpack $ exe
                           , "calls on the command line will not use this version."
                           ]
                 Nothing -> do
                     prettyWarnL
                       [ flow "Installation path"
-                      , styleDir . fromString $ destDir
+                      , style Dir . fromString $ destDir
                       , flow "is on the PATH but the"
-                      , styleFile . fromString . T.unpack $ exe
+                      , style File . fromString . T.unpack $ exe
                       , flow "executable that was just installed could not be found on the PATH."
                       ]
         else do
             prettyWarnL
               [ flow "Installation path "
-              , styleDir . fromString $ destDir
+              , style Dir . fromString $ destDir
               , "not found on the PATH environment variable."
               ]

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1446,7 +1446,7 @@ singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} installedMap
                       "- In" <+>
                       fromString (T.unpack (renderComponent comp)) <>
                       ":" <> line <>
-                      indent 4 (mconcat $ intersperse line $ map (styleGood . fromString . C.display) modules)
+                      indent 4 (mconcat $ intersperse line $ map (style Good . fromString . C.display) modules)
                 forM_ mlocalWarnings $ \(cabalfp, warnings) -> do
                     unless (null warnings) $ prettyWarn $
                         "The following modules should be added to exposed-modules or other-modules in" <+>

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -483,7 +483,7 @@ findPackageFieldForBuiltPackage pkgDir pkgId internalLibs field = do
                     T.pack (toFilePath inplaceDir) <> ". Maybe try 'stack clean' on this package?"
 
 displayReportPath :: (HasRunner env)
-                  => Text -> AnsiDoc -> RIO env ()
+                  => Text -> StyleDoc -> RIO env ()
 displayReportPath report reportPath =
      prettyInfo $ "The" <+> fromString (T.unpack report) <+> "is available at" <+> reportPath
 

--- a/src/Stack/DefaultStyles.hs
+++ b/src/Stack/DefaultStyles.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Stack.DefaultStyles
+  (
+    defaultStyles
+  ) where
+
+import Data.Array.IArray (array)
+import Stack.Prelude
+import Stack.Types.PrettyPrint (Style (..), Styles)
+import System.Console.ANSI.Codes (Color (..), ColorIntensity (..),
+  ConsoleIntensity (..), ConsoleLayer (..), SGR (..))
+
+-- |Default styles for stack's output.
+defaultStyles :: Styles
+defaultStyles = array (minBound, maxBound)
+  [ (Error, ("error", [SetColor Foreground Vivid Red]))
+  , (Warning, ("warning", [SetColor Foreground Dull Yellow]))
+  , (Good, ("good", [SetColor Foreground Vivid Green]))
+  , (Shell, ("shell", [SetColor Foreground Vivid Magenta]))
+  , (File, ("file", [SetColor Foreground Dull Cyan]))
+  -- For now 'Url' using the same style as 'File'
+  , (Url, ("url", [SetColor Foreground Dull Cyan]))
+  , (Dir, ("dir", [ SetConsoleIntensity BoldIntensity
+                  , SetColor Foreground Vivid Blue ]))
+  , (Recommendation, ("recommendation", [ SetConsoleIntensity BoldIntensity
+                                      , SetColor Foreground Vivid Green]))
+  , (Current, ("current", [SetColor Foreground Dull Yellow]))
+  , (Target, ("target", [SetColor Foreground Vivid Cyan]))
+  -- TODO: what color should Module be?
+  , (Module, ("module", [SetColor Foreground Vivid Magenta]))
+  , (PkgComponent, ("package-component", [SetColor Foreground Vivid Cyan])) ]

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -803,11 +803,11 @@ checkForDuplicateModules pkgs = do
       filter (\(_, mp) -> M.size mp > 1) $
       M.toList $
       unionModuleMaps (map ghciPkgModules pkgs)
-    prettyDuplicate :: (ModuleName, Map (Path Abs File) (Set (PackageName, NamedComponent))) -> AnsiDoc
+    prettyDuplicate :: (ModuleName, Map (Path Abs File) (Set (PackageName, NamedComponent))) -> StyleDoc
     prettyDuplicate (mn, mp) =
-      styleError (display mn) <+> "found at the following paths" <> line <>
+      style Error (display mn) <+> "found at the following paths" <> line <>
       bulletedList (map fileDuplicate (M.toList mp))
-    fileDuplicate :: (Path Abs File, Set (PackageName, NamedComponent)) -> AnsiDoc
+    fileDuplicate :: (Path Abs File, Set (PackageName, NamedComponent)) -> StyleDoc
     fileDuplicate (fp, comps) =
       display fp <+> parens (fillSep (punctuate "," (map display (S.toList comps))))
 
@@ -822,10 +822,10 @@ targetWarnings stackYaml localTargets nonLocalTargets mfileTargets = do
   unless (null nonLocalTargets) $
     prettyWarnL
       [ flow "Some targets"
-      , parens $ fillSep $ punctuate "," $ map (styleGood . display) nonLocalTargets
+      , parens $ fillSep $ punctuate "," $ map (style Good . display) nonLocalTargets
       , flow "are not local packages, and so cannot be directly loaded."
       , flow "In future versions of stack, this might be supported - see"
-      , styleUrl "https://github.com/commercialhaskell/stack/issues/1441"
+      , style Url "https://github.com/commercialhaskell/stack/issues/1441"
       , "."
       , flow "It can still be useful to specify these, as they will be passed to ghci via -package flags."
       ]
@@ -838,7 +838,7 @@ targetWarnings stackYaml localTargets nonLocalTargets mfileTargets = do
           , bulletedList
               [ fillSep
                   [ flow "If you want to start a different project configuration than" <+> display stackYaml <> ", then you can use"
-                  , styleShell "stack init"
+                  , style Shell "stack init"
                   , flow "to create a new stack.yaml for the packages in the current directory."
                   , line
                   ]

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -22,6 +22,7 @@ import           Options.Applicative
 import           Options.Applicative.Builder.Extra
 import           Stack.Config (getLocalPackages)
 import           Stack.DefaultColorWhen (defaultColorWhen)
+import           Stack.DefaultStyles (defaultStyles)
 import           Stack.Options.GlobalParser (globalOptsFromMonoid)
 import           Stack.Runners (loadConfigWithOpts)
 import           Stack.Prelude hiding (lift)
@@ -59,7 +60,7 @@ buildConfigCompleter inner = mkCompleter $ \inputRaw -> do
         ('-': _) -> return []
         _ -> do
             defColorWhen <- liftIO defaultColorWhen
-            let go = (globalOptsFromMonoid False defColorWhen mempty)
+            let go = (globalOptsFromMonoid False defColorWhen defaultStyles mempty)
                     { globalLogLevel = LevelOther "silent" }
             loadConfigWithOpts go $ \lc -> do
               bconfig <- liftIO $ lcLoadBuildConfig lc (globalCompiler go)

--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -14,6 +14,7 @@ import           Stack.Options.ResolverParser
 import           Stack.Options.Utils
 import           Stack.Types.Config
 import           Stack.Types.Docker
+import           Stack.Types.PrettyPrint (Styles)
 import           Stack.Types.Runner
 
 -- | Parser for global command-line options.
@@ -61,8 +62,8 @@ globalOptsParser currentDir kind defLogLevel =
     hide0 = kind /= OuterGlobalOpts
 
 -- | Create GlobalOpts from GlobalOptsMonoid.
-globalOptsFromMonoid :: Bool -> ColorWhen -> GlobalOptsMonoid -> GlobalOpts
-globalOptsFromMonoid defaultTerminal defaultColorWhen GlobalOptsMonoid{..} = GlobalOpts
+globalOptsFromMonoid :: Bool -> ColorWhen -> Styles -> GlobalOptsMonoid -> GlobalOpts
+globalOptsFromMonoid defaultTerminal defaultColorWhen defaultStyles GlobalOptsMonoid{..} = GlobalOpts
     { globalReExecVersion = getFirst globalMonoidReExecVersion
     , globalDockerEntrypoint = getFirst globalMonoidDockerEntrypoint
     , globalLogLevel = fromFirst defaultLogLevel globalMonoidLogLevel
@@ -72,6 +73,7 @@ globalOptsFromMonoid defaultTerminal defaultColorWhen GlobalOptsMonoid{..} = Glo
     , globalCompiler = getFirst globalMonoidCompiler
     , globalTerminal = fromFirst defaultTerminal globalMonoidTerminal
     , globalColorWhen = fromFirst defaultColorWhen globalMonoidColorWhen
+    , globalStyles = defaultStyles
     , globalTermWidth = getFirst globalMonoidTermWidth
     , globalStackYaml = maybe SYLDefault SYLOverride $ getFirst globalMonoidStackYaml }
 

--- a/src/Stack/PrettyPrint.hs
+++ b/src/Stack/PrettyPrint.hs
@@ -55,7 +55,7 @@ displayWithColor
 displayWithColor x = do
     useAnsi <- view useColorL
     termWidth <- view $ runnerL.to runnerTermWidth
-    return $ (if useAnsi then displayAnsi else displayPlain) termWidth x
+    (if useAnsi then displayAnsi else displayPlain) termWidth x
 
 -- TODO: switch to using implicit callstacks once 7.8 support is dropped
 

--- a/src/Stack/PrettyPrint.hs
+++ b/src/Stack/PrettyPrint.hs
@@ -13,19 +13,16 @@ module Stack.PrettyPrint
     , prettyDebugL, prettyInfoL, prettyNoteL, prettyWarnL, prettyErrorL, prettyWarnNoIndentL, prettyErrorNoIndentL
     , prettyDebugS, prettyInfoS, prettyNoteS, prettyWarnS, prettyErrorS, prettyWarnNoIndentS, prettyErrorNoIndentS
       -- * Semantic styling functions
-      -- | These are preferred to styling or colors directly, so that we can
-      -- encourage consistency.
-    , styleWarning, styleError, styleGood
-    , styleShell, styleFile, styleUrl, styleDir, styleModule
-    , styleCurrent, styleTarget
-    , styleRecommendation
+      -- | These are used rather than applying colors or other styling directly,
+      -- to provide consistency.
+    , style
     , displayMilliseconds
       -- * Formatting utils
     , bulletedList
     , spacedBulletedList
     , debugBracket
       -- * Re-exports from "Text.PrettyPrint.Leijen.Extended"
-    , Display(..), AnsiDoc, AnsiAnn(..), HasAnsiAnn(..), Doc
+    , Display (..), StyleDoc, StyleAnn (..), HasStyleAnn(..), Doc
     , nest, line, linebreak, group, softline, softbreak
     , align, hang, indent, encloseSep
     , (<+>)
@@ -33,6 +30,8 @@ module Stack.PrettyPrint
     , fill, fillBreak
     , enclose, squotes, dquotes, parens, angles, braces, brackets
     , indentAfterLabel, wordDocs, flow
+      -- * Re-exports from "Stack.Types.PrettyPrint"
+    , Style (..)
     ) where
 
 import qualified RIO
@@ -44,12 +43,20 @@ import qualified Distribution.Text as C (display)
 import           Stack.Types.NamedComponent
 import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageName
+import           Stack.Types.PrettyPrint (Style (..))
 import           Stack.Types.Runner
 import           Stack.Types.Version
-import           Text.PrettyPrint.Leijen.Extended
+import           Text.PrettyPrint.Leijen.Extended (Ann, Display (display), Doc,
+                     HasStyleAnn (..), StyleAnn (..), StyleDoc, (<+>), align,
+                     angles, braces, brackets, cat,
+                     displayAnsi, displayPlain, dquotes, enclose, encloseSep,
+                     fill, fillBreak, fillCat, fillSep, group, hang, hcat, hsep,
+                     indent, line, linebreak,
+                     nest, parens, punctuate, sep, softbreak, softline, squotes,
+                     styleAnn, vcat, vsep)
 
 displayWithColor
-    :: (HasRunner env, Display a, HasAnsiAnn (Ann a),
+    :: (HasRunner env, Display a, HasStyleAnn (Ann a),
         MonadReader env m, HasLogFunc env, HasCallStack)
     => a -> m T.Text
 displayWithColor x = do
@@ -59,7 +66,7 @@ displayWithColor x = do
 
 -- TODO: switch to using implicit callstacks once 7.8 support is dropped
 
-prettyWith :: (HasRunner env, HasCallStack, Display b, HasAnsiAnn (Ann b),
+prettyWith :: (HasRunner env, HasCallStack, Display b, HasStyleAnn (Ann b),
                MonadReader env m, MonadIO m)
            => LogLevel -> (a -> b) -> a -> m ()
 prettyWith level f = logGeneric "" level . RIO.display <=< displayWithColor . f
@@ -69,26 +76,26 @@ prettyWith level f = logGeneric "" level . RIO.display <=< displayWithColor . f
 
 prettyDebugWith, prettyInfoWith, prettyNoteWith, prettyWarnWith, prettyErrorWith, prettyWarnNoIndentWith, prettyErrorNoIndentWith
   :: (HasCallStack, HasRunner env, MonadReader env m, MonadIO m)
-  => (a -> Doc AnsiAnn) -> a -> m ()
+  => (a -> StyleDoc) -> a -> m ()
 prettyDebugWith = prettyWith LevelDebug
 prettyInfoWith  = prettyWith LevelInfo
 prettyNoteWith f  = prettyWith LevelInfo
-                          ((line <>) . (styleGood "Note:" <+>) .
+                          ((line <>) . (style Good "Note:" <+>) .
                            indentAfterLabel . f)
 prettyWarnWith f  = prettyWith LevelWarn
-                          ((line <>) . (styleWarning "Warning:" <+>) .
+                          ((line <>) . (style Warning "Warning:" <+>) .
                            indentAfterLabel . f)
 prettyErrorWith f = prettyWith LevelError
-                          ((line <>) . (styleError   "Error:" <+>) .
+                          ((line <>) . (style Error   "Error:" <+>) .
                            indentAfterLabel . f)
 prettyWarnNoIndentWith f  = prettyWith LevelWarn
-                                  ((line <>) . (styleWarning "Warning:" <+>) . f)
+                                  ((line <>) . (style Warning "Warning:" <+>) . f)
 prettyErrorNoIndentWith f = prettyWith LevelError
-                                  ((line <>) . (styleError   "Error:" <+>) . f)
+                                  ((line <>) . (style Error   "Error:" <+>) . f)
 
 prettyDebug, prettyInfo, prettyNote, prettyWarn, prettyError, prettyWarnNoIndent, prettyErrorNoIndent
   :: (HasCallStack, HasRunner env, MonadReader env m, MonadIO m)
-  => Doc AnsiAnn -> m ()
+  => StyleDoc -> m ()
 prettyDebug         = prettyDebugWith         id
 prettyInfo          = prettyInfoWith          id
 prettyNote          = prettyNoteWith          id
@@ -99,7 +106,7 @@ prettyErrorNoIndent = prettyErrorNoIndentWith id
 
 prettyDebugL, prettyInfoL, prettyNoteL, prettyWarnL, prettyErrorL, prettyWarnNoIndentL, prettyErrorNoIndentL
   :: (HasCallStack, HasRunner env, MonadReader env m, MonadIO m)
-  => [Doc AnsiAnn] -> m ()
+  => [StyleDoc] -> m ()
 prettyDebugL         = prettyDebugWith         fillSep
 prettyInfoL          = prettyInfoWith          fillSep
 prettyNoteL          = prettyNoteWith          fillSep
@@ -137,7 +144,7 @@ flow :: String -> Doc a
 flow = fillSep . wordDocs
 
 debugBracket :: (HasCallStack, HasRunner env, MonadReader env m,
-                 MonadIO m, MonadUnliftIO m) => Doc AnsiAnn -> m a -> m a
+                 MonadIO m, MonadUnliftIO m) => StyleDoc -> m a -> m a
 debugBracket msg f = do
   let output = logDebug . RIO.display <=< displayWithColor
   output $ "Start: " <> msg
@@ -154,59 +161,9 @@ debugBracket msg f = do
   output $ "Finished in" <+> displayMilliseconds diff <> ":" <+> msg
   return x
 
---   The following syles do not affect the colour of the background.
-
--- | Style an 'AnsiDoc' as an error. Should be used sparingly, not to style
---   entire long messages. For example, it's used to style the "Error:"
---   label for an error message, not the entire message.
-styleError :: AnsiDoc -> AnsiDoc
-styleError = dullred
-
--- | Style an 'AnsiDoc' as a warning. Should be used sparingly, not to style
---   entire long messages. For example, it's used to style the "Warning:"
---   label for an error message, not the entire message.
-styleWarning :: AnsiDoc -> AnsiDoc
-styleWarning = dullyellow
-
--- | Style an 'AnsiDoc' in a way to emphasize that it is a particularly good
---   thing.
-styleGood :: AnsiDoc -> AnsiDoc
-styleGood = green
-
--- | Style an 'AnsiDoc' as a shell command, i.e. when suggesting something
---   to the user that should be typed in directly as written.
-styleShell :: AnsiDoc -> AnsiDoc
-styleShell = magenta
-
--- | Style an 'AnsiDoc' as a filename. See 'styleDir' for directories.
-styleFile :: AnsiDoc -> AnsiDoc
-styleFile = dullcyan
-
--- | Style an 'AsciDoc' as a URL.  For now using the same style as files.
-styleUrl :: AnsiDoc -> AnsiDoc
-styleUrl = styleFile
-
--- | Style an 'AnsiDoc' as a directory name. See 'styleFile' for files.
-styleDir :: AnsiDoc -> AnsiDoc
-styleDir = bold . blue
-
--- | Style used to highlight part of a recommended course of action.
-styleRecommendation :: AnsiDoc -> AnsiDoc
-styleRecommendation = bold . green
-
--- | Style an 'AnsiDoc' in a way that emphasizes that it is related to
---   a current thing. For example, could be used when talking about the
---   current package we're processing when outputting the name of it.
-styleCurrent :: AnsiDoc -> AnsiDoc
-styleCurrent = dullyellow
-
--- TODO: figure out how to describe this
-styleTarget :: AnsiDoc -> AnsiDoc
-styleTarget = cyan
-
--- | Style an 'AnsiDoc' as a module name
-styleModule :: AnsiDoc -> AnsiDoc
-styleModule = magenta -- TODO: what color should this be?
+-- |Annotate a 'StyleDoc' with a 'Style'.
+style :: Style -> StyleDoc -> StyleDoc
+style = styleAnn
 
 instance Display PackageName where
     display = fromString . packageNameString
@@ -218,27 +175,27 @@ instance Display Version where
     display = fromString . versionString
 
 instance Display (Path b File) where
-    display = styleFile . fromString . toFilePath
+    display = style File . fromString . toFilePath
 
 instance Display (Path b Dir) where
-    display = styleDir . fromString . toFilePath
+    display = style Dir . fromString . toFilePath
 
 instance Display (PackageName, NamedComponent) where
-    display = cyan . fromString . T.unpack . renderPkgComponent
+    display = style PkgComponent . fromString . T.unpack . renderPkgComponent
 
 instance Display C.ModuleName where
     display = fromString . C.display
 
 -- Display milliseconds.
-displayMilliseconds :: Double -> AnsiDoc
-displayMilliseconds t = green $
+displayMilliseconds :: Double -> StyleDoc
+displayMilliseconds t = style Good $
     fromString (show (round (t * 1000) :: Int)) <> "ms"
 
--- | Display a bulleted list of 'AnsiDoc'.
-bulletedList :: [AnsiDoc] -> AnsiDoc
+-- | Display a bulleted list of 'StyleDoc'.
+bulletedList :: [StyleDoc] -> StyleDoc
 bulletedList = mconcat . intersperse line . map (("*" <+>) . align)
 
--- | Display a bulleted list of 'AnsiDoc' with a blank line between
+-- | Display a bulleted list of 'StyleDoc' with a blank line between
 -- each.
-spacedBulletedList :: [AnsiDoc] -> AnsiDoc
+spacedBulletedList :: [StyleDoc] -> StyleDoc
 spacedBulletedList = mconcat . intersperse (line <> line) . map (("*" <+>) . align)

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -215,6 +215,7 @@ withRunnerGlobal GlobalOpts{..} = withRunner
   globalTimeInLog
   globalTerminal
   globalColorWhen
+  globalStyles
   globalTermWidth
   (isJust globalReExecVersion)
 
@@ -245,4 +246,3 @@ withBuildConfigDot opts go f = withBuildConfig go' f
         (if dotTestTargets opts then set (globalOptsBuildOptsMonoidL.buildOptsMonoidTestsL) (Just True) else id) $
         (if dotBenchTargets opts then set (globalOptsBuildOptsMonoidL.buildOptsMonoidBenchmarksL) (Just True) else id)
         go
-

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -223,19 +223,19 @@ getCabalLbs pvpBounds mrev cabalfp = do
             prettyWarn $ vsep $ roundtripErrs ++
               [ "This seems to be fixed in development versions of Cabal, but at time of writing, the fix is not in any released versions."
               , ""
-              ,  "Please see this GitHub issue for status:" <+> styleUrl "https://github.com/commercialhaskell/stack/issues/3549"
+              ,  "Please see this GitHub issue for status:" <+> style Url "https://github.com/commercialhaskell/stack/issues/3549"
               , ""
               , fillSep
                 [ flow "If the issue is closed as resolved, then you may be able to fix this by upgrading to a newer version of stack via"
-                , styleShell "stack upgrade"
+                , style Shell "stack upgrade"
                 , flow "for latest stable version or"
-                , styleShell "stack upgrade --git"
+                , style Shell "stack upgrade --git"
                 , flow "for the latest development version."
                 ]
               , ""
               , fillSep
                 [ flow "If the issue is fixed, but updating doesn't solve the problem, please check if there are similar open issues, and if not, report a new issue to the stack issue tracker, at"
-                , styleUrl "https://github.com/commercialhaskell/stack/issues/new"
+                , style Url "https://github.com/commercialhaskell/stack/issues/new"
                 ]
               , ""
               , flow "If the issue is not fixed, feel free to leave a comment on it indicating that you would like it to be fixed."
@@ -245,8 +245,8 @@ getCabalLbs pvpBounds mrev cabalfp = do
         prettyWarn $ vsep $ roundtripErrs ++
           [ flow "In particular, parsing the rendered cabal file is yielding a parse error.  Please check if there are already issues tracking this, and if not, please report new issues to the stack and cabal issue trackers, via"
           , bulletedList
-            [ styleUrl "https://github.com/commercialhaskell/stack/issues/new"
-            , styleUrl "https://github.com/haskell/cabal/issues/new"
+            [ style Url "https://github.com/commercialhaskell/stack/issues/new"
+            , style Url "https://github.com/haskell/cabal/issues/new"
             ]
           , flow $ "The parse error is: " ++ unlines (map show errs)
           , ""

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -1111,7 +1111,7 @@ installGHCPosix version downloadInfo _ archiveFile archiveType tempDir destDir =
                     prettyError $
                         hang 2
                           ("Error encountered while" <+> step <+> "GHC with" <> line <>
-                           styleShell (fromString (unwords (cmd : args))) <> line <>
+                           style Shell (fromString (unwords (cmd : args))) <> line <>
                            -- TODO: Figure out how to insert \ in the appropriate spots
                            -- hang 2 (shellColor (fillSep (fromString cmd : map fromString args))) <> line <>
                            "run in " <> display wd) <> line <> line <>

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -221,6 +221,7 @@ import           Stack.Types.Nix
 import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageIndex
 import           Stack.Types.PackageName
+import           Stack.Types.PrettyPrint (Styles)
 import           Stack.Types.Resolver
 import           Stack.Types.Runner
 import           Stack.Types.TemplateName
@@ -438,6 +439,7 @@ data GlobalOpts = GlobalOpts
     , globalCompiler     :: !(Maybe (CompilerVersion 'CVWanted)) -- ^ Compiler override
     , globalTerminal     :: !Bool -- ^ We're in a terminal?
     , globalColorWhen    :: !ColorWhen -- ^ When to use ansi terminal colors
+    , globalStyles       :: !Styles -- ^ SGR (Ansi) codes for styles
     , globalTermWidth    :: !(Maybe Int) -- ^ Terminal width override
     , globalStackYaml    :: !(StackYamlLoc FilePath) -- ^ Override project stack.yaml
     } deriving (Show)

--- a/src/Stack/Types/PrettyPrint.hs
+++ b/src/Stack/Types/PrettyPrint.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-|
+For the most part, the data constructors of 'Style' do not clash with other
+names. When they do, import the module qualified. For example:
+
+> import qualified Stack.Types.PrettyPrint as PP
+-}
+module Stack.Types.PrettyPrint
+  (
+    Style (..)
+  , Styles
+  , StyleSpec
+  ) where
+
+import Data.Array.IArray (Array)
+import Data.Ix (Ix)
+import Stack.Prelude
+import System.Console.ANSI.Types (SGR)
+
+-- |A style of stack's output.
+data Style
+  = Error    -- Should be used sparingly, not to style entire long messages. For
+             -- example, it's used to style the "Error:" label for an error
+             -- message, not the entire message.
+  | Warning  -- Should be used sparingly, not to style entire long messages. For
+             -- example, it's used to style the "Warning:" label for an error
+             -- message, not the entire message.
+  | Good     -- Style in a way to emphasize that it is a particularly good
+             -- thing
+  | Shell    -- Style as a shell command, i.e. when suggesting something to the
+             -- user that should be typed in directly as written.
+  | File     -- Style as a filename. See 'Dir' for directories.
+  | Url      -- Style as a URL.
+  | Dir      -- Style as a directory name. See 'File' for files.
+  | Recommendation  -- Style used to highlight part of a recommended course of
+                    -- action.
+  | Current  -- Style in a way that emphasizes that it is related to a current
+             -- thing. For example, could be used when talking about the current
+             -- package we're processing when outputting the name of it.
+  | Target   -- TODO: figure out how to describe this
+  | Module   -- Style as a module name
+  | PkgComponent    -- Style used to highlight the named component of a package.
+  deriving (Bounded, Enum, Eq, Ix, Ord, Show)
+
+-- |The first style overrides the second.
+instance Semigroup Style where
+  s <> _ = s
+
+-- |A style specification, pairing its \'key\' with the corresponding list of
+-- 'SGR' codes.
+type StyleSpec = (Text, [SGR])
+
+-- |Style specifications indexed by the style.
+type Styles = Array Style StyleSpec

--- a/src/Stack/Types/Runner.hs
+++ b/src/Stack/Types/Runner.hs
@@ -15,6 +15,7 @@ module Stack.Types.Runner
     , HasRunner (..)
     , terminalL
     , useColorL
+    , stylesL
     , reExecL
     , ColorWhen (..)
     , withRunner
@@ -25,6 +26,7 @@ import           Lens.Micro
 import           Stack.Prelude              hiding (lift)
 import           Stack.Constants
 import           Stack.Types.PackageIdentifier (PackageIdentifierRevision)
+import           Stack.Types.PrettyPrint (Styles)
 import           System.Console.ANSI
 import           RIO.Process (HasProcessContext (..), ProcessContext, mkDefaultProcessContext)
 import           System.Terminal
@@ -34,6 +36,7 @@ data Runner = Runner
   { runnerReExec     :: !Bool
   , runnerTerminal   :: !Bool
   , runnerUseColor   :: !Bool
+  , runnerStyles     :: !Styles
   , runnerLogFunc    :: !LogFunc
   , runnerTermWidth  :: !Int
   , runnerProcessContext :: !ProcessContext
@@ -64,6 +67,9 @@ terminalL = runnerL.lens runnerTerminal (\x y -> x { runnerTerminal = y })
 useColorL :: HasRunner env => Lens' env Bool
 useColorL = runnerL.lens runnerUseColor (\x y -> x { runnerUseColor = y })
 
+stylesL :: HasRunner env => Lens' env Styles
+stylesL = runnerL.lens runnerStyles (\x y -> x { runnerStyles = y })
+
 reExecL :: HasRunner env => Lens' env Bool
 reExecL = runnerL.lens runnerReExec (\x y -> x { runnerReExec = y })
 
@@ -79,11 +85,12 @@ withRunner :: MonadUnliftIO m
            -> Bool -- ^ use time?
            -> Bool -- ^ terminal?
            -> ColorWhen
+           -> Styles
            -> Maybe Int -- ^ terminal width override
            -> Bool -- ^ reexec?
            -> (Runner -> m a)
            -> m a
-withRunner logLevel useTime terminal colorWhen widthOverride reExec inner = do
+withRunner logLevel useTime terminal colorWhen styles widthOverride reExec inner = do
   useColor <- case colorWhen of
     ColorNever -> return False
     ColorAlways -> return True
@@ -105,6 +112,7 @@ withRunner logLevel useTime terminal colorWhen widthOverride reExec inner = do
     { runnerReExec = reExec
     , runnerTerminal = terminal
     , runnerUseColor = useColor
+    , runnerStyles = styles
     , runnerLogFunc = logFunc
     , runnerTermWidth = termWidth
     , runnerParsedCabalFiles = ref

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -58,6 +58,7 @@ import           Stack.Constants
 import           Stack.Constants.Config
 import           Stack.Coverage
 import           Stack.DefaultColorWhen (defaultColorWhen)
+import           Stack.DefaultStyles (defaultStyles)
 import qualified Stack.Docker as Docker
 import           Stack.Dot
 import           Stack.GhcPkg (findGhcPkgField)
@@ -89,6 +90,7 @@ import           Stack.Options.Utils
 import qualified Stack.PackageIndex
 import qualified Stack.Path
 import           Stack.PrettyPrint
+import qualified Stack.PrettyPrint as PP (style)
 import           Stack.Runners
 import           Stack.Script
 import           Stack.SDist (getSDistTarball, checkSDistTarball, checkSDistTarball', SDistOpts(..))
@@ -190,7 +192,7 @@ main = do
     Left (exitCode :: ExitCode) ->
       throwIO exitCode
     Right (globalMonoid,run) -> do
-      let global = globalOptsFromMonoid isTerminal defColorWhen globalMonoid
+      let global = globalOptsFromMonoid isTerminal defColorWhen defaultStyles globalMonoid
       when (globalLogLevel global == LevelDebug) $ hPutStrLn stderr versionString'
       case globalReExecVersion global of
           Just expectVersion -> do
@@ -659,7 +661,7 @@ uninstallCmd _ go = withConfigAndLock go $
       [ flow "stack does not manage installations in global locations."
       , flow "The only global mutation stack performs is executable copying."
       , flow "For the default executable destination, please run"
-      , styleShell "stack path --local-bin"
+      , PP.style Shell "stack path --local-bin"
       ]
 
 -- | Unpack packages to the filesystem
@@ -689,7 +691,7 @@ uploadCmd :: SDistOpts -> GlobalOpts -> IO ()
 uploadCmd (SDistOpts [] _ _ _ _ _ _) go =
     withConfigAndLock go . prettyErrorL $
         [ flow "To upload the current package, please run"
-        , styleShell "stack upload ."
+        , PP.style Shell "stack upload ."
         , flow "(with the period at the end)"
         ]
 uploadCmd sdistOpts go = do
@@ -702,9 +704,9 @@ uploadCmd sdistOpts go = do
     (dirs, invalid) <- partitionM D.doesDirectoryExist nonFiles
     withBuildConfigAndLock go $ \_ -> do
         unless (null invalid) $ do
-            let invalidList = bulletedList $ map (styleFile . fromString) invalid
+            let invalidList = bulletedList $ map (PP.style File . fromString) invalid
             prettyErrorL
-                [ styleShell "stack upload"
+                [ PP.style Shell "stack upload"
                 , flow "expects a list of sdist tarballs or package directories."
                 , flow "Can't find:"
                 , line <> invalidList
@@ -712,7 +714,7 @@ uploadCmd sdistOpts go = do
             liftIO exitFailure
         when (null files && null dirs) $ do
             prettyErrorL
-                [ styleShell "stack upload"
+                [ PP.style Shell "stack upload"
                 , flow "expects a list of sdist tarballs or package directories, but none were specified."
                 ]
             liftIO exitFailure
@@ -761,7 +763,7 @@ sdistCmd sdistOpts go =
                 when (null dirs) $ do
                     stackYaml <- view stackYamlL
                     prettyErrorL
-                        [ styleShell "stack sdist"
+                        [ PP.style Shell "stack sdist"
                         , flow "expects a list of targets, and otherwise defaults to all of the project's packages."
                         , flow "However, the configuration at"
                         , display stackYaml

--- a/src/test/Network/HTTP/Download/VerifiedSpec.hs
+++ b/src/test/Network/HTTP/Download/VerifiedSpec.hs
@@ -7,6 +7,7 @@ import           Network.HTTP.StackClient
 import           Network.HTTP.Download.Verified
 import           Path
 import           Path.IO hiding (withSystemTempDir)
+import           Stack.DefaultStyles (defaultStyles)
 import           Stack.Prelude
 import           Stack.Types.Runner
 import           System.IO (writeFile, readFile)
@@ -66,7 +67,8 @@ spec = do
   let exampleProgressHook _ = return ()
 
   describe "verifiedDownload" $ do
-    let run func = withRunner LevelError True True ColorNever Nothing False
+    let run func =
+          withRunner LevelError True True ColorNever defaultStyles Nothing False
                  $ \runner -> runRIO runner func
     -- Preconditions:
     -- * the exampleReq server is running

--- a/src/test/Stack/ConfigSpec.hs
+++ b/src/test/Stack/ConfigSpec.hs
@@ -10,6 +10,7 @@ import Data.Yaml
 import Path
 import Path.IO hiding (withSystemTempDir)
 import Stack.Config
+import Stack.DefaultStyles (defaultStyles)
 import Stack.Prelude
 import Stack.Types.Config
 import Stack.Types.Runner
@@ -84,7 +85,7 @@ spec = beforeAll setup $ do
 
   describe "loadConfig" $ do
     let loadConfig' inner =
-          withRunner logLevel True False ColorAuto Nothing False $ \runner -> do
+          withRunner logLevel True False ColorAuto defaultStyles Nothing False $ \runner -> do
             lc <- runRIO runner $ loadConfig mempty Nothing SYLDefault
             inner lc
     -- TODO(danburton): make sure parent dirs also don't have config file

--- a/src/test/Stack/NixSpec.hs
+++ b/src/test/Stack/NixSpec.hs
@@ -7,6 +7,7 @@ import Data.Maybe (fromJust)
 import Options.Applicative
 import Path
 import Prelude (writeFile)
+import Stack.DefaultStyles (defaultStyles)
 import Stack.Config
 import Stack.Config.Nix
 import Stack.Constants
@@ -43,7 +44,7 @@ setup = unsetEnv "STACK_YAML"
 spec :: Spec
 spec = beforeAll setup $ do
   let loadConfig' cmdLineArgs =
-        withRunner LevelDebug True False ColorAuto Nothing False $ \runner ->
+        withRunner LevelDebug True False ColorAuto defaultStyles Nothing False $ \runner ->
         runRIO runner $ loadConfig cmdLineArgs Nothing SYLDefault
       inTempDir test = do
         currentDirectory <- getCurrentDirectory


### PR DESCRIPTION
These changes do not affect the existing functionality of stack but provide a foundation for the next steps of suggestion #4205.

After the changes, Stack's styles are implemented as type `Style` in new module `Stack.PrettyPrint`, which also defines a `StyleSpec` as `(Text, [SGR])` (the first item providing the name of the key) and `Styles` as `Data.Array.IArray.Array Style StyleSpec`. Package `array` is added as a dependency in `package.yaml`, accordingly.

Given the use of `cyan` in the original instance of `Display` for `(PackageName, NamedComponent)`, a new _style_ `PkgComponent` (with key `package-component`) is added to `Style`.

Given the use of `green` in `displayMilliseconds`, it is assumed the intended style was `Good`.

Functions like `StyleWarning`, `StyleError` can be, and are, replaced throughout by `style :: Style -> ...` (eg `style Warning`, `style Error`).

The type `Runner` is modified to include field `runnerStyles :: !Styles`. New module `Stack.DefaultStyles` provides `defaultStyles`. Consequent changes are made to the plumbing.

`AnsiDoc` is replaced by `type StyleDoc = Doc StyleAnn`, throughout. In module `Stack.PrettyPrint`, use is made of the `HasRunner` environment and it is there that `SimpleDoc StyleDoc` is translated to `SimpleDoc AnsiDoc`.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md _There is no change for users_
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested by building on Windows 10 and using.