### PR TITLE
Expand mustache variables in template file names

### DIFF
--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -238,11 +238,19 @@ applyTemplate project template nonceParams dir templateText = do
           -- Too large or too binary
           | otherwise = pure bytes
 
+    -- Apply Mustache templating to a string
+    -- template.
+    let applyMustacheStr str = do
+          let bs = LB.fromStrict . T.encodeUtf8 . T.pack $ str
+          r <- applyMustache bs
+          pure . T.unpack . T.decodeUtf8 . LB.toStrict $ r
+
     liftM
         M.fromList
         (mapM
              (\(fp,bytes) ->
-                   do path <- parseRelFile fp
+                   do path' <- applyMustacheStr fp
+                      path <- parseRelFile path'
                       bytes' <- applyMustache bytes
                       return (dir </> path, bytes'))
              (M.toList files))


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Previously stack templates supported mustache variables in the file names, e.g. most often `{-# START_FILE {{name}}.cabal #-}`. With the 1.9.1 fix mustache expansion only happens in the file body and no longer in the names. This fix expands the file names as well.

Tested with a local template and several online ones e.g. `scotty-hello-world`. The .cabal files are now correctly named, i.e they are no longer named `{{name}}.cabal`

Fixes https://github.com/commercialhaskell/stack/issues/4344 and https://github.com/commercialhaskell/stack/issues/4395
