### PR TITLE
To prevent download ghc when using `stack clean`.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -96,7 +96,7 @@ Bug fixes:
 * Fix for git packages to update submodules to the correct state. See
   [#4314](https://github.com/commercialhaskell/stack/pull/4314)
 * Add `--cabal-files` flag to `stack ide targets` command.
-
+* Don't download ghc when using `stack clean`.
 
 ## v1.9.1
 

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -616,7 +616,7 @@ loadBuildConfig mproject maresolver mcompiler = do
                 LCSProject _ -> False
                 LCSNoConfig _ -> False
         , bcCurator = projectCurator project
-        , bcClean = False
+        , bcDownloadCompiler = WithDownloadCompiler
         }
   where
     getEmptyProject :: Maybe SnapshotLocation -> RIO Config Project

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -616,6 +616,7 @@ loadBuildConfig mproject maresolver mcompiler = do
                 LCSProject _ -> False
                 LCSNoConfig _ -> False
         , bcCurator = projectCurator project
+        , bcClean = False
         }
   where
     getEmptyProject :: Maybe SnapshotLocation -> RIO Config Project

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -11,6 +11,8 @@ module Stack.Runners
     , withMiniConfigAndLock
     , withBuildConfigAndLock
     , withBuildConfigAndLockNoDocker
+    , withBuildConfigAndLockInClean
+    , withBuildConfigAndLockNoDockerInClean
     , withBuildConfig
     , withBuildConfigExt
     , withBuildConfigDot
@@ -127,7 +129,7 @@ withBuildConfigAndLock
     -> (Maybe FileLock -> RIO EnvConfig ())
     -> IO ()
 withBuildConfigAndLock go inner =
-    withBuildConfigExt False go Nothing inner Nothing
+    withBuildConfigExt False False go Nothing inner Nothing
 
 -- | See issue #2010 for why this exists. Currently just used for the
 -- specific case of "stack clean --full".
@@ -136,7 +138,23 @@ withBuildConfigAndLockNoDocker
     -> (Maybe FileLock -> RIO EnvConfig ())
     -> IO ()
 withBuildConfigAndLockNoDocker go inner =
-    withBuildConfigExt True go Nothing inner Nothing
+    withBuildConfigExt True False go Nothing inner Nothing
+
+withBuildConfigAndLockInClean
+    :: GlobalOpts
+    -> (Maybe FileLock -> RIO EnvConfig ())
+    -> IO ()
+withBuildConfigAndLockInClean go inner =
+    withBuildConfigExt False True go Nothing inner Nothing
+
+-- | See issue #2010 for why this exists. Currently just used for the
+-- specific case of "stack clean --full".
+withBuildConfigAndLockNoDockerInClean
+    :: GlobalOpts
+    -> (Maybe FileLock -> RIO EnvConfig ())
+    -> IO ()
+withBuildConfigAndLockNoDockerInClean go inner =
+    withBuildConfigExt True True go Nothing inner Nothing
 
 withBuildConfigExt
     :: Bool

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -234,9 +234,9 @@ setupEnv mResolveMissingGHC = do
             , soptsGHCJSBootOpts = ["--clean"]
             }
 
-    (mghcBin, compilerBuild, _) <-
+    (mghcBin, mCompilerBuild, _) <-
       case bcDownloadCompiler bconfig of
-        SkipDownloadCompiler -> pure (Nothing, CompilerBuildStandard, False)
+        SkipDownloadCompiler -> return (Nothing, Nothing, False)
         WithDownloadCompiler -> ensureCompiler sopts
 
     -- Modify the initial environment to include the GHC path, if a local GHC
@@ -269,7 +269,7 @@ setupEnv mResolveMissingGHC = do
             { envConfigBuildConfig = bc
             , envConfigCabalVersion = cabalVer
             , envConfigCompilerVersion = compilerVer
-            , envConfigCompilerBuild = compilerBuild
+            , envConfigCompilerBuild = mCompilerBuild
             , envConfigLoadedSnapshot = ls
             }
 
@@ -356,7 +356,7 @@ setupEnv mResolveMissingGHC = do
             }
         , envConfigCabalVersion = cabalVer
         , envConfigCompilerVersion = compilerVer
-        , envConfigCompilerBuild = compilerBuild
+        , envConfigCompilerBuild = mCompilerBuild
         , envConfigLoadedSnapshot = ls
         }
 
@@ -374,7 +374,7 @@ addIncludeLib (ExtraDirs _bins includes libs) config = config
 -- | Ensure compiler (ghc or ghcjs) is installed and provide the PATHs to add if necessary
 ensureCompiler :: (HasConfig env, HasGHCVariant env)
                => SetupOpts
-               -> RIO env (Maybe ExtraDirs, CompilerBuild, Bool)
+               -> RIO env (Maybe ExtraDirs, Maybe CompilerBuild, Bool)
 ensureCompiler sopts = do
     let wc = whichCompiler (wantedToActual (soptsWantedCompiler sopts))
     when (getGhcVersion (wantedToActual (soptsWantedCompiler sopts)) < mkVersion [7, 8]) $ do
@@ -532,7 +532,7 @@ ensureCompiler sopts = do
 
     when (soptsSanityCheck sopts) $ withProcessContext menv $ sanityCheck wc
 
-    return (mpaths, compilerBuild, needLocal)
+    return (mpaths, Just compilerBuild, needLocal)
 
 -- | Determine which GHC builds to use depending on which shared libraries are available
 -- on the system.

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -234,7 +234,7 @@ setupEnv mResolveMissingGHC = do
             , soptsGHCJSBootOpts = ["--clean"]
             }
 
-    (mghcBin, compilerBuild, _) <- ensureCompiler sopts
+    (mghcBin, compilerBuild, _) <- if bcClean bconfig then pure (Nothing, CompilerBuildStandard, False) else ensureCompiler sopts
 
     -- Modify the initial environment to include the GHC path, if a local GHC
     -- is being used

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -234,7 +234,10 @@ setupEnv mResolveMissingGHC = do
             , soptsGHCJSBootOpts = ["--clean"]
             }
 
-    (mghcBin, compilerBuild, _) <- if bcClean bconfig then pure (Nothing, CompilerBuildStandard, False) else ensureCompiler sopts
+    (mghcBin, compilerBuild, _) <-
+      case bcDownloadCompiler bconfig of
+        SkipDownloadCompiler -> pure (Nothing, CompilerBuildStandard, False)
+        WithDownloadCompiler -> ensureCompiler sopts
 
     -- Modify the initial environment to include the GHC path, if a local GHC
     -- is being used

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -81,6 +81,8 @@ module Stack.Types.Config
   ,defaultLogLevel
   -- ** LoadConfig
   ,LoadConfig(..)
+  -- ** WithDocker
+  ,WithDocker(..)
 
   -- ** Project & ProjectAndConfigMonoid
   ,Project(..)
@@ -509,6 +511,10 @@ data BuildConfig = BuildConfig
     , bcCurator :: !(Maybe Curator)
     , bcClean :: !Bool
     }
+
+data WithDocker
+  = SkipDocker
+  | WithDocker
 
 stackYamlL :: HasBuildConfig env => Lens' env (Path Abs File)
 stackYamlL = buildConfigL.lens bcStackYaml (\x y -> x { bcStackYaml = y })

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -543,7 +543,7 @@ data EnvConfig = EnvConfig
     -- ^ The actual version of the compiler to be used, as opposed to
     -- 'wantedCompilerL', which provides the version specified by the
     -- build plan.
-    ,envConfigCompilerBuild :: !CompilerBuild
+    ,envConfigCompilerBuild :: !(Maybe CompilerBuild)
     ,envConfigLoadedSnapshot :: !LoadedSnapshot
     -- ^ The fully resolved snapshot information.
     }
@@ -1282,9 +1282,9 @@ platformGhcRelDir
     => m (Path Rel Dir)
 platformGhcRelDir = do
     ec <- view envConfigL
+    let cbSuffix = maybe "" compilerBuildSuffix $ envConfigCompilerBuild ec
     verOnly <- platformGhcVerOnlyRelDirStr
-    parseRelDir (mconcat [ verOnly
-                         , compilerBuildSuffix (envConfigCompilerBuild ec)])
+    parseRelDir (mconcat [ verOnly, cbSuffix ])
 
 -- | Relative directory for the platform and GHC identifier without GHC bindist build
 platformGhcVerOnlyRelDir

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -507,6 +507,7 @@ data BuildConfig = BuildConfig
       -- ^ Are we loading from the implicit global stack.yaml? This is useful
       -- for providing better error messages.
     , bcCurator :: !(Maybe Curator)
+    , bcClean :: !Bool
     }
 
 stackYamlL :: HasBuildConfig env => Lens' env (Path Abs File)

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -83,6 +83,8 @@ module Stack.Types.Config
   ,LoadConfig(..)
   -- ** WithDocker
   ,WithDocker(..)
+  -- ** WithDownloadCompiler
+  ,WithDownloadCompiler(..)
 
   -- ** Project & ProjectAndConfigMonoid
   ,Project(..)
@@ -509,12 +511,16 @@ data BuildConfig = BuildConfig
       -- ^ Are we loading from the implicit global stack.yaml? This is useful
       -- for providing better error messages.
     , bcCurator :: !(Maybe Curator)
-    , bcClean :: !Bool
+    , bcDownloadCompiler :: !WithDownloadCompiler
     }
 
 data WithDocker
   = SkipDocker
   | WithDocker
+
+data WithDownloadCompiler
+  = SkipDownloadCompiler
+  | WithDownloadCompiler
 
 stackYamlL :: HasBuildConfig env => Lens' env (Path Abs File)
 stackYamlL = buildConfigL.lens bcStackYaml (\x y -> x { bcStackYaml = y })

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -635,8 +635,8 @@ cleanCmd opts go =
   -- See issues #2010 and #3468 for why "stack clean --full" is not used
   -- within docker.
   case opts of
-    CleanFull{} -> withBuildConfigAndLockNoDocker go (const (clean opts))
-    CleanShallow{} -> withBuildConfigAndLock go (const (clean opts))
+    CleanFull{} -> withBuildConfigAndLockNoDockerInClean go (const (clean opts))
+    CleanShallow{} -> withBuildConfigAndLockInClean go (const (clean opts))
 
 -- | Helper for build and install commands
 buildCmd :: BuildOptsCLI -> GlobalOpts -> IO ()

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -964,7 +964,7 @@ imgDockerCmd (rebuild,images) go@GlobalOpts{..} = loadConfigWithOpts go $ \lc ->
     let mProjectRoot = lcProjectRoot lc
     withBuildConfigExt
         WithDocker
-        False
+        WithDownloadCompiler
         go
         Nothing
         (\lk ->

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -963,7 +963,7 @@ imgDockerCmd :: (Bool, [Text]) -> GlobalOpts -> IO ()
 imgDockerCmd (rebuild,images) go@GlobalOpts{..} = loadConfigWithOpts go $ \lc -> do
     let mProjectRoot = lcProjectRoot lc
     withBuildConfigExt
-        False
+        WithDocker
         False
         go
         Nothing

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -964,6 +964,7 @@ imgDockerCmd (rebuild,images) go@GlobalOpts{..} = loadConfigWithOpts go $ \lc ->
     let mProjectRoot = lcProjectRoot lc
     withBuildConfigExt
         False
+        False
         go
         Nothing
         (\lk ->

--- a/test/integration/tests/4181-clean-wo-dl-ghc/Main.hs
+++ b/test/integration/tests/4181-clean-wo-dl-ghc/Main.hs
@@ -1,0 +1,12 @@
+-- |
+-- The integration tests have no ghc present, initially. Stack should not
+-- require ghc present to run the `clean` command.
+
+import StackTest
+
+main :: IO ()
+main = do
+  -- `stack clean` should succeed even though there is no ghc available.
+  -- See the stack.yaml file for how this works.
+  stack ["clean"]
+  stack ["clean", "--full"]

--- a/test/integration/tests/4181-clean-wo-dl-ghc/files/foo.cabal
+++ b/test/integration/tests/4181-clean-wo-dl-ghc/files/foo.cabal
@@ -1,0 +1,13 @@
+cabal-version: >= 1.10
+
+-- This file has been generated from package.yaml by hpack version 0.29.6.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 941a1ab4bea2f0ee229dd6ab7fe9730517a0397fb9141fe2841a0f9748dbfd57
+
+name:           foo
+version:        0.1.0.0
+build-type:     Simple
+
+library

--- a/test/integration/tests/4181-clean-wo-dl-ghc/files/stack.yaml
+++ b/test/integration/tests/4181-clean-wo-dl-ghc/files/stack.yaml
@@ -1,0 +1,8 @@
+# Update the resolver as necessary
+resolver: ghc-8.22
+# Do not use the system ghc, as ghc must not be available
+system-ghc: false
+# Do not install any other ghc, as ghc must not be available
+install-ghc: false
+packages:
+- '.'


### PR DESCRIPTION
`stack clean` always download the ghc even if it already deleted.

```shell
$ stack --version
Version 1.10.0, Git revision 65dd1d673a75d867325bb1c70f5170386900dd80 (dirty) (6415 commits) x86_64 hpack-0.29.6

$ stack clean
Preparing to install GHC to an isolated location.
This will not interfere with any system-level installation.
Preparing to download ghc-7.10.2 ...^C
```



Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
