### PR TITLE
Support KDE Neon distribution

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,9 @@ Behavior changes:
 
 Other enhancements:
 
+* Support KDE Neon distribution in installer.
+  [#4371](https://github.com/commercialhaskell/stack/pull/4371)
+
 Bug fixes:
 
 * Handle a change in GHC's hi-dump format around `addDependentFile`,

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -412,7 +412,7 @@ GETDISTRO
   fi
 
   case "$DISTRO" in
-    ubuntu|linuxmint|elementary)
+    ubuntu|linuxmint|elementary|neon)
       do_ubuntu_install "$VERSION"
       ;;
     debian|kali|raspbian)


### PR DESCRIPTION
KDE Neon is based on Ubuntu, so the Ubuntu installer should work fine.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.
