### PR TITLE
Add System.Uname as an 'other-module' in package.yaml.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -133,8 +133,6 @@ library:
   source-dirs: src/
   ghc-options:
   - -fwarn-identities
-  generated-exposed-modules:
-  - Paths_stack
   exposed-modules:
   - Control.Concurrent.Execute
   - Data.Attoparsec.Args
@@ -150,6 +148,7 @@ library:
   - Path.CheckInstall
   - Path.Extra
   - Path.Find
+  - Paths_stack  # Generated
   - Stack.Build
   - Stack.Build.Cache
   - Stack.Build.ConstructPlan
@@ -259,8 +258,10 @@ library:
   - System.Permissions
   - System.Process.PagerEditor
   - System.Terminal
+  other-modules:
+  - System.Uname
   when:
-  - condition: 'os(windows)'
+  - condition: os(windows)
     then:
       source-dirs: src/windows/
     else:
@@ -270,7 +271,7 @@ executables:
   stack:
     main: Main.hs
     source-dirs: src/main
-    generated-other-modules:
+    other-modules:
     - Build_stack,
     - Paths_stack
     ghc-options:

--- a/package.yaml
+++ b/package.yaml
@@ -133,6 +133,8 @@ library:
   source-dirs: src/
   ghc-options:
   - -fwarn-identities
+  generated-exposed-modules:
+  - Paths_stack
   exposed-modules:
   - Control.Concurrent.Execute
   - Data.Attoparsec.Args
@@ -148,7 +150,6 @@ library:
   - Path.CheckInstall
   - Path.Extra
   - Path.Find
-  - Paths_stack  # Generated
   - Stack.Build
   - Stack.Build.Cache
   - Stack.Build.ConstructPlan
@@ -271,7 +272,7 @@ executables:
   stack:
     main: Main.hs
     source-dirs: src/main
-    other-modules:
+    generated-other-modules:
     - Build_stack,
     - Paths_stack
     ghc-options:

--- a/src/windows/System/Uname.hs
+++ b/src/windows/System/Uname.hs
@@ -1,0 +1,3 @@
+module System.Uname where
+
+data VoidSystemUnameType

--- a/subs/pantry/pantry.cabal
+++ b/subs/pantry/pantry.cabal
@@ -1,10 +1,8 @@
-cabal-version: 1.12
-
--- This file has been generated from package.yaml by hpack version 0.30.0.
+-- This file has been generated from package.yaml by hpack version 0.28.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bfc4bfcec8fa396290c6a92012ae46cae07ca2bd329e9ae0ca7aaec18202474f
+-- hash: 0a721ca8742195db985b41ea5ca6e0c941a621ca8e59f57ac6ad9e9eafa72c08
 
 name:           pantry
 version:        0.1.0.0
@@ -18,10 +16,11 @@ maintainer:     michael@snoyman.com
 copyright:      2018 FP Complete
 license:        MIT
 build-type:     Simple
+cabal-version:  >= 1.10
 extra-source-files:
-    README.md
-    ChangeLog.md
     attic/package-0.1.2.3.tar.gz
+    ChangeLog.md
+    README.md
 
 source-repository head
   type: git


### PR DESCRIPTION
Additionally, we need to add a dummy System.Uname in the windows sources
directory in order to workaround an issue where hpack doesn't support the
'other-modules' directive in library conditionals.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

I ran `stack build`. My sense is that `hpack` will usually accurately infer the contents of `other-modules`. However, on my machine, it was not adding `System.Uname` after the commit 9b61953e320796875df30646001b4dd1eefec1eb. This adds the module explicitly to `other-modules` and places a dummy module in the windows sources in order to avoid having "not found" errors on that platform.