### PR TITLE
Use Cabal 2.4 for the 1.9 branch

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,10 @@ Release notes:
 Major changes:
 
 * Upgrade to Cabal 2.4
+    * Note that, in this process, the behavior of file globbing has
+      been modified to match that of Cabal. In particular, this means
+      that for Cabal spec versions less than 2.4, `*.txt` will
+      match `foo.txt`, but not `foo.2.txt`.
 
 Behavior changes:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@ Release notes:
 
 Major changes:
 
+* Upgrade to Cabal 2.4
+
 Behavior changes:
 
 Other enhancements:
@@ -24,7 +26,6 @@ Release notes:
 Major changes:
 
 * `GHCJS` support is being downgraded to 'experimental'. A warning notifying the user of the experimental status of `GHCJS` will be displayed.
-* Upgrade to Cabal 2.4
 
 Behavior changes:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,17 +3,15 @@
 
 ## Unreleased changes
 
-        ## Unreleased changes
+Release notes:
 
-        Release notes:
+Major changes:
 
-        Major changes:
+Behavior changes:
 
-        Behavior changes:
+Other enhancements:
 
-        Other enhancements:
-
-        Bug fixes:
+Bug fixes:
 
 
 ## v1.9.0.1 (release candidate)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,7 @@ Release notes:
 Major changes:
 
 * `GHCJS` support is being downgraded to 'experimental'. A warning notifying the user of the experimental status of `GHCJS` will be displayed.
+* Upgrade to Cabal 2.4
 
 Behavior changes:
 

--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ homepage: http://haskellstack.org
 custom-setup:
   dependencies:
   - base >=4.10 && < 5
-  - Cabal >= 2.4
+  - Cabal
   - filepath
 extra-source-files:
 # note: leaving out 'package.yaml' because it causes confusion with hackage metadata revisions
@@ -35,7 +35,7 @@ ghc-options:
 - -fwarn-incomplete-record-updates
 - -optP-Wno-nonportable-include-path # workaround [Filename case on macOS · Issue #4739 · haskell/cabal](https://github.com/haskell/cabal/issues/4739)
 dependencies:
-- Cabal >= 2.4
+- Cabal
 - aeson
 - annotated-wl-pprint
 - ansi-terminal

--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ homepage: http://haskellstack.org
 custom-setup:
   dependencies:
   - base >=4.10 && < 5
-  - Cabal
+  - Cabal >= 2.4
   - filepath
 extra-source-files:
 # note: leaving out 'package.yaml' because it causes confusion with hackage metadata revisions
@@ -35,7 +35,7 @@ ghc-options:
 - -fwarn-incomplete-record-updates
 - -optP-Wno-nonportable-include-path # workaround [Filename case on macOS · Issue #4739 · haskell/cabal](https://github.com/haskell/cabal/issues/4739)
 dependencies:
-- Cabal
+- Cabal >= 2.4
 - aeson
 - annotated-wl-pprint
 - ansi-terminal

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -39,7 +39,7 @@ module Stack.Package
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as CL8
-import           Data.List (isSuffixOf, isPrefixOf, unzip)
+import           Data.List (isPrefixOf, unzip)
 import           Data.Maybe (maybe)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -56,7 +56,7 @@ import           Distribution.PackageDescription hiding (FlagName)
 import           Distribution.PackageDescription.Parsec
 import qualified Distribution.PackageDescription.Parsec as D
 import           Distribution.Parsec.Common (PWarning (..), showPos)
-import           Distribution.Simple.Utils
+import           Distribution.Simple.Glob (matchDirFileGlob)
 import           Distribution.System (OS (..), Arch, Platform (..))
 import qualified Distribution.Text as D
 import qualified Distribution.Types.CondTree as Cabal
@@ -65,6 +65,7 @@ import           Distribution.Types.ForeignLib
 import qualified Distribution.Types.LegacyExeDependency as Cabal
 import           Distribution.Types.MungedPackageName
 import qualified Distribution.Types.UnqualComponentName as Cabal
+import qualified Distribution.Types.Version as Cabal
 import qualified Distribution.Verbosity as D
 import           Lens.Micro (lens)
 import qualified Hpack
@@ -93,7 +94,7 @@ import           Stack.Types.PackageName
 import           Stack.Types.Runner
 import           Stack.Types.Version
 import qualified System.Directory as D
-import           System.FilePath (splitExtensions, replaceExtension)
+import           System.FilePath (replaceExtension)
 import qualified System.FilePath as FilePath
 import           System.IO.Error
 import           RIO.Process
@@ -799,7 +800,7 @@ packageDescModulesAndFiles pkg = do
             (mapM
                  (asModuleAndFileMap benchComponent benchmarkFiles)
                  (benchmarks pkg))
-    dfiles <- resolveGlobFiles
+    dfiles <- resolveGlobFiles (specVersion pkg)
                     (extraSrcFiles pkg
                         ++ map (dataDir pkg FilePath.</>) (dataFiles pkg))
     let modules = libraryMods <> subLibrariesMods <> executableMods <> testMods <> benchModules
@@ -820,8 +821,11 @@ packageDescModulesAndFiles pkg = do
     foldTuples = foldl' (<>) (M.empty, M.empty, [])
 
 -- | Resolve globbing of files (e.g. data files) to absolute paths.
-resolveGlobFiles :: [String] -> RIO Ctx (Set (Path Abs File))
-resolveGlobFiles =
+resolveGlobFiles
+  :: Cabal.Version -- ^ cabal file version
+  -> [String]
+  -> RIO Ctx (Set (Path Abs File))
+resolveGlobFiles cabalFileVersion =
     liftM (S.fromList . catMaybes . concat) .
     mapM resolve
   where
@@ -838,7 +842,7 @@ resolveGlobFiles =
         mapM resolveFileOrWarn names
     matchDirFileGlob' dir glob =
         catch
-            (matchDirFileGlob_ dir glob)
+            (liftIO (matchDirFileGlob minBound cabalFileVersion dir glob))
             (\(e :: IOException) ->
                   if isUserError e
                       then do
@@ -850,48 +854,6 @@ resolveGlobFiles =
                               ]
                           return []
                       else throwIO e)
-
--- | This is a copy/paste of the Cabal library function, but with
---
--- @ext == ext'@
---
--- Changed to
---
--- @isSuffixOf ext ext'@
---
--- So that this will work:
---
--- @
--- λ> matchDirFileGlob_ "." "test/package-dump/*.txt"
--- ["test/package-dump/ghc-7.8.txt","test/package-dump/ghc-7.10.txt"]
--- @
---
-matchDirFileGlob_ :: HasRunner env => String -> String -> RIO env [String]
-matchDirFileGlob_ dir filepath = case parseFileGlob filepath of
-  Nothing -> liftIO $ throwString $
-      "invalid file glob '" ++ filepath
-      ++ "'. Wildcards '*' are only allowed in place of the file"
-      ++ " name, not in the directory name or file extension."
-      ++ " If a wildcard is used it must be with an file extension."
-  Just (NoGlob filepath') -> return [filepath']
-  Just (FileGlob dir' ext) -> do
-    efiles <- liftIO $ try $ D.getDirectoryContents (dir FilePath.</> dir')
-    let matches =
-            case efiles of
-                Left (_ :: IOException) -> []
-                Right files ->
-                    [ dir' FilePath.</> file
-                    | file <- files
-                    , let (name, ext') = splitExtensions file
-                    , not (null name) && isSuffixOf ext ext'
-                    ]
-    when (null matches) $
-        prettyWarnL
-            [ flow "filepath wildcard"
-            , "'" <> styleFile (fromString filepath) <> "'"
-            , flow "does not match any files."
-            ]
-    return matches
 
 -- | Get all files referenced by the benchmark.
 benchmarkFiles

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -424,7 +424,7 @@ checkPackageInExtractedTarball pkgDir = do
           case Check.checkPackage gdesc Nothing of
             [] -> Check.checkPackage gdesc (Just pkgDesc)
             x -> x
-    fileChecks <- liftIO $ Check.checkPackageFiles pkgDesc (toFilePath pkgDir)
+    fileChecks <- liftIO $ Check.checkPackageFiles minBound pkgDesc (toFilePath pkgDir)
     let checks = pkgChecks ++ fileChecks
         (errors, warnings) =
           let criticalIssue (Check.PackageBuildImpossible _) = True

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,5 +1,12 @@
 resolver: nightly-2018-09-02
 
+extra-deps:
+- Cabal-2.4.0.0@rev:0
+- cabal-install-2.4.0.0@rev:1
+- http-api-data-0.3.8.1@rev:1
+- cabal-doctest-1.0.6@rev:2
+- happy-1.19.9@rev:3
+
 # docker:
 #   enable: true
 #   repo: fpco/stack-full

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,15 +17,17 @@ flags:
     hide-dependency-versions: true
     supported-build: true
 extra-deps:
-- Cabal-2.2.0.1@rev:0
-- cabal-install-2.2.0.0@rev:1
+- Cabal-2.4.0.1@rev:0
+- cabal-install-2.4.0.0@rev:1
 - resolv-0.1.1.1@rev:0
 - infer-license-0.2.0@rev:0
 - hpack-0.31.0@rev:0
-- http-api-data-0.3.8.1@rev:0
+- http-api-data-0.3.8.1@rev:1
 - githash-0.1.0.1@rev:0
 - yaml-0.10.1.1@rev:0 #for hpack-0.31
 - windns-0.1.0.0@rev:0
+- hackage-security-0.5.3.0@rev:2
+- cabal-doctest-1.0.6@rev:2
 
 # Avoid https://github.com/commercialhaskell/stack/issues/4125
 # (triggered because later versions of persistent transitively depends


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
