### PR TITLE
removed typo in GUIDE.md

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1203,7 +1203,7 @@ what needs to be removed:
 
 ## exec
 
-We've already used `stack exec` used multiple times in this guide. As you've
+We've already used `stack exec` multiple times in this guide. As you've
 likely already guessed, it allows you to run executables, but with a slightly
 modified environment. In particular: `stack exec` looks for executables on
 stack's bin paths, and sets a few additional environment variables (like adding


### PR DESCRIPTION
`We've already used 'stack exec' used multiple times in this guide.` should be `We've already used 'stack exec' multiple times in this guide.`

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
