### PR TITLE
Doc/nopie 4009

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@ Other enhancements:
 
 * Support KDE Neon distribution in installer.
   [#4371](https://github.com/commercialhaskell/stack/pull/4371)
+* Document supression of `'nopie'` warning on macOS in FAQ.
+  [#4009](https://github.com/commercialhaskell/stack/issues/4009)
 
 Bug fixes:
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -543,17 +543,15 @@ clang: warning: argument unused during compilation: '-nopie'
  [-Wunused-command-line-argument]
 ```
 
-This warning is shown when compiler support of `-no-pie` is expected.
-For `ghc-8.2.2`, the warning suppressing setting change
-would be;
+This warning is shown when compiler support of `-no-pie` is expected but unavailable.
+It's possible to bypass the warning for a specific version of GHC by modifying a global setting:
 
 ```
 # ~/.stack/programs/x86_64-osx/ghc-8.2.2/lib/ghc-8.2.2/settings
-
 -- ("C compiler supports -no-pie", "YES"),
 ++ ("C compiler supports -no-pie", "NO"),
 ```
 
-Make the change of expectation in stack's settings for the version of GHC that
-matches the resolver in use in the build. The related issue is
-[#4009](https://github.com/commercialhaskell/stack/issues/4009).
+**Note that we're fixing `ghc-8.2.2` in this case; repeat for other versions as necessary.** You should apply this fix for the version of GHC that matches your resolver.
+
+Issue [#4009](https://github.com/commercialhaskell/stack/issues/4009) on GitHub goes into further detail.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -555,4 +555,5 @@ would be;
 ```
 
 Make the change of expectation in stack's settings for the version of GHC that
-matches the resolver in use in the build.
+matches the resolver in use in the build. The related issue is
+[#4009](https://github.com/commercialhaskell/stack/issues/4009).

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -535,3 +535,24 @@ error "bad relocation (Invalid pointer diff)". The compiler picks up
 inconsistent versions of binaries and the mysterious error occurs.
 
 The workaround is to remove LLVM binaries from the `PATH`.
+
+## How do I suppress `'-nopie'` warnings with `stack build` on macOS?
+
+```
+clang: warning: argument unused during compilation: '-nopie'
+ [-Wunused-command-line-argument]
+```
+
+This warning is shown when compiler support of `-no-pie` is expected.
+For `ghc-8.2.2`, the warning suppressing setting change
+would be;
+
+```
+# ~/.stack/programs/x86_64-osx/ghc-8.2.2/lib/ghc-8.2.2/settings
+
+-- ("C compiler supports -no-pie", "YES"),
+++ ("C compiler supports -no-pie", "NO"),
+```
+
+Make the change of expectation in stack's settings for the version of GHC that
+matches the resolver in use in the build.


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Markdown preview was used to test documentation changes. The fix I tested locally with `resolver: lts-11.22 (ghc-8.2.2)`.
