### PR TITLE
Add `--cabal-files` flag to `ide packages` command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -90,6 +90,7 @@ Bug fixes:
 * Fix `subdirs` for git repos in `extra-deps` to match whole directory names.
   Also fixes for `subdirs: .`. See
   [#4292](https://github.com/commercialhaskell/stack/issues/4292)
+* Add `--cabal-files` flag to `stack ide targets` command.
 
 
 ## v1.9.0.1 (release candidate)

--- a/src/Stack/IDE.hs
+++ b/src/Stack/IDE.hs
@@ -7,7 +7,8 @@
 
 -- | Functions for IDEs.
 module Stack.IDE
-    ( listPackages
+    ( ListPackagesCmd(..)
+    , listPackages
     , listTargets
     ) where
 
@@ -18,11 +19,19 @@ import           Stack.Prelude
 import           Stack.Types.Config
 import           Stack.Types.NamedComponent
 
+data ListPackagesCmd = ListPackageNames
+                     | ListPackageCabalFiles
+
 -- | List the packages inside the current project.
-listPackages :: HasBuildConfig env => RIO env ()
-listPackages = do
+listPackages :: HasBuildConfig env => ListPackagesCmd -> RIO env ()
+listPackages flag = do
   packages <- view $ buildConfigL.to bcPackages
-  for_ (Map.keys packages) (logInfo . fromString . packageNameString)
+  let strs = case flag of
+        ListPackageNames ->
+          map packageNameString (Map.keys packages)
+        ListPackageCabalFiles ->
+          map (toFilePath . ppCabalFP) (Map.elems packages)
+  mapM_ (logInfo . fromString) strs
 
 -- | List the targets in the current project.
 listTargets :: forall env. HasBuildConfig env => RIO env ()

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -417,7 +417,11 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                     "packages"
                     "List all available local loadable packages"
                     idePackagesCmd
-                    (pure ())
+                    (flag
+                         IDE.ListPackageNames
+                         IDE.ListPackageCabalFiles
+                         (long "cabal-files" <>
+                          help "Print paths to package cabal-files instead of package names"))
                 addCommand'
                     "targets"
                     "List all available stack targets"
@@ -912,9 +916,9 @@ ghciCmd ghciOpts go@GlobalOpts{..} =
           (ghci ghciOpts)
 
 -- | List packages in the project.
-idePackagesCmd :: () -> GlobalOpts -> IO ()
-idePackagesCmd () go =
-    withBuildConfig go IDE.listPackages -- TODO don't need EnvConfig any more
+idePackagesCmd :: IDE.ListPackagesCmd -> GlobalOpts -> IO ()
+idePackagesCmd cmd go =
+    withBuildConfig go (IDE.listPackages cmd) -- TODO don't need EnvConfig any more
 
 -- | List targets in the project.
 ideTargetsCmd :: () -> GlobalOpts -> IO ()


### PR DESCRIPTION
With the `--cabal-files` flag active `stack ide packages` will print the paths to packages' cabal-files instead of just the package name. Having the full path to all packages within a Stack project will allow me to expose a more unified project representation in  [`cabal-helper`](https://github.com/DanielG/cabal-helper) in light of upcoming `cabal new-build` support.

---

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
