### PR TITLE
Fixes #4506 - Add fsnotify-0.3.0.1 to snapshot.yml

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -108,6 +108,9 @@ Bug fixes:
   [#4402](https://github.com/commercialhaskell/stack/pull/4402)
 * Fix handling of GitHub and URL templates on Windows. See
   [commercialhaskell/stack#4394](https://github.com/commercialhaskell/stack/issues/4394)
+* Fix `--file-watch` not responding to file modifications when running
+  inside docker on Mac. See
+  [#4506](https://github.com/commercialhaskell/stack/issues/4506)
 
 ## v1.9.3
 

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -17,6 +17,7 @@ packages:
 - cabal-doctest-1.0.6@rev:2
 - unliftio-0.2.8.0@sha256:5a47f12ffcee837215c67b05abf35dffb792096564a6f81652d75a54668224cd,2250
 - happy-1.19.9@sha256:f8c774230735a390c287b2980cfcd2703d24d8dde85a01ea721b7b4b4c82944f,4667
+- fsnotify-0.3.0.1@rev:1
 
 flags:
   cabal-install:


### PR DESCRIPTION
lts-11.22 includes fsnotify-0.2.1.1, which listens to Modify events on
Linux rather than CloseWrite events. For many applications the
difference is neglible because writing a file will result in both
events, but if you run stack inside of docker on Mac this breaks
the --file-watch option because the file sharing integration only
emits Modify events, never CloseWrite events.

fsnotify-0.3.0.1 changed to listen to Modify events rather than
CloseWrite events. Switching to the new version fixes the issue.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary. (not necessary)

Please also shortly describe how you tested your change. Bonus points for added tests!

I built stack against fsnotify-0.2.1.1 inside a docker container and verified that `--file-watch`
did *not* recompile when editing a file from MacOS on a newly creating stack project. Then I
rebuilt stack against fsnotify-0.3.0.1 in the same docker container and verified that `--file-watch`
*did* recompile when editing a file from MacOS.

Also ran `stack test` to ensure all the tests pass.