### PR TITLE
Pull bindings-uname package into Stack and fix it to work with FreeBSD.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -128,7 +128,6 @@ when:
     build-tools:
     - hsc2hs
     dependencies:
-    - bindings-uname
     - unix
 library:
   source-dirs: src/
@@ -273,6 +272,7 @@ library:
       source-dirs: src/windows/
     else:
       source-dirs: src/unix/
+      c-sources: src/unix/cbits/uname.c
 executables:
   stack:
     main: Main.hs

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -101,7 +101,7 @@ import              RIO.Process
 import              Text.Printf (printf)
 
 #if !WINDOWS
-import              Bindings.Uname (uname, release)
+import              System.Uname (uname, release)
 import              Data.List.Split (splitOn)
 import              Foreign.C (throwErrnoIfMinus1_, peekCString)
 import              Foreign.Marshal (alloca)

--- a/src/unix/System/Uname.hsc
+++ b/src/unix/System/Uname.hsc
@@ -1,0 +1,54 @@
+module System.Uname
+    ( Utsname
+    , uname
+
+    , sysname
+    , nodename
+    , release
+    , version
+    , machine
+    )
+    where
+
+#include <sys/utsname.h>
+
+import Foreign
+import Foreign.C
+
+-- | @'uname' name@ stores nul-terminated strings of information
+--   identifying the current system info to the structure referenced
+--   by name.
+--
+--   > import Foreign.C
+--   > import Foreign.Marshal
+--   >
+--   > sysName :: IO String
+--   > sysName = alloca $ \ ptr ->
+--   >           do throwErrnoIfMinus1_ "uname" $ uname ptr
+--   >              peekCString $ sysname ptr
+--
+foreign import ccall unsafe "haskell_uname"
+        uname :: Ptr Utsname -> IO CInt
+
+data Utsname
+
+instance Storable Utsname where
+    sizeOf    = const #size struct utsname
+    alignment = const #alignment struct utsname
+    poke      = error "Storable Utsname: peek: unsupported operation"
+    peek      = error "Storable Utsname: poke: unsupported operation"
+
+sysname :: Ptr Utsname -> CString
+sysname = (#ptr struct utsname, sysname)
+
+nodename :: Ptr Utsname -> CString
+nodename = (#ptr struct utsname, nodename)
+
+release :: Ptr Utsname -> CString
+release = (#ptr struct utsname, release)
+
+version :: Ptr Utsname -> CString
+version = (#ptr struct utsname, version)
+
+machine :: Ptr Utsname -> CString
+machine = (#ptr struct utsname, machine)

--- a/src/unix/cbits/uname.c
+++ b/src/unix/cbits/uname.c
@@ -1,0 +1,6 @@
+#include <sys/utsname.h>
+
+int haskell_uname(struct utsname *name)
+{
+    return uname(name);
+}


### PR DESCRIPTION
Due to https://github.com/commercialhaskell/stack/issues/3515 I wasn't able to test if Stack builds with this change, but changes made for `bindings-uname` do work.