### PR TITLE
Avoid unnecessary recompilations

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -231,6 +231,7 @@ library:
   - Stack.Sig.Sign
   - Stack.Snapshot
   - Stack.Solver
+  - Stack.StoreTH
   - Stack.Types.Build
   - Stack.Types.BuildPlan
   - Stack.Types.CompilerBuild

--- a/package.yaml
+++ b/package.yaml
@@ -93,7 +93,7 @@ dependencies:
 - project-template
 - regex-applicative-text
 - resourcet
-- retry
+- retry >= 0.7
 - rio
 - semigroups
 - split
@@ -258,6 +258,7 @@ library:
   - Stack.Upgrade
   - Stack.Upload
   - Text.PrettyPrint.Leijen.Extended
+  - System.Permissions
   - System.Process.PagerEditor
   - System.Terminal
   when:

--- a/src/Data/Attoparsec/Interpreter.hs
+++ b/src/Data/Attoparsec/Interpreter.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 {- |  This module implements parsing of additional arguments embedded in a
       comment when stack is invoked as a script interpreter
 
@@ -145,11 +144,7 @@ getInterpreterArgs file = do
 
     decodeError e =
       case e of
-#if MIN_VERSION_conduit_extra(1,2,0)
         ParseError ctxs _ (Position line col _) ->
-#else
-        ParseError ctxs _ (Position line col) ->
-#endif
           if null ctxs
           then "Parse error"
           else ("Expecting " ++ intercalate " or " ctxs)

--- a/src/Data/Attoparsec/Interpreter.hs
+++ b/src/Data/Attoparsec/Interpreter.hs
@@ -62,7 +62,6 @@ import           Conduit
 import           Data.Conduit.Attoparsec
 import           Data.List (intercalate)
 import           Data.Text (pack)
-import           Stack.Constants
 import           Stack.Prelude
 import           System.FilePath (takeExtension)
 import           System.IO (stderr, hPutStrLn)

--- a/src/Network/HTTP/Download/Verified.hs
+++ b/src/Network/HTTP/Download/Verified.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -192,11 +191,7 @@ hashChecksToZipSink req = traverse_ (ZipSink . sinkCheckHash req)
 -- 'Control.Retry.recovering' customized for HTTP failures
 recoveringHttp :: forall env a. HasRunner env => RetryPolicy -> RIO env a -> RIO env a
 recoveringHttp retryPolicy =
-#if MIN_VERSION_retry(0,7,0)
     helper $ \run -> recovering retryPolicy (handlers run) . const
-#else
-    helper $ \run -> recovering retryPolicy (handlers run)
-#endif
   where
     helper :: (UnliftIO (RIO env) -> IO a -> IO a) -> RIO env a -> RIO env a
     helper wrapper action = withUnliftIO $ \run -> wrapper run (unliftIO run action)

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE DataKinds             #-}

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -42,18 +41,17 @@ import           Data.Char (ord)
 import qualified Data.Map as M
 import qualified Data.Set as Set
 import qualified Data.Store as Store
-import           Data.Store.VersionTagged
 import qualified Data.Text as T
 import           Path
 import           Path.IO
 import           Stack.Constants
 import           Stack.Constants.Config
+import           Stack.StoreTH
 import           Stack.Types.Build
 import           Stack.Types.Compiler
 import           Stack.Types.Config
 import           Stack.Types.GhcPkgId
 import           Stack.Types.NamedComponent
-import           Stack.Types.Package
 import qualified System.FilePath as FP
 
 -- | Directory containing files to mark an executable as installed
@@ -124,17 +122,17 @@ tryGetBuildCache :: HasEnvConfig env
                  => Path Abs Dir
                  -> NamedComponent
                  -> RIO env (Maybe (Map FilePath FileCacheInfo))
-tryGetBuildCache dir component = liftM (fmap buildCacheTimes) . $(versionedDecodeFile buildCacheVC) =<< buildCacheFile dir component
+tryGetBuildCache dir component = liftM (fmap buildCacheTimes) . decodeBuildCache =<< buildCacheFile dir component
 
 -- | Try to read the dirtiness cache for the given package directory.
 tryGetConfigCache :: HasEnvConfig env
                   => Path Abs Dir -> RIO env (Maybe ConfigCache)
-tryGetConfigCache dir = $(versionedDecodeFile configCacheVC) =<< configCacheFile dir
+tryGetConfigCache dir = decodeConfigCache =<< configCacheFile dir
 
 -- | Try to read the mod time of the cabal file from the last build
 tryGetCabalMod :: HasEnvConfig env
                => Path Abs Dir -> RIO env (Maybe ModTime)
-tryGetCabalMod dir = $(versionedDecodeFile modTimeVC) =<< configCabalMod dir
+tryGetCabalMod dir = decodeModTime =<< configCabalMod dir
 
 -- | Write the dirtiness cache for this package's files.
 writeBuildCache :: HasEnvConfig env
@@ -143,7 +141,7 @@ writeBuildCache :: HasEnvConfig env
                 -> Map FilePath FileCacheInfo -> RIO env ()
 writeBuildCache dir component times = do
     fp <- buildCacheFile dir component
-    $(versionedEncodeFile buildCacheVC) fp BuildCache
+    encodeBuildCache fp BuildCache
         { buildCacheTimes = times
         }
 
@@ -154,7 +152,7 @@ writeConfigCache :: HasEnvConfig env
                 -> RIO env ()
 writeConfigCache dir x = do
     fp <- configCacheFile dir
-    $(versionedEncodeFile configCacheVC) fp x
+    encodeConfigCache fp x
 
 -- | See 'tryGetCabalMod'
 writeCabalMod :: HasEnvConfig env
@@ -163,7 +161,7 @@ writeCabalMod :: HasEnvConfig env
               -> RIO env ()
 writeCabalMod dir x = do
     fp <- configCabalMod dir
-    $(versionedEncodeFile modTimeVC) fp x
+    encodeModTime fp x
 
 -- | Delete the caches for the project.
 deleteCaches :: (MonadIO m, MonadReader env m, HasEnvConfig env, MonadThrow m)
@@ -193,7 +191,7 @@ tryGetFlagCache :: HasEnvConfig env
                 -> RIO env (Maybe ConfigCache)
 tryGetFlagCache gid = do
     fp <- flagCacheFile gid
-    $(versionedDecodeFile configCacheVC) fp
+    decodeConfigCache fp
 
 writeFlagCache :: HasEnvConfig env
                => Installed
@@ -202,7 +200,7 @@ writeFlagCache :: HasEnvConfig env
 writeFlagCache gid cache = do
     file <- flagCacheFile gid
     ensureDir (parent file)
-    $(versionedEncodeFile configCacheVC) file cache
+    encodeConfigCache file cache
 
 -- | Mark a test suite as having succeeded
 setTestSuccess :: HasEnvConfig env
@@ -210,7 +208,7 @@ setTestSuccess :: HasEnvConfig env
                -> RIO env ()
 setTestSuccess dir = do
     fp <- testSuccessFile dir
-    $(versionedEncodeFile testSuccessVC) fp True
+    encodeTestSuccess fp True
 
 -- | Mark a test suite as not having succeeded
 unsetTestSuccess :: HasEnvConfig env
@@ -218,7 +216,7 @@ unsetTestSuccess :: HasEnvConfig env
                  -> RIO env ()
 unsetTestSuccess dir = do
     fp <- testSuccessFile dir
-    $(versionedEncodeFile testSuccessVC) fp False
+    encodeTestSuccess fp False
 
 -- | Check if the test suite already passed
 checkTestSuccess :: HasEnvConfig env
@@ -227,7 +225,7 @@ checkTestSuccess :: HasEnvConfig env
 checkTestSuccess dir =
     liftM
         (fromMaybe False)
-        ($(versionedDecodeFile testSuccessVC) =<< testSuccessFile dir)
+        (decodeTestSuccess =<< testSuccessFile dir)
 
 --------------------------------------
 -- Precompiled Cache
@@ -315,7 +313,7 @@ writePrecompiledCache baseConfigOpts loc copts depIDs mghcPkgId sublibs exes = d
       name <- parseRelFile $ T.unpack exe
       relPath <- stackRootRelative $ bcoSnapInstallRoot baseConfigOpts </> bindirSuffix </> name
       return $ toFilePath relPath
-  $(versionedEncodeFile precompiledCacheVC) file PrecompiledCache
+  encodePrecompiledCache file PrecompiledCache
       { pcLibrary = mlibpath
       , pcSubLibs = sublibpaths
       , pcExes = exes'
@@ -335,7 +333,7 @@ readPrecompiledCache :: forall env. HasEnvConfig env
                      -> RIO env (Maybe PrecompiledCache)
 readPrecompiledCache loc copts depIDs = do
     file <- precompiledCacheFile loc copts depIDs
-    mcache <- $(versionedDecodeFile precompiledCacheVC) file
+    mcache <- decodePrecompiledCache file
     maybe (pure Nothing) (fmap Just . mkAbs) mcache
   where
     -- Since commit ed9ccc08f327bad68dd2d09a1851ce0d055c0422,

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -39,9 +38,7 @@ import qualified Data.ByteArray as Mem (convert)
 import qualified Data.ByteString.Base64.URL as B64URL
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as S8
-#ifdef mingw32_HOST_OS
 import           Data.Char (ord)
-#endif
 import qualified Data.Map as M
 import qualified Data.Set as Set
 import qualified Data.Store as Store
@@ -359,8 +356,9 @@ readPrecompiledCache loc copts depIDs = do
 
 -- | Check if a filesystem path is too long.
 pathTooLong :: FilePath -> Bool
-#ifdef mingw32_HOST_OS
-pathTooLong path = utf16StringLength path >= win32MaxPath
+pathTooLong
+  | osIsWindows = \path -> utf16StringLength path >= win32MaxPath
+  | otherwise = const False
   where
     win32MaxPath = 260
     -- Calculate the length of a string in 16-bit units
@@ -370,6 +368,3 @@ pathTooLong path = utf16StringLength path >= win32MaxPath
       where
         utf16CharLength c | ord c < 0x10000 = 1
                           | otherwise       = 2
-#else
-pathTooLong _ = False
-#endif

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -49,6 +49,7 @@ import           Data.Store.VersionTagged
 import qualified Data.Text as T
 import           Path
 import           Path.IO
+import           Stack.Constants
 import           Stack.Constants.Config
 import           Stack.Types.Build
 import           Stack.Types.Compiler
@@ -61,8 +62,8 @@ import qualified System.FilePath as FP
 -- | Directory containing files to mark an executable as installed
 exeInstalledDir :: (MonadReader env m, HasEnvConfig env, MonadThrow m)
                 => InstallLocation -> m (Path Abs Dir)
-exeInstalledDir Snap = (</> $(mkRelDir "installed-packages")) `liftM` installationRootDeps
-exeInstalledDir Local = (</> $(mkRelDir "installed-packages")) `liftM` installationRootLocal
+exeInstalledDir Snap = (</> relDirInstalledPackages) `liftM` installationRootDeps
+exeInstalledDir Local = (</> relDirInstalledPackages) `liftM` installationRootLocal
 
 -- | Get all of the installed executables
 getInstalledExes :: (MonadReader env m, HasEnvConfig env, MonadIO m, MonadThrow m)
@@ -268,7 +269,7 @@ precompiledCacheFile loc copts installedPackageIDs = do
   platformRelDir <- platformGhcRelDir
   let precompiledDir =
             view stackRootL ec
-        </> $(mkRelDir "precompiled")
+        </> relDirPrecompiled
         </> platformRelDir
         </> compiler
         </> cabal

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE RankNTypes            #-}

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
@@ -43,7 +42,6 @@ import           Data.Conduit.Process.Typed
                      createPipe, runProcess_, getStdout,
                      getStderr, createSource)
 import qualified Data.Conduit.Text as CT
-import           Data.FileEmbed (embedFile, makeRelativeToProject)
 import           Data.IORef.RunOnce (runOnce)
 import           Data.List hiding (any)
 import qualified Data.Map.Strict as M
@@ -228,11 +226,6 @@ buildSetupArgs =
      , "StackSetupShim.mainOverride"
      ]
 
-setupGhciShimCode :: S.ByteString
-setupGhciShimCode = $(do
-    path <- makeRelativeToProject "src/setup-shim/StackSetupShim.hs"
-    embedFile path)
-
 simpleSetupCode :: S.ByteString
 simpleSetupCode = "import Distribution.Simple\nmain = defaultMain"
 
@@ -274,7 +267,7 @@ getSetupExe setupHs setupShimHs tmpdir = do
             baseNameS ++ ".jsexe"
         setupDir =
             view stackRootL config </>
-            $(mkRelDir "setup-exe-cache") </>
+            relDirSetupExeCache </>
             platformDir
 
     exePath <- (setupDir </>) <$> parseRelFile exeNameS
@@ -333,7 +326,7 @@ withExecuteEnv bopts boptsCli baseConfigOpts locals globalPackages snapshotPacka
         -- Create files for simple setup and setup shim, if necessary
         let setupSrcDir =
                 view stackRootL config </>
-                $(mkRelDir "setup-exe-src")
+                relDirSetupExeSrc
         ensureDir setupSrcDir
         setupFileName <- parseRelFile ("setup-" ++ simpleSetupHash ++ ".hs")
         let setupHs = setupSrcDir </> setupFileName
@@ -864,7 +857,7 @@ ensureConfig newConfigCache pkgDir ExecuteEnv {..} announce cabal cabalfp task =
     -- with autoreconf -i. See:
     -- https://github.com/commercialhaskell/stack/issues/3534
     ensureConfigureScript = do
-      let fp = pkgDir </> $(mkRelFile "configure")
+      let fp = pkgDir </> relFileConfigure
       exists <- doesFileExist fp
       unless exists $ do
         logInfo $ "Trying to generate configure with autoreconf in " <> fromString (toFilePath pkgDir)
@@ -951,7 +944,7 @@ withSingleContext ActionContext {..} ExecuteEnv {..} task@Task {..} mdeps msuffi
 
                 -- See: https://github.com/fpco/stack/issues/157
                 distDir <- distRelativeDir
-                let oldDist = dir </> $(mkRelDir "dist")
+                let oldDist = dir </> relDirDist
                     newDist = dir </> distDir
                 exists <- doesDirExist oldDist
                 when exists $ do
@@ -1086,7 +1079,7 @@ withSingleContext ActionContext {..} ExecuteEnv {..} task@Task {..} mdeps msuffi
                             let depsArgs = map fst matchedDeps
                             -- Generate setup_macros.h and provide it to ghc
                             let macroDeps = mapMaybe snd matchedDeps
-                                cppMacrosFile = toFilePath $ setupDir </> $(mkRelFile "setup_macros.h")
+                                cppMacrosFile = toFilePath $ setupDir </> relFileSetupMacrosH
                                 cppArgs = ["-optP-include", "-optP" ++ cppMacrosFile]
                             liftIO $ S.writeFile cppMacrosFile (encodeUtf8 (T.pack (C.generatePackageVersionMacros macroDeps)))
                             return (packageDBArgs ++ depsArgs ++ cppArgs)
@@ -1193,8 +1186,8 @@ withSingleContext ActionContext {..} ExecuteEnv {..} task@Task {..} mdeps msuffi
                 Left setupExe -> return setupExe
                 Right setuphs -> do
                     distDir <- distDirFromDir pkgDir
-                    let setupDir = distDir </> $(mkRelDir "setup")
-                        outputFile = setupDir </> $(mkRelFile "setup")
+                    let setupDir = distDir </> relDirSetup
+                        outputFile = setupDir </> relFileSetupLower
                     customBuilt <- liftIO $ readIORef eeCustomBuilt
                     if Set.member (packageName package) customBuilt
                         then return outputFile
@@ -1662,7 +1655,7 @@ checkExeStatus
     -> RIO env (Text, ExecutableBuildStatus)
 checkExeStatus compiler platform distDir name = do
     exename <- parseRelDir (T.unpack name)
-    exists <- checkPath (distDir </> $(mkRelDir "build") </> exename)
+    exists <- checkPath (distDir </> relDirBuild </> exename)
     pure
         ( name
         , if exists
@@ -1984,8 +1977,8 @@ getSetupHs dir = do
                 then return fp2
                 else throwM $ NoSetupHsFound dir
   where
-    fp1 = dir </> $(mkRelFile "Setup.hs")
-    fp2 = dir </> $(mkRelFile "Setup.lhs")
+    fp1 = dir </> relFileSetupHs
+    fp2 = dir </> relFileSetupLhs
 
 -- Do not pass `-hpcdir` as GHC option if the coverage is not enabled.
 -- This helps running stack-compiled programs with dynamic interpreters like `hint`.

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
 
 -- | Generate haddocks
 module Stack.Build.Haddock
@@ -26,6 +25,7 @@ import           Data.Time (UTCTime)
 import           Path
 import           Path.Extra
 import           Path.IO
+import           Stack.Constants
 import           Stack.PackageDump
 import           Stack.PrettyPrint
 import           Stack.Types.Build
@@ -283,7 +283,7 @@ lookupDumpPackage ghcPkgId dumpPkgs =
 
 -- | Path of haddock index file.
 haddockIndexFile :: Path Abs Dir -> Path Abs File
-haddockIndexFile destDir = destDir </> $(mkRelFile "index.html")
+haddockIndexFile destDir = destDir </> relFileIndexHtml
 
 -- | Path of local packages documentation directory.
 localDocDir :: BaseConfigOpts -> Path Abs Dir
@@ -291,7 +291,7 @@ localDocDir bco = bcoLocalInstallRoot bco </> docDirSuffix
 
 -- | Path of documentation directory for the dependencies of local packages
 localDepsDocDir :: BaseConfigOpts -> Path Abs Dir
-localDepsDocDir bco = localDocDir bco </> $(mkRelDir "all")
+localDepsDocDir bco = localDocDir bco </> relDirAll
 
 -- | Path of snapshot packages documentation directory.
 snapDocDir :: BaseConfigOpts -> Path Abs Dir

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -5,14 +5,10 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE TupleSections #-}
 
 -- | The general Stack configuration that starts everything off. This should

--- a/src/Stack/Config/Docker.hs
+++ b/src/Stack/Config/Docker.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP, DeriveDataTypeable, RecordWildCards #-}
+{-# LANGUAGE DeriveDataTypeable, RecordWildCards #-}
 
 -- | Docker configuration
 module Stack.Config.Docker where

--- a/src/Stack/Config/Docker.hs
+++ b/src/Stack/Config/Docker.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP, DeriveDataTypeable, RecordWildCards, TemplateHaskell #-}
+{-# LANGUAGE CPP, DeriveDataTypeable, RecordWildCards #-}
 
 -- | Docker configuration
 module Stack.Config.Docker where
@@ -11,6 +11,7 @@ import qualified Data.Text as T
 import           Data.Text.Read (decimal)
 import           Distribution.Version (simplifyVersionRange)
 import           Path
+import           Stack.Constants
 import           Stack.Types.Version
 import           Stack.Types.Config
 import           Stack.Types.Docker
@@ -78,7 +79,7 @@ dockerOptsFromMonoid mproject stackRoot maresolver DockerOptsMonoid{..} = do
         dockerSetUser = getFirst dockerMonoidSetUser
         dockerRequireDockerVersion =
             simplifyVersionRange (getIntersectingVersionRange dockerMonoidRequireDockerVersion)
-        dockerDatabasePath = fromFirst (stackRoot </> $(mkRelFile "docker.db")) dockerMonoidDatabasePath
+        dockerDatabasePath = fromFirst (stackRoot </> relFileDockerDb) dockerMonoidDatabasePath
         dockerStackExe = getFirst dockerMonoidStackExe
 
     return DockerOpts{..}

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -118,7 +118,7 @@ module Stack.Constants
     ,relFileStackDotExe
     ,relFileStackDotTmpDotExe
     ,relFileStackDotTmp
-    ,defaultTemplateName
+    ,ghcShowOptionsOutput
     )
     where
 
@@ -127,11 +127,12 @@ import           Data.FileEmbed (embedFile, makeRelativeToProject)
 import qualified Data.Set as Set
 import           Distribution.Package (mkPackageName)
 import qualified Hpack.Config as Hpack
+import qualified Language.Haskell.TH.Syntax as TH (runIO, lift)
 import           Path as FL
 import           Stack.Prelude
 import           Stack.Types.Compiler
-import           Stack.Types.TemplateName
 import           System.Permissions (osIsWindows)
+import           System.Process (readProcess)
 
 -- | Extensions used for Haskell modules. Excludes preprocessor ones.
 haskellFileExts :: [Text]
@@ -584,6 +585,8 @@ relFileStackDotTmp = $(mkRelFile "stack.tmp")
 relFileStack :: Path Rel File
 relFileStack = $(mkRelFile "stack")
 
--- | The default template name you can use if you don't have one.
-defaultTemplateName :: TemplateName
-defaultTemplateName = $(mkTemplateName "new-template")
+-- Technically, we should be consulting the user's current ghc,
+-- but that would require loading up a BuildConfig.
+ghcShowOptionsOutput :: [String]
+ghcShowOptionsOutput =
+  $(TH.runIO (readProcess "ghc" ["--show-options"] "") >>= TH.lift . lines)

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-} -- keep TH usage here
@@ -132,6 +131,7 @@ import           Path as FL
 import           Stack.Prelude
 import           Stack.Types.Compiler
 import           Stack.Types.TemplateName
+import           System.Permissions (osIsWindows)
 
 -- | Extensions used for Haskell modules. Excludes preprocessor ones.
 haskellFileExts :: [Text]
@@ -324,15 +324,6 @@ maxTerminalWidth = 200
 -- automatically detect it and when the user doesn't supply one.
 defaultTerminalWidth :: Int
 defaultTerminalWidth = 100
-
--- | True if using Windows OS.
-osIsWindows :: Bool
-osIsWindows =
-#ifdef WINDOWS
-  True
-#else
-  False
-#endif
 
 relFileSetupHs :: Path Rel File
 relFileSetupHs = $(mkRelFile "Setup.hs")

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell #-} -- keep TH usage here
 
 -- | Constants used throughout the project.
 
@@ -17,7 +17,6 @@ module Stack.Constants
     ,deprecatedStackRootOptionName
     ,inContainerEnvVar
     ,inNixShellEnvVar
-    ,stackProgName
     ,stackProgNameUpper
     ,wiredInPackages
     ,ghcjsBootPackages
@@ -35,15 +34,104 @@ module Stack.Constants
     ,maxTerminalWidth
     ,defaultTerminalWidth
     ,osIsWindows
+    ,relFileSetupHs
+    ,relFileSetupLhs
+    ,relFileHpackPackageConfig
+    ,relDirGlobalAutogen
+    ,relDirAutogen
+    ,relDirLogs
+    ,relFileCabalMacrosH
+    ,relDirBuild
+    ,relDirBin
+    ,relDirPantry
+    ,relDirPrograms
+    ,relDirUpperPrograms
+    ,relDirStackProgName
+    ,relDirStackWork
+    ,relFileReadmeTxt
+    ,relDirScript
+    ,relFileConfigYaml
+    ,relFileInstalledCacheBin
+    ,relDirSnapshots
+    ,relDirGlobalHints
+    ,relFileGlobalHintsYaml
+    ,relDirInstall
+    ,relDirCompilerTools
+    ,relDirHoogle
+    ,relFileDatabaseHoo
+    ,relDirPkgdb
+    ,relDirFlagCache
+    ,relDirLoadedSnapshotCache
+    ,bindirSuffix
+    ,docDirSuffix
+    ,relDirHpc
+    ,relDirLib
+    ,relDirShare
+    ,relDirLibexec
+    ,relDirEtc
+    ,setupGhciShimCode
+    ,relDirSetupExeCache
+    ,relDirSetupExeSrc
+    ,relFileConfigure
+    ,relDirDist
+    ,relFileSetupMacrosH
+    ,relDirSetup
+    ,relFileSetupLower
+    ,relDirMingw
+    ,relDirMingw32
+    ,relDirMingw64
+    ,relDirLocal
+    ,relDirUsr
+    ,relDirInclude
+    ,relFileDockerDb
+    ,relFileIndexHtml
+    ,relDirAll
+    ,relFilePackageCache
+    ,relFileDockerfile
+    ,relDirHaskellStackGhci
+    ,relFileGhciScript
+    ,relFileLockfile
+    ,relDirCombined
+    ,relFileHpcIndexHtml
+    ,relDirCustom
+    ,relDirPackageConfInplace
+    ,relDirExtraTixFiles
+    ,relDirInstalledPackages
+    ,relDirPrecompiled
+    ,backupUrlRelPath
+    ,relDirDotLocal
+    ,relDirDotSsh
+    ,relDirDotStackProgName
+    ,relDirUnderHome
+    ,relDirSrc
+    ,relFileLibtinfoSo5
+    ,relFileLibtinfoSo6
+    ,relFileLibncurseswSo6
+    ,relFileLibgmpSo10
+    ,relFileLibgmpSo3
+    ,relDirNewCabal
+    ,relFileSetupExe
+    ,relFileSetupUpper
+    ,relFile7zexe
+    ,relFile7zdll
+    ,relFileMainHs
+    ,relFileStack
+    ,relFileStackDotExe
+    ,relFileStackDotTmpDotExe
+    ,relFileStackDotTmp
+    ,defaultTemplateName
     )
     where
 
 import           Data.Char (toUpper)
+import           Data.FileEmbed (embedFile, makeRelativeToProject)
 import qualified Data.Set as Set
 import           Distribution.Package (mkPackageName)
+import qualified Hpack.Config as Hpack
 import           Path as FL
 import           Stack.Prelude
 import           Stack.Types.Compiler
+import           Stack.Types.TemplateName
 
 -- | Extensions used for Haskell modules. Excludes preprocessor ones.
 haskellFileExts :: [Text]
@@ -56,10 +144,6 @@ haskellPreprocessorExts = ["gc", "chs", "hsc", "x", "y", "ly", "cpphs"]
 -- | Name of the 'stack' program, uppercased
 stackProgNameUpper :: String
 stackProgNameUpper = map toUpper stackProgName
-
--- | Name of the 'stack' program.
-stackProgName :: String
-stackProgName = "stack"
 
 -- | The filename used for the stack config file.
 stackDotYaml :: Path Rel File
@@ -249,3 +333,266 @@ osIsWindows =
 #else
   False
 #endif
+
+relFileSetupHs :: Path Rel File
+relFileSetupHs = $(mkRelFile "Setup.hs")
+
+relFileSetupLhs :: Path Rel File
+relFileSetupLhs = $(mkRelFile "Setup.lhs")
+
+relFileHpackPackageConfig :: Path Rel File
+relFileHpackPackageConfig = $(mkRelFile Hpack.packageConfig)
+
+relDirGlobalAutogen :: Path Rel Dir
+relDirGlobalAutogen = $(mkRelDir "global-autogen")
+
+relDirAutogen :: Path Rel Dir
+relDirAutogen = $(mkRelDir "autogen")
+
+relDirLogs :: Path Rel Dir
+relDirLogs = $(mkRelDir "logs")
+
+relFileCabalMacrosH :: Path Rel File
+relFileCabalMacrosH = $(mkRelFile "cabal_macros.h")
+
+relDirBuild :: Path Rel Dir
+relDirBuild = $(mkRelDir "build")
+
+relDirBin :: Path Rel Dir
+relDirBin = $(mkRelDir "bin")
+
+relDirPantry :: Path Rel Dir
+relDirPantry = $(mkRelDir "pantry")
+
+relDirPrograms :: Path Rel Dir
+relDirPrograms = $(mkRelDir "programs")
+
+relDirUpperPrograms :: Path Rel Dir
+relDirUpperPrograms = $(mkRelDir "Programs")
+
+relDirStackProgName :: Path Rel Dir
+relDirStackProgName = $(mkRelDir stackProgName)
+
+relDirStackWork :: Path Rel Dir
+relDirStackWork = $(mkRelDir ".stack-work")
+
+relFileReadmeTxt :: Path Rel File
+relFileReadmeTxt = $(mkRelFile "README.txt")
+
+relDirScript :: Path Rel Dir
+relDirScript = $(mkRelDir "script")
+
+relFileConfigYaml :: Path Rel File
+relFileConfigYaml = $(mkRelFile "config.yaml")
+
+relFileInstalledCacheBin :: Path Rel File
+relFileInstalledCacheBin = $(mkRelFile "installed-cache.bin")
+
+relDirSnapshots :: Path Rel Dir
+relDirSnapshots = $(mkRelDir "snapshots")
+
+relDirGlobalHints :: Path Rel Dir
+relDirGlobalHints = $(mkRelDir "global-hints")
+
+relFileGlobalHintsYaml :: Path Rel File
+relFileGlobalHintsYaml = $(mkRelFile "global-hints.yaml")
+
+relDirInstall :: Path Rel Dir
+relDirInstall = $(mkRelDir "install")
+
+relDirCompilerTools :: Path Rel Dir
+relDirCompilerTools = $(mkRelDir "compiler-tools")
+
+relDirHoogle :: Path Rel Dir
+relDirHoogle = $(mkRelDir "hoogle")
+
+relFileDatabaseHoo :: Path Rel File
+relFileDatabaseHoo = $(mkRelFile "database.hoo")
+
+relDirPkgdb :: Path Rel Dir
+relDirPkgdb = $(mkRelDir "pkgdb")
+
+relDirFlagCache :: Path Rel Dir
+relDirFlagCache = $(mkRelDir "flag-cache")
+
+relDirLoadedSnapshotCache :: Path Rel Dir
+relDirLoadedSnapshotCache = $(mkRelDir "loaded-snapshot-cached")
+
+-- | Suffix applied to an installation root to get the bin dir
+bindirSuffix :: Path Rel Dir
+bindirSuffix = relDirBin
+
+-- | Suffix applied to an installation root to get the doc dir
+docDirSuffix :: Path Rel Dir
+docDirSuffix = $(mkRelDir "doc")
+
+relDirHpc :: Path Rel Dir
+relDirHpc = $(mkRelDir "hpc")
+
+relDirLib :: Path Rel Dir
+relDirLib = $(mkRelDir "lib")
+
+relDirShare :: Path Rel Dir
+relDirShare = $(mkRelDir "share")
+
+relDirLibexec :: Path Rel Dir
+relDirLibexec = $(mkRelDir "libexec")
+
+relDirEtc :: Path Rel Dir
+relDirEtc = $(mkRelDir "etc")
+
+setupGhciShimCode :: ByteString
+setupGhciShimCode = $(do
+    path <- makeRelativeToProject "src/setup-shim/StackSetupShim.hs"
+    embedFile path)
+
+relDirSetupExeCache :: Path Rel Dir
+relDirSetupExeCache = $(mkRelDir "setup-exe-cache")
+
+relDirSetupExeSrc :: Path Rel Dir
+relDirSetupExeSrc = $(mkRelDir "setup-exe-src")
+
+relFileConfigure :: Path Rel File
+relFileConfigure = $(mkRelFile "configure")
+
+relDirDist :: Path Rel Dir
+relDirDist = $(mkRelDir "dist")
+
+relFileSetupMacrosH :: Path Rel File
+relFileSetupMacrosH = $(mkRelFile "setup_macros.h")
+
+relDirSetup :: Path Rel Dir
+relDirSetup = $(mkRelDir "setup")
+
+relFileSetupLower :: Path Rel File
+relFileSetupLower = $(mkRelFile "setup")
+
+relDirMingw :: Path Rel Dir
+relDirMingw = $(mkRelDir "mingw")
+
+relDirMingw32 :: Path Rel Dir
+relDirMingw32 = $(mkRelDir "mingw32")
+
+relDirMingw64 :: Path Rel Dir
+relDirMingw64 = $(mkRelDir "mingw64")
+
+relDirLocal :: Path Rel Dir
+relDirLocal = $(mkRelDir "local")
+
+relDirUsr :: Path Rel Dir
+relDirUsr = $(mkRelDir "usr")
+
+relDirInclude :: Path Rel Dir
+relDirInclude = $(mkRelDir "include")
+
+relFileDockerDb :: Path Rel File
+relFileDockerDb = $(mkRelFile "docker.db")
+
+relFileIndexHtml :: Path Rel File
+relFileIndexHtml = $(mkRelFile "index.html")
+
+relDirAll :: Path Rel Dir
+relDirAll = $(mkRelDir "all")
+
+relFilePackageCache :: Path Rel File
+relFilePackageCache = $(mkRelFile "package.cache")
+
+relFileDockerfile :: Path Rel File
+relFileDockerfile = $(mkRelFile "Dockerfile")
+
+relDirHaskellStackGhci :: Path Rel Dir
+relDirHaskellStackGhci = $(mkRelDir "haskell-stack-ghci")
+
+relFileGhciScript :: Path Rel File
+relFileGhciScript = $(mkRelFile "ghci-script")
+
+relFileLockfile :: Path Rel File
+relFileLockfile = $(mkRelFile "lockfile")
+
+relDirCombined :: Path Rel Dir
+relDirCombined = $(mkRelDir "combined")
+
+relFileHpcIndexHtml :: Path Rel File
+relFileHpcIndexHtml = $(mkRelFile "hpc_index.html")
+
+relDirCustom :: Path Rel Dir
+relDirCustom = $(mkRelDir "custom")
+
+relDirPackageConfInplace :: Path Rel Dir
+relDirPackageConfInplace = $(mkRelDir "package.conf.inplace")
+
+relDirExtraTixFiles :: Path Rel Dir
+relDirExtraTixFiles = $(mkRelDir "extra-tix-files")
+
+relDirInstalledPackages :: Path Rel Dir
+relDirInstalledPackages = $(mkRelDir "installed-packages")
+
+relDirPrecompiled :: Path Rel Dir
+relDirPrecompiled = $(mkRelDir "precompiled")
+
+backupUrlRelPath :: Path Rel File
+backupUrlRelPath = $(mkRelFile "downloaded.template.file.hsfiles")
+
+relDirDotLocal :: Path Rel Dir
+relDirDotLocal = $(mkRelDir ".local")
+
+relDirDotSsh :: Path Rel Dir
+relDirDotSsh = $(mkRelDir ".ssh")
+
+relDirDotStackProgName :: Path Rel Dir
+relDirDotStackProgName = $(mkRelDir ('.' : stackProgName))
+
+relDirUnderHome :: Path Rel Dir
+relDirUnderHome = $(mkRelDir "_home")
+
+relDirSrc :: Path Rel Dir
+relDirSrc = $(mkRelDir "src")
+
+relFileLibtinfoSo5 :: Path Rel File
+relFileLibtinfoSo5 = $(mkRelFile "libtinfo.so.5")
+
+relFileLibtinfoSo6 :: Path Rel File
+relFileLibtinfoSo6 = $(mkRelFile "libtinfo.so.6")
+
+relFileLibncurseswSo6 :: Path Rel File
+relFileLibncurseswSo6 = $(mkRelFile "libncursesw.so.6")
+
+relFileLibgmpSo10 :: Path Rel File
+relFileLibgmpSo10 = $(mkRelFile "libgmp.so.10")
+
+relFileLibgmpSo3 :: Path Rel File
+relFileLibgmpSo3 = $(mkRelFile "libgmp.so.3")
+
+relDirNewCabal :: Path Rel Dir
+relDirNewCabal = $(mkRelDir "new-cabal")
+
+relFileSetupExe :: Path Rel File
+relFileSetupExe = $(mkRelFile "Setup.exe")
+
+relFileSetupUpper :: Path Rel File
+relFileSetupUpper = $(mkRelFile "Setup")
+
+relFile7zexe :: Path Rel File
+relFile7zexe = $(mkRelFile "7z.exe")
+
+relFile7zdll :: Path Rel File
+relFile7zdll = $(mkRelFile "7z.dll")
+
+relFileMainHs :: Path Rel File
+relFileMainHs = $(mkRelFile "Main.hs")
+
+relFileStackDotExe :: Path Rel File
+relFileStackDotExe = $(mkRelFile "stack.exe")
+
+relFileStackDotTmpDotExe :: Path Rel File
+relFileStackDotTmpDotExe = $(mkRelFile "stack.tmp.exe")
+
+relFileStackDotTmp :: Path Rel File
+relFileStackDotTmp = $(mkRelFile "stack.tmp")
+
+relFileStack :: Path Rel File
+relFileStack = $(mkRelFile "stack")
+
+-- | The default template name you can use if you don't have one.
+defaultTemplateName :: TemplateName
+defaultTemplateName = $(mkTemplateName "new-template")

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE TupleSections         #-}
 
 -- | Generate HPC (Haskell Program Coverage) reports

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE TupleSections         #-}
@@ -35,6 +34,7 @@ import           Path.Extra (toFilePathNoTrailingSep)
 import           Path.IO
 import           Stack.Build.Target
 import           Stack.Config (getLocalPackages)
+import           Stack.Constants
 import           Stack.Constants.Config
 import           Stack.Package
 import           Stack.PrettyPrint
@@ -194,7 +194,7 @@ generateHpcReportInternal tixSrc reportDir report extraMarkupArgs extraReportArg
                     generateHpcErrorReport reportDir (msg True)
                     return Nothing
                 else do
-                    let reportPath = reportDir </> $(mkRelFile "hpc_index.html")
+                    let reportPath = reportDir </> relFileHpcIndexHtml
                     -- Print output, stripping @\r@ characters because Windows.
                     forM_ outputLines (logInfo . displayBytesUtf8)
                     -- Generate the markup.
@@ -261,7 +261,7 @@ generateHpcReportForTargets opts = do
         throwString "Not generating combined report, because no targets or tix files are specified."
     outputDir <- hpcReportDir
     reportDir <- case hroptsDestDir opts of
-        Nothing -> return (outputDir </> $(mkRelDir "combined/custom"))
+        Nothing -> return (outputDir </> relDirCombined </> relDirCustom)
         Just destDir -> do
             dest <- resolveDir' destDir
             ensureDir dest
@@ -287,7 +287,7 @@ generateHpcUnifiedReport = do
             return (filter ((".tix" `isSuffixOf`) . toFilePath) files)
     extraTixFiles <- findExtraTixFiles
     let tixFiles = tixFiles0  ++ extraTixFiles
-        reportDir = outputDir </> $(mkRelDir "combined/all")
+        reportDir = outputDir </> relDirCombined </> relDirAll
     if length tixFiles < 2
         then logInfo $
             (if null tixFiles then "No tix files" else "Only one tix file") <>
@@ -342,13 +342,13 @@ unionTixes tixes = (Map.keys errs, Tix (Map.elems outputs))
 generateHpcMarkupIndex :: HasEnvConfig env => RIO env ()
 generateHpcMarkupIndex = do
     outputDir <- hpcReportDir
-    let outputFile = outputDir </> $(mkRelFile "index.html")
+    let outputFile = outputDir </> relFileIndexHtml
     ensureDir outputDir
     (dirs, _) <- listDir outputDir
     rows <- liftM (catMaybes . concat) $ forM dirs $ \dir -> do
         (subdirs, _) <- listDir dir
         forM subdirs $ \subdir -> do
-            let indexPath = subdir </> $(mkRelFile "hpc_index.html")
+            let indexPath = subdir </> relFileHpcIndexHtml
             exists' <- doesFileExist indexPath
             if not exists' then return Nothing else do
                 relPath <- stripProperPrefix outputDir indexPath
@@ -395,7 +395,7 @@ generateHpcMarkupIndex = do
 generateHpcErrorReport :: MonadIO m => Path Abs Dir -> Utf8Builder -> m ()
 generateHpcErrorReport dir err = do
     ensureDir dir
-    let fp = toFilePath (dir </> $(mkRelFile "hpc_index.html"))
+    let fp = toFilePath (dir </> relFileHpcIndexHtml)
     writeFileUtf8Builder fp $
         "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>" <>
         "<h1>HPC Report Generation Error</h1>" <>
@@ -431,7 +431,7 @@ findPackageFieldForBuiltPackage
     -> RIO env (Either Text [Text])
 findPackageFieldForBuiltPackage pkgDir pkgId internalLibs field = do
     distDir <- distDirFromDir pkgDir
-    let inplaceDir = distDir </> $(mkRelDir "package.conf.inplace")
+    let inplaceDir = distDir </> relDirPackageConfInplace
         pkgIdStr = packageIdentifierString pkgId
         notFoundErr = return $ Left $ "Failed to find package key for " <> T.pack pkgIdStr
         extractField path = do
@@ -488,7 +488,7 @@ displayReportPath report reportPath =
 findExtraTixFiles :: HasEnvConfig env => RIO env [Path Abs File]
 findExtraTixFiles = do
     outputDir <- hpcReportDir
-    let dir = outputDir </> $(mkRelDir "extra-tix-files")
+    let dir = outputDir </> relDirExtraTixFiles
     dirExists <- doesDirExist dir
     if dirExists
         then do

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -66,6 +66,7 @@ import           System.IO.Unsafe (unsafePerformIO)
 import qualified System.PosixCompat.User as User
 import qualified System.PosixCompat.Files as Files
 import           System.Process.PagerEditor (editByteString)
+import           System.Terminal (hIsTerminalDeviceOrMinTTY)
 import           RIO.Process
 import           Text.Printf (printf)
 
@@ -347,6 +348,8 @@ runContainerAndExit getCmdArgs
          ,[cmnd]
          ,args])
      before
+-- MSS 2018-08-30 can the CPP below be removed entirely, and instead exec the
+-- `docker` process so that it can handle the signals directly?
 #ifndef WINDOWS
      run <- askRunInIO
      oldHandlers <- forM [sigINT,sigABRT,sigHUP,sigPIPE,sigTERM,sigUSR1,sigUSR2] $ \sig -> do

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -1,7 +1,14 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE CPP, ConstraintKinds, DeriveDataTypeable, FlexibleContexts, MultiWayIf, NamedFieldPuns,
-             OverloadedStrings, PackageImports, RankNTypes, RecordWildCards, ScopedTypeVariables,
-             TupleSections #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 
 -- | Run commands in Docker containers
 module Stack.Docker

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE CPP, ConstraintKinds, DeriveDataTypeable, FlexibleContexts, MultiWayIf, NamedFieldPuns,
              OverloadedStrings, PackageImports, RankNTypes, RecordWildCards, ScopedTypeVariables,
-             TemplateHaskell, TupleSections #-}
+             TupleSections #-}
 
 -- | Run commands in Docker containers
 module Stack.Docker
@@ -286,7 +286,7 @@ runContainerAndExit getCmdArgs
      newPathEnv <- either throwM return $ augmentPath
                       ( toFilePath <$>
                       [ hostBinDirPath
-                      , sandboxHomeDir </> $(mkRelDir ".local/bin")])
+                      , sandboxHomeDir </> relDirDotLocal </> relDirBin])
                       (T.pack <$> lookupImageEnv "PATH" imageEnvVars)
      (cmnd,args,envVars,extraMount) <- getCmdArgs docker imageInfo isRemoteDocker
      pwd <- getCurrentDir
@@ -388,7 +388,7 @@ runContainerAndExit getCmdArgs
         _ -> Nothing
     mountArg (Mount host container) = ["-v",host ++ ":" ++ container]
     projectRoot = fromMaybeProjectRoot mprojectRoot
-    sshRelDir = $(mkRelDir ".ssh/")
+    sshRelDir = relDirDotSsh
 
 -- | Clean-up old docker images and containers.
 cleanup :: HasConfig env => CleanupOpts -> RIO env ()
@@ -746,7 +746,7 @@ entrypoint config@Config{..} DockerEntrypoint{..} =
           -- If the 'stack' user exists in the image, copy any build plans and package indices from
           -- its original home directory to the host's stack root, to avoid needing to download them
           origStackHomeDir <- liftIO $ parseAbsDir (User.homeDirectory ue)
-          let origStackRoot = origStackHomeDir </> $(mkRelDir ("." ++ stackProgName))
+          let origStackRoot = origStackHomeDir </> relDirDotStackProgName
           buildPlanDirExists <- doesDirExist (buildPlanDir origStackRoot)
           when buildPlanDirExists $ do
             (_, buildPlans) <- listDir (buildPlanDir origStackRoot)
@@ -832,7 +832,7 @@ readDockerProcess args = BL.toStrict <$> proc "docker" args readProcessStdout_ -
 
 -- | Name of home directory within docker sandbox.
 homeDirName :: Path Rel Dir
-homeDirName = $(mkRelDir "_home/")
+homeDirName = relDirUnderHome
 
 -- | Directory where 'stack' executable is bind-mounted in Docker container
 hostBinDir :: FilePath

--- a/src/Stack/FileWatch.hs
+++ b/src/Stack/FileWatch.hs
@@ -14,6 +14,7 @@ import GHC.IO.Exception
 import Path
 import System.FSNotify
 import System.IO (hPutStrLn, getLine)
+import System.Terminal
 
 fileWatch :: Handle
           -> ((Set (Path Abs File) -> IO ()) -> IO ())

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -3,8 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE TupleSections #-}
 {-# OPTIONS -fno-warn-unused-do-bind #-}
 
 -- | Functions for the GHC package database.

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# OPTIONS -fno-warn-unused-do-bind #-}
 
@@ -28,7 +27,7 @@ import           Data.List
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import           Distribution.Version (mkVersion)
-import           Path (parent, mkRelFile, (</>))
+import           Path (parent, (</>))
 import           Path.Extra (toFilePathNoTrailingSep)
 import           Path.IO
 import           Stack.Constants
@@ -79,7 +78,7 @@ createDatabase
   :: (HasProcessContext env, HasLogFunc env)
   => WhichCompiler -> Path Abs Dir -> RIO env ()
 createDatabase wc db = do
-    exists <- doesFileExist (db </> $(mkRelFile "package.cache"))
+    exists <- doesFileExist (db </> relFilePackageCache)
     unless exists $ do
         -- ghc-pkg requires that the database directory does not exist
         -- yet. If the directory exists but the package.cache file

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 
 -- | Run a GHCi configured with the user's package(s).
@@ -50,10 +49,7 @@ import           Stack.Types.Package
 import           Stack.Types.Runner
 import           System.IO (putStrLn)
 import           System.IO.Temp (getCanonicalTemporaryDirectory)
-
-#ifndef WINDOWS
-import qualified System.Posix.Files as Posix
-#endif
+import           System.Permissions (setScriptPerms)
 
 -- | Command-line options for GHC.
 data GhciOpts = GhciOpts
@@ -886,20 +882,6 @@ getExtraLoadDeps loadAllDeps sourceMap targets =
                         return False
             (_, Just PSRemote{}) -> return loadAllDeps
             (_, _) -> return False
-
-setScriptPerms :: MonadIO m => FilePath -> m ()
-#ifdef WINDOWS
-setScriptPerms _ = do
-    return ()
-#else
-setScriptPerms fp = do
-    liftIO $ Posix.setFileMode fp $ foldl1 Posix.unionFileModes
-        [ Posix.ownerReadMode
-        , Posix.ownerWriteMode
-        , Posix.groupReadMode
-        , Posix.otherReadMode
-        ]
-#endif
 
 unionTargets :: Ord k => Map k Target -> Map k Target -> Map k Target
 unionTargets = M.unionWith $ \l r ->

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -38,6 +37,7 @@ import           Stack.Build.Installed
 import           Stack.Build.Source
 import           Stack.Build.Target
 import           Stack.Config (getLocalPackages)
+import           Stack.Constants
 import           Stack.Constants.Config
 import           Stack.Ghci.Script
 import           Stack.Package
@@ -416,7 +416,7 @@ runGhci GhciOpts{..} targets mainFile pkgs extraFiles exposePackages = do
     -- effect of making it possible to copy the ghci invocation out of
     -- the log and have it still work.
     tmpDirectory <-
-        (</> $(mkRelDir "haskell-stack-ghci")) <$>
+        (</> relDirHaskellStackGhci) <$>
         (parseAbsDir =<< liftIO getCanonicalTemporaryDirectory)
     ghciDir <- view ghciDirL
     ensureDir ghciDir
@@ -443,13 +443,13 @@ writeMacrosFile outputDirectory pkgs = do
                     return Nothing
     files <- liftIO $ mapM (S8.readFile . toFilePath) fps
     if null files then return [] else do
-        out <- liftIO $ writeHashedFile outputDirectory $(mkRelFile "cabal_macros.h") $
+        out <- liftIO $ writeHashedFile outputDirectory relFileCabalMacrosH $
             S8.concat $ map (<> "\n#undef CURRENT_PACKAGE_KEY\n#undef CURRENT_COMPONENT_ID\n") files
         return ["-optP-include", "-optP" <> toFilePath out]
 
 writeGhciScript :: (MonadIO m) => Path Abs Dir -> GhciScript -> m [String]
 writeGhciScript outputDirectory script = do
-    scriptPath <- liftIO $ writeHashedFile outputDirectory $(mkRelFile "ghci-script") $
+    scriptPath <- liftIO $ writeHashedFile outputDirectory relFileGhciScript $
         LBS.toStrict $ scriptToLazyByteString script
     let scriptFilePath = toFilePath scriptPath
     setScriptPerms scriptFilePath

--- a/src/Stack/Image.hs
+++ b/src/Stack/Image.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RecordWildCards    #-}
-{-# LANGUAGE TemplateHaskell    #-}
 
 -- | This module builds Docker (OpenContainer) images.
 module Stack.Image
@@ -21,6 +20,7 @@ import qualified Data.Text as T
 import           Path
 import           Path.Extra
 import           Path.IO
+import           Stack.Constants
 import           Stack.Constants.Config
 import           Stack.PrettyPrint
 import           Stack.Types.Config
@@ -82,8 +82,8 @@ stageExesInDir
     :: HasEnvConfig env
     => ImageDockerOpts -> Path Abs Dir -> RIO env ()
 stageExesInDir opts dir = do
-    srcBinPath <- fmap (</> $(mkRelDir "bin")) installationRootLocal
-    let destBinPath = dir </> $(mkRelDir "usr/local/bin")
+    srcBinPath <- fmap (</> relDirBin) installationRootLocal
+    let destBinPath = dir </> relDirUsr </> relDirLocal </> relDirBin
     ensureDir destBinPath
     case imgDockerExecutables opts of
         Nothing -> do
@@ -136,7 +136,7 @@ createDockerImage dockerConfig dir =
         Just base -> do
             liftIO
                 (B.writeFile
-                     (toFilePath (dir </> $(mkRelFile "Dockerfile")))
+                     (toFilePath (dir </> relFileDockerfile))
                      (encodeUtf8 (T.pack (unlines ["FROM " ++ base, "ADD ./ /"]))))
             let args =
                     [ "build"
@@ -166,7 +166,7 @@ extendDockerImageWithEntrypoint dockerConfig dir = do
                       do liftIO
                              (B.writeFile
                                   (toFilePath
-                                       (dir </> $(mkRelFile "Dockerfile")))
+                                       (dir </> relFileDockerfile))
                                   (encodeUtf8 (T.pack (unlines
                                        [ "FROM " ++ dockerImageName
                                        , "ENTRYPOINT [\"/usr/local/bin/" ++

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 -- | Create new a new project directory populated with a basic working
 -- project.
@@ -169,8 +168,6 @@ loadTemplate name logIt = do
                 logWarn "Using cached local version. It may not be the most recent version though."
         else throwM (FailedToDownloadTemplate name exception)
 
-    backupUrlRelPath = $(mkRelFile "downloaded.template.file.hsfiles")
-
 -- | Construct a URL for downloading from a repo.
 urlFromRepoTemplatePath :: RepoTemplatePath -> Text
 urlFromRepoTemplatePath (RepoTemplatePath Github user name) =
@@ -296,10 +293,6 @@ templatesHelp = do
 
 --------------------------------------------------------------------------------
 -- Defaults
-
--- | The default template name you can use if you don't have one.
-defaultTemplateName :: TemplateName
-defaultTemplateName = $(mkTemplateName "new-template")
 
 -- | The default service to use to download templates.
 defaultRepoService :: RepoService

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 
 module Stack.Options.Completion
@@ -21,14 +20,13 @@ import qualified Distribution.Types.UnqualComponentName as C
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
 import           Stack.Config (getLocalPackages)
+import           Stack.Constants (ghcShowOptionsOutput)
 import           Stack.Options.GlobalParser (globalOptsFromMonoid)
 import           Stack.Runners (loadConfigWithOpts)
-import           Stack.Prelude hiding (lift)
+import           Stack.Prelude
 import           Stack.Setup
 import           Stack.Types.Config
 import           Stack.Types.NamedComponent
-import           System.Process (readProcess)
-import           Language.Haskell.TH.Syntax (runIO, lift)
 
 ghcOptsCompleter :: Completer
 ghcOptsCompleter = mkCompleter $ \inputRaw -> return $
@@ -38,10 +36,7 @@ ghcOptsCompleter = mkCompleter $ \inputRaw -> return $
         otherArgs = reverse otherArgsReversed
      in if null curArg then [] else
          map (otherArgs ++) $
-         filter (curArg `isPrefixOf`)
-                -- Technically, we should be consulting the user's current ghc,
-                -- but that would require loading up a BuildConfig.
-                $(runIO (readProcess "ghc" ["--show-options"] "") >>= lift . lines)
+         filter (curArg `isPrefixOf`) ghcShowOptionsOutput
 
 -- TODO: Ideally this would pay attention to --stack-yaml, may require
 -- changes to optparse-applicative.

--- a/src/Stack/Options/DockerParser.hs
+++ b/src/Stack/Options/DockerParser.hs
@@ -8,7 +8,6 @@ import           Distribution.Version              (anyVersion)
 import           Options.Applicative
 import           Options.Applicative.Args
 import           Options.Applicative.Builder.Extra
-import           Stack.Constants
 import           Stack.Docker
 import qualified Stack.Docker                      as Docker
 import           Stack.Prelude

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -8,7 +7,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | Dealing with Cabal.

--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric #-}
 module Stack.PackageDump
     ( Line
     , eachSection

--- a/src/Stack/Prelude.hs
+++ b/src/Stack/Prelude.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE NoImplicitPrelude          #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
@@ -11,7 +10,6 @@ module Stack.Prelude
   , readProcessNull
   , withProcessContext
   , stripCR
-  , hIsTerminalDeviceOrMinTTY
   , prompt
   , promptPassword
   , promptBool
@@ -30,10 +28,6 @@ import           Data.Monoid          as X (First (..), Any (..), Sum (..), Endo
 import qualified Path.IO
 
 import           System.IO.Echo (withoutInputEcho)
-
-#ifdef WINDOWS
-import           System.Win32 (isMinTTYHandle, withHandleToHANDLE)
-#endif
 
 import qualified Data.Conduit.Binary as CB
 import qualified Data.Conduit.List as CL
@@ -126,19 +120,6 @@ withProcessContext pcNew inner = do
 -- | Remove a trailing carriage return if present
 stripCR :: Text -> Text
 stripCR = T.dropSuffix "\r"
-
--- | hIsTerminaDevice does not recognise handles to mintty terminals as terminal
--- devices, but isMinTTYHandle does.
-hIsTerminalDeviceOrMinTTY :: MonadIO m => Handle -> m Bool
-#ifdef WINDOWS
-hIsTerminalDeviceOrMinTTY h = do
-  isTD <- hIsTerminalDevice h
-  if isTD
-    then return True
-    else liftIO $ withHandleToHANDLE h isMinTTYHandle
-#else
-hIsTerminalDeviceOrMinTTY = hIsTerminalDevice
-#endif
 
 -- | Prompt the user by sending text to stdout, and taking a line of
 -- input from stdin.

--- a/src/Stack/Prelude.hs
+++ b/src/Stack/Prelude.hs
@@ -15,6 +15,7 @@ module Stack.Prelude
   , prompt
   , promptPassword
   , promptBool
+  , stackProgName
   , module X
   ) where
 
@@ -176,3 +177,10 @@ promptBool txt = liftIO $ do
     _ -> do
       T.putStrLn "Please press either 'y' or 'n', and then enter."
       promptBool txt
+
+-- | Name of the 'stack' program.
+--
+-- NOTE: Should be defined in "Stack.Constants", but not doing so due to the
+-- GHC stage restrictions.
+stackProgName :: String
+stackProgName = "stack"

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 -- | Utilities for running stack commands.
 module Stack.Runners
@@ -25,6 +24,7 @@ import           Stack.Prelude
 import           Path
 import           Path.IO
 import           Stack.Config
+import           Stack.Constants
 import           Stack.DefaultColorWhen (defaultColorWhen)
 import qualified Stack.Docker as Docker
 import qualified Stack.Nix as Nix
@@ -60,7 +60,7 @@ withUserFileLock go@GlobalOpts{} dir act = do
     let toLock = lookup "STACK_LOCK" env == Just "true"
     if toLock
         then do
-            let lockfile = $(mkRelFile "lockfile")
+            let lockfile = relFileLockfile
             let pth = dir </> lockfile
             ensureDir dir
             -- Just in case of asynchronous exceptions, we need to be careful

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -53,7 +53,6 @@ import           Stack.Build.Installed
 import           Stack.Build.Source (loadSourceMap)
 import           Stack.Build.Target hiding (PackageType (..))
 import           Stack.PrettyPrint
-import           Stack.Constants
 import           Stack.Package
 import           Stack.Types.Build
 import           Stack.Types.Config

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections     #-}
 module Stack.Script

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -95,6 +95,7 @@ import              System.Exit (ExitCode (..), exitFailure)
 import              System.IO.Error (isPermissionError)
 import              System.FilePath (searchPathSeparator)
 import qualified    System.FilePath as FP
+import              System.Permissions (setFileExecutable)
 import              RIO.Process
 import              Text.Printf (printf)
 
@@ -103,7 +104,6 @@ import              System.Uname (uname, release)
 import              Data.List.Split (splitOn)
 import              Foreign.C (throwErrnoIfMinus1_, peekCString)
 import              Foreign.Marshal (alloca)
-import              System.Posix.Files (setFileMode)
 #endif
 
 -- | Default location of the stack-setup.yaml file
@@ -1899,9 +1899,7 @@ downloadStackExe platforms0 archiveInfo destDir checkPath testExe = do
     platform <- view platformL
 
     liftIO $ do
-#if !WINDOWS
-      setFileMode (toFilePath tmpFile) 0o755
-#endif
+      setFileExecutable (toFilePath tmpFile)
 
       testExe tmpFile
 
@@ -1986,9 +1984,7 @@ performPathChecking newFile = do
     tmpFile <- parseAbsFile $ executablePath ++ ".tmp"
     eres <- tryIO $ do
       liftIO $ copyFile newFile tmpFile
-#if !WINDOWS
-      liftIO $ setFileMode (toFilePath tmpFile) 0o755
-#endif
+      setFileExecutable (toFilePath tmpFile)
       liftIO $ renameFile tmpFile executablePath'
       logInfo "Stack executable copied successfully!"
     case eres of

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE MultiWayIf #-}
@@ -76,7 +75,7 @@ import              Prelude (until)
 import qualified    RIO
 import              Stack.Build (build)
 import              Stack.Config (loadConfig)
-import              Stack.Constants (stackProgName)
+import              Stack.Constants
 import              Stack.Constants.Config (distRelativeDir)
 import              Stack.GhcPkg (createDatabase, getCabalPkgVer, getGlobalDB, mkGhcPackagePath, ghcPkgPathEnvVar)
 import              Stack.Prelude hiding (Display (..))
@@ -585,29 +584,28 @@ getGhcBuilds = do
                         | libT `elem` firstWords = do
                             logDebug ("Found shared library " <> libD <> " in 'ldconfig -p' output")
                             return True
-                        | otherwise = do
-#ifdef WINDOWS
-                            -- (mkAbsDir "/usr/lib") fails to compile on Windows, thus the CPP
+                        | osIsWindows =
+                            -- Cannot parse /usr/lib on Windows
                             return False
-#else
+                        | otherwise = do
                             -- This is a workaround for the fact that libtinfo.so.6 doesn't appear in
                             -- the 'ldconfig -p' output on Arch even when it exists.
                             -- There doesn't seem to be an easy way to get the true list of directories
                             -- to scan for shared libs, but this works for our particular case.
-                            e <- doesFileExist ($(mkAbsDir "/usr/lib") </> lib)
+                            usrLib <- parseAbsDir "/usr/lib"
+                            e <- doesFileExist (usrLib </> lib)
                             if e
                                 then logDebug ("Found shared library " <> libD <> " in /usr/lib")
                                 else logDebug ("Did not find shared library " <> libD)
                             return e
-#endif
                       where
                         libT = T.pack (toFilePath lib)
                         libD = fromString (toFilePath lib)
-                hastinfo5 <- checkLib $(mkRelFile "libtinfo.so.5")
-                hastinfo6 <- checkLib $(mkRelFile "libtinfo.so.6")
-                hasncurses6 <- checkLib $(mkRelFile "libncursesw.so.6")
-                hasgmp5 <- checkLib $(mkRelFile "libgmp.so.10")
-                hasgmp4 <- checkLib $(mkRelFile "libgmp.so.3")
+                hastinfo5 <- checkLib relFileLibtinfoSo5
+                hastinfo6 <- checkLib relFileLibtinfoSo6
+                hasncurses6 <- checkLib relFileLibncurseswSo6
+                hasgmp5 <- checkLib relFileLibgmpSo10
+                hasgmp4 <- checkLib relFileLibgmpSo3
                 let libComponents = concat
                         [ [["tinfo6"] | hastinfo6 && hasgmp5]
                         , [[] | hastinfo5 && hasgmp5]
@@ -664,7 +662,7 @@ ensureDockerStackExe containerPlatform = do
     let programsPath = configLocalProgramsBase config </> containerPlatformDir
         tool = Tool (PackageIdentifier (mkPackageName "stack") stackVersion)
     stackExeDir <- installDir programsPath tool
-    let stackExePath = stackExeDir </> $(mkRelFile "stack")
+    let stackExePath = stackExeDir </> relFileStack
     stackExeExists <- doesFileExist stackExePath
     unless stackExeExists $ do
         logInfo $
@@ -736,13 +734,13 @@ doCabalInstall wc installed wantedVersion = do
                     >>= either throwM parseAbsFile
         versionDir <- parseRelDir $ versionString wantedVersion
         let installRoot = toFilePath $ parent (parent compilerPath)
-                                    </> $(mkRelDir "new-cabal")
+                                    </> relDirNewCabal
                                     </> versionDir
         withWorkingDir (toFilePath dir) $ proc (compilerExeName wc) ["Setup.hs"] runProcess_
         platform <- view platformL
         let setupExe = dir </> case platform of
-                Platform _ Cabal.Windows -> $(mkRelFile "Setup.exe")
-                _                        -> $(mkRelFile "Setup")
+                Platform _ Cabal.Windows -> relFileSetupExe
+                _                        -> relFileSetupUpper
             dirArgument name' = concat [ "--"
                                        , name'
                                        , "dir="
@@ -1129,7 +1127,7 @@ installGHCPosix version downloadInfo _ archiveFile archiveType tempDir destDir =
     logSticky "Configuring GHC ..."
     runStep "configuring" dir
         (gdiConfigureEnv downloadInfo)
-        (toFilePath $ dir </> $(mkRelFile "configure"))
+        (toFilePath $ dir </> relFileConfigure)
         (("--prefix=" ++ toFilePath destDir) : map T.unpack (gdiConfigureOpts downloadInfo))
 
     logSticky "Installing GHC ..."
@@ -1165,7 +1163,7 @@ installGHCJS si archiveFile archiveType _tempDir destDir = do
     -- environment of the stack.yaml which came with ghcjs, in order to
     -- install cabal-install. This lets us also fix the version of
     -- cabal-install used.
-    let unpackDir = destDir </> $(mkRelDir "src")
+    let unpackDir = destDir </> relDirSrc
     runUnpack <- case platform of
         Platform _ Cabal.Windows -> return $
             withUnpackedTarball7z "GHCJS" si archiveFile archiveType Nothing unpackDir
@@ -1196,8 +1194,8 @@ installGHCJS si archiveFile archiveType _tempDir destDir = do
     runUnpack
 
     logSticky "Setting up GHCJS build environment"
-    let stackYaml = unpackDir </> $(mkRelFile "stack.yaml")
-        destBinDir = destDir </> $(mkRelDir "bin")
+    let stackYaml = unpackDir </> stackDotYaml
+        destBinDir = destDir </> relDirBin
     ensureDir destBinDir
     loadGhcjsEnvConfig stackYaml destBinDir $ \envConfig' -> do
 
@@ -1213,9 +1211,9 @@ installGHCJS si archiveFile archiveType _tempDir destDir = do
       buildInGhcjsEnv envConfig' defaultBuildOptsCLI
       -- Copy over *.options files needed on windows.
       forM_ mwindowsInstallDir $ \dir -> do
-          (_, files) <- listDir (dir </> $(mkRelDir "bin"))
+          (_, files) <- listDir (dir </> relDirBin)
           forM_ (filter ((".options" `isSuffixOf`). toFilePath) files) $ \optionsFile -> do
-              let dest = destDir </> $(mkRelDir "bin") </> filename optionsFile
+              let dest = destDir </> relDirBin </> filename optionsFile
               liftIO $ ignoringAbsence (removeFile dest)
               copyFile optionsFile dest
       logStickyDone "Installed GHCJS."
@@ -1233,7 +1231,7 @@ ensureGhcjsBooted cv shouldBoot bootOpts = do
             if not shouldBoot then throwM GHCJSNotBooted else do
                 config <- view configL
                 destDir <- installDir (configLocalPrograms config) (ToolGhcjs cv)
-                let stackYaml = destDir </> $(mkRelFile "src/stack.yaml")
+                let stackYaml = destDir </> relDirSrc </> stackDotYaml
                 -- TODO: Remove 'actualStackYaml' and just use
                 -- 'stackYaml' for a version after 0.1.6. It's for
                 -- compatibility with the directories setup used for
@@ -1248,7 +1246,7 @@ ensureGhcjsBooted cv shouldBoot bootOpts = do
                         _ -> error "ensureGhcjsBooted invoked on non GhcjsVersion"
                 actualStackYaml <- if stackYamlExists then return stackYaml
                     else
-                        liftM ((destDir </> $(mkRelDir "src")) </>) $
+                        liftM ((destDir </> relDirSrc) </>) $
                         parseRelFile $ "ghcjs-" ++ versionString ghcjsVersion ++ "/stack.yaml"
                 actualStackYamlExists <- doesFileExist actualStackYaml
                 unless actualStackYamlExists $
@@ -1259,7 +1257,7 @@ ensureGhcjsBooted cv shouldBoot bootOpts = do
 bootGhcjs :: (HasRunner env, HasProcessContext env)
           => Version -> Path Abs File -> Path Abs Dir -> [String] -> RIO env ()
 bootGhcjs ghcjsVersion stackYaml destDir bootOpts =
-  loadGhcjsEnvConfig stackYaml (destDir </> $(mkRelDir "bin")) $ \envConfig -> do
+  loadGhcjsEnvConfig stackYaml (destDir </> relDirBin) $ \envConfig -> do
     menv <- liftIO $ configProcessContextSettings (view configL envConfig) defaultEnvSettings
     -- Install cabal-install if missing, or if the installed one is old.
     mcabal <- withProcessContext menv getCabalInstallVersion
@@ -1439,7 +1437,7 @@ installMsys2Windows osKey si archiveFile archiveType _tempDir destDir = do
     menv0 <- view processContextL
     newEnv0 <- modifyEnvVars menv0 $ Map.insert "MSYSTEM" "MSYS"
     newEnv <- either throwM return $ augmentPathMap
-                  [toFilePath $ destDir </> $(mkRelDir "usr") </> $(mkRelDir "bin")]
+                  [toFilePath $ destDir </> relDirUsr </> relDirBin]
                   (view envVarsL newEnv0)
     menv <- mkProcessContext newEnv
     withWorkingDir (toFilePath destDir) $ withProcessContext menv
@@ -1501,8 +1499,8 @@ setup7z :: (HasConfig env, MonadIO m)
 setup7z si = do
     dir <- view $ configL.to configLocalPrograms
     ensureDir dir
-    let exe = dir </> $(mkRelFile "7z.exe")
-        dll = dir </> $(mkRelFile "7z.dll")
+    let exe = dir </> relFile7zexe
+        dll = dir </> relFile7zdll
     case (siSevenzDll si, siSevenzExe si) of
         (Just sevenzDll, Just sevenzExe) -> do
             chattyDownload "7z.dll" sevenzDll dll
@@ -1646,7 +1644,7 @@ sanityCheck :: (HasProcessContext env, HasLogFunc env)
             => WhichCompiler
             -> RIO env ()
 sanityCheck wc = withSystemTempDir "stack-sanity-check" $ \dir -> do
-    let fp = toFilePath $ dir </> $(mkRelFile "Main.hs")
+    let fp = toFilePath $ dir </> relFileMainHs
     liftIO $ S.writeFile fp $ T.encodeUtf8 $ T.pack $ unlines
         [ "import Distribution.Simple" -- ensure Cabal library is present
         , "main = putStrLn \"Hello World\""
@@ -1879,12 +1877,12 @@ downloadStackExe platforms0 archiveInfo destDir checkPath testExe = do
 
     let (destFile, tmpFile)
             | isWindows =
-                ( destDir </> $(mkRelFile "stack.exe")
-                , destDir </> $(mkRelFile "stack.tmp.exe")
+                ( destDir </> relFileStackDotExe
+                , destDir </> relFileStackDotTmpDotExe
                 )
             | otherwise =
-                ( destDir </> $(mkRelFile "stack")
-                , destDir </> $(mkRelFile "stack.tmp")
+                ( destDir </> relFileStack
+                , destDir </> relFileStackDotTmp
                 )
 
     logInfo $ "Downloading from: " <> RIO.display archiveURL

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE LambdaCase #-}
 
@@ -35,6 +34,7 @@ import qualified Distribution.System as Cabal
 import           Generics.Deriving.Monoid (mappenddefault, memptydefault)
 import           Path
 import           Path.IO
+import           Stack.Constants
 import           Stack.Types.Compiler
 import           Stack.Types.Config
 import           RIO.Process
@@ -130,46 +130,46 @@ extraDirs tool = do
     case (configPlatform config, toolNameString tool) of
         (Platform _ Cabal.Windows, isGHC -> True) -> return mempty
             { edBins =
-                [ dir </> $(mkRelDir "bin")
-                , dir </> $(mkRelDir "mingw") </> $(mkRelDir "bin")
+                [ dir </> relDirBin
+                , dir </> relDirMingw </> relDirBin
                 ]
             }
         (Platform Cabal.I386 Cabal.Windows, "msys2") -> return mempty
             { edBins =
-                [ dir </> $(mkRelDir "mingw32") </> $(mkRelDir "bin")
-                , dir </> $(mkRelDir "usr") </> $(mkRelDir "bin")
-                , dir </> $(mkRelDir "usr") </> $(mkRelDir "local") </> $(mkRelDir "bin")
+                [ dir </> relDirMingw32 </> relDirBin
+                , dir </> relDirUsr </> relDirBin
+                , dir </> relDirUsr </> relDirLocal </> relDirBin
                 ]
             , edInclude =
-                [ dir </> $(mkRelDir "mingw32") </> $(mkRelDir "include")
+                [ dir </> relDirMingw32 </> relDirInclude
                 ]
             , edLib =
-                [ dir </> $(mkRelDir "mingw32") </> $(mkRelDir "lib")
-                , dir </> $(mkRelDir "mingw32") </> $(mkRelDir "bin")
+                [ dir </> relDirMingw32 </> relDirLib
+                , dir </> relDirMingw32 </> relDirBin
                 ]
             }
         (Platform Cabal.X86_64 Cabal.Windows, "msys2") -> return mempty
             { edBins =
-                [ dir </> $(mkRelDir "mingw64") </> $(mkRelDir "bin")
-                , dir </> $(mkRelDir "usr") </> $(mkRelDir "bin")
-                , dir </> $(mkRelDir "usr") </> $(mkRelDir "local") </> $(mkRelDir "bin")
+                [ dir </> relDirMingw64 </> relDirBin
+                , dir </> relDirUsr </> relDirBin
+                , dir </> relDirUsr </> relDirLocal </> relDirBin
                 ]
             , edInclude =
-                [ dir </> $(mkRelDir "mingw64") </> $(mkRelDir "include")
+                [ dir </> relDirMingw64 </> relDirInclude
                 ]
             , edLib =
-                [ dir </> $(mkRelDir "mingw64") </> $(mkRelDir "lib")
-                , dir </> $(mkRelDir "mingw64") </> $(mkRelDir "bin")
+                [ dir </> relDirMingw64 </> relDirLib
+                , dir </> relDirMingw64 </> relDirBin
                 ]
             }
         (_, isGHC -> True) -> return mempty
             { edBins =
-                [ dir </> $(mkRelDir "bin")
+                [ dir </> relDirBin
                 ]
             }
         (_, isGHCJS -> True) -> return mempty
             { edBins =
-                [ dir </> $(mkRelDir "bin")
+                [ dir </> relDirBin
                 ]
             }
         (Platform _ x, toolName) -> do

--- a/src/Stack/Sig/Sign.hs
+++ b/src/Stack/Sig/Sign.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}

--- a/src/Stack/Snapshot.hs
+++ b/src/Stack/Snapshot.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE ViewPatterns        #-}
 
@@ -24,7 +23,6 @@ module Stack.Snapshot
 
 import           Stack.Prelude hiding (Display (..))
 import           Control.Monad.State.Strict      (get, put, StateT, execStateT)
-import           Data.Store.VersionTagged
 import qualified Data.Conduit.List as CL
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -44,6 +42,7 @@ import qualified Pantry
 import qualified Pantry.SHA256 as SHA256
 import           Stack.Package
 import           Stack.PackageDump
+import           Stack.StoreTH
 import           Stack.Types.BuildPlan
 import           Stack.Types.GhcPkgId
 import           Stack.Types.VersionIntervals
@@ -174,7 +173,7 @@ loadSnapshot mcompiler =
       path <- configLoadedSnapshotCache
         sd
         (maybe GISSnapshotHints GISCompiler mcompiler)
-      $(versionedDecodeOrLoad loadedSnapshotVC) path (inner sd)
+      decodeOrLoadLoadedSnapshot path (inner sd)
 
     inner :: SnapshotDef -> RIO env LoadedSnapshot
     inner sd = do

--- a/src/Stack/Snapshot.hs
+++ b/src/Stack/Snapshot.hs
@@ -2,15 +2,11 @@
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE EmptyDataDecls      #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
-{-# LANGUAGE ViewPatterns        #-}
 
 -- | Reading in @SnapshotDef@s and converting them into
 -- @LoadedSnapshot@s.

--- a/src/Stack/StoreTH.hs
+++ b/src/Stack/StoreTH.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Stack.StoreTH
+  ( decodeBuildCache
+  , encodeBuildCache
+
+  , decodeConfigCache
+  , encodeConfigCache
+
+  , decodeModTime
+  , encodeModTime
+
+  , decodeTestSuccess
+  , encodeTestSuccess
+
+  , decodePrecompiledCache
+  , encodePrecompiledCache
+
+  , decodeOrLoadInstalledCache
+  , encodeInstalledCache
+
+  , decodeOrLoadLoadedSnapshot
+  ) where
+
+import Data.Store.VersionTagged
+import Stack.Prelude
+import Stack.Types.Build
+import Stack.Types.BuildPlan
+import Stack.Types.Package
+import Stack.Types.PackageDump
+
+decodeBuildCache
+  :: HasLogFunc env
+  => Path Abs File
+  -> RIO env (Maybe BuildCache)
+encodeBuildCache = $(versionedEncodeFile buildCacheVC)
+
+encodeBuildCache
+  :: HasLogFunc env
+  => Path Abs File
+  -> BuildCache
+  -> RIO env ()
+decodeBuildCache = $(versionedDecodeFile buildCacheVC)
+
+decodeConfigCache
+  :: HasLogFunc env
+  => Path Abs File
+  -> RIO env (Maybe ConfigCache)
+decodeConfigCache = $(versionedDecodeFile configCacheVC)
+
+encodeConfigCache
+  :: HasLogFunc env
+  => Path Abs File
+  -> ConfigCache
+  -> RIO env ()
+encodeConfigCache = $(versionedEncodeFile configCacheVC)
+
+decodeModTime
+  :: HasLogFunc env
+  => Path Abs File
+  -> RIO env (Maybe ModTime)
+decodeModTime = $(versionedDecodeFile modTimeVC)
+
+encodeModTime
+  :: HasLogFunc env
+  => Path Abs File
+  -> ModTime
+  -> RIO env ()
+encodeModTime = $(versionedEncodeFile modTimeVC)
+
+decodeTestSuccess
+  :: HasLogFunc env
+  => Path Abs File
+  -> RIO env (Maybe Bool)
+decodeTestSuccess = $(versionedDecodeFile testSuccessVC)
+
+encodeTestSuccess
+  :: HasLogFunc env
+  => Path Abs File
+  -> Bool
+  -> RIO env ()
+encodeTestSuccess = $(versionedEncodeFile testSuccessVC)
+
+decodePrecompiledCache
+  :: HasLogFunc env
+  => Path Abs File
+  -> RIO env (Maybe PrecompiledCache)
+decodePrecompiledCache = $(versionedDecodeFile precompiledCacheVC)
+
+encodePrecompiledCache
+  :: HasLogFunc env
+  => Path Abs File
+  -> PrecompiledCache
+  -> RIO env ()
+encodePrecompiledCache = $(versionedEncodeFile precompiledCacheVC)
+
+decodeOrLoadInstalledCache
+  :: HasLogFunc env
+  => Path Abs File
+  -> RIO env InstalledCacheInner
+  -> RIO env InstalledCacheInner
+decodeOrLoadInstalledCache = $(versionedDecodeOrLoad installedCacheVC)
+
+encodeInstalledCache
+  :: HasLogFunc env
+  => Path Abs File
+  -> InstalledCacheInner
+  -> RIO env ()
+encodeInstalledCache = $(versionedEncodeFile installedCacheVC)
+
+decodeOrLoadLoadedSnapshot
+  :: HasLogFunc env
+  => Path Abs File
+  -> RIO env LoadedSnapshot
+  -> RIO env LoadedSnapshot
+decodeOrLoadLoadedSnapshot = $(versionedDecodeOrLoad loadedSnapshotVC)

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE TemplateHaskell            #-}
 
 -- | Build-specific types.
 
@@ -65,7 +64,7 @@ import           Distribution.PackageDescription (TestSuiteInterface)
 import           Distribution.System             (Arch)
 import qualified Distribution.Text               as C
 import           Distribution.Version            (mkVersion)
-import           Path                            (mkRelDir, parseRelDir, (</>), parent)
+import           Path                            (parseRelDir, (</>), parent)
 import           Path.Extra                      (toFilePathNoTrailingSep)
 import           Stack.Constants
 import           Stack.Types.Compiler
@@ -548,11 +547,11 @@ configureOptsDirs bco loc package = concat
     , map (("--package-db=" ++) . toFilePathNoTrailingSep) $ case loc of
         Snap -> bcoExtraDBs bco ++ [bcoSnapDB bco]
         Local -> bcoExtraDBs bco ++ [bcoSnapDB bco] ++ [bcoLocalDB bco]
-    , [ "--libdir=" ++ toFilePathNoTrailingSep (installRoot </> $(mkRelDir "lib"))
+    , [ "--libdir=" ++ toFilePathNoTrailingSep (installRoot </> relDirLib)
       , "--bindir=" ++ toFilePathNoTrailingSep (installRoot </> bindirSuffix)
-      , "--datadir=" ++ toFilePathNoTrailingSep (installRoot </> $(mkRelDir "share"))
-      , "--libexecdir=" ++ toFilePathNoTrailingSep (installRoot </> $(mkRelDir "libexec"))
-      , "--sysconfdir=" ++ toFilePathNoTrailingSep (installRoot </> $(mkRelDir "etc"))
+      , "--datadir=" ++ toFilePathNoTrailingSep (installRoot </> relDirShare)
+      , "--libexecdir=" ++ toFilePathNoTrailingSep (installRoot </> relDirLibexec)
+      , "--sysconfdir=" ++ toFilePathNoTrailingSep (installRoot </> relDirEtc)
       , "--docdir=" ++ toFilePathNoTrailingSep docDir
       , "--htmldir=" ++ toFilePathNoTrailingSep docDir
       , "--haddockdir=" ++ toFilePathNoTrailingSep docDir]

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -9,15 +9,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
 

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
@@ -1305,12 +1304,9 @@ platformGhcVerOnlyRelDirStr = do
 -- SHA1 hash of the path used on other architectures, encode with base
 -- 16 and take first 8 symbols of it.
 useShaPathOnWindows :: MonadThrow m => Path Rel Dir -> m (Path Rel Dir)
-useShaPathOnWindows =
-#ifdef mingw32_HOST_OS
-    shaPath
-#else
-    return
-#endif
+useShaPathOnWindows
+  | osIsWindows = shaPath
+  | otherwise = pure
 
 shaPath :: (IsPath Rel t, MonadThrow m) => Path Rel t -> m (Path Rel t)
 shaPath = shaPathForBytes . encodeUtf8 . T.pack . toFilePath

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -18,7 +18,6 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -1193,7 +1192,7 @@ getProjectWorkDir = do
 
 -- | File containing the installed cache, see "Stack.PackageDump"
 configInstalledCache :: (HasBuildConfig env, MonadReader env m) => m (Path Abs File)
-configInstalledCache = liftM (</> $(mkRelFile "installed-cache.bin")) getProjectWorkDir
+configInstalledCache = liftM (</> relFileInstalledCacheBin) getProjectWorkDir
 
 -- | Relative directory for the platform identifier
 platformOnlyRelDir
@@ -1209,13 +1208,13 @@ snapshotsDir :: (MonadReader env m, HasEnvConfig env, MonadThrow m) => m (Path A
 snapshotsDir = do
     root <- view stackRootL
     platform <- platformGhcRelDir
-    return $ root </> $(mkRelDir "snapshots") </> platform
+    return $ root </> relDirSnapshots </> platform
 
 -- | Cached global hints file
 globalHintsFile :: (MonadReader env m, HasConfig env) => m (Path Abs File)
 globalHintsFile = do
   root <- view stackRootL
-  pure $ root </> $(mkRelDir "global-hints") </> $(mkRelFile "global-hints.yaml")
+  pure $ root </> relDirGlobalHints </> relFileGlobalHintsYaml
 
 -- | Installation root for dependencies
 installationRootDeps :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs Dir)
@@ -1223,14 +1222,14 @@ installationRootDeps = do
     root <- view stackRootL
     -- TODO: also useShaPathOnWindows here, once #1173 is resolved.
     psc <- platformSnapAndCompilerRel
-    return $ root </> $(mkRelDir "snapshots") </> psc
+    return $ root </> relDirSnapshots </> psc
 
 -- | Installation root for locals
 installationRootLocal :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs Dir)
 installationRootLocal = do
     workDir <- getProjectWorkDir
     psc <- useShaPathOnWindows =<< platformSnapAndCompilerRel
-    return $ workDir </> $(mkRelDir "install") </> psc
+    return $ workDir </> relDirInstall </> psc
 
 -- | Installation root for compiler tools
 bindirCompilerTools :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs Dir)
@@ -1241,7 +1240,7 @@ bindirCompilerTools = do
     compiler <- parseRelDir $ compilerVersionString compilerVersion
     return $
         view stackRootL config </>
-        $(mkRelDir "compiler-tools") </>
+        relDirCompilerTools </>
         platform </>
         compiler </>
         bindirSuffix
@@ -1251,13 +1250,13 @@ hoogleRoot :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs
 hoogleRoot = do
     workDir <- getProjectWorkDir
     psc <- useShaPathOnWindows =<< platformSnapAndCompilerRel
-    return $ workDir </> $(mkRelDir "hoogle") </> psc
+    return $ workDir </> relDirHoogle </> psc
 
 -- | Get the hoogle database path.
 hoogleDatabasePath :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs File)
 hoogleDatabasePath = do
     dir <- hoogleRoot
-    return (dir </> $(mkRelFile "database.hoo"))
+    return (dir </> relFileDatabaseHoo)
 
 -- | Path for platform followed by snapshot name followed by compiler
 -- name.
@@ -1342,13 +1341,13 @@ compilerVersionDir = do
 packageDatabaseDeps :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs Dir)
 packageDatabaseDeps = do
     root <- installationRootDeps
-    return $ root </> $(mkRelDir "pkgdb")
+    return $ root </> relDirPkgdb
 
 -- | Package database for installing local packages into
 packageDatabaseLocal :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs Dir)
 packageDatabaseLocal = do
     root <- installationRootLocal
-    return $ root </> $(mkRelDir "pkgdb")
+    return $ root </> relDirPkgdb
 
 -- | Extra package databases
 packageDatabaseExtra :: (MonadReader env m, HasEnvConfig env) => m [Path Abs Dir]
@@ -1358,7 +1357,7 @@ packageDatabaseExtra = view $ buildConfigL.to bcExtraPackageDBs
 flagCacheLocal :: (MonadThrow m, MonadReader env m, HasEnvConfig env) => m (Path Abs Dir)
 flagCacheLocal = do
     root <- installationRootLocal
-    return $ root </> $(mkRelDir "flag-cache")
+    return $ root </> relDirFlagCache
 
 -- | Where to store 'LoadedSnapshot' caches
 configLoadedSnapshotCache
@@ -1375,7 +1374,7 @@ configLoadedSnapshotCache sd gis = do
             GISSnapshotHints -> "__snapshot_hints__"
             GISCompiler cv -> compilerVersionString cv
     -- Yes, cached plans differ based on platform
-    return (root </> $(mkRelDir "loaded-snapshot-cache") </> platform </> gis' </> file)
+    return (root </> relDirLoadedSnapshotCache </> platform </> gis' </> file)
 
 -- | Where do we get information on global packages for loading up a
 -- 'LoadedSnapshot'?
@@ -1385,20 +1384,12 @@ data GlobalInfoSource
   | GISCompiler ActualCompiler
   -- ^ Look up the actual information in the installed compiler
 
--- | Suffix applied to an installation root to get the bin dir
-bindirSuffix :: Path Rel Dir
-bindirSuffix = $(mkRelDir "bin")
-
--- | Suffix applied to an installation root to get the doc dir
-docDirSuffix :: Path Rel Dir
-docDirSuffix = $(mkRelDir "doc")
-
 -- | Where HPC reports and tix files get stored.
 hpcReportDir :: (MonadThrow m, MonadReader env m, HasEnvConfig env)
              => m (Path Abs Dir)
 hpcReportDir = do
    root <- installationRootLocal
-   return $ root </> $(mkRelDir "hpc")
+   return $ root </> relDirHpc
 
 -- | Get the extra bin directories (for the PATH). Puts more local first
 --

--- a/src/Stack/Types/Docker.hs
+++ b/src/Stack/Types/Docker.hs
@@ -18,7 +18,6 @@ import Distribution.Text (simpleParse, display)
 import Distribution.Version (anyVersion)
 import Generics.Deriving.Monoid (mappenddefault, memptydefault)
 import Path
-import Stack.Constants
 import Stack.Types.Version
 import Text.Read (Read (..))
 

--- a/src/Stack/Types/Resolver.hs
+++ b/src/Stack/Types/Resolver.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/src/Stack/Types/Runner.hs
+++ b/src/Stack/Types/Runner.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}

--- a/src/Stack/Types/TemplateName.hs
+++ b/src/Stack/Types/TemplateName.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- | Template name handling.
 

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RecordWildCards       #-}
 module Stack.Upgrade
     ( upgrade
     , UpgradeOpts

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude     #-}
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -21,10 +20,7 @@ import qualified Paths_stack as Paths
 import           Stack.Build
 import           Stack.Config
 import           Stack.Constants
--- Following import is redundant on non-Windows operating systems
-#ifdef WINDOWS
 import           Stack.DefaultColorWhen (defaultColorWhen)
-#endif
 import           Stack.PrettyPrint
 import           Stack.Setup
 import           Stack.Types.Config
@@ -207,13 +203,11 @@ sourceUpgrade gConfigMonoid mresolver builtHash (SourceOpts gitRepo) =
                 -- --git" not working for earlier versions.
                 let args = [ "clone", repo , "stack", "--depth", "1", "--recursive", "--branch", branch]
                 withWorkingDir (toFilePath tmp) $ proc "git" args runProcess_
-#ifdef WINDOWS
                 -- On Windows 10, an upstream issue with the `git clone` command
                 -- means that command clears, but does not then restore, the
                 -- ENABLE_VIRTUAL_TERMINAL_PROCESSING flag for native terminals.
                 -- The folowing hack re-enables the lost ANSI-capability.
-                _ <- liftIO defaultColorWhen
-#endif
+                when osIsWindows $ void $ liftIO defaultColorWhen
                 return $ Just $ tmp </> relDirStackProgName
       Nothing -> do
         void $ updateHackageIndex

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE TemplateHaskell       #-}
 module Stack.Upgrade
     ( upgrade
     , UpgradeOpts
@@ -21,6 +20,7 @@ import           Path
 import qualified Paths_stack as Paths
 import           Stack.Build
 import           Stack.Config
+import           Stack.Constants
 -- Following import is redundant on non-Windows operating systems
 #ifdef WINDOWS
 import           Stack.DefaultColorWhen (defaultColorWhen)
@@ -214,7 +214,7 @@ sourceUpgrade gConfigMonoid mresolver builtHash (SourceOpts gitRepo) =
                 -- The folowing hack re-enables the lost ANSI-capability.
                 _ <- liftIO defaultColorWhen
 #endif
-                return $ Just $ tmp </> $(mkRelDir "stack")
+                return $ Just $ tmp </> relDirStackProgName
       Nothing -> do
         void $ updateHackageIndex
              $ Just "Updating index to make sure we find the latest Stack version"
@@ -238,7 +238,7 @@ sourceUpgrade gConfigMonoid mresolver builtHash (SourceOpts gitRepo) =
       loadConfig
       gConfigMonoid
       mresolver
-      (SYLOverride $ dir </> $(mkRelFile "stack.yaml")) $ \lc -> do
+      (SYLOverride $ dir </> stackDotYaml) $ \lc -> do
         bconfig <- liftIO $ lcLoadBuildConfig lc Nothing
         envConfig1 <- runRIO bconfig $ setupEnv $ Just $
             "Try rerunning with --install-ghc to install the correct GHC into " <>

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -110,6 +110,7 @@ import           System.Exit
 import           System.FilePath (isValid, pathSeparator)
 import qualified System.FilePath as FP
 import           System.IO (stderr, stdin, stdout, BufferMode(..), hPutStrLn, hPrint, hGetEncoding, hSetEncoding)
+import           System.Terminal (hIsTerminalDeviceOrMinTTY)
 
 -- | Change the character encoding of the given Handle to transliterate
 -- on unsupported characters instead of throwing an exception

--- a/src/test/Stack/ArgsSpec.hs
+++ b/src/test/Stack/ArgsSpec.hs
@@ -8,7 +8,6 @@ import Data.Attoparsec.Args (EscapingMode(..), parseArgsFromString)
 import Data.Attoparsec.Interpreter (interpreterArgsParser)
 import qualified Data.Attoparsec.Text as P
 import Data.Text (pack)
-import Stack.Constants (stackProgName)
 import Stack.Prelude
 import Test.Hspec
 import Prelude (head)

--- a/src/test/Stack/ConfigSpec.hs
+++ b/src/test/Stack/ConfigSpec.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards  #-}
-{-# LANGUAGE TemplateHaskell  #-}
 module Stack.ConfigSpec where
 
 import Control.Arrow
@@ -58,7 +57,7 @@ hpackConfig =
   "packages: ['.']\n"
 
 stackDotYaml :: Path Rel File
-stackDotYaml = $(mkRelFile "stack.yaml")
+stackDotYaml = either impureThrow id (parseRelFile "stack.yaml")
 
 setup :: IO ()
 setup = unsetEnv "STACK_YAML"
@@ -154,8 +153,8 @@ spec = beforeAll setup $ do
 
     it "STACK_YAML can be relative" $ inTempDir $ do
         parentDir <- getCurrentDirectory >>= parseAbsDir
-        let childRel = $(mkRelDir "child")
-            yamlRel = childRel </> $(mkRelFile "some-other-name.config")
+        let childRel = either impureThrow id (parseRelDir "child")
+            yamlRel = childRel </> either impureThrow id (parseRelFile "some-other-name.config")
             yamlAbs = parentDir </> yamlRel
         createDirectoryIfMissing True $ toFilePath $ parent yamlAbs
         writeFile (toFilePath yamlAbs) "resolver: ghc-7.8"

--- a/src/test/Stack/GhciSpec.hs
+++ b/src/test/Stack/GhciSpec.hs
@@ -46,11 +46,11 @@ shouldBeLE actual expected = shouldBe actual (textToLazy $ T.filter (/= '\r') ex
 
 baseProjDir, projDirA, projDirB :: Path Abs Dir
 baseProjDir = $(mkAbsDir $ defaultDrive FP.</> "Users" FP.</> "someone" FP.</> "src")
-projDirA = baseProjDir </> $(mkRelDir "project-a")
-projDirB = baseProjDir </> $(mkRelDir "project-b")
+projDirA = baseProjDir </> either impureThrow id (parseRelDir "project-a")
+projDirB = baseProjDir </> either impureThrow id (parseRelDir "project-b")
 
 relFile :: Path Rel File
-relFile = $(mkRelFile $ "exe" FP.</> "Main.hs")
+relFile = either impureThrow id (parseRelFile $ "exe" FP.</> "Main.hs")
 
 absFile :: Path Abs File
 absFile = projDirA </> relFile

--- a/src/unix/System/Permissions.hs
+++ b/src/unix/System/Permissions.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module System.Permissions
+  ( setScriptPerms
+  , osIsWindows
+  , setFileExecutable
+  ) where
+
+import qualified System.Posix.Files as Posix
+import Stack.Prelude
+
+-- | True if using Windows OS.
+osIsWindows :: Bool
+osIsWindows = False
+
+setScriptPerms :: MonadIO m => FilePath -> m ()
+setScriptPerms fp = do
+    liftIO $ Posix.setFileMode fp $
+        Posix.ownerReadMode `Posix.unionFileModes`
+        Posix.ownerWriteMode `Posix.unionFileModes`
+        Posix.groupReadMode `Posix.unionFileModes`
+        Posix.otherReadMode
+
+setFileExecutable :: MonadIO m => FilePath -> m ()
+setFileExecutable fp = liftIO $ Posix.setFileMode fp 0o755

--- a/src/unix/System/Terminal.hsc
+++ b/src/unix/System/Terminal.hsc
@@ -2,10 +2,13 @@
 
 module System.Terminal
 ( getTerminalWidth
+, fixCodePage
+, hIsTerminalDeviceOrMinTTY
 ) where
 
 import           Foreign
 import           Foreign.C.Types
+import           RIO (MonadIO, Handle, hIsTerminalDevice)
 
 #include <sys/ioctl.h>
 #include <unistd.h>
@@ -33,3 +36,11 @@ getTerminalWidth =
       else do
         WindowWidth w <- peek p
         return . Just . fromIntegral $ w
+
+fixCodePage :: x -> y -> a -> a
+fixCodePage _ _ = id
+
+-- | hIsTerminaDevice does not recognise handles to mintty terminals as terminal
+-- devices, but isMinTTYHandle does.
+hIsTerminalDeviceOrMinTTY :: MonadIO m => Handle -> m Bool
+hIsTerminalDeviceOrMinTTY = hIsTerminalDevice

--- a/src/windows/System/Permissions.hs
+++ b/src/windows/System/Permissions.hs
@@ -1,0 +1,15 @@
+module System.Permissions
+  ( setScriptPerms
+  , osIsWindows
+  , setFileExecutable
+  ) where
+
+-- | True if using Windows OS.
+osIsWindows :: Bool
+osIsWindows = True
+
+setScriptPerms :: Monad m => FilePath -> m ()
+setScriptPerms _ = return ()
+
+setFileExecutable :: Monad m => FilePath -> m ()
+setFileExecutable _ = return ()

--- a/src/windows/System/Terminal.hs
+++ b/src/windows/System/Terminal.hs
@@ -1,6 +1,71 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
 module System.Terminal
 ( getTerminalWidth
+, fixCodePage
+,hIsTerminalDeviceOrMinTTY
 ) where
+
+import Distribution.Types.Version (mkVersion)
+import Stack.Prelude
+import System.Win32 (isMinTTYHandle, withHandleToHANDLE)
+import System.Win32.Console (setConsoleCP, setConsoleOutputCP, getConsoleCP, getConsoleOutputCP)
+
 -- | Get the width, in columns, of the terminal if we can.
 getTerminalWidth :: IO (Maybe Int)
 getTerminalWidth = return Nothing
+
+-- | Set the code page for this process as necessary. Only applies to Windows.
+-- See: https://github.com/commercialhaskell/stack/issues/738
+fixCodePage
+  :: HasLogFunc env
+  => Bool -- ^ modify code page?
+  -> Version -- ^ GHC version
+  -> RIO env a
+  -> RIO env a
+fixCodePage mcp ghcVersion inner = do
+    if mcp && ghcVersion < mkVersion [7, 10, 3]
+        then fixCodePage'
+        -- GHC >=7.10.3 doesn't need this code page hack.
+        else inner
+  where
+    fixCodePage' = do
+        origCPI <- liftIO getConsoleCP
+        origCPO <- liftIO getConsoleOutputCP
+
+        let setInput = origCPI /= expected
+            setOutput = origCPO /= expected
+            fixInput
+                | setInput = bracket_
+                    (liftIO $ do
+                        setConsoleCP expected)
+                    (liftIO $ setConsoleCP origCPI)
+                | otherwise = id
+            fixOutput
+                | setOutput = bracket_
+                    (liftIO $ do
+                        setConsoleOutputCP expected)
+                    (liftIO $ setConsoleOutputCP origCPO)
+                | otherwise = id
+
+        case (setInput, setOutput) of
+            (False, False) -> return ()
+            (True, True) -> warn ""
+            (True, False) -> warn " input"
+            (False, True) -> warn " output"
+
+        fixInput $ fixOutput inner
+    expected = 65001 -- UTF-8
+    warn typ = logInfo $
+        "Setting" <>
+        typ <>
+        " codepage to UTF-8 (65001) to ensure correct output from GHC"
+
+-- | hIsTerminaDevice does not recognise handles to mintty terminals as terminal
+-- devices, but isMinTTYHandle does.
+hIsTerminalDeviceOrMinTTY :: MonadIO m => Handle -> m Bool
+hIsTerminalDeviceOrMinTTY h = do
+  isTD <- hIsTerminalDevice h
+  if isTD
+    then return True
+    else liftIO $ withHandleToHANDLE h isMinTTYHandle


### PR DESCRIPTION
This PR reduces the number of modules in the codebase which enable either `TemplateHaskell` or `CPP`, via a few techniques:

* Moving conditional code into separate Windows and Unix directories
* Moving all of the Store-related TH into a single module
* Moving `mkRelDir` and `mkRelFile` calls into `Stack.Constants`
* Replacing a few CPP usages with runtime checking of the OS, which I prefer using anyway (it reduces the amount of code which is only built on one OS or the other)

There should be no impact from these changes besides how it affects compile time.