### PR TITLE
Make dot and ls dependencies work without ghc installed

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -97,7 +97,7 @@ Bug fixes:
   [#4314](https://github.com/commercialhaskell/stack/pull/4314)
 * Add `--cabal-files` flag to `stack ide targets` command.
 * Don't download ghc when using `stack clean`.
-* `dot` and `ls dependencies` commands is no longer require ghc installed. And, fix not respected `--no-install-ghc` flag. (See [#4390](https://github.com/commercialhaskell/stack/issues/4390))
+* `dot` and `ls dependencies` commands no longer require GHC to be installed. Also, ensures the `--no-install-ghc` flag is respected. See: [#4390](https://github.com/commercialhaskell/stack/issues/4390)
 
 ## v1.9.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -97,6 +97,7 @@ Bug fixes:
   [#4314](https://github.com/commercialhaskell/stack/pull/4314)
 * Add `--cabal-files` flag to `stack ide targets` command.
 * Don't download ghc when using `stack clean`.
+* `dot` and `ls dependencies` commands is no longer require ghc installed. And, fix not respected `--no-install-ghc` flag. (See [#4390](https://github.com/commercialhaskell/stack/issues/4390))
 
 ## v1.9.1
 

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -267,4 +267,8 @@ withBuildConfigDot opts go f = withBuildConfig go' f
     go' =
         (if dotTestTargets opts then set (globalOptsBuildOptsMonoidL.buildOptsMonoidTestsL) (Just True) else id) $
         (if dotBenchTargets opts then set (globalOptsBuildOptsMonoidL.buildOptsMonoidBenchmarksL) (Just True) else id)
+        $
+        (set (globalOptsL.configMonoidSkipGHCCheckL) (Just True))
+        $
+        (set (globalOptsL.configMonoidInstallGHCL) (Just False))
         go

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -269,8 +269,8 @@ withBuildConfigDot opts go = withBuildConfig (updateGlobalOpts go)
     updateGlobalOpts
       = updateOpts (dotTestTargets opts)  (globalOptsBuildOptsMonoidL.buildOptsMonoidTestsL)      (Just True)
       . updateOpts (dotBenchTargets opts) (globalOptsBuildOptsMonoidL.buildOptsMonoidBenchmarksL) (Just True)
-      . updateOpts True                   (globalOptsL.configMonoidSkipGHCCheckL)                 (Just True)
-      . updateOpts True                   (globalOptsL.configMonoidInstallGHCL)                   (Just False)
+      . set (globalOptsL.configMonoidSkipGHCCheckL) (Just True)
+      . set (globalOptsL.configMonoidInstallGHCL)   (Just False)
 
 -- helper function for update some option
 updateOpts :: Bool -> Lens' opts v -> v -> opts -> opts

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -163,6 +163,8 @@ module Stack.Types.Config
   ,loadedSnapshotL
   ,shouldForceGhcColorFlag
   ,appropriateGhcColorFlag
+  ,configMonoidSkipGHCCheckL
+  ,configMonoidInstallGHCL
   -- * Lens reexport
   ,view
   ,to
@@ -1984,3 +1986,13 @@ appropriateGhcColorFlag :: (HasRunner env, HasEnvConfig env)
 appropriateGhcColorFlag = f <$> shouldForceGhcColorFlag
   where f True = Just ghcColorForceFlag
         f False = Nothing
+
+configMonoidSkipGHCCheckL :: Lens' ConfigMonoid (Maybe Bool)
+configMonoidSkipGHCCheckL = 
+  lens (getFirst . configMonoidSkipGHCCheck)
+       (\configMonoid t -> configMonoid {configMonoidSkipGHCCheck = First t})
+
+configMonoidInstallGHCL :: Lens' ConfigMonoid (Maybe Bool)
+configMonoidInstallGHCL = 
+  lens (getFirst . configMonoidInstallGHC)
+       (\configMonoid t -> configMonoid {configMonoidInstallGHC = First t})


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

@dbaynard fixed #4390. Could you please confirm it?