### PR TITLE
Separate out Snapshot and SnapshotLayer

### DIFF
--- a/src/Stack/Freeze.hs
+++ b/src/Stack/Freeze.hs
@@ -56,7 +56,7 @@ freeze (FreezeOpts FreezeSnapshot) = do
   msnapshot <- view $ buildConfigL.to bcSnapshotDef.to sdSnapshot
   case msnapshot of
     Just (snap, _) -> do
-      snap' <- completeSnapshot snap
+      snap' <- completeSnapshotLayer snap
       if snap' == snap
       then
         logInfo "No freezing is required for the snapshot of this project"

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -47,7 +47,7 @@ import           Stack.Types.VersionIntervals
 -- repos, figure out package names, and assigned values appropriately.
 data SnapshotDef = SnapshotDef -- To be removed as part of https://github.com/commercialhaskell/stack/issues/3922
     { sdResolver        :: !SnapshotLocation
-    , sdSnapshot        :: !(Maybe (Snapshot, SnapshotDef))
+    , sdSnapshot        :: !(Maybe (SnapshotLayer, SnapshotDef))
     , sdWantedCompilerVersion :: !WantedCompiler
     , sdUniqueHash :: !SHA256
     }
@@ -59,9 +59,9 @@ sdResolverName :: SnapshotDef -> Text
 sdResolverName sd =
   case sdSnapshot sd of
     Nothing -> utf8BuilderToText $ display $ sdWantedCompilerVersion sd
-    Just (snapshot, _) -> snapshotName snapshot
+    Just (snapshot, _) -> slName snapshot
 
-sdSnapshots :: SnapshotDef -> [Snapshot]
+sdSnapshots :: SnapshotDef -> [SnapshotLayer]
 sdSnapshots sd =
   case sdSnapshot sd of
     Nothing -> []

--- a/src/Stack/Unpack.hs
+++ b/src/Stack/Unpack.hs
@@ -95,7 +95,7 @@ unpackPackages mSnapshotDef dest input = do
 
     toLocSnapshot :: SnapshotDef -> PackageName -> RIO env (Either String (PackageLocationImmutable, PackageIdentifier))
     toLocSnapshot sd name =
-        go $ concatMap snapshotLocations $ sdSnapshots sd
+        go $ concatMap slLocations $ sdSnapshots sd
       where
         go [] = pure $ Left $ "Package does not appear in snapshot: " ++ packageNameString name
         go (loc:locs) = do

--- a/subs/curator/app/Main.hs
+++ b/subs/curator/app/Main.hs
@@ -7,7 +7,6 @@ import Data.Yaml (encodeFile, decodeFileThrow)
 import Options.Generic (ParseRecord, getRecord)
 import Path.IO (resolveFile', resolveDir')
 import RIO.Process
-import qualified Curator
 
 data CuratorOptions
   = Update
@@ -77,7 +76,7 @@ build = do
     (words "build --test --bench --no-rerun-tests --no-run-benchmarks --haddock")
     runProcess_
 
-loadPantrySnapshotLayerFile :: FilePath -> RIO PantryApp Curator.SnapshotLayer
+loadPantrySnapshotLayerFile :: FilePath -> RIO PantryApp SnapshotLayer
 loadPantrySnapshotLayerFile fp = do
   abs' <- resolveFile' fp
   eres <- loadSnapshotLayer $ SLFilePath (ResolvedPath (RelFilePath (fromString fp)) abs')

--- a/subs/curator/src/Curator/Snapshot.hs
+++ b/subs/curator/src/Curator/Snapshot.hs
@@ -13,18 +13,18 @@ makeSnapshot
   :: (HasPantryConfig env, HasLogFunc env, HasProcessContext env)
   => Constraints
   -> Text -- ^ name
-  -> RIO env Snapshot
+  -> RIO env SnapshotLayer
 makeSnapshot cons name = do
   locs <- traverseValidate (uncurry toLoc) $ Map.toList $ consPackages cons
-  pure Snapshot
-    { snapshotParent = SLCompiler $ WCGhc $ consGhcVersion cons
-    , snapshotCompiler = Nothing
-    , snapshotName = name
-    , snapshotLocations = catMaybes locs
-    , snapshotDropPackages = mempty
-    , snapshotFlags = Map.mapMaybe getFlags (consPackages cons)
-    , snapshotHidden = Map.filter id (pcHide <$> consPackages cons)
-    , snapshotGhcOptions = mempty
+  pure SnapshotLayer
+    { slParent = SLCompiler $ WCGhc $ consGhcVersion cons
+    , slCompiler = Nothing
+    , slName = name
+    , slLocations = catMaybes locs
+    , slDropPackages = mempty
+    , slFlags = Map.mapMaybe getFlags (consPackages cons)
+    , slHidden = Map.filter id (pcHide <$> consPackages cons)
+    , slGhcOptions = mempty
     }
 
 getFlags :: PackageConstraints -> Maybe (Map FlagName Bool)

--- a/subs/curator/src/Curator/Unpack.hs
+++ b/subs/curator/src/Curator/Unpack.hs
@@ -24,13 +24,15 @@ unpackSnapshot
   -> RIO env ()
 unpackSnapshot cons snap root = do
   unpacked <- parseRelDir "unpacked"
-  (suffixes, flags, skipTest, skipBench, skipHaddock) <- fmap fold $ for (snapshotLocations snap) $ \pl -> do
+  (suffixes, flags, skipTest, skipBench, skipHaddock) <- fmap fold $ for (snapshotPackages snap) $ \sp -> do
+    let pl = spLocation sp
     TreeKey (BlobKey sha _size) <- getPackageLocationTreeKey pl
     PackageIdentifier name version <- getPackageLocationIdent pl
     pc <-
       case Map.lookup name $ consPackages cons of
         Nothing -> error $ "Package not found in constraints: " ++ packageNameString name
         Just pc -> pure pc
+    unless (pcFlags pc == spFlags sp) $ error "mismatched flags!"
     if pcSkipBuild pc
       then pure mempty
       else do

--- a/subs/pantry/src/Pantry.hs
+++ b/subs/pantry/src/Pantry.hs
@@ -767,7 +767,7 @@ warnUnusedAddPackagesConfig
   => Utf8Builder -- ^ source
   -> AddPackagesConfig
   -> RIO env ()
-warnUnusedAddPackagesConfig source (AddPackagesConfig drops flags hiddens options) = do
+warnUnusedAddPackagesConfig source (AddPackagesConfig _drops flags hiddens options) = do
   unless (null ls) $ do
     logWarn $ "Some warnings discovered when adding packages to snapshot (" <> source <> ")"
     traverse_ logWarn ls

--- a/subs/pantry/src/Pantry/Types.hs
+++ b/subs/pantry/src/Pantry/Types.hs
@@ -800,7 +800,7 @@ instance Display PantryException where
   display (InvalidCabalFilePath fp) =
     "File path contains a name which is not a valid package name: " <>
     fromString (toFilePath fp)
-  display (DuplicatePackageNames source pairs) =
+  display (DuplicatePackageNames source pairs') =
     "Duplicate package names (" <> source <> "):\n" <>
     foldMap
       (\(name, locs) ->
@@ -809,7 +809,7 @@ instance Display PantryException where
           (\loc -> "- " <> display loc <> "\n")
           locs
       )
-      pairs
+      pairs'
 
 data FuzzyResults
   = FRNameNotFound ![PackageName]


### PR DESCRIPTION
A single snapshot YAML file is in fact just a layer in the creation of a
snapshot. In the current code, Stack will ask Pantry to perform the
parsing of the individual layers, and then combine the layers into its
own representation of a snapshot. This means that the code for this is
less easily testable, and other tooling (e.g., stack2nix) will not have
access to this logic.

This commit separates out the idea of a snapshot and a snapshot layer at
the type level. The next commit will be a simple change to the Stack
codebase to use the updated names, but keep the layer combining logic it
currently has. A future, somewhat more involved change will drop the
duplicated logic from Stack entirely and rely on Pantry's logic
exclusively.