### PR TITLE
Use default resolver for test 4101-dependency-tree

### DIFF
--- a/test/integration/tests/4101-dependency-tree/Main.hs
+++ b/test/integration/tests/4101-dependency-tree/Main.hs
@@ -6,22 +6,22 @@ main = do
   stackCheckStdout ["ls", "dependencies", "--tree"] $ \stdOut -> do
     let expected = unlines [ "Packages"
                            , "└─┬ files mkVersion [0,1,0,0]"
-                           , "  ├─┬ base mkVersion [4,11,1,0]"
-                           , "  │ ├─┬ ghc-prim mkVersion [0,5,2,0]"
+                           , "  ├─┬ base mkVersion [4,10,1,0]"
+                           , "  │ ├─┬ ghc-prim mkVersion [0,5,1,1]"
                            , "  │ │ └── rts mkVersion [1,0]"
-                           , "  │ ├─┬ integer-gmp mkVersion [1,0,2,0]"
-                           , "  │ │ └─┬ ghc-prim mkVersion [0,5,2,0]"
+                           , "  │ ├─┬ integer-gmp mkVersion [1,0,1,0]"
+                           , "  │ │ └─┬ ghc-prim mkVersion [0,5,1,1]"
                            , "  │ │   └── rts mkVersion [1,0]"
                            , "  │ └── rts mkVersion [1,0]"
                            , "  └─┬ mtl mkVersion [2,2,2]"
-                           , "    ├─┬ base mkVersion [4,11,1,0]"
-                           , "    │ ├─┬ ghc-prim mkVersion [0,5,2,0]"
+                           , "    ├─┬ base mkVersion [4,10,1,0]"
+                           , "    │ ├─┬ ghc-prim mkVersion [0,5,1,1]"
                            , "    │ │ └── rts mkVersion [1,0]"
-                           , "    │ ├─┬ integer-gmp mkVersion [1,0,2,0]"
-                           , "    │ │ └─┬ ghc-prim mkVersion [0,5,2,0]"
+                           , "    │ ├─┬ integer-gmp mkVersion [1,0,1,0]"
+                           , "    │ │ └─┬ ghc-prim mkVersion [0,5,1,1]"
                            , "    │ │   └── rts mkVersion [1,0]"
                            , "    │ └── rts mkVersion [1,0]"
-                           , "    └── transformers mkVersion [0,5,5,0]"
+                           , "    └── transformers mkVersion [0,5,2,0]"
                            ]
     when (stdOut /= expected) $
       error $ unlines [ "Expected:", expected, "Actual:", stdOut ]
@@ -29,7 +29,7 @@ main = do
   stackCheckStdout ["ls", "dependencies", "--tree", "--depth=1"] $ \stdOut -> do
     let expected = unlines [ "Packages"
                            , "└─┬ files mkVersion [0,1,0,0]"
-                           , "  ├── base mkVersion [4,11,1,0]"
+                           , "  ├── base mkVersion [4,10,1,0]"
                            , "  └── mtl mkVersion [2,2,2]"
                            ]
     when (stdOut /= expected) $

--- a/test/integration/tests/4101-dependency-tree/files/stack.yaml
+++ b/test/integration/tests/4101-dependency-tree/files/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-12.14
+resolver: lts-11.22
 packages:
 - .


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

That's a fix for a new test. Fix in #4402 also resolved a similar problem (apart from fixing GHCi behavior) - its stack was using LTS-12 while integration tests use `install-ghc:false` - https://github.com/commercialhaskell/stack/blob/ca9ee4c6a5ca2474f627e814e8463bb1b9dcae94/test/integration/IntegrationSpec.hs#L84
I guess it's worth to check new integration tests when they appear whether they use the default resolver. This way we could prevent this kind of problem.

