### PR TITLE
Add HASKELL_PACKAGE_IDS as a way around amibuous modules in doctests

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -53,7 +53,7 @@ import           Distribution.System            (OS (Windows),
                                                  Platform (Platform))
 import qualified Distribution.Text as C
 import           Distribution.Types.PackageName (mkPackageName)
-import           Distribution.Version (mkVersion)
+import           Distribution.Version (mkVersion, nullVersion)
 import           Foreign.C.Types (CTime)
 import           Path
 import           Path.CheckInstall
@@ -1752,7 +1752,22 @@ singleTest topts testsToRun ac ee task installedMap = do
                 tixPath <- liftM (pkgDir </>) $ parseRelFile $ exeName ++ ".tix"
                 exePath <- liftM (buildDir </>) $ parseRelFile $ "build/" ++ testName' ++ "/" ++ exeName
                 exists <- doesFileExist exePath
-                menv <- liftIO $ configProcessContextSettings config EnvSettings
+                packageIds <- forMaybeM (M.toList $ packageDeps package) $ \(name, dv) -> do
+                    let pkgId = PackageIdentifier name nullVersion
+                    case Map.lookupGT pkgId allDepsMap of
+                        Just (PackageIdentifier name' version, ghcPkgId)
+                            | name' == name && dvType dv == AsLibrary &&
+                              version `withinRange` dvVersionRange dv ->
+                            return $ Just (unGhcPkgId ghcPkgId)
+                        _ -> do
+                            logWarn $ "Could not find GHC package id for dependency " <> fromString (packageNameString name)
+                            return Nothing
+                -- env var HASKELL_PACKAGE_IDS is used by doctest so module names for
+                -- packages with proper dependencies should no longer get ambiguous
+                -- see e.g. https://github.com/doctest/issues/119
+                let usePackageIds pc = modifyEnvVars pc $ \envVars ->
+                      Map.insert "HASKELL_PACKAGE_IDS" (T.unwords packageIds) envVars
+                menv <- liftIO $ usePackageIds =<< configProcessContextSettings config EnvSettings
                     { esIncludeLocals = taskLocation task == Local
                     , esIncludeGhcPackagePath = True
                     , esStackExe = True

--- a/src/Stack/Types/GhcPkgId.hs
+++ b/src/Stack/Types/GhcPkgId.hs
@@ -6,6 +6,7 @@
 
 module Stack.Types.GhcPkgId
   (GhcPkgId
+  ,unGhcPkgId
   ,ghcPkgIdParser
   ,parseGhcPkgId
   ,ghcPkgIdString)
@@ -61,3 +62,7 @@ ghcPkgIdParser =
 -- | Get a string representation of GHC package id.
 ghcPkgIdString :: GhcPkgId -> String
 ghcPkgIdString (GhcPkgId x) = T.unpack x
+
+-- | Get a text value of GHC package id
+unGhcPkgId :: GhcPkgId -> Text
+unGhcPkgId (GhcPkgId v) = v


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

It was tested with the project https://github.com/qrilka/doctest-conflict which also uses modifed `doctest` version taking use of `HASKELL_PACKAGE_IDS`
