### PR TITLE
Fix #4205 (Step 4): Add `stack-colors` to `config.yaml`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,12 +16,12 @@ Other enhancements:
   work when only building a subset of packages. This is especially
   useful for the curator use case.
 * New command `stack ls stack-colors` lists the styles and the associated 'ANSI'
-  control character sequences that stack uses to color some of its output. This
-  addition is a precursor to allowing a stack user to redefine the default
-  styles. See `stack ls stack-colors --help` for more information.
-* New global option `--stack-colors=STYLES` allows a stack user to redefine the
-  default styles that stack uses to color some of its output. See `stack --help`
-  for more information.
+  control character sequences that stack uses to color some of its output. See
+  `stack ls stack-colors --help` for more information.
+* New global option `--stack-colors=STYLES`, also available as a
+  non-project-specific yaml configuration parameter, allows a stack user to
+  redefine the default styles that stack uses to color some of its output. See
+  `stack --help` for more information.
 
 Bug fixes:
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -1010,3 +1010,33 @@ Since 1.3.0
 This option specifies which template to use with `stack new`, when none is
 specified. The default is called `new-template`. The other templates are listed
 in [the stack-templates repo](https://github.com/commercialhaskell/stack-templates/).
+
+### stack-colors
+
+Stack uses styles to format some of its output. The default styles do not work
+well with every terminal theme. This option specifies stack's output styles,
+allowing new styles to replace the defaults. The option is used as
+`stack-colors: <STYLES>`, where `<STYLES>` is a colon-delimited sequence of
+key=value, 'key' is a style name and 'value' is a semicolon-delimited list of
+'ANSI' SGR (Select Graphic Rendition) control codes (in decimal). Use the
+command `stack ls stack-colors --basic` to see the current sequence.
+
+The 'ANSI' standards refer to (1) standard ECMA-48 'Control Functions for Coded
+Character Sets' (5th edition, 1991); (2) extensions in ITU-T Recommendation
+(previously CCITT Recommendation) T.416 (03/93) 'Information Technology – Open
+Document Architecture (ODA) and Interchange Format: Character Content
+Architectures' (also published as ISO/IEC International Standard 8613-6); and
+(3) further extensions used by 'XTerm', a terminal emulator for the X Window
+System. The 'ANSI' SGR codes are described in a
+[Wikipedia article](http://en.wikipedia.org/wiki/ANSI_escape_code)
+and those codes supported on current versions of Windows in
+[Microsoft's documentation](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences).
+
+For example, users of the popular
+[Solarized Dark](https://ethanschoonover.com/solarized/)
+terminal theme might wish to set the styles as follows:
+
+```yaml
+stack-colors: error=31:good=32:shell=35:dir=34:recommendation=32:target=95:module=35:package-component=95
+```
+The styles can also be set at the command line using the equivalent `--stack-colors=<STYLES>` global option. Styles set at the command line take precedence over those set in a yaml configuration file.

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -64,7 +64,7 @@ import           Distribution.System (OS (..), Platform (..), buildPlatform, Arc
 import qualified Distribution.Text
 import           Distribution.Version (simplifyVersionRange, mkVersion')
 import           GHC.Conc (getNumProcessors)
-import           Lens.Micro (lens, set)
+import           Lens.Micro ((.~), lens)
 import           Network.HTTP.StackClient (httpJSON, parseUrlThrow, getResponseBody)
 import           Options.Applicative (Parser, strOption, long, help)
 import           Path
@@ -388,7 +388,10 @@ configFromConfigMonoid
      clCache <- newIORef Nothing
      clUpdateRef <- newMVar True
 
-     let configRunner = set processContextL origEnv configRunner'
+     let stylesUpdate' = runnerStylesUpdate configRunner' <>
+           configMonoidStyles
+         configRunner = configRunner' & processContextL .~ origEnv &
+           stylesUpdateL .~ stylesUpdate'
          configCabalLoader = CabalLoader {..}
 
      return Config {..}
@@ -966,5 +969,12 @@ defaultConfigYaml = S.intercalate "\n"
      , "#    author-email:"
      , "#    copyright:"
      , "#    github-username:"
+     , ""
+     , "# The following parameter specifies stack's output styles; STYLES is a"
+     , "# colon-delimited sequence of key=value, where 'key' is a style name and"
+     , "# 'value' is a semicolon-delimited list of 'ANSI' SGR (Select Graphic"
+     , "# Rendition) control codes (in decimal). Use \"stack ls stack-colors --basic\""
+     , "# to see the current sequence."
+     , "# stack-colors: STYLES"
      , ""
      ]

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -22,7 +22,6 @@ import           Options.Applicative
 import           Options.Applicative.Builder.Extra
 import           Stack.Config (getLocalPackages)
 import           Stack.DefaultColorWhen (defaultColorWhen)
-import           Stack.DefaultStyles (defaultStyles)
 import           Stack.Options.GlobalParser (globalOptsFromMonoid)
 import           Stack.Runners (loadConfigWithOpts)
 import           Stack.Prelude hiding (lift)
@@ -60,7 +59,7 @@ buildConfigCompleter inner = mkCompleter $ \inputRaw -> do
         ('-': _) -> return []
         _ -> do
             defColorWhen <- liftIO defaultColorWhen
-            let go = (globalOptsFromMonoid False defColorWhen defaultStyles mempty)
+            let go = (globalOptsFromMonoid False defColorWhen mempty)
                     { globalLogLevel = LevelOther "silent" }
             loadConfigWithOpts go $ \lc -> do
               bconfig <- liftIO $ lcLoadBuildConfig lc (globalCompiler go)

--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -3,7 +3,6 @@
 
 module Stack.Options.GlobalParser where
 
-import           Data.Array.IArray ((//))
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
 import qualified Stack.Docker                      as Docker
@@ -15,9 +14,7 @@ import           Stack.Options.ResolverParser
 import           Stack.Options.Utils
 import           Stack.Types.Config
 import           Stack.Types.Docker
-import           Stack.Types.PrettyPrint (Styles)
 import           Stack.Types.Runner
-import           Stack.Types.StylesUpdate (StylesUpdate (..))
 
 -- | Parser for global command-line options.
 globalOptsParser :: FilePath -> GlobalOptsContext -> Maybe LogLevel -> Parser GlobalOptsMonoid
@@ -46,9 +43,10 @@ globalOptsParser currentDir kind defLogLevel =
               \that do not support color codes, the default is 'never'; color \
               \may work on terminals that support color codes" <>
          hide)) <*>
-    optionalFirst (option readStyles
+    option readStyles
          (long "stack-colors" <>
           metavar "STYLES" <>
+          value mempty <>
           help "Specify stack's output styles; STYLES is a colon-delimited \
                \sequence of key=value, where 'key' is a style name and 'value' \
                \is a semicolon-delimited list of 'ANSI' SGR (Select Graphic \
@@ -56,7 +54,7 @@ globalOptsParser currentDir kind defLogLevel =
                \stack-colors --basic' to see the current sequence. In shells \
                \where a semicolon is a command separator, enclose STYLES in \
                \quotes." <>
-          hide)) <*>
+          hide) <*>
     optionalFirst (option auto
         (long "terminal-width" <>
          metavar "INT" <>
@@ -75,8 +73,8 @@ globalOptsParser currentDir kind defLogLevel =
     hide0 = kind /= OuterGlobalOpts
 
 -- | Create GlobalOpts from GlobalOptsMonoid.
-globalOptsFromMonoid :: Bool -> ColorWhen -> Styles -> GlobalOptsMonoid -> GlobalOpts
-globalOptsFromMonoid defaultTerminal defaultColorWhen defaultStyles GlobalOptsMonoid{..} = GlobalOpts
+globalOptsFromMonoid :: Bool -> ColorWhen -> GlobalOptsMonoid -> GlobalOpts
+globalOptsFromMonoid defaultTerminal defaultColorWhen GlobalOptsMonoid{..} = GlobalOpts
     { globalReExecVersion = getFirst globalMonoidReExecVersion
     , globalDockerEntrypoint = getFirst globalMonoidDockerEntrypoint
     , globalLogLevel = fromFirst defaultLogLevel globalMonoidLogLevel
@@ -86,8 +84,7 @@ globalOptsFromMonoid defaultTerminal defaultColorWhen defaultStyles GlobalOptsMo
     , globalCompiler = getFirst globalMonoidCompiler
     , globalTerminal = fromFirst defaultTerminal globalMonoidTerminal
     , globalColorWhen = fromFirst defaultColorWhen globalMonoidColorWhen
-    , globalStyles = defaultStyles // stylesUpdate
-                       (fromFirst (StylesUpdate []) globalMonoidStyles)
+    , globalStylesUpdate = globalMonoidStyles
     , globalTermWidth = getFirst globalMonoidTermWidth
     , globalStackYaml = maybe SYLDefault SYLOverride $ getFirst globalMonoidStackYaml }
 

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -215,7 +215,7 @@ withRunnerGlobal GlobalOpts{..} = withRunner
   globalTimeInLog
   globalTerminal
   globalColorWhen
-  globalStyles
+  globalStylesUpdate
   globalTermWidth
   (isJust globalReExecVersion)
 

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -223,7 +223,6 @@ import           Stack.Types.Nix
 import           Stack.Types.PackageIdentifier
 import           Stack.Types.PackageIndex
 import           Stack.Types.PackageName
-import           Stack.Types.PrettyPrint (Styles)
 import           Stack.Types.Resolver
 import           Stack.Types.Runner
 import           Stack.Types.StylesUpdate (StylesUpdate,
@@ -443,7 +442,7 @@ data GlobalOpts = GlobalOpts
     , globalCompiler     :: !(Maybe (CompilerVersion 'CVWanted)) -- ^ Compiler override
     , globalTerminal     :: !Bool -- ^ We're in a terminal?
     , globalColorWhen    :: !ColorWhen -- ^ When to use ansi terminal colors
-    , globalStyles       :: !Styles -- ^ SGR (Ansi) codes for styles
+    , globalStylesUpdate :: !StylesUpdate -- ^ SGR (Ansi) codes for styles
     , globalTermWidth    :: !(Maybe Int) -- ^ Terminal width override
     , globalStackYaml    :: !(StackYamlLoc FilePath) -- ^ Override project stack.yaml
     } deriving (Show)
@@ -468,7 +467,7 @@ data GlobalOptsMonoid = GlobalOptsMonoid
     , globalMonoidCompiler     :: !(First (CompilerVersion 'CVWanted)) -- ^ Compiler override
     , globalMonoidTerminal     :: !(First Bool) -- ^ We're in a terminal?
     , globalMonoidColorWhen    :: !(First ColorWhen) -- ^ When to use ansi colors
-    , globalMonoidStyles       :: !(First StylesUpdate) -- ^ Stack's output styles
+    , globalMonoidStyles       :: !StylesUpdate -- ^ Stack's output styles
     , globalMonoidTermWidth    :: !(First Int) -- ^ Terminal width override
     , globalMonoidStackYaml    :: !(First FilePath) -- ^ Override project stack.yaml
     } deriving (Show, Generic)
@@ -794,6 +793,7 @@ data ConfigMonoid =
     -- ^ See 'configHackageBaseUrl'
     , configMonoidIgnoreRevisionMismatch :: !(First Bool)
     -- ^ See 'configIgnoreRevisionMismatch'
+    , configMonoidStyles :: !StylesUpdate
     }
   deriving (Show, Generic)
 
@@ -891,6 +891,7 @@ parseConfigMonoidObject rootDir obj = do
     configMonoidSaveHackageCreds <- First <$> obj ..:? configMonoidSaveHackageCredsName
     configMonoidHackageBaseUrl <- First <$> obj ..:? configMonoidHackageBaseUrlName
     configMonoidIgnoreRevisionMismatch <- First <$> obj ..:? configMonoidIgnoreRevisionMismatchName
+    configMonoidStyles <- fromMaybe mempty <$> obj ..:? configMonoidStylesName
 
     return ConfigMonoid {..}
   where
@@ -1035,6 +1036,9 @@ configMonoidHackageBaseUrlName = "hackage-base-url"
 
 configMonoidIgnoreRevisionMismatchName :: Text
 configMonoidIgnoreRevisionMismatchName = "ignore-revision-mismatch"
+
+configMonoidStylesName :: Text
+configMonoidStylesName = "stack-colors"
 
 data ConfigException
   = ParseConfigFileException (Path Abs File) ParseException

--- a/src/Stack/Types/PrettyPrint.hs
+++ b/src/Stack/Types/PrettyPrint.hs
@@ -14,6 +14,7 @@ module Stack.Types.PrettyPrint
 
 import Data.Array.IArray (Array)
 import Data.Ix (Ix)
+import Data.Text (Text)
 import Stack.Prelude
 import System.Console.ANSI.Types (SGR)
 

--- a/src/Stack/Types/Runner.hs
+++ b/src/Stack/Types/Runner.hs
@@ -15,7 +15,7 @@ module Stack.Types.Runner
     , HasRunner (..)
     , terminalL
     , useColorL
-    , stylesL
+    , stylesUpdateL
     , reExecL
     , ColorWhen (..)
     , withRunner
@@ -26,7 +26,7 @@ import           Lens.Micro
 import           Stack.Prelude              hiding (lift)
 import           Stack.Constants
 import           Stack.Types.PackageIdentifier (PackageIdentifierRevision)
-import           Stack.Types.PrettyPrint (Styles)
+import           Stack.Types.StylesUpdate (StylesUpdate)
 import           System.Console.ANSI
 import           RIO.Process (HasProcessContext (..), ProcessContext, mkDefaultProcessContext)
 import           System.Terminal
@@ -36,7 +36,7 @@ data Runner = Runner
   { runnerReExec     :: !Bool
   , runnerTerminal   :: !Bool
   , runnerUseColor   :: !Bool
-  , runnerStyles     :: !Styles
+  , runnerStylesUpdate :: !StylesUpdate
   , runnerLogFunc    :: !LogFunc
   , runnerTermWidth  :: !Int
   , runnerProcessContext :: !ProcessContext
@@ -67,8 +67,8 @@ terminalL = runnerL.lens runnerTerminal (\x y -> x { runnerTerminal = y })
 useColorL :: HasRunner env => Lens' env Bool
 useColorL = runnerL.lens runnerUseColor (\x y -> x { runnerUseColor = y })
 
-stylesL :: HasRunner env => Lens' env Styles
-stylesL = runnerL.lens runnerStyles (\x y -> x { runnerStyles = y })
+stylesUpdateL :: HasRunner env => Lens' env StylesUpdate
+stylesUpdateL = runnerL.lens runnerStylesUpdate (\x y -> x { runnerStylesUpdate = y })
 
 reExecL :: HasRunner env => Lens' env Bool
 reExecL = runnerL.lens runnerReExec (\x y -> x { runnerReExec = y })
@@ -85,12 +85,12 @@ withRunner :: MonadUnliftIO m
            -> Bool -- ^ use time?
            -> Bool -- ^ terminal?
            -> ColorWhen
-           -> Styles
+           -> StylesUpdate
            -> Maybe Int -- ^ terminal width override
            -> Bool -- ^ reexec?
            -> (Runner -> m a)
            -> m a
-withRunner logLevel useTime terminal colorWhen styles widthOverride reExec inner = do
+withRunner logLevel useTime terminal colorWhen stylesUpdate widthOverride reExec inner = do
   useColor <- case colorWhen of
     ColorNever -> return False
     ColorAlways -> return True
@@ -112,7 +112,7 @@ withRunner logLevel useTime terminal colorWhen styles widthOverride reExec inner
     { runnerReExec = reExec
     , runnerTerminal = terminal
     , runnerUseColor = useColor
-    , runnerStyles = styles
+    , runnerStylesUpdate = stylesUpdate
     , runnerLogFunc = logFunc
     , runnerTermWidth = termWidth
     , runnerParsedCabalFiles = ref

--- a/src/Text/PrettyPrint/Leijen/Extended.hs
+++ b/src/Text/PrettyPrint/Leijen/Extended.hs
@@ -111,14 +111,16 @@ module Text.PrettyPrint.Leijen.Extended
   ) where
 
 import Control.Monad.Reader (runReader, local)
-import Data.Array.IArray ((!))
+import Data.Array.IArray ((!), (//))
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Builder as LTB
+import Stack.DefaultStyles (defaultStyles)
 import Stack.Prelude hiding (Display (..))
 import Stack.Types.PrettyPrint (Style, Styles)
-import Stack.Types.Runner (HasRunner, stylesL)
+import Stack.Types.Runner (HasRunner, stylesUpdateL)
+import Stack.Types.StylesUpdate (StylesUpdate (..))
 import System.Console.ANSI (ConsoleLayer (..), SGR (..), setSGRCode)
 import qualified Text.PrettyPrint.Annotated.Leijen as P
 import Text.PrettyPrint.Annotated.Leijen hiding ((<>), display)
@@ -229,8 +231,9 @@ displayAnsiSimple
     :: (HasRunner env, HasLogFunc env, MonadReader env m, HasCallStack)
     => SimpleDoc StyleAnn -> m LT.Text
 displayAnsiSimple doc = do
-    styles <- view stylesL
-    let doc' = toAnsiDoc styles doc
+    update <- view stylesUpdateL
+    let styles = defaultStyles // stylesUpdate update
+        doc' = toAnsiDoc styles doc
     return $
         LTB.toLazyText $ flip runReader mempty $ displayDecoratedWrap go doc'
   where

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -58,7 +58,6 @@ import           Stack.Constants
 import           Stack.Constants.Config
 import           Stack.Coverage
 import           Stack.DefaultColorWhen (defaultColorWhen)
-import           Stack.DefaultStyles (defaultStyles)
 import qualified Stack.Docker as Docker
 import           Stack.Dot
 import           Stack.GhcPkg (findGhcPkgField)
@@ -192,7 +191,7 @@ main = do
     Left (exitCode :: ExitCode) ->
       throwIO exitCode
     Right (globalMonoid,run) -> do
-      let global = globalOptsFromMonoid isTerminal defColorWhen defaultStyles globalMonoid
+      let global = globalOptsFromMonoid isTerminal defColorWhen globalMonoid
       when (globalLogLevel global == LevelDebug) $ hPutStrLn stderr versionString'
       case globalReExecVersion global of
           Just expectVersion -> do

--- a/src/test/Network/HTTP/Download/VerifiedSpec.hs
+++ b/src/test/Network/HTTP/Download/VerifiedSpec.hs
@@ -7,7 +7,6 @@ import           Network.HTTP.StackClient
 import           Network.HTTP.Download.Verified
 import           Path
 import           Path.IO hiding (withSystemTempDir)
-import           Stack.DefaultStyles (defaultStyles)
 import           Stack.Prelude
 import           Stack.Types.Runner
 import           System.IO (writeFile, readFile)
@@ -68,7 +67,7 @@ spec = do
 
   describe "verifiedDownload" $ do
     let run func =
-          withRunner LevelError True True ColorNever defaultStyles Nothing False
+          withRunner LevelError True True ColorNever mempty Nothing False
                  $ \runner -> runRIO runner func
     -- Preconditions:
     -- * the exampleReq server is running

--- a/src/test/Stack/ConfigSpec.hs
+++ b/src/test/Stack/ConfigSpec.hs
@@ -10,7 +10,6 @@ import Data.Yaml
 import Path
 import Path.IO hiding (withSystemTempDir)
 import Stack.Config
-import Stack.DefaultStyles (defaultStyles)
 import Stack.Prelude
 import Stack.Types.Config
 import Stack.Types.Runner
@@ -85,7 +84,7 @@ spec = beforeAll setup $ do
 
   describe "loadConfig" $ do
     let loadConfig' inner =
-          withRunner logLevel True False ColorAuto defaultStyles Nothing False $ \runner -> do
+          withRunner logLevel True False ColorAuto mempty Nothing False $ \runner -> do
             lc <- runRIO runner $ loadConfig mempty Nothing SYLDefault
             inner lc
     -- TODO(danburton): make sure parent dirs also don't have config file

--- a/src/test/Stack/NixSpec.hs
+++ b/src/test/Stack/NixSpec.hs
@@ -7,7 +7,6 @@ import Data.Maybe (fromJust)
 import Options.Applicative
 import Path
 import Prelude (writeFile)
-import Stack.DefaultStyles (defaultStyles)
 import Stack.Config
 import Stack.Config.Nix
 import Stack.Constants
@@ -44,7 +43,7 @@ setup = unsetEnv "STACK_YAML"
 spec :: Spec
 spec = beforeAll setup $ do
   let loadConfig' cmdLineArgs =
-        withRunner LevelDebug True False ColorAuto defaultStyles Nothing False $ \runner ->
+        withRunner LevelDebug True False ColorAuto mempty Nothing False $ \runner ->
         runRIO runner $ loadConfig cmdLineArgs Nothing SYLDefault
       inTempDir test = do
         currentDirectory <- getCurrentDirectory


### PR DESCRIPTION
This builds on step 0 (commit https://github.com/commercialhaskell/stack/commit/68718a784a0eec52968540ea3de3885f1ae707a0), step 3 (commit https://github.com/commercialhaskell/stack/commit/62866ceef2fafee00ebb034ab08751169bb0e8c8) and step 5 (commit https://github.com/commercialhaskell/stack/commit/3d388accc6862e082a0531e65fe109817d7a643c) and is the final major proposed commit that pulls everything together to implement #4205. It adds the `stack-colors:` non-project-specific option to `config.yaml` (or `stack.yaml`). The documentation in `yaml_configuration.md` is updated, accordingly.

To allow the composition of yaml and command line options, in module `Stack.Types.Runner`, `runnerStyles :: !Styles` becomes `runnerStylesUpdate :: !StylesUpdate`. Consequent changes are made throughout and these are the majority of the changes. `Semigroup`, `Monoid` and `FromJSON` instances are added to module `Stack.Types.StylesUpdate`.

The composition of options from various sources is done in `configFromConfigMonoid`. The composition (perhaps `config.yaml`, perhaps `stack.yaml`, perhaps the command line, in order of increasing precedence) means that `configMonoidStyles :: !StylesUpdate` as opposed to, say, `configMonoidStyles :: !(First StylesUpdate)`. As documented in the comment in `Stack.Types.StylesUpdate`, this relies on GHC's implementation of `(//)` - when updating the array (`Styles`) the last value specified for a duplicated `Style` index is used.

The plumbing for `stack-colors` as a yaml option is added to module `Stack.Types.Config`, and that requires some consequent changes in module `Stack.Ls` (`LoadConfig` replaces `GlobalOpts`).

Some information is added to the pro forma `config.yaml` file, `defaultConfigYaml`.

This has been tested by building on Windows 10 - `stack test` - and then using the tool.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md _Edits also made to rationalise the updates made following steps 0, 3 and 5._
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

This has been tested by building on Windows 10 - `stack test` - and then using the tool.