### PR TITLE
Add `--cabal-files` flag to `ide packages` command (backported to stable)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ Behavior changes:
 Other enhancements:
 
 * Travis no longer builds using `sudo: false` as that behaviour is due to be deprecated.
+* Add `--cabal-files` flag to `stack ide targets` command.
 
 Bug fixes:
 

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -414,7 +414,11 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                     "packages"
                     "List all available local loadable packages"
                     idePackagesCmd
-                    (pure ())
+                    (flag
+                         IDE.ListPackageNames
+                         IDE.ListPackageCabalFiles
+                         (long "cabal-files" <>
+                          help "Print paths to package cabal-files instead of package names"))
                 addCommand'
                     "targets"
                     "List all available stack targets"
@@ -907,9 +911,9 @@ ghciCmd ghciOpts go@GlobalOpts{..} =
           (ghci ghciOpts)
 
 -- | List packages in the project.
-idePackagesCmd :: () -> GlobalOpts -> IO ()
-idePackagesCmd () go =
-    withBuildConfig go IDE.listPackages
+idePackagesCmd :: IDE.ListPackagesCmd -> GlobalOpts -> IO ()
+idePackagesCmd cmd go =
+    withBuildConfig go (IDE.listPackages cmd)
 
 -- | List targets in the project.
 ideTargetsCmd :: () -> GlobalOpts -> IO ()


### PR DESCRIPTION
Backport to of #4312 to `stable`. I was hoping this would have landed in a realease by now, didn't realise there was a big project happening on master.

FYI: This will be necessary for haskell-ide-engine to keep ineroperating with Stack once cabal new-build support lands there. 

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
