### PR TITLE
Have "stack script" set import search path #3377

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -46,6 +46,12 @@ Major changes:
 Behavior changes:
 * `stack.yaml` now supports `snapshot`: a synonym for `resolver`. See [#4256](https://github.com/commercialhaskell/stack/issues/4256)
 
+* `stack script` now passes `-i -idir` in to the `ghc`
+  invocation. This makes it so that the script can import local
+  modules, and fixes an issue where `.hs` files in the current
+  directory could affect interpretation of the script. See
+  [#4538](https://github.com/commercialhaskell/stack/pull/4538)
+
 Other enhancements:
 
 * Defer loading up of files for local packages. This allows us to get


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

This issue was brought to my attention by https://github.com/rcook .  The primary problem is that stack scripts can only import modules if the script is run from the same directory as the modules.  However, I realized that this implies a gnarlier issue, which is that since `-i` isn't being passed to `runghc`, it will use the work dir as a search dir for imports.

This also addresses part of the problem described in #3377 , which was a difference in how imports are treated when `--compile` is used.

Here's a concrete example.  The contents of `~/tmp/hmm.hs` is

```haskell
#!/usr/bin/env stack
-- stack --resolver lts-13.0 script

import Yargh

main :: IO ()
main = yargh
```

The contents of `~/tmp/Yargh.hs` is

```haskell
module Yargh where

yargh :: IO ()
yargh = putStrLn "works!"
```

The contents of `~/Yargh.hs` is

```haskell
module Yargh where

yargh :: IO ()
yargh = putStrLn "YARGH, broken!
```

Check out what happens when I run the script from different directories:

```
mgsloan@treetop:~/tmp$ ./hmm.hs                                                                               
works!                                                                                                        
mgsloan@treetop:~/tmp$ cd ../                                                                                 
mgsloan@treetop:~$ ./tmp/hmm.hs                                                                               
YARGH, broken!      
```

This PR resolves the issue.  After applying this patch, it behaves like this:

```
mgsloan@treetop:~/tmp$ ./hmm.hs                                                                               
works!                                                                                                        
mgsloan@treetop:~/tmp$ cd ../                                                                         
mgsloan@treetop:~$ ./tmp/hmm.hs                                                                               
works!                      
```