### PR TITLE
Update git package submodules after clone and reset

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -90,6 +90,8 @@ Bug fixes:
 * Fix `subdirs` for git repos in `extra-deps` to match whole directory names.
   Also fixes for `subdirs: .`. See
   [#4292](https://github.com/commercialhaskell/stack/issues/4292)
+* Fix for git packages to update submodules to the correct state. See
+  [#4314](https://github.com/commercialhaskell/stack/pull/4314)
 
 
 ## v1.9.0.1 (release candidate)


### PR DESCRIPTION
Related to https://github.com/commercialhaskell/stack/issues/1764 and a subtle fix for what was implemented in https://github.com/commercialhaskell/stack/pull/1852, this changes the logic for packages identified by git locations so that submodules are properly updated. The process now looks like this:

1. clone the repo
2. `reset --hard` to a specific commit
3. update submodules (recursively)

The problem with the existing implementation is that a hard reset (`git reset --hard`) doesn't update submodules so the state of submodules in a package will always be whatever's on the default branch.

> Please also shortly describe how you tested your change. Bonus points for added tests!

I tested a similar version of this patch against the [v1.9.0.1 tag](https://github.com/commercialhaskell/stack/releases/tag/v1.9.0.1), but I was unable to get stack on master to properly read the `stack.yaml` of my project. To test requires a little bit of setup. You need:

- A stack project with a package identified using a [git location](https://docs.haskellstack.org/en/v1.2.0/yaml_configuration/#complex-package-locations-location)
- A package that uses submodules
- A commit SHA of that package where the submodule SHAs are different than what's on the default branch.

TODO:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] ~~The documentation has been updated, if necessary.~~ I don't believe there's anything to update here, but please let me know!
