### PR TITLE
Have travis build after trusty support is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@
 # use cabal without any Stackage snapshots.
 #
 language: generic
+dist: xenial
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@
 # use cabal without any Stackage snapshots.
 #
 language: generic
-sudo: false
 
 cache:
     directories:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@ Behavior changes:
 
 Other enhancements:
 
+* Travis no longer builds using `sudo: false` as that behaviour is due to be deprecated.
+
 Bug fixes:
 
 


### PR DESCRIPTION
Targeting stable as this means all relevant branches can straightforwardly benefit from the change.

This may require a little back and forth with CI.

I suggest we also change the travis templates, too, before merging.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.