### PR TITLE
Do not use Set for files

### DIFF
--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -439,8 +439,8 @@ getPackageFilesForTargets pkg cabalFP nonLibComponents = do
     let necessaryComponents = Set.insert CLib $ Set.filter isCInternalLib (M.keysSet components')
         components = necessaryComponents `Set.union` nonLibComponents
         componentsFiles =
-            M.map (\files -> Set.union otherFiles (Set.map dotCabalGetPath files)) $
-                M.filterWithKey (\component _ -> component `Set.member` components) compFiles
+            M.map (\files -> Set.union otherFiles (Set.map dotCabalGetPath $ Set.fromList files)) $
+                M.filterWithKey (\component _ -> component `elem` components) compFiles
     return (componentsFiles, warnings)
 
 -- | Get file modification time, if it exists.

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -68,10 +68,10 @@ data GhciOpts = GhciOpts
     , ghciOnlyMain           :: !Bool
     } deriving Show
 
+-- | Necessary information to load a package or its components.
+--
 -- NOTE: GhciPkgInfo has paths as list instead of a Set to preserve files order
 -- as a workaround for bug https://ghc.haskell.org/trac/ghc/ticket/13786
-
--- | Necessary information to load a package or its components.
 data GhciPkgInfo = GhciPkgInfo
     { ghciPkgName :: !PackageName
     , ghciPkgOpts :: ![(NamedComponent, BuildInfoOpts)]

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -68,15 +68,18 @@ data GhciOpts = GhciOpts
     , ghciOnlyMain           :: !Bool
     } deriving Show
 
+-- NOTE: GhciPkgInfo has paths as list instead of a Set to preserve files order
+-- as a workaround for bug https://ghc.haskell.org/trac/ghc/ticket/13786
+
 -- | Necessary information to load a package or its components.
 data GhciPkgInfo = GhciPkgInfo
     { ghciPkgName :: !PackageName
     , ghciPkgOpts :: ![(NamedComponent, BuildInfoOpts)]
     , ghciPkgDir :: !(Path Abs Dir)
     , ghciPkgModules :: !ModuleMap
-    , ghciPkgCFiles :: !(Set (Path Abs File)) -- ^ C files.
-    , ghciPkgMainIs :: !(Map NamedComponent (Set (Path Abs File)))
-    , ghciPkgTargetFiles :: !(Maybe (Set (Path Abs File)))
+    , ghciPkgCFiles :: ![Path Abs File] -- ^ C files.
+    , ghciPkgMainIs :: !(Map NamedComponent [Path Abs File])
+    , ghciPkgTargetFiles :: !(Maybe [Path Abs File])
     , ghciPkgPackage :: !Package
     } deriving Show
 
@@ -215,16 +218,16 @@ findFileTargets
     :: HasEnvConfig env
     => [LocalPackage]
     -> [Path Abs File]
-    -> RIO env (Map PackageName Target, Map PackageName (Set (Path Abs File)), [Path Abs File])
+    -> RIO env (Map PackageName Target, Map PackageName [Path Abs File], [Path Abs File])
 findFileTargets locals fileTargets = do
     filePackages <- forM locals $ \lp -> do
         (_,compFiles,_,_) <- getPackageFiles (packageFiles (lpPackage lp)) (lpCabalFile lp)
-        return (lp, M.map (S.map dotCabalGetPath) compFiles)
+        return (lp, M.map (map dotCabalGetPath) compFiles)
     let foundFileTargetComponents :: [(Path Abs File, [(PackageName, NamedComponent)])]
         foundFileTargetComponents =
             map (\fp -> (fp, ) $ sort $
                         concatMap (\(lp, files) -> map ((packageName (lpPackage lp), ) . fst)
-                                                       (filter (S.member fp . snd) (M.toList files))
+                                                       (filter (elem fp . snd) (M.toList files))
                                   ) filePackages
                 ) fileTargets
     results <- forM foundFileTargetComponents $ \(fp, xs) ->
@@ -255,8 +258,8 @@ findFileTargets locals fileTargets = do
             map (\(_, (name, comp)) -> M.singleton name (TargetComps (S.singleton comp)))
                 associatedFiles
         infoMap =
-            foldl (M.unionWith S.union) M.empty $
-            map (\(fp, (name, _)) -> M.singleton name (S.singleton fp))
+            foldl (M.unionWith (<>)) M.empty $
+            map (\(fp, (name, _)) -> M.singleton name [fp])
                 associatedFiles
     return (targetMap, infoMap, extraFiles)
 
@@ -486,7 +489,7 @@ renderScript isIntero pkgs mainFile onlyMain extraFiles = do
 -- Hacky check if module / main phase should be omitted. This should be
 -- improved if / when we have a better per-component load.
 getFileTargets :: [GhciPkgInfo] -> [Path Abs File]
-getFileTargets = concatMap (concatMap S.toList . maybeToList . ghciPkgTargetFiles)
+getFileTargets = concatMap (concat . maybeToList . ghciPkgTargetFiles)
 
 -- | Figure out the main-is file to load based on the targets. Asks the
 -- user for input if there is more than one candidate main-is file.
@@ -530,7 +533,7 @@ figureOutMainFile bopts mainIsTargets targets0 packages = do
                     M.toList $
                     M.filterWithKey (\k _ -> k `S.member` wantedComponents)
                                     (ghciPkgMainIs pkg)
-                main <- S.toList mains
+                main <- mains
                 return (ghciPkgName pkg, component, main)
               where
                 wantedComponents =
@@ -641,7 +644,7 @@ getGhciPkgInfos
     :: HasEnvConfig env
     => SourceMap
     -> [PackageName]
-    -> Maybe (Map PackageName (Set (Path Abs File)))
+    -> Maybe (Map PackageName [Path Abs File])
     -> [GhciPkgDesc]
     -> RIO env [GhciPkgInfo]
 getGhciPkgInfos sourceMap addPkgs mfileTargets localTargets = do
@@ -667,7 +670,7 @@ makeGhciPkgInfo
     -> InstalledMap
     -> [PackageName]
     -> [PackageName]
-    -> Maybe (Map PackageName (Set (Path Abs File)))
+    -> Maybe (Map PackageName [Path Abs File])
     -> GhciPkgDesc
     -> RIO env GhciPkgInfo
 makeGhciPkgInfo sourceMap installedMap locals addPkgs mfileTargets pkgDesc = do
@@ -680,7 +683,6 @@ makeGhciPkgInfo sourceMap installedMap locals addPkgs mfileTargets pkgDesc = do
     let filteredOpts = filterWanted opts
         filterWanted = M.filterWithKey (\k _ -> k `S.member` allWanted)
         allWanted = wantedPackageComponents bopts target pkg
-        setMapMaybe f = S.fromList . mapMaybe f . S.toList
     return
         GhciPkgInfo
         { ghciPkgName = name
@@ -689,8 +691,8 @@ makeGhciPkgInfo sourceMap installedMap locals addPkgs mfileTargets pkgDesc = do
         , ghciPkgModules = unionModuleMaps $
           map (\(comp, mp) -> M.map (\fp -> M.singleton fp (S.singleton (packageName pkg, comp))) mp)
               (M.toList (filterWanted mods))
-        , ghciPkgMainIs = M.map (setMapMaybe dotCabalMainPath) files
-        , ghciPkgCFiles = mconcat (M.elems (filterWanted (M.map (setMapMaybe dotCabalCFilePath) files)))
+        , ghciPkgMainIs = M.map (mapMaybe dotCabalMainPath) files
+        , ghciPkgCFiles = mconcat (M.elems (filterWanted (M.map (mapMaybe dotCabalCFilePath) files)))
         , ghciPkgTargetFiles = mfileTargets >>= M.lookup name
         , ghciPkgPackage = pkg
         }
@@ -810,7 +812,7 @@ targetWarnings
   => Path Abs File
   -> [(PackageName, (Path Abs File, Target))]
   -> [PackageName]
-  -> Maybe (Map PackageName (Set (Path Abs File)), [Path Abs File])
+  -> Maybe (Map PackageName [Path Abs File], [Path Abs File])
   -> RIO env ()
 targetWarnings stackYaml localTargets nonLocalTargets mfileTargets = do
   unless (null nonLocalTargets) $

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -155,7 +155,7 @@ newtype GetPackageOpts = GetPackageOpts
                      -> Path Abs File
                      -> RIO env
                           (Map NamedComponent (Map ModuleName (Path Abs File))
-                          ,Map NamedComponent (Set DotCabalPath)
+                          ,Map NamedComponent [DotCabalPath]
                           ,Map NamedComponent BuildInfoOpts)
     }
 instance Show GetPackageOpts where
@@ -184,7 +184,7 @@ newtype GetPackageFiles = GetPackageFiles
                       => Path Abs File
                       -> RIO env
                            (Map NamedComponent (Map ModuleName (Path Abs File))
-                           ,Map NamedComponent (Set DotCabalPath)
+                           ,Map NamedComponent [DotCabalPath]
                            ,Set (Path Abs File)
                            ,[PackageWarning])
     }

--- a/test/integration/tests/4270-files-order/Main.hs
+++ b/test/integration/tests/4270-files-order/Main.hs
@@ -1,0 +1,10 @@
+import Control.Monad
+import StackTest
+
+main :: IO ()
+main = do
+    stack ["build"]
+    repl [] $ do
+        replCommand "putStrLn greeting"
+        line <- replGetLine
+        when (line /= "Hello, world!") $ error "Didn't load correctly."

--- a/test/integration/tests/4270-files-order/files/cbits-ordering.cabal
+++ b/test/integration/tests/4270-files-order/files/cbits-ordering.cabal
@@ -1,0 +1,27 @@
+-- This file has been generated from package.yaml by hpack version 0.28.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: e76488d28476ba7cd8aa51be80b2c7eb71e870238b2a548581cf6093bd7c7994
+
+name:           cbits-ordering
+version:        0.0.0
+build-type:     Simple
+cabal-version:  >= 1.10
+
+library
+  exposed-modules:
+      Lib
+  other-modules:
+      Paths_cbits_ordering
+  hs-source-dirs:
+      src
+  include-dirs:
+      cbits
+  c-sources:
+      cbits/the_dependency.c
+      cbits/a_dependent.c
+
+  build-depends:
+      base >=4.7 && <5
+  default-language: Haskell2010

--- a/test/integration/tests/4270-files-order/files/cbits/a_dependent.c
+++ b/test/integration/tests/4270-files-order/files/cbits/a_dependent.c
@@ -1,0 +1,6 @@
+extern const char *msg;
+
+const char *greeting()
+{
+  return msg;
+}

--- a/test/integration/tests/4270-files-order/files/cbits/a_dependent.h
+++ b/test/integration/tests/4270-files-order/files/cbits/a_dependent.h
@@ -1,0 +1,1 @@
+const char *greeting();

--- a/test/integration/tests/4270-files-order/files/cbits/the_dependency.c
+++ b/test/integration/tests/4270-files-order/files/cbits/the_dependency.c
@@ -1,0 +1,1 @@
+const char *msg = "Hello, world!";

--- a/test/integration/tests/4270-files-order/files/src/Lib.hs
+++ b/test/integration/tests/4270-files-order/files/src/Lib.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Lib where
+
+import Foreign.C.String
+import System.IO.Unsafe
+
+foreign import ccall unsafe "a_dependent.h greeting"
+  c_greeting :: CString
+
+greeting :: String
+greeting = unsafePerformIO $ peekCString c_greeting

--- a/test/integration/tests/4270-files-order/files/src/Lib.hs
+++ b/test/integration/tests/4270-files-order/files/src/Lib.hs
@@ -8,5 +8,6 @@ import System.IO.Unsafe
 foreign import ccall unsafe "a_dependent.h greeting"
   c_greeting :: CString
 
+{-# NOINLINE greeting #-}
 greeting :: String
 greeting = unsafePerformIO $ peekCString c_greeting

--- a/test/integration/tests/4270-files-order/files/stack.yaml
+++ b/test/integration/tests/4270-files-order/files/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-12.8
+
+packages:
+- .


### PR DESCRIPTION
While investigating issue #4270 I came to a conclusion what the reason was indeed https://ghc.haskell.org/trac/ghc/ticket/13786 in conjunction with the fact that stack (unlike cabal-install) uses `Set` datatype while producing arguments list for ghci which leads to manually crafted c files order to be discarded. I tried to replace Set with simple lists and the issue seems gone. Tests run fine.

Could some of the developers have a look at this and either review the changes or suggest another way to deal with the issue?