### PR TITLE
Remove trailing ',' from generated-other-modules.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -271,7 +271,7 @@ executables:
     main: Main.hs
     source-dirs: src/main
     generated-other-modules:
-    - Build_stack,
+    - Build_stack
     - Paths_stack
     ghc-options:
     - -threaded


### PR DESCRIPTION
This is a one character change in a YAML list element, removing a trailing comma. I'll defer to CI to test this.

I found this possible problem when trying to generate stack's `package.yaml` from a `package.dhall` using the executable `dhall-hpack-yaml` from package hpack-dhall when adding a real world golden test for https://github.com/BlockScope/hpack-dhall/issues/24.
