### PR TITLE
Workaround for libtinfo detection on Slackware64 14.2, solves #4362.

### DIFF
--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -593,7 +593,10 @@ getGhcBuilds = do
                         -- the 'ldconfig -p' output on Arch or Slackware even when it exists.
                         -- There doesn't seem to be an easy way to get the true list of directories
                         -- to scan for shared libs, but this works for our particular cases.
-                            let extraPaths = [$(mkAbsDir "/usr/lib"),$(mkAbsDir "/usr/lib64")]
+                            let extraPaths = []
+#if !WINDOWS
+                                 ++ [$(mkAbsDir "/usr/lib"),$(mkAbsDir "/usr/lib64")]
+#endif
                             matches <- filterM (doesFileExist .(</> lib)) extraPaths
                             case matches of
                                 [] -> logDebug ("Did not find shared library " <> libD)

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Stack.Setup
   ( setupEnv
@@ -588,18 +589,18 @@ getGhcBuilds = do
                             -- Cannot parse /usr/lib on Windows
                             return False
                         | otherwise = do
-                            let extraPaths = ["/usr/lib","/usr/lib64"]
                         -- This is a workaround for the fact that libtinfo.so.x doesn't appear in
                         -- the 'ldconfig -p' output on Arch or Slackware even when it exists.
                         -- There doesn't seem to be an easy way to get the true list of directories
                         -- to scan for shared libs, but this works for our particular cases.
-                            usrLibs <- forM extraPaths (\p -> liftM ((,)p) $ parseAbsDir p)
-                            matches <- forM usrLibs (\(p,dir) -> liftM ((,)p) $ doesFileExist (dir </> lib))
-                            let e = find (snd) matches
-                            case e of
-                                Just (dir,_) -> logDebug ("Found shared library " <> libD <> " in " <> fromString dir)
-                                Nothing -> logDebug ("Did not find shared library " <> libD)
-                            return (isJust e)
+                            let extraPaths = [$(mkAbsDir "/usr/lib"),$(mkAbsDir "/usr/lib64")]
+                            matches <- filterM (doesFileExist .(</> lib)) extraPaths
+                            case matches of
+                                [] -> logDebug ("Did not find shared library " <> libD)
+                                    >> return False
+                                (path:_) -> logDebug ("Found shared library " <> libD
+                                        <> " in " <> fromString (Path.toFilePath path))
+                                    >> return True
                       where
                         libT = T.pack (toFilePath lib)
                         libD = fromString (toFilePath lib)


### PR DESCRIPTION
Expanded the already present workaround for finding libtinfo on Arch linux (when `ldconfig -p` doesn't find it) to also work in 64 bit Slackware.
Basically also searches the directory `/usr/lib64/` in addition to `/usr/lib/` for libtinfo or ncurses libraries (see discussion in #4362 and others).

Do we want to add `/lib/` and `/lib64/` or any other paths to the list of checked directories?

I haven't written any haskell in a long time (I stumbled upon this issue while trying to get back into it) so any suggestions and criticisms on the code are more than welcome; it actually doesn't look really readable to me as is but considering it is a (temporary) workaround for such a limited issue I think it doesn't matter.

I don't think this change requires a changelog or documentation update since it doesn't affect users or developers in any way except solving the issue.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I checked it with hlint and run stack test without problems but I could only test the binary with Slackware linux.