### PR TITLE
Fix (in part) #4204: Honour `NO_COLOR` variable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,8 @@ Other enhancements:
   plan construction errors much faster, and avoid some unnecessary
   work when only building a subset of packages. This is especially
   useful for the curator use case.
+* Adopt the standard proposed at http://no-color.org/, that color should not be
+  added by default if the `NO_COLOR` environment variable is present.
 * New command `stack ls stack-colors` lists the styles and the associated 'ANSI'
   control character sequences that stack uses to color some of its output. See
   `stack ls stack-colors --help` for more information.

--- a/src/unix/Stack/DefaultColorWhen.hs
+++ b/src/unix/Stack/DefaultColorWhen.hs
@@ -7,5 +7,12 @@ module Stack.DefaultColorWhen
 
 import Stack.Types.Runner (ColorWhen (ColorAuto))
 
+-- |The default adopts the standard proposed at http://no-color.org/, that color
+-- should not be added by default if the @NO_COLOR@ environment variable is
+-- present.
 defaultColorWhen :: IO ColorWhen
-defaultColorWhen = return ColorAuto
+defaultColorWhen =  do
+  mIsNoColor <- lookupEnv "NO_COLOR"
+  return $ case mIsNoColor of
+    Just _ -> ColorNever
+    _      -> ColorAuto


### PR DESCRIPTION
Adopt the standard proposed at http://no-color.org/, that colour should not be added by default if the `NO_COLOR` environment variable is present, by adapting `defaultColorWhen` in module `Stack.DefaultColorWhen` (which varies depending on whether the operating system is Windows or Unix-like).

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary. (Not necessary.)

Please also shortly describe how you tested your change. Bonus points for added tests!
Tested on Windows 10 by building - `stack test` - and using the built tool, as below:
![image](https://user-images.githubusercontent.com/14206448/44619988-62698780-a885-11e8-9a2c-1daa3d40d476.png)

