### PR TITLE
Fix #4205 (step 6): Alias 'colour' for 'color'

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -57,6 +57,9 @@ Other enhancements:
   non-project-specific yaml configuration parameter, allows a stack user to
   redefine the default styles that stack uses to color some of its output. See
   `stack --help` for more information.
+* British English spelling of 'color' (colour) accepted as an alias for
+  `--color`, `--stack-colors`, `stack ls stack-colors` at the command line and
+  for `color:` and `stack-colors:` in yaml configuration files.
 * New build option `--ddump-dir`. (See [#4225](https://github.com/commercialhaskell/stack/issues/4225))
 * Stack parses and respects the `preferred-versions` information from
   Hackage for choosing latest version of a package in some cases,

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -955,6 +955,9 @@ The color use can also be set at the command line using the equivalent
 `--color=<WHEN>` global option. Color use set at the command line takes
 precedence over that set in a yaml configuration file.
 
+(The British English spelling (colour) is also accepted. In yaml configuration
+files, the American spelling is the alternative that has priority.)
+
 ### stack-colors
 
 Stack uses styles to format some of its output. The default styles do not work
@@ -983,4 +986,9 @@ terminal theme might wish to set the styles as follows:
 ```yaml
 stack-colors: error=31:good=32:shell=35:dir=34:recommendation=32:target=95:module=35:package-component=95
 ```
-The styles can also be set at the command line using the equivalent `--stack-colors=<STYLES>` global option. Styles set at the command line take precedence over those set in a yaml configuration file.
+The styles can also be set at the command line using the equivalent `--stack-colors=<STYLES>`
+global option. Styles set at the command line take precedence over those set in
+a yaml configuration file.
+
+(The British English spelling (colour) is also accepted. In yaml configuration
+files, the American spelling is the alternative that has priority.)

--- a/src/Stack/Ls.hs
+++ b/src/Stack/Ls.hs
@@ -132,7 +132,14 @@ lsStylesCmd :: OA.Mod OA.CommandFields LsCmds
 lsStylesCmd =
     OA.command
         "stack-colors"
-        (OA.info lsStylesOptsParser (OA.progDesc "View stack's output styles"))
+        (OA.info lsStylesOptsParser
+                 (OA.progDesc "View stack's output styles"))
+    <>
+    OA.command
+        "stack-colours"
+        (OA.info lsStylesOptsParser
+                 (OA.progDesc "View stack's output styles (alias for \
+                              \'stack-colors')"))
 
 data Snapshot = Snapshot
     { snapId :: Text

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -145,6 +145,7 @@ configOptsParser currentDir hide0 =
              hide)
     <*> optionalFirst (option readColorWhen
              ( long "color"
+            <> long "colour"
             <> metavar "WHEN"
             <> completeWith ["always", "never", "auto"]
             <> help "Specify when to use color in output; WHEN is 'always', \

--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -36,6 +36,7 @@ globalOptsParser currentDir kind defLogLevel =
         hide <*>
     option readStyles
          (long "stack-colors" <>
+          long "stack-colours" <>
           metavar "STYLES" <>
           value mempty <>
           help "Specify stack's output styles; STYLES is a colon-delimited \

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -854,8 +854,16 @@ parseConfigMonoidObject rootDir obj = do
     configMonoidDumpLogs <- First <$> obj ..:? configMonoidDumpLogsName
     configMonoidSaveHackageCreds <- First <$> obj ..:? configMonoidSaveHackageCredsName
     configMonoidHackageBaseUrl <- First <$> obj ..:? configMonoidHackageBaseUrlName
-    configMonoidColorWhen <- First <$> obj ..:? configMonoidColorWhenName
-    configMonoidStyles <- fromMaybe mempty <$> obj ..:? configMonoidStylesName
+
+    configMonoidColorWhenUS <- obj ..:? configMonoidColorWhenUSName
+    configMonoidColorWhenGB <- obj ..:? configMonoidColorWhenGBName
+    let configMonoidColorWhen =  First $   configMonoidColorWhenUS
+                                       <|> configMonoidColorWhenGB
+
+    configMonoidStylesUS <- obj ..:? configMonoidStylesUSName
+    configMonoidStylesGB <- obj ..:? configMonoidStylesGBName
+    let configMonoidStyles = fromMaybe mempty $   configMonoidStylesUS
+                                              <|> configMonoidStylesGB
 
     return ConfigMonoid {..}
   where
@@ -998,11 +1006,17 @@ configMonoidSaveHackageCredsName = "save-hackage-creds"
 configMonoidHackageBaseUrlName :: Text
 configMonoidHackageBaseUrlName = "hackage-base-url"
 
-configMonoidColorWhenName :: Text
-configMonoidColorWhenName = "color"
+configMonoidColorWhenUSName :: Text
+configMonoidColorWhenUSName = "color"
 
-configMonoidStylesName :: Text
-configMonoidStylesName = "stack-colors"
+configMonoidColorWhenGBName :: Text
+configMonoidColorWhenGBName = "colour"
+
+configMonoidStylesUSName :: Text
+configMonoidStylesUSName = "stack-colors"
+
+configMonoidStylesGBName :: Text
+configMonoidStylesGBName = "stack-colours"
 
 data ConfigException
   = ParseConfigFileException (Path Abs File) ParseException


### PR DESCRIPTION
This implements the final part of #4205. Although it is 'cosmetic', it is in the tradition of GHC and other Haskell tools (eg hlint) accepting alternative spellings.

This pull request allows the British English spelling of 'color' (colour) as aliases. Implemented at the command line for `--color`, `--stack-colors` and `stack ls stack-colors`. Implemented in yaml configuration files for `color:` and `stack-colors:` (in each case, the American spelling is the alternative that has priority).

The documentation in `yaml_configuration.md` is updated, accordingly.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
Tested on macOS 10.13.6 and on Windows 10 by building - `stack test` - and then using the built tool, including:
* `stack --help`
* `stack ls --help`
* `stack ls stack-colours --help`
* `stack --color=always --stack-colors=file=31 ls stack-colours` (and the equivalent using `config.yaml`)
* `stack --colour=always --stack-colours=file=31 ls stack-colors` (and the equivalent using `config.yaml`)