### PR TITLE
Update get-stack.sh for centos 6 (`git cherry-pick` to `stable`)

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -230,7 +230,7 @@ do_centos_install() {
   if is_64_bit ; then
     install_dependencies
     case "$1" in
-      "6")
+      "6"*)
         print_bindist_notice "libgmp4"
         install_64bit_gmp4_linked_binary
         ;;
@@ -241,7 +241,7 @@ do_centos_install() {
     esac
   else
     case "$1" in
-      "6")
+      "6"*)
         die "Sorry, there is currently no Linux 32-bit gmp4 binary available."
         ;;
       *)


### PR DESCRIPTION
Applies @erjenkins29 fix in #4352 via `git cherry-pick` to the `stable` branch based on @borsboom's suggestion (thanks BTW!).
