### PR TITLE
Fix use of "--ghc-options" with "stack script --compile"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -111,6 +111,7 @@ Bug fixes:
 * Fix `--file-watch` not responding to file modifications when running
   inside docker on Mac. See
   [#4506](https://github.com/commercialhaskell/stack/issues/4506)
+* Using `--ghc-options` with `stack script --compile` now works.
 
 ## v1.9.3
 

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -102,7 +102,7 @@ scriptCmd opts go' = do
                     SEInterpret -> []
                     SECompile -> []
                     SEOptimize -> ["-O2"]
-                , map (\x -> "--ghc-arg=" ++ x) (soGhcOptions opts)
+                , soGhcOptions opts
                 ]
         munlockFile lk -- Unlock before transferring control away.
         case soCompile opts of


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Here's an example.  The contents of `~/tmp/hmm.hs` is:

```haskell
#!/usr/bin/env stack
-- stack --resolver lts-13.0 script --compile --ghc-options "-i"

main :: IO ()
main = putStrLn "hmm
```

running it results in

```
ghc: unrecognised flag: --ghc-arg=-i                                                                          
                                                                                                              
Usage: For basic information, try the `--help' option.
Received ExitFailure 1 when running
Raw command: /home/mgsloan/.stack/programs/x86_64-linux/ghc-8.6.3/bin/ghc -hide-all-packages -fdiagnostics-color=always -packagebase --ghc-arg=-i /home/mgsloan/tmp/hmm.hs
Run from: /home/mgsloan/tmp/
```

Note that `stack --resolver lts-13.0 script --ghc-options "-i"` (no use of `--compile`)  works fine