### PR TITLE
Make `stack setup` command differentiate between FreeBSD versions.

### DIFF
--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -96,6 +96,7 @@ import              System.FilePath (searchPathSeparator)
 import qualified    System.FilePath as FP
 import              System.Permissions (setFileExecutable)
 import              RIO.Process
+import              RIO.List
 import              Text.Printf (printf)
 
 #if !WINDOWS
@@ -614,6 +615,13 @@ getGhcBuilds = do
                         _ -> CompilerBuildSpecialized (intercalate "-" c))
                     libComponents
 #if !WINDOWS
+            Platform _ Cabal.FreeBSD -> do
+                let getMajorVer = readMaybe <=< headMaybe . (splitOn ".")
+                majorVer <- getMajorVer <$> sysRelease
+                if majorVer >= Just (12 :: Int) then
+                  useBuilds [CompilerBuildSpecialized "ino64"]
+                else
+                  useBuilds [CompilerBuildStandard]
             Platform _ Cabal.OpenBSD -> do
                 releaseStr <- mungeRelease <$> sysRelease
                 useBuilds [CompilerBuildSpecialized releaseStr]


### PR DESCRIPTION
The upcoming FreeBSD 12.0 release have some serious ABI changes. These changes prevent GHC's compiled on FreeBSD 10 and 11 from functioning correctly on FreeBSD 12. Stack would need to differentiate pre-12 FreeBSDs and post-12 ones.

This patch makes `stack setup` to append `-ino64` suffix when running on FreeBSD 12+. Once last pre-12 FreeBSD release goes EoL, this patch will be removed as well as `-ino64` entries from `stack-setup-2.yaml`.