### PR TITLE
Choose virtual machine based infrastructure

### DIFF
--- a/doc/travis-simple.yml
+++ b/doc/travis-simple.yml
@@ -8,8 +8,8 @@
 # Copy these contents into the root directory of your Github project in a file
 # named .travis.yml
 
-# Use new container infrastructure to enable caching
-sudo: false
+# Choose a build environment
+dist: xenial
 
 # Do not choose a language; we provide our own build tools.
 language: generic


### PR DESCRIPTION
Travis CI is deprecating container based build environments. See https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures for more.

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested by pushing the configuration to travis. See [this sample travis build](https://travis-ci.org/IsumiF/leetcode-hs/jobs/472522777/config).