### PR TITLE
Fix (in part) #4204: Add `color:` to `config.yaml`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,8 @@ Other enhancements:
   plan construction errors much faster, and avoid some unnecessary
   work when only building a subset of packages. This is especially
   useful for the curator use case.
+* Existing global option `--color=WHEN` is now also available as a
+  non-project-specific yaml configuration parameter `color:`.
 * New command `stack ls stack-colors` lists the styles and the associated 'ANSI'
   control character sequences that stack uses to color some of its output. See
   `stack ls stack-colors --help` for more information.

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -1014,6 +1014,17 @@ This option specifies which template to use with `stack new`, when none is
 specified. The default is called `new-template`. The other templates are listed
 in [the stack-templates repo](https://github.com/commercialhaskell/stack-templates/).
 
+### color
+
+This option specifies when to use color in output. The option is used as
+`color: <WHEN>`, where `<WHEN>` is 'always', 'never', or 'auto'. On Windows
+versions before Windows 10, for terminals that do not support color codes, the
+default is 'never'; color may work on terminals that support color codes.
+
+The color use can also be set at the command line using the equivalent
+`--color=<WHEN>` global option. Color use set at the command line takes
+precedence over that set in a yaml configuration file.
+
 ### stack-colors
 
 Stack uses styles to format some of its output. The default styles do not work

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -21,7 +21,6 @@ import qualified Distribution.Types.UnqualComponentName as C
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
 import           Stack.Config (getLocalPackages)
-import           Stack.DefaultColorWhen (defaultColorWhen)
 import           Stack.Options.GlobalParser (globalOptsFromMonoid)
 import           Stack.Runners (loadConfigWithOpts)
 import           Stack.Prelude hiding (lift)
@@ -58,8 +57,7 @@ buildConfigCompleter inner = mkCompleter $ \inputRaw -> do
         -- If it looks like a flag, skip this more costly completion.
         ('-': _) -> return []
         _ -> do
-            defColorWhen <- liftIO defaultColorWhen
-            let go = (globalOptsFromMonoid False defColorWhen mempty)
+            let go = (globalOptsFromMonoid False mempty)
                     { globalLogLevel = LevelOther "silent" }
             loadConfigWithOpts go $ \lc -> do
               bconfig <- liftIO $ lcLoadBuildConfig lc (globalCompiler go)

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -20,29 +20,33 @@ import qualified System.FilePath as FilePath
 -- | Command-line arguments parser for configuration.
 configOptsParser :: FilePath -> GlobalOptsContext -> Parser ConfigMonoid
 configOptsParser currentDir hide0 =
-    (\stackRoot workDir buildOpts dockerOpts nixOpts systemGHC installGHC arch ghcVariant ghcBuild jobs includes libs overrideGccPath overrideHpack skipGHCCheck skipMsys localBin modifyCodePage allowDifferentUser dumpLogs -> mempty
-        { configMonoidStackRoot = stackRoot
-        , configMonoidWorkDir = workDir
-        , configMonoidBuildOpts = buildOpts
-        , configMonoidDockerOpts = dockerOpts
-        , configMonoidNixOpts = nixOpts
-        , configMonoidSystemGHC = systemGHC
-        , configMonoidInstallGHC = installGHC
-        , configMonoidSkipGHCCheck = skipGHCCheck
-        , configMonoidArch = arch
-        , configMonoidGHCVariant = ghcVariant
-        , configMonoidGHCBuild = ghcBuild
-        , configMonoidJobs = jobs
-        , configMonoidExtraIncludeDirs = includes
-        , configMonoidExtraLibDirs = libs
-        , configMonoidOverrideGccPath = overrideGccPath
-        , configMonoidOverrideHpack = overrideHpack
-        , configMonoidSkipMsys = skipMsys
-        , configMonoidLocalBinPath = localBin
-        , configMonoidModifyCodePage = modifyCodePage
-        , configMonoidAllowDifferentUser = allowDifferentUser
-        , configMonoidDumpLogs = dumpLogs
-        })
+    (\stackRoot workDir buildOpts dockerOpts nixOpts systemGHC installGHC arch
+        ghcVariant ghcBuild jobs includes libs overrideGccPath overrideHpack
+        skipGHCCheck skipMsys localBin modifyCodePage allowDifferentUser
+        dumpLogs colorWhen -> mempty
+            { configMonoidStackRoot = stackRoot
+            , configMonoidWorkDir = workDir
+            , configMonoidBuildOpts = buildOpts
+            , configMonoidDockerOpts = dockerOpts
+            , configMonoidNixOpts = nixOpts
+            , configMonoidSystemGHC = systemGHC
+            , configMonoidInstallGHC = installGHC
+            , configMonoidSkipGHCCheck = skipGHCCheck
+            , configMonoidArch = arch
+            , configMonoidGHCVariant = ghcVariant
+            , configMonoidGHCBuild = ghcBuild
+            , configMonoidJobs = jobs
+            , configMonoidExtraIncludeDirs = includes
+            , configMonoidExtraLibDirs = libs
+            , configMonoidOverrideGccPath = overrideGccPath
+            , configMonoidOverrideHpack = overrideHpack
+            , configMonoidSkipMsys = skipMsys
+            , configMonoidLocalBinPath = localBin
+            , configMonoidModifyCodePage = modifyCodePage
+            , configMonoidAllowDifferentUser = allowDifferentUser
+            , configMonoidDumpLogs = dumpLogs
+            , configMonoidColorWhen = colorWhen
+            })
     <$> optionalFirst (absDirOption
             ( long stackRootOptionName
             <> metavar (map toUpper stackRootOptionName)
@@ -139,6 +143,17 @@ configOptsParser currentDir hide0 =
              "dump-logs"
              "dump the build output logs for local packages to the console"
              hide)
+    <*> optionalFirst (option readColorWhen
+             ( long "color"
+            <> metavar "WHEN"
+            <> completeWith ["always", "never", "auto"]
+            <> help "Specify when to use color in output; WHEN is 'always', \
+                    \'never', or 'auto'. On Windows versions before Windows \
+                    \10, for terminals that do not support color codes, the \
+                    \default is 'never'; color may work on terminals that \
+                    \support color codes"
+            <> hide
+             ))
   where
     hide = hideMods (hide0 /= OuterGlobalOpts)
     toDumpLogs (First (Just True)) = First (Just DumpAllLogs)

--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -14,7 +14,6 @@ import           Stack.Options.ResolverParser
 import           Stack.Options.Utils
 import           Stack.Types.Config
 import           Stack.Types.Docker
-import           Stack.Types.Runner
 
 -- | Parser for global command-line options.
 globalOptsParser :: FilePath -> GlobalOptsContext -> Maybe LogLevel -> Parser GlobalOptsMonoid
@@ -34,15 +33,6 @@ globalOptsParser currentDir kind defLogLevel =
         "terminal"
         "overriding terminal detection in the case of running in a false terminal"
         hide <*>
-    optionalFirst (option readColorWhen
-        (long "color" <>
-         metavar "WHEN" <>
-         completeWith ["always", "never", "auto"] <>
-         help "Specify when to use color in output; WHEN is 'always', 'never', \
-              \or 'auto'. On Windows versions before Windows 10, for terminals \
-              \that do not support color codes, the default is 'never'; color \
-              \may work on terminals that support color codes" <>
-         hide)) <*>
     option readStyles
          (long "stack-colors" <>
           metavar "STYLES" <>
@@ -73,8 +63,8 @@ globalOptsParser currentDir kind defLogLevel =
     hide0 = kind /= OuterGlobalOpts
 
 -- | Create GlobalOpts from GlobalOptsMonoid.
-globalOptsFromMonoid :: Bool -> ColorWhen -> GlobalOptsMonoid -> GlobalOpts
-globalOptsFromMonoid defaultTerminal defaultColorWhen GlobalOptsMonoid{..} = GlobalOpts
+globalOptsFromMonoid :: Bool -> GlobalOptsMonoid -> GlobalOpts
+globalOptsFromMonoid defaultTerminal GlobalOptsMonoid{..} = GlobalOpts
     { globalReExecVersion = getFirst globalMonoidReExecVersion
     , globalDockerEntrypoint = getFirst globalMonoidDockerEntrypoint
     , globalLogLevel = fromFirst defaultLogLevel globalMonoidLogLevel
@@ -83,7 +73,6 @@ globalOptsFromMonoid defaultTerminal defaultColorWhen GlobalOptsMonoid{..} = Glo
     , globalResolver = getFirst globalMonoidResolver
     , globalCompiler = getFirst globalMonoidCompiler
     , globalTerminal = fromFirst defaultTerminal globalMonoidTerminal
-    , globalColorWhen = fromFirst defaultColorWhen globalMonoidColorWhen
     , globalStylesUpdate = globalMonoidStyles
     , globalTermWidth = getFirst globalMonoidTermWidth
     , globalStackYaml = maybe SYLDefault SYLOverride $ getFirst globalMonoidStackYaml }

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -25,6 +25,7 @@ import           Stack.Prelude
 import           Path
 import           Path.IO
 import           Stack.Config
+import           Stack.DefaultColorWhen (defaultColorWhen)
 import qualified Stack.Docker as Docker
 import qualified Stack.Nix as Nix
 import           Stack.Setup
@@ -210,14 +211,19 @@ loadConfigWithOpts go@GlobalOpts{..} inner = withRunnerGlobal go $ \runner -> do
         liftIO $ inner lc
 
 withRunnerGlobal :: GlobalOpts -> (Runner -> IO a) -> IO a
-withRunnerGlobal GlobalOpts{..} = withRunner
-  globalLogLevel
-  globalTimeInLog
-  globalTerminal
-  globalColorWhen
-  globalStylesUpdate
-  globalTermWidth
-  (isJust globalReExecVersion)
+withRunnerGlobal GlobalOpts{..} inner = do
+    defColorWhen <- defaultColorWhen
+    let globalColorWhen =
+            fromFirst defColorWhen (configMonoidColorWhen globalConfigMonoid)
+    withRunner
+        globalLogLevel
+        globalTimeInLog
+        globalTerminal
+        globalColorWhen
+        globalStylesUpdate
+        globalTermWidth
+        (isJust globalReExecVersion)
+        inner
 
 withMiniConfigAndLock
     :: GlobalOpts

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -441,7 +441,6 @@ data GlobalOpts = GlobalOpts
     , globalResolver     :: !(Maybe AbstractResolver) -- ^ Resolver override
     , globalCompiler     :: !(Maybe (CompilerVersion 'CVWanted)) -- ^ Compiler override
     , globalTerminal     :: !Bool -- ^ We're in a terminal?
-    , globalColorWhen    :: !ColorWhen -- ^ When to use ansi terminal colors
     , globalStylesUpdate :: !StylesUpdate -- ^ SGR (Ansi) codes for styles
     , globalTermWidth    :: !(Maybe Int) -- ^ Terminal width override
     , globalStackYaml    :: !(StackYamlLoc FilePath) -- ^ Override project stack.yaml
@@ -466,7 +465,6 @@ data GlobalOptsMonoid = GlobalOptsMonoid
     , globalMonoidResolver     :: !(First AbstractResolver) -- ^ Resolver override
     , globalMonoidCompiler     :: !(First (CompilerVersion 'CVWanted)) -- ^ Compiler override
     , globalMonoidTerminal     :: !(First Bool) -- ^ We're in a terminal?
-    , globalMonoidColorWhen    :: !(First ColorWhen) -- ^ When to use ansi colors
     , globalMonoidStyles       :: !StylesUpdate -- ^ Stack's output styles
     , globalMonoidTermWidth    :: !(First Int) -- ^ Terminal width override
     , globalMonoidStackYaml    :: !(First FilePath) -- ^ Override project stack.yaml
@@ -793,7 +791,9 @@ data ConfigMonoid =
     -- ^ See 'configHackageBaseUrl'
     , configMonoidIgnoreRevisionMismatch :: !(First Bool)
     -- ^ See 'configIgnoreRevisionMismatch'
-    , configMonoidStyles :: !StylesUpdate
+    , configMonoidColorWhen          :: !(First ColorWhen)
+    -- ^ When to use 'ANSI' colors
+    , configMonoidStyles             :: !StylesUpdate
     }
   deriving (Show, Generic)
 
@@ -891,6 +891,7 @@ parseConfigMonoidObject rootDir obj = do
     configMonoidSaveHackageCreds <- First <$> obj ..:? configMonoidSaveHackageCredsName
     configMonoidHackageBaseUrl <- First <$> obj ..:? configMonoidHackageBaseUrlName
     configMonoidIgnoreRevisionMismatch <- First <$> obj ..:? configMonoidIgnoreRevisionMismatchName
+    configMonoidColorWhen <- First <$> obj ..:? configMonoidColorWhenName
     configMonoidStyles <- fromMaybe mempty <$> obj ..:? configMonoidStylesName
 
     return ConfigMonoid {..}
@@ -1036,6 +1037,9 @@ configMonoidHackageBaseUrlName = "hackage-base-url"
 
 configMonoidIgnoreRevisionMismatchName :: Text
 configMonoidIgnoreRevisionMismatchName = "ignore-revision-mismatch"
+
+configMonoidColorWhenName :: Text
+configMonoidColorWhenName = "color"
 
 configMonoidStylesName :: Text
 configMonoidStylesName = "stack-colors"

--- a/src/Stack/Types/Runner.hs
+++ b/src/Stack/Types/Runner.hs
@@ -21,6 +21,7 @@ module Stack.Types.Runner
     , withRunner
     ) where
 
+import           Data.Aeson (FromJSON (parseJSON))
 import           Distribution.PackageDescription (GenericPackageDescription)
 import           Lens.Micro
 import           Stack.Prelude              hiding (lift)
@@ -125,3 +126,13 @@ withRunner logLevel useTime terminal colorWhen stylesUpdate widthOverride reExec
 
 data ColorWhen = ColorNever | ColorAlways | ColorAuto
     deriving (Eq, Show, Generic)
+
+instance FromJSON ColorWhen where
+    parseJSON v = do
+        s <- parseJSON v
+        case s of
+            "never"  -> return ColorNever
+            "always" -> return ColorAlways
+            "auto"   -> return ColorAuto
+            _ -> fail ("Unknown color use: " <> s <> ". Expected values of " <>
+                       "option are 'never', 'always', or 'auto'.")

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -57,7 +57,6 @@ import           Stack.ConfigCmd as ConfigCmd
 import           Stack.Constants
 import           Stack.Constants.Config
 import           Stack.Coverage
-import           Stack.DefaultColorWhen (defaultColorWhen)
 import qualified Stack.Docker as Docker
 import           Stack.Dot
 import           Stack.GhcPkg (findGhcPkgField)
@@ -175,7 +174,6 @@ main = do
   -- On Windows, where applicable, defaultColorWhen has the side effect of
   -- enabling ANSI for ANSI-capable native (ConHost) terminals, if not already
   -- ANSI-enabled.
-  defColorWhen <- defaultColorWhen
   execExtraHelp args
                 Docker.dockerHelpOptName
                 (dockerOptsParser False)
@@ -191,7 +189,7 @@ main = do
     Left (exitCode :: ExitCode) ->
       throwIO exitCode
     Right (globalMonoid,run) -> do
-      let global = globalOptsFromMonoid isTerminal defColorWhen globalMonoid
+      let global = globalOptsFromMonoid isTerminal globalMonoid
       when (globalLogLevel global == LevelDebug) $ hPutStrLn stderr versionString'
       case globalReExecVersion global of
           Just expectVersion -> do


### PR DESCRIPTION
This pull request allows the global option `--color=<WHEN>` to be set also in a yaml configuration file.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested on Windows 10 by building - `stack test` - and then using. Principally tested by reference to the output of the new `stack ls stack-colors` command, as follows:

* `stack ls stack-colors` gives a report with colour Examples (as expected)
* `stack --color=never ls stack-colors` gives a report without colour Examples (as expected)
* set `color: never` in `config.yaml`, `stack ls stack-colors` gives a report without colour Examples (as expected)
* set `color: never` in `config.yaml`, `stack --color=always ls stack-colors` gives a report with colour Examples (as expected)
* set `color: dummy` in `config.yaml`, `stack --color=always ls stack-colors` gives a useful error report about not being able to parse `config.yaml` (as expected)