### PR TITLE
Remove obsolete hindent-style

### DIFF
--- a/dot-dir-locals.el
+++ b/dot-dir-locals.el
@@ -1,6 +1,5 @@
 ((haskell-mode
   . ((haskell-indent-spaces . 4)
-     (hindent-style . "johan-tibell")
      (haskell-process-type . ghci)
      (haskell-process-path-ghci . "stack")
      (haskell-process-args-ghci . ("ghci"))))


### PR DESCRIPTION
Removed in this PR option was made obsolete in hindent 5

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

emacs-specific change, tested locally
