### PR TITLE
Fix #3797 (Windows 10: re `git submodule` usage)

### DIFF
--- a/subs/pantry/src/Pantry/Repo.hs
+++ b/subs/pantry/src/Pantry/Repo.hs
@@ -101,6 +101,11 @@ getRepo' repo@(Repo url commit repoType' subdir) pm =
     withWorkingDir dir $ do
       runCommand resetArgs
       traverse_ runCommand submoduleArgs
+      -- On Windows 10, an upstream issue with the `git submodule` command means
+      -- that command clears, but does not then restore, the
+      -- ENABLE_VIRTUAL_TERMINAL_PROCESSING flag for native terminals. The
+      -- folowing hack re-enables the lost ANSI-capability.
+      when osIsWindows $ void $ liftIO $ hSupportsANSIWithoutEmulation stdout
       runCommand archiveArgs
     abs' <- resolveFile' tarball
     getArchive


### PR DESCRIPTION
Commit 8bda49d9bd6030920a6c23aa82fcc98b6cd8137b introduced the `git submodule` command into `Pantry.Repo.getRepo'`. Tests suggest that, on Windows 10, this suffers from the same upstream bug as `git clone` (see https://github.com/commercialhaskell/stack/issues/3992#issuecomment-401207463 .)

This pull request proposes the same 'fix'; on Windows 10, re-enable ANSI capability after the `git submodule` command is used.

Tests on Windows 10 suggest the fix works as intended. (Tested by adding some temporary dummy lines of code at the relevant point to output ANSI codes to `stdout` and seeing how the native Windows 10 console deals with them.)

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md (None)
* [x] The documentation has been updated, if necessary. (None)