### PR TITLE
Fix test 4270

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -97,7 +97,10 @@ Bug fixes:
   [#4314](https://github.com/commercialhaskell/stack/pull/4314)
 * Add `--cabal-files` flag to `stack ide targets` command.
 * Don't download ghc when using `stack clean`.
-* Support loading in GHCi definitions from symlinked C files. See
+* Support loading in GHCi definitions from symlinked C files. Without this
+  patch, Stack will try to find object files in the directory pointed to
+  by symlinks, while GCC will produce the object files in the original
+  directory. See
   [#4402](https://github.com/commercialhaskell/stack/pull/4402)
 
 ## v1.9.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -94,6 +94,8 @@ Bug fixes:
 * Fix for git packages to update submodules to the correct state. See
   [#4314](https://github.com/commercialhaskell/stack/pull/4314)
 * Add `--cabal-files` flag to `stack ide targets` command.
+* Support loading in GHCi definitions from symlinked C files. See
+  [#4402](https://github.com/commercialhaskell/stack/pull/4402)
 
 
 ## v1.9.1

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -1238,6 +1238,8 @@ findCandidate dirs name = do
                   (xs, ys) -> xs ++ ys
     resolveCandidate dir = fmap maybeToList . resolveDirFile dir
 
+-- | Resolve file as a child of a specified directory, symlinks
+-- don't get followed.
 resolveDirFile
     :: (MonadIO m, MonadThrow m)
     => Path Abs Dir -> FilePath.FilePath -> m (Maybe (Path Abs File))

--- a/test/integration/IntegrationSpec.hs
+++ b/test/integration/IntegrationSpec.hs
@@ -139,6 +139,7 @@ toCopyRoot srcfp = any (`isSuffixOf` srcfp)
     -- FIXME command line parameters to control how many of these get
     -- copied, trade-off of runtime/bandwidth vs isolation of tests
     [ ".tar"
+    , ".tar.gz"
     , ".xz"
     -- , ".gz"
     , ".7z.exe"

--- a/test/integration/lib/StackTest.hs
+++ b/test/integration/lib/StackTest.hs
@@ -98,8 +98,10 @@ runRepl cmd args actions = do
     hSetBuffering rStderr NoBuffering
 
     _ <- forkIO $ withFile "/tmp/stderr" WriteMode
-        $ \err -> forever $ catch (hGetChar rStderr >>= hPutChar err)
-                  $ \e -> unless (isEOFError e) $ throw e
+        $ \err -> do
+            hSetBuffering err NoBuffering
+            forever $ catch (hGetChar rStderr >>= hPutChar err)
+                    $ \e -> unless (isEOFError e) $ throw e
 
     runReaderT (nextPrompt >> actions) (ReplConnection rStdin rStdout)
     waitForProcess ph

--- a/test/integration/tests/4270-files-order/files/stack.yaml
+++ b/test/integration/tests/4270-files-order/files/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.8
+resolver: lts-11.22
 
 packages:
 - .


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

This is a fix for a test `4270-files-order`, the main point of it is in af36e04 other commits improve Stack integration tests a bit.
Integration tests succeed locally.
