### PR TITLE
 Add option to print dependencies as tree

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -75,6 +75,8 @@ Other enhancements:
 * Use en_US.UTF-8 locale by default in pure Nix mode so programs won't
   crash because of Unicode in their output
   [#4095](https://github.com/commercialhaskell/stack/issues/4095)
+* Add `--tree` to `ls dependencies` to list dependencies as tree.
+  [#4101](https://github.com/commercialhaskell/stack/issues/4101)
 
 Bug fixes:
 

--- a/src/Stack/Options/DotParser.hs
+++ b/src/Stack/Options/DotParser.hs
@@ -67,4 +67,8 @@ listDepsOptsParser = ListDepsOpts
                                 "license"
                                 "printing of dependency licenses instead of versions"
                                 idm
+                 <*> boolFlags False
+                                "tree"
+                                "printing of dependencies as a tree"
+                                idm
   where escapeSep sep = T.replace "\\t" "\t" (T.replace "\\n" "\n" sep)

--- a/test/integration/tests/4101-dependency-tree/Main.hs
+++ b/test/integration/tests/4101-dependency-tree/Main.hs
@@ -1,0 +1,36 @@
+import Control.Monad (when)
+import StackTest
+
+main :: IO ()
+main = do
+  stackCheckStdout ["ls", "dependencies", "--tree"] $ \stdOut -> do
+    let expected = unlines [ "Packages"
+                           , "└─┬ files mkVersion [0,1,0,0]"
+                           , "  ├─┬ base mkVersion [4,11,1,0]"
+                           , "  │ ├─┬ ghc-prim mkVersion [0,5,2,0]"
+                           , "  │ │ └── rts mkVersion [1,0]"
+                           , "  │ ├─┬ integer-gmp mkVersion [1,0,2,0]"
+                           , "  │ │ └─┬ ghc-prim mkVersion [0,5,2,0]"
+                           , "  │ │   └── rts mkVersion [1,0]"
+                           , "  │ └── rts mkVersion [1,0]"
+                           , "  └─┬ mtl mkVersion [2,2,2]"
+                           , "    ├─┬ base mkVersion [4,11,1,0]"
+                           , "    │ ├─┬ ghc-prim mkVersion [0,5,2,0]"
+                           , "    │ │ └── rts mkVersion [1,0]"
+                           , "    │ ├─┬ integer-gmp mkVersion [1,0,2,0]"
+                           , "    │ │ └─┬ ghc-prim mkVersion [0,5,2,0]"
+                           , "    │ │   └── rts mkVersion [1,0]"
+                           , "    │ └── rts mkVersion [1,0]"
+                           , "    └── transformers mkVersion [0,5,5,0]"
+                           ]
+    when (stdOut /= expected) $
+      error $ unlines [ "Expected:", expected, "Actual:", stdOut ]
+
+  stackCheckStdout ["ls", "dependencies", "--tree", "--depth=1"] $ \stdOut -> do
+    let expected = unlines [ "Packages"
+                           , "└─┬ files mkVersion [0,1,0,0]"
+                           , "  ├── base mkVersion [4,11,1,0]"
+                           , "  └── mtl mkVersion [2,2,2]"
+                           ]
+    when (stdOut /= expected) $
+      error $ unlines [ "Expected:", expected, "Actual:", stdOut ]

--- a/test/integration/tests/4101-dependency-tree/files/files.cabal
+++ b/test/integration/tests/4101-dependency-tree/files/files.cabal
@@ -1,0 +1,10 @@
+name:                files
+version:             0.1.0.0
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  exposed-modules:     Lib
+  build-depends:       base >= 4.7 && < 5, mtl
+  default-language:    Haskell2010

--- a/test/integration/tests/4101-dependency-tree/files/src/Main.hs
+++ b/test/integration/tests/4101-dependency-tree/files/src/Main.hs
@@ -1,0 +1,5 @@
+module Main where
+
+main :: IO ()
+main = do
+  putStrLn "hello world"

--- a/test/integration/tests/4101-dependency-tree/files/stack.yaml
+++ b/test/integration/tests/4101-dependency-tree/files/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-12.14
+packages:
+- .


### PR DESCRIPTION
Fixes #4101 

### Checklist
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I think this is pretty discoverable by `stack ls dependencies --help` so I didn't add anything to the docs.

### How did I test this?

Unfortunately, manually. The `listDependencies` function was directly printing and had no tests and I built on top of that without much thought of testing. So, I couldn't add any automated tests.
Here is output from `stack ls dependencies --depth=0 --tree` on the stack repository:

```
Packages
├── curator mkVersion [2,0,0,0]
├── pantry mkVersion [0,1,0,0]
└── stack mkVersion [1,10,0]
```

Depth=1 onwards, the output becomes really large, so I will not paste it here.
Additionally, if you could me some pointers around how to test this, I would be happy to add tests.