### PR TITLE
list-dependencies is deprecated

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -359,10 +359,10 @@ michael@d30748af6d3d:~/helloworld$ stack build
 # build output ...
 ```
 
-Finally, to find out which versions of these libraries stack installed, we can ask stack to `list-dependencies`:
+Finally, to find out which versions of these libraries stack installed, we can ask stack to `ls dependencies`:
 
 ```
-michael@d30748af6d3d:~/helloworld$ stack list-dependencies
+michael@d30748af6d3d:~/helloworld$ stack ls dependencies
 # dependency output ...
 ```
 


### PR DESCRIPTION
This commit replaces a reference to `stack list-dependencies`, which generates a deprecation warning, with `stack ls dependencies`, which doesn't.