### PR TITLE
Update get-stack.sh for centos 6

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -237,7 +237,7 @@ do_centos_install() {
   if is_64_bit ; then
     install_dependencies
     case "$1" in
-      "6")
+      "6"*)
         print_bindist_notice "libgmp4"
         install_64bit_gmp4_linked_binary
         ;;
@@ -248,7 +248,7 @@ do_centos_install() {
     esac
   else
     case "$1" in
-      "6")
+      "6"*)
         die "Sorry, there is currently no Linux 32-bit gmp4 binary available."
         ;;
       *)


### PR DESCRIPTION
## PR summary

Allows users with Centos 6 who have an lsb_release command to be pointed to the proper gmp4 linked binary download when using `curl -sSL https://get.haskellstack.org | sh`

## Problem Description

If a CentOS user has command `lsb_release`, the VERSION variable for `distro_info()` will be "6.xx", not just "6".  Since `try_lsb()` is the first test done in `distro_info()`, if the user has `lsb_release`, and any version of CentOS 6, the case statement will not point the user to the correct gmp linked binary.

NOTE:  I can't perform the test for stack 1.9 because an update to the `sudocmd()` function fails... not sure if that's just a temporary edit to the function, but will need to be fixed.  Happy to make another pull request for that if needed.

On testing:  I tested by only running the distro_info() function at the bottom of the script, but changing the end of the function to...
```
  echo "lsb" && try_lsb
  echo "release" && try_release
  echo "issue" && try_issue
  #try_lsb || try_release || try_issue
```
which when run....
```
[jupyter@Server scripts]$ ./testinstallscript.sh
lsb
centos;6.9
release
centos;6
issue
centos;6
```

test worked once changing the case statement.



Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

