### PR TITLE
Fixes #4234

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -104,7 +104,8 @@ Use the [generic Linux option](#linux).
 There is also a [Ubuntu
 package](http://packages.ubuntu.com/search?keywords=haskell-stack&searchon=names&suite=all&section=all)
 for Ubuntu 16.10 and up, but the distribution's Stack version lags behind, so we
-recommend running `stack upgrade` after installing it. The
+recommend running `stack upgrade --binary-only` after installing it. For older stack
+versions which do not support `--binary-only`, just `stack upgrade` may work too. The
 version in Ubuntu 16.04 is too old to upgrade successfully, and so in that case
 stack should be installed from a [release
 tarball](https://github.com/commercialhaskell/stack/releases).
@@ -116,7 +117,8 @@ Use the [generic Linux option](#linux).
 There is also a [Debian
 package](https://packages.debian.org/search?keywords=haskell-stack&searchon=names&suite=all&section=all)
 for Stretch and up, but the distribution's Stack version lags behind, so running
-`stack upgrade` is recommended after installing it.
+`stack upgrade --binary-only` is recommended after installing it. For older stack
+versions which do not support `--binary-only`, just `stack upgrade` may work too.
 
 ## <a name="centos"></a>CentOS / Red Hat / Amazon Linux
 

--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -104,8 +104,7 @@ Use the [generic Linux option](#linux).
 There is also a [Ubuntu
 package](http://packages.ubuntu.com/search?keywords=haskell-stack&searchon=names&suite=all&section=all)
 for Ubuntu 16.10 and up, but the distribution's Stack version lags behind, so we
-recommend running `stack upgrade --binary` after installing it. For older stack
-versions which do not support `--binary`, just `stack upgrade` may work too. The
+recommend running `stack upgrade` after installing it. The
 version in Ubuntu 16.04 is too old to upgrade successfully, and so in that case
 stack should be installed from a [release
 tarball](https://github.com/commercialhaskell/stack/releases).
@@ -117,8 +116,7 @@ Use the [generic Linux option](#linux).
 There is also a [Debian
 package](https://packages.debian.org/search?keywords=haskell-stack&searchon=names&suite=all&section=all)
 for Stretch and up, but the distribution's Stack version lags behind, so running
-`stack upgrade --binary` is recommended after installing it. For older stack
-versions which do not support `--binary`, just `stack upgrade` may work too.
+`stack upgrade` is recommended after installing it.
 
 ## <a name="centos"></a>CentOS / Red Hat / Amazon Linux
 


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Updates an outdated instruction for upgrading stack in Ubuntu and Debian.
