### PR TITLE
Add --stdout flag to `stack ide` commands

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ Other enhancements:
 
 * Travis no longer builds using `sudo: false` as that behaviour is due to be deprecated.
 * Add `--cabal-files` flag to `stack ide targets` command.
+* Add `--stdout` flag to all `stack ide` subcommands.
 
 Bug fixes:
 


### PR DESCRIPTION
The `stack ide` commands use `logInfo` to write output. This seems to end up on
stderr, which is quite annoying to pick up for tools. This new flag sends output
to stdout instead.

This is a follow-up to #4477.

Since it loolks like `stable` gets merged into `master` occationally I am pushing this to `stable` first and then sending a PR with a hand written merge into `master` since just having two unrelated commits on the two branches seems to have [caused problems](https://github.com/commercialhaskell/stack/commit/530219ad56907a3806006ce1515a408da7df9fdc) before. Not sure this is the right thing to do, I'm open to suggestions.  PR: #4483

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
