### PR TITLE
No FK checks during migrations and better error if migration fails

### DIFF
--- a/subs/pantry/src/Pantry/Storage.hs
+++ b/subs/pantry/src/Pantry/Storage.hs
@@ -223,7 +223,7 @@ initStorage fp inner = do
     (createSqlitePoolFromInfo (sqinfo True) 1)
     (liftIO . destroyAllResources) $ \pool -> inner (P.Storage pool)
   where
-    wrapMigrationFailure = handle (throwIO . MigrationFailure)
+    wrapMigrationFailure = handle (throwIO . MigrationFailure fp)
     sqinfo fk = set extraPragmas ["PRAGMA busy_timeout=2000;"]
            $ set fkEnabled fk
            $ mkSqliteConnectionInfo (fromString $ toFilePath fp)

--- a/subs/pantry/src/Pantry/Storage.hs
+++ b/subs/pantry/src/Pantry/Storage.hs
@@ -84,7 +84,7 @@ import Data.Pool (destroyAllResources)
 import Pantry.HPack (hpackVersion, hpack)
 import Conduit
 import Data.Acquire (with)
-import Pantry.Types (PackageNameP (..), VersionP (..), SHA256, FileSize (..), FileType (..), HasPantryConfig, BlobKey, Repo (..), TreeKey, SafeFilePath, Revision (..), Package (..))
+import Pantry.Types (PackageNameP (..), VersionP (..), SHA256, FileSize (..), FileType (..), HasPantryConfig, BlobKey, Repo (..), TreeKey, SafeFilePath, Revision (..), Package (..), PantryException (MigrationFailure))
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
 -- Raw blobs
@@ -215,15 +215,17 @@ initStorage
 initStorage fp inner = do
   ensureDir $ parent fp
   bracket
-    (createSqlitePoolFromInfo sqinfo 1)
+    (createSqlitePoolFromInfo (sqinfo False) 1)
     (liftIO . destroyAllResources) $ \pool -> do
-
-    migrates <- runSqlPool (runMigrationSilent migrateAll) pool
-    forM_ migrates $ \mig -> logDebug $ "Migration output: " <> display mig
-    inner (P.Storage pool)
+    migrates <- wrapMigrationFailure $ runSqlPool (runMigrationSilent migrateAll) pool
+    forM_ migrates $ \mig -> logDebug $ "Migration executed: " <> display mig
+  bracket
+    (createSqlitePoolFromInfo (sqinfo True) 1)
+    (liftIO . destroyAllResources) $ \pool -> inner (P.Storage pool)
   where
-    sqinfo = set extraPragmas ["PRAGMA busy_timeout=2000;"]
-           $ set fkEnabled True
+    wrapMigrationFailure = handle (throwIO . MigrationFailure)
+    sqinfo fk = set extraPragmas ["PRAGMA busy_timeout=2000;"]
+           $ set fkEnabled fk
            $ mkSqliteConnectionInfo (fromString $ toFilePath fp)
 
 withStorage

--- a/subs/pantry/src/Pantry/Types.hs
+++ b/subs/pantry/src/Pantry/Types.hs
@@ -106,6 +106,7 @@ import Data.Aeson.Extended
 import Data.ByteString.Builder (toLazyByteString, byteString, wordDec)
 import Database.Persist
 import Database.Persist.Sql
+import Database.Sqlite (SqliteException)
 import Pantry.SHA256 (SHA256)
 import qualified Pantry.SHA256 as SHA256
 import qualified Distribution.Compat.ReadP as Parse
@@ -651,6 +652,7 @@ data PantryException
   | PackageVersionParseFail !Text
   | InvalidCabalFilePath !(Path Abs File)
   | DuplicatePackageNames !Utf8Builder ![(PackageName, [PackageLocationImmutable])]
+  | MigrationFailure !SqliteException
 
   deriving Typeable
 instance Exception PantryException where
@@ -829,6 +831,11 @@ instance Display PantryException where
           locs
       )
       pairs'
+  display (MigrationFailure ex) =
+    "Encountered error while migrating Pantry database:" <>
+    "\n    " <> displayShow ex <>
+    "\nPlease report this on https://github.com/commercialhaskell/stack/issues" <>
+    "\nAs a workaround you may delete Pantry database in your $STACK_ROOT triggering its recreation."
 
 data FuzzyResults
   = FRNameNotFound ![PackageName]

--- a/subs/pantry/src/Pantry/Types.hs
+++ b/subs/pantry/src/Pantry/Types.hs
@@ -652,7 +652,7 @@ data PantryException
   | PackageVersionParseFail !Text
   | InvalidCabalFilePath !(Path Abs File)
   | DuplicatePackageNames !Utf8Builder ![(PackageName, [PackageLocationImmutable])]
-  | MigrationFailure !SqliteException
+  | MigrationFailure !(Path Abs File) !SqliteException
 
   deriving Typeable
 instance Exception PantryException where
@@ -831,11 +831,12 @@ instance Display PantryException where
           locs
       )
       pairs'
-  display (MigrationFailure ex) =
+  display (MigrationFailure fp ex) =
     "Encountered error while migrating Pantry database:" <>
     "\n    " <> displayShow ex <>
     "\nPlease report this on https://github.com/commercialhaskell/stack/issues" <>
-    "\nAs a workaround you may delete Pantry database in your $STACK_ROOT triggering its recreation."
+    "\nAs a workaround you may delete Pantry database in " <>
+    fromString (toFilePath fp) <> " triggering its recreation."
 
 data FuzzyResults
   = FRNameNotFound ![PackageName]


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Tested it manually with a DB created with Stack sources before #4439 was merged

Fixes #4519 

@snoyberg is it OK to reference `$STACK_ROOT` in Pantry error messages? It doesn't look clean to me but I'm not sure how to deal with it better in this case