### PR TITLE
Fix #4205 (Step 5): Add `stack ls stack-colors`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,10 @@ Other enhancements:
   plan construction errors much faster, and avoid some unnecessary
   work when only building a subset of packages. This is especially
   useful for the curator use case.
+* New command `stack ls stack-colors` lists the styles and the associated 'ANSI'
+  control character sequences that stack uses to color some of its output. This
+  addition is a precursor to allowing a stack user to redefine the default
+  styles. See `stack ls stack-colors --help` for more information.
 
 Bug fixes:
 

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -308,7 +308,7 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                     pathCmd
                     Stack.Path.pathParser
         addCommand' "ls"
-                    "List command. (Supports snapshots and dependencies)"
+                    "List command. (Supports snapshots, dependencies and stack's styles)"
                     lsCmd
                     lsParser
         addCommand' "unpack"


### PR DESCRIPTION
This builds on step 0 (commit https://github.com/commercialhaskell/stack/commit/68718a784a0eec52968540ea3de3885f1ae707a0). It adds `stack ls stack-colors` to the `stack ls` command, in module `Stack.Ls`. The command's functionality is provided by `listStylesCmd`. The rest of the changes add the `optparse-applicative` plumbing.

The `ls` command documentation, in module `Main`, is updated.

`ChangeLog.md` is updated.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! 

This has been tested by building - `stack test` - on Windows 10 and using the new function with its various options.