### PR TITLE
Fix #4205 (Step 3): Add `--stack-colors=STYLES`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,9 @@ Other enhancements:
   plan construction errors much faster, and avoid some unnecessary
   work when only building a subset of packages. This is especially
   useful for the curator use case.
+* New global option `--stack-colors=STYLES` allows a stack user to redefine the
+  default styles that stack uses to color some of its output. See `stack --help`
+  for more information.
 
 Bug fixes:
 

--- a/package.yaml
+++ b/package.yaml
@@ -45,6 +45,7 @@ dependencies:
 - base >=4.10 && < 5
 - base64-bytestring
 - bytestring
+- colour
 - conduit
 - conduit-extra
 - containers
@@ -255,6 +256,7 @@ library:
   - Stack.Types.Resolver
   - Stack.Types.Runner
   - Stack.Types.Sig
+  - Stack.Types.StylesUpdate
   - Stack.Types.TemplateName
   - Stack.Types.Version
   - Stack.Types.VersionIntervals

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -100,6 +100,8 @@ module Stack.Types.Config
   ,parsePvpBounds
   -- ** ColorWhen
   ,readColorWhen
+  -- ** Styles
+  ,readStyles
   -- ** SCM
   ,SCM(..)
   -- * Paths
@@ -224,6 +226,8 @@ import           Stack.Types.PackageName
 import           Stack.Types.PrettyPrint (Styles)
 import           Stack.Types.Resolver
 import           Stack.Types.Runner
+import           Stack.Types.StylesUpdate (StylesUpdate,
+                     parseStylesUpdateFromString)
 import           Stack.Types.TemplateName
 import           Stack.Types.Urls
 import           Stack.Types.Version
@@ -464,6 +468,7 @@ data GlobalOptsMonoid = GlobalOptsMonoid
     , globalMonoidCompiler     :: !(First (CompilerVersion 'CVWanted)) -- ^ Compiler override
     , globalMonoidTerminal     :: !(First Bool) -- ^ We're in a terminal?
     , globalMonoidColorWhen    :: !(First ColorWhen) -- ^ When to use ansi colors
+    , globalMonoidStyles       :: !(First StylesUpdate) -- ^ Stack's output styles
     , globalMonoidTermWidth    :: !(First Int) -- ^ Terminal width override
     , globalMonoidStackYaml    :: !(First FilePath) -- ^ Override project stack.yaml
     } deriving (Show, Generic)
@@ -487,6 +492,9 @@ readColorWhen = do
         "always" -> return ColorAlways
         "auto" -> return ColorAuto
         _ -> OA.readerError "Expected values of color option are 'never', 'always', or 'auto'."
+
+readStyles :: ReadM StylesUpdate
+readStyles = parseStylesUpdateFromString <$> OA.readerAsk
 
 -- | A superset of 'Config' adding information on how to build code. The reason
 -- for this breakdown is because we will need some of the information from

--- a/src/Stack/Types/StylesUpdate.hs
+++ b/src/Stack/Types/StylesUpdate.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Stack.Types.StylesUpdate
+  (
+    StylesUpdate (..)
+  , parseStylesUpdateFromString
+  ) where
+
+import Data.Array.IArray (assocs)
+import Data.Colour.SRGB (Colour, sRGB24)
+import Data.Text as T (pack)
+import Data.Text (Text)
+import Stack.DefaultStyles (defaultStyles)
+import Stack.Prelude
+import Stack.Types.PrettyPrint (Style, StyleSpec)
+import System.Console.ANSI.Types (BlinkSpeed (..), Color (..),
+        ColorIntensity (..), ConsoleIntensity (..), ConsoleLayer (..), SGR (..),
+        Underlining (..))
+
+-- |Updates to 'Styles'
+newtype StylesUpdate = StylesUpdate { stylesUpdate :: [(Style, StyleSpec)] }
+  deriving (Eq, Show)
+
+-- |Parse a string that is a colon-delimited sequence of key=value, where 'key'
+-- is a style name and 'value' is a semicolon-delimited list of 'ANSI' SGR
+-- (Select Graphic Rendition) control codes (in decimal). Keys that are not
+-- present in 'defaultStyles' are ignored. Items in the semicolon-delimited
+-- list that are not recognised as valid control codes are ignored.
+parseStylesUpdateFromString :: String -> StylesUpdate
+parseStylesUpdateFromString s = StylesUpdate $ mapMaybe process table
+ where
+  table = do
+    w <- split ':' s
+    let (k, v') = break (== '=') w
+    case v' of
+      '=' : v -> return (T.pack k, parseCodes v)
+      _ -> []
+
+  process :: StyleSpec -> Maybe (Style, StyleSpec)
+  process (k, sgrs) = do
+    style <- lookup k styles
+    return (style, (k, sgrs))
+
+styles :: [(Text, Style)]
+styles = map (\(s, (k, _)) -> (k, s)) $ assocs defaultStyles
+
+parseCodes :: String -> [SGR]
+parseCodes [] = []
+parseCodes s = parseCodes' c
+ where
+  s' = split ';' s
+  c :: [Word8]
+  c = mapMaybe readMaybe s'
+
+parseCodes' :: [Word8] -> [SGR]
+parseCodes' c = case codeToSGR c of
+  (Nothing, []) -> []
+  (Just sgr, []) -> [sgr]
+  (Nothing, cs) -> parseCodes' cs
+  (Just sgr, cs) -> sgr : parseCodes' cs
+
+split :: Char -> String -> [String]
+split c s = case rest of
+                []     -> [chunk]
+                _:rest1 -> chunk : split c rest1
+  where
+    (chunk, rest) = break (==c) s
+
+-- |This function is, essentially, the inverse of 'sgrToCode' exported by
+-- module "System.Console.ANSI.Codes" of the @ansi-terminal@ package. The
+-- \'ANSI\' standards refer to (1) standard ECMA-48 \`Control Functions for
+-- Coded Character Sets\' (5th edition, 1991); (2) extensions in ITU-T
+-- Recommendation (previously CCITT Recommendation) T.416 (03/93) \'Information
+-- Technology – Open Document Architecture (ODA) and Interchange Format:
+-- Character Content Architectures\` (also published as ISO/IEC International
+-- Standard 8613-6); and (3) further extensions used by \'XTerm\', a terminal
+-- emulator for the X Window System. The escape codes are described in a
+-- Wikipedia article at <http://en.wikipedia.org/wiki/ANSI_escape_code> and
+-- those codes supported on current versions of Windows at
+-- <https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences>.
+codeToSGR :: [Word8] -> (Maybe SGR, [Word8])
+codeToSGR [] = (Nothing, [])
+codeToSGR (c:cs)
+  | c ==  0 = (Just Reset, cs)
+  | c ==  1 = (Just $ SetConsoleIntensity BoldIntensity, cs)
+  | c ==  2 = (Just $ SetConsoleIntensity FaintIntensity, cs)
+  | c ==  3 = (Just $ SetItalicized True, cs)
+  | c ==  4 = (Just $ SetUnderlining SingleUnderline, cs)
+  | c ==  5 = (Just $ SetBlinkSpeed SlowBlink, cs)
+  | c ==  6 = (Just $ SetBlinkSpeed RapidBlink, cs)
+  | c ==  7 = (Just $ SetSwapForegroundBackground True, cs)
+  | c ==  8 = (Just $ SetVisible False, cs)
+  | c == 21 = (Just $ SetUnderlining DoubleUnderline, cs)
+  | c == 22 = (Just $ SetConsoleIntensity NormalIntensity, cs)
+  | c == 23 = (Just $ SetItalicized False, cs)
+  | c == 24 = (Just $ SetUnderlining NoUnderline, cs)
+  | c == 25 = (Just $ SetBlinkSpeed NoBlink, cs)
+  | c == 27 = (Just $ SetSwapForegroundBackground False, cs)
+  | c == 28 = (Just $ SetVisible True, cs)
+  | c >= 30 && c <= 37 =
+    (Just $ SetColor Foreground Dull $ codeToColor (c - 30), cs)
+  | c == 38 = case codeToRGB cs of
+    (Nothing, cs') -> (Nothing, cs')
+    (Just color, cs') -> (Just $ SetRGBColor Foreground color, cs')
+  | c >= 40 && c <= 47 =
+    (Just $ SetColor Background Dull $ codeToColor (c - 40), cs)
+  | c == 48 = case codeToRGB cs of
+    (Nothing, cs') -> (Nothing, cs')
+    (Just color, cs') -> (Just $ SetRGBColor Background color, cs')
+  | c >= 90 && c <= 97 =
+    (Just $ SetColor Foreground Vivid $ codeToColor (c - 90), cs)
+  | c >= 100 && c <= 107 =
+    (Just $ SetColor Background Vivid $ codeToColor (c - 100), cs)
+  | otherwise = (Nothing, cs)
+
+-- |This function is, essentially, the inverse of 'colorToCode' exported by
+-- module "System.Console.ANSI.Codes" of the @ansi-terminal@ package. The
+-- \'ANSI\' standards refer to eight named colours in a specific order. The code
+-- is a 0-based index of those colours.
+codeToColor :: Word8 -> Color
+codeToColor c
+  -- 'toEnum' is not used because the @ansi-terminal@ package does not
+  -- /guarantee/ the order of the data constructors of type 'Color' will be the
+  -- same as that of the \'ANSI\' standards (although it currently is). (The
+  -- 'colorToCode' function itself does not use 'fromEnum'.)
+  | c == 0 = Black
+  | c == 1 = Red
+  | c == 2 = Green
+  | c == 3 = Yellow
+  | c == 4 = Blue
+  | c == 5 = Magenta
+  | c == 6 = Cyan
+  | c == 7 = White
+  | otherwise = error "Error: codeToColor, code outside 0 to 7."
+
+codeToRGB :: [Word8] -> (Maybe (Colour Float), [Word8])
+codeToRGB [] = (Nothing, [])
+codeToRGB (2:r:g:b:cs) = (Just $ sRGB24 r g b, cs)
+codeToRGB cs = (Nothing, cs)


### PR DESCRIPTION
This builds on step 0 (commit https://github.com/commercialhaskell/stack/commit/68718a784a0eec52968540ea3de3885f1ae707a0). It adds the `--stack-colors=STYLES` global option. The functionality is primarily implemented via `readStyles` in module `Stack.Config`. `GlobalOptsMonoid` is extended to include `globalMonoidStyles`; a list of `(Style, StyleSpec)` that are then used to update the array that is `defaultStyles`.

24-bit colour is now a possibility and so package `colour` is added as a dependency in `package.yaml`.

`ChangeLog.md` is updated, accordingly.

Please include the following checklist in your PR:
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
Tested by building - `stack test` - on Windows 10 and using the new option.