### PR TITLE
Make `ide packages --cabal-files` write to stdout

### DIFF
--- a/src/Stack/IDE.hs
+++ b/src/Stack/IDE.hs
@@ -14,6 +14,7 @@ module Stack.IDE
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
+import           System.IO (putStrLn)
 import           Stack.Config (getLocalPackages)
 import           Stack.Package (readPackageUnresolvedDir, gpdPackageName)
 import           Stack.Prelude
@@ -39,7 +40,7 @@ listPackages flag = do
             (gpd, _) <- readPackageUnresolvedDir dir False
             logInfo $ display $ gpdPackageName gpd
           ListPackageCabalFiles ->
-            logInfo $ fromString cabal_file
+            liftIO $ putStrLn $ fromString cabal_file
 
 -- | List the targets in the current project.
 listTargets :: HasEnvConfig env => RIO env ()


### PR DESCRIPTION
I didn't realise `logInfo` writes to stderr when writing #4446. On master the `ide packages` command already writes everything to stdout, including with the `--cabal-files` flag. This commit only changes the behaviour of the new (and unreleased) `--cabal-files` flag so as not to break anything.