### PR TITLE
Update install page for China

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -309,6 +309,26 @@ To get tab-completion of commands on bash, just run the following (or add it to
 
 For more information and other shells, see [the shell auto-completion page](shell_autocompletion.md)
 
+## China-based users
+
+If you're attempting to install stack from within China: 
+
+* As of 2018-10-24, the download link has limited connectivity from within mainland China.  If this is the case, please proceed by manually downloading (ideally via a VPN) and installing stack per the instructions found on this page pertinent to your OS.
+
+* After install, your `~/.stack/config.yaml` will need to be configured before stack can download large files consistently from within China (without reliance on a VPN).  Please add the following to the bottom of the `~/.stack/config.yaml` file (for Windows: use the `%STACK_ROOT%\config.yaml`):
+
+```    
+###ADD THIS IF YOU LIVE IN CHINA
+setup-info: "http://mirrors.tuna.tsinghua.edu.cn/stackage/stack-setup.yaml"
+urls:
+  latest-snapshot: http://mirrors.tuna.tsinghua.edu.cn/stackage/snapshots.json
+  lts-build-plans: http://mirrors.tuna.tsinghua.edu.cn/stackage/lts-haskell/
+  nightly-build-plans: http://mirrors.tuna.tsinghua.edu.cn/stackage/stackage-nightly/
+package-indices:
+ - name: Tsinghua
+   download-prefix: http://mirrors.tuna.tsinghua.edu.cn/hackage/package/
+   http: http://mirrors.tuna.tsinghua.edu.cn/hackage/00-index.tar.gz
+```
 ## Upgrade
 
 There are essentially four different approaches to upgrade:


### PR DESCRIPTION
Adding documentation update per issue #4349, to help simplify the installation experience for users who are located in mainland China.  I decided to add this to the "installation" section instead of the "yaml configuration" section, since `stack new` basically can't get up and running until this has been accounted for.

===============
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!