### PR TITLE
Repair PR #4260: Add imports to Stack.DefaultColorWhen

### DIFF
--- a/src/unix/Stack/DefaultColorWhen.hs
+++ b/src/unix/Stack/DefaultColorWhen.hs
@@ -5,7 +5,8 @@ module Stack.DefaultColorWhen
   ( defaultColorWhen
   ) where
 
-import Stack.Types.Runner (ColorWhen (ColorAuto))
+import Stack.Types.Runner (ColorWhen (ColorAuto, ColorNever))
+import System.Environment (lookupEnv)
 
 -- |The default adopts the standard proposed at http://no-color.org/, that color
 -- should not be added by default if the @NO_COLOR@ environment variable is


### PR DESCRIPTION
Merged #4260 was missing some imports in the unix version.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
Tested by building on macOS 10.13.6.
