### PR TITLE
Fix #2426: use removePathForcibly instead of removeDirRecur everywhere

### DIFF
--- a/src/Path/Extra.hs
+++ b/src/Path/Extra.hs
@@ -14,6 +14,7 @@ module Path.Extra
   ,pathToByteString
   ,pathToLazyByteString
   ,pathToText
+  ,removePathForcibly
   ,tryGetModificationTime
   ) where
 
@@ -28,6 +29,7 @@ import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified System.Directory as D
 import qualified System.FilePath as FP
 
 -- | Convert to FilePath but don't add a trailing slash.
@@ -122,3 +124,14 @@ pathToText = T.pack . toFilePath
 
 tryGetModificationTime :: MonadIO m => Path Abs File -> m (Either () UTCTime)
 tryGetModificationTime = liftIO . tryJust (guard . isDoesNotExistError) . getModificationTime
+
+-- Copied from path-io
+liftD :: MonadIO m
+  => (FilePath -> IO a) -- ^ Original action
+  -> Path b t          -- ^ 'Path' argument
+  -> m a               -- ^ Lifted action
+liftD m = liftIO . m . toFilePath
+{-# INLINE liftD #-}
+
+removePathForcibly :: MonadIO m => Path b Dir -> m ()
+removePathForcibly = liftD D.removePathForcibly

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -59,7 +59,7 @@ import           Distribution.System            (OS (Windows),
 import qualified Distribution.Text as C
 import           Path
 import           Path.CheckInstall
-import           Path.Extra (toFilePathNoTrailingSep, rejectMissingFile)
+import           Path.Extra (toFilePathNoTrailingSep, rejectMissingFile, removePathForcibly)
 import           Path.IO hiding (findExecutable, makeAbsolute, withSystemTempDir)
 import qualified RIO
 import           Stack.Build.Cache
@@ -1575,7 +1575,7 @@ singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} installedMap
             -- require it, to reduce space usage in tmp (#3018).
             TTIndex{} -> do
                 let remaining = filter (\(ActionId x _) -> x == taskProvides) (Set.toList acRemaining)
-                when (null remaining) $ removeDirRecur pkgDir
+                when (null remaining) $ removePathForcibly pkgDir
             _ -> return ()
 
         return mpkgid

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -269,11 +269,11 @@ generateHaddockIndex descr wc bco dumpPackages docRelFP destDir = do
                 | otherwise -> return ()
       where
         doCopy = do
-            ignoringAbsence (removeDirRecur destHtmlAbsDir)
+            ignoringAbsence (removePathForcibly destHtmlAbsDir)
             ensureDir destHtmlAbsDir
             onException
                 (copyDirRecur' (parent srcInterfaceAbsFile) destHtmlAbsDir)
-                (ignoringAbsence (removeDirRecur destHtmlAbsDir))
+                (ignoringAbsence (removePathForcibly destHtmlAbsDir))
         destHtmlAbsDir = parent destInterfaceAbsFile
 
 -- | Find first DumpPackage matching the GhcPkgId

--- a/src/Stack/Clean.hs
+++ b/src/Stack/Clean.hs
@@ -14,7 +14,8 @@ module Stack.Clean
 import           Stack.Prelude
 import           Data.List ((\\),intercalate)
 import qualified Data.Map.Strict as Map
-import           Path.IO (ignoringAbsence, removeDirRecur)
+import           Path.IO (ignoringAbsence)
+import           Path.Extra (removePathForcibly)
 import           Stack.Config (getLocalPackages)
 import           Stack.Constants.Config (distDirFromDir, workDirFromDir)
 import           Stack.Types.PackageName
@@ -30,7 +31,7 @@ clean cleanOpts = do
     when (or failures) $ liftIO exitFailure
   where
     cleanDir dir =
-      liftIO (ignoringAbsence (removeDirRecur dir) >> return False) `catchAny` \ex -> do
+      liftIO (ignoringAbsence (removePathForcibly dir) >> return False) `catchAny` \ex -> do
         logError $ "Exception while recursively deleting " <> fromString (toFilePath dir) <> "\n" <> displayShow ex
         logError "Perhaps you do not have permission to delete these files or they are in use?"
         return True

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -30,7 +30,7 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as LT
 import           Path
-import           Path.Extra (toFilePathNoTrailingSep)
+import           Path.Extra (toFilePathNoTrailingSep, removePathForcibly)
 import           Path.IO
 import           Stack.Build.Target
 import           Stack.Config (getLocalPackages)
@@ -55,7 +55,7 @@ import           Web.Browser (openBrowser)
 deleteHpcReports :: HasEnvConfig env => RIO env ()
 deleteHpcReports = do
     hpcDir <- hpcReportDir
-    liftIO $ ignoringAbsence (removeDirRecur hpcDir)
+    liftIO $ ignoringAbsence (removePathForcibly hpcDir)
 
 -- | Move a tix file into a sub-directory of the hpc report directory. Deletes the old one if one is
 -- present.

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -44,7 +44,7 @@ import           Data.Version (showVersion)
 import           GHC.Exts (sortWith)
 import           Lens.Micro (set)
 import           Path
-import           Path.Extra (toFilePathNoTrailingSep)
+import           Path.Extra (toFilePathNoTrailingSep, removePathForcibly)
 import           Path.IO hiding (canonicalizePath)
 import qualified Paths_stack as Meta
 import           Stack.Config (getInContainer)
@@ -836,7 +836,7 @@ removeDirectoryContents path excludeDirs excludeFiles =
           (do (lsd,lsf) <- listDir path
               forM_ lsd
                     (\d -> unless (dirname d `elem` excludeDirs)
-                                  (removeDirRecur d))
+                                  (removePathForcibly d))
               forM_ lsf
                     (\f -> unless (filename f `elem` excludeFiles)
                                   (removeFile f)))

--- a/src/Stack/Image.hs
+++ b/src/Stack/Image.hs
@@ -43,7 +43,7 @@ stageContainerImageArtifacts mProjectRoot imageNames = do
         (\(idx,opts) ->
               do imageDir <-
                      imageStagingDir (fromMaybeProjectRoot mProjectRoot) idx
-                 liftIO (ignoringAbsence (removeDirRecur imageDir))
+                 liftIO (ignoringAbsence (removePathForcibly imageDir))
                  ensureDir imageDir
                  stageExesInDir opts imageDir
                  syncAddContentToDir opts imageDir)

--- a/src/Stack/PackageLocation.hs
+++ b/src/Stack/PackageLocation.hs
@@ -64,10 +64,10 @@ resolveSinglePackageLocation projRoot (PLArchive (Archive url subdir msha)) = do
 
     exists <- doesDirExist dir
     unless exists $ do
-        liftIO $ ignoringAbsence (removeDirRecur dir)
+        liftIO $ ignoringAbsence (removePathForcibly dir)
 
         let dirTmp = root </> dirRelTmp
-        liftIO $ ignoringAbsence (removeDirRecur dirTmp)
+        liftIO $ ignoringAbsence (removePathForcibly dirTmp)
 
         urlExists <- liftIO $ Dir.doesFileExist $ T.unpack url
         file <-
@@ -141,7 +141,7 @@ resolveSinglePackageLocation projRoot (PLArchive (Archive url subdir msha)) = do
         ([dir'], []) -> resolveDir dir' subdir
         (dirs, files) -> liftIO $ do
             ignoringAbsence (removeFile fileDownload)
-            ignoringAbsence (removeDirRecur dir)
+            ignoringAbsence (removePathForcibly dir)
             throwIO $ UnexpectedArchiveContents dirs files
 resolveSinglePackageLocation projRoot (PLRepo (Repo url commit repoType' subdir)) =
     cloneRepo projRoot url commit repoType' >>= flip resolveDir subdir
@@ -200,7 +200,7 @@ cloneRepo projRoot url commit repoType' = do
 
     exists <- doesDirExist dir
     unless exists $ do
-        liftIO $ ignoringAbsence (removeDirRecur dir)
+        liftIO $ ignoringAbsence (removePathForcibly dir)
 
         let cloneAndExtract commandName cloneArgs resetCommand =
               withWorkingDir (toFilePath root) $ do


### PR DESCRIPTION
I've left tests alone as the problem doesn't appear there (and the testing
environment is more under our control).
I have blindly modified *all* uses in the code, because
* I don't know which one triggers the issue
* in principle it might affect many/all calls
* while this *might* trigger regressions, I'm not sure which ones concretely.
  Unless the user is an admin and somehow this manages to remove non-Stack files
  that shouldn't be removed; this sounds unlikely (we'd have reports where this
  is attempted and fails) but I can't exclude it yet without at least closer
  review.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
