### PR TITLE
Globals (GHC boot packages) pruning

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,6 +37,10 @@ Major changes:
       their exact versions.
     * The `ignore-revision-mismatch` setting is no longer needed, and
       has been removed.
+    * Overriding GHC boot packages results in any other GHC boot
+      packages depending on it being no longer available as a dependency,
+      such packages need to be added explicitly when needed. See
+      [#4510] (https://github.com/commercialhaskell/stack/issues/4510).
 * Upgrade to Cabal 2.4
     * Note that, in this process, the behavior of file globbing has
       been modified to match that of Cabal. In particular, this means

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -107,13 +107,14 @@ loadSourceMap smt boptsCli sma = do
         maybeProjectFlags _ = Nothing
         actualGlobals = flip Map.mapMaybe (smaGlobal sma) $ \gp ->
             case gp of
-                ReplacedGlobalPackage -> Nothing
+                ReplacedGlobalPackage _ -> Nothing
                 GlobalPackage v -> Just v
+    check <- globalCondCheck
     (prunedGlobals, keptGlobals) <-
-        partitionReplacedDependencies actualGlobals (Map.keysSet deps)
+        partitionReplacedDependencies actualGlobals (Map.keysSet deps) check
     let globals = Map.map GlobalPackage keptGlobals <>
-                  Map.fromSet (const ReplacedGlobalPackage) prunedGlobals <>
-                  Map.filter (==ReplacedGlobalPackage) (smaGlobal sma)
+                  Map.map ReplacedGlobalPackage prunedGlobals <>
+                  Map.filter isReplacedGlobal (smaGlobal sma)
     checkFlagsUsedThrowing packageCliFlags FSCommandLine project deps
     smh <- hashSourceMapData (whichCompiler compiler) deps
     return

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -304,26 +304,13 @@ resolveRawTarget sma allLocs (ri, rt) =
           , rrAddedDep = Nothing
           , rrPackageType = PTProject
           }
-      | Map.member name deps ||
-        Map.member name globals = return $ Right ResolveResult
-          { rrName = name
-          , rrRaw = ri
-          , rrComponent = Nothing
-          , rrAddedDep = Nothing
-          , rrPackageType = PTDependency
-          }
-      | otherwise = do
-          mloc <- getLatestHackageLocation name UsePreferredVersions
-          pure $ case mloc of
-            Nothing -> deferToConstructPlan name
-            Just loc -> do
-              Right ResolveResult
-                    { rrName = name
-                    , rrRaw = ri
-                    , rrComponent = Nothing
-                    , rrAddedDep = Just loc
-                    , rrPackageType = PTDependency
-                    }
+      | Map.member name deps =
+          pure $ deferToConstructPlan name
+      | Just gp <- Map.lookup name globals =
+          case gp of
+              GlobalPackage _ -> pure $ deferToConstructPlan name
+              ReplacedGlobalPackage -> hackageLatest name
+      | otherwise = hackageLatest name
 
     -- Note that we use CFILatest below, even though it's
     -- non-reproducible, to avoid user confusion. In any event,
@@ -341,20 +328,10 @@ resolveRawTarget sma allLocs (ri, rt) =
           case Map.lookup name allLocs of
             -- Installing it from the package index, so we're cool
             -- with overriding it if necessary
-            Just (PLImmutable (PLIHackage (PackageIdentifier _name versionLoc) cfKey treeKey)) ->
-              pure $ Right ResolveResult
-                  { rrName = name
-                  , rrRaw = ri
-                  , rrComponent = Nothing
-                  , rrAddedDep =
-                      if version == versionLoc
-                        -- But no need to override anyway, this is already the
-                        -- version we have
-                        then Nothing
-                        -- OK, we'll override it
-                        else Just $ PLIHackage (PackageIdentifier name version) cfKey treeKey
-                  , rrPackageType = PTDependency
-                  }
+            Just (PLImmutable (PLIHackage (PackageIdentifier _name versionLoc) _cfKey _treeKey)) ->
+              if version == versionLoc
+              then pure $ deferToConstructPlan name
+              else hackageLatestRevision name version
             -- The package was coming from something besides the
             -- index, so refuse to do the override
             Just loc' -> pure $ Left $ T.concat
@@ -376,6 +353,31 @@ resolveRawTarget sma allLocs (ri, rt) =
                   , rrAddedDep = Just $ PLIHackage (PackageIdentifier name version) cfKey treeKey
                   , rrPackageType = PTDependency
                   }
+
+    hackageLatest name = do
+        mloc <- getLatestHackageLocation name UsePreferredVersions
+        pure $ case mloc of
+          Nothing -> deferToConstructPlan name
+          Just loc -> do
+            Right ResolveResult
+                  { rrName = name
+                  , rrRaw = ri
+                  , rrComponent = Nothing
+                  , rrAddedDep = Just loc
+                  , rrPackageType = PTDependency
+                  }
+
+    hackageLatestRevision name version = do
+        mrev <- getLatestHackageRevision name version
+        pure $ case mrev of
+          Nothing -> deferToConstructPlan name
+          Just (_rev, cfKey, treeKey) -> Right ResolveResult
+            { rrName = name
+            , rrRaw = ri
+            , rrComponent = Nothing
+            , rrAddedDep = Just $ PLIHackage (PackageIdentifier name version) cfKey treeKey
+            , rrPackageType = PTDependency
+            }
 
     -- This is actually an error case. We _could_ return a
     -- Left value here, but it turns out to be better to defer
@@ -446,8 +448,8 @@ parseTargets needTargets haddockDeps boptscli smActual = do
 
   let deps = smaDeps smActual
       globals = smaGlobal smActual
-      latestGlobal name gp = do
-        let version = gpVersion gp
+      latestGlobal _ ReplacedGlobalPackage = pure Nothing
+      latestGlobal name (GlobalPackage version) = do
         mrev <- getLatestHackageRevision name version
         forM mrev $ \(_rev, cfKey, treeKey) -> do
           let ident = PackageIdentifier name version

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -309,7 +309,7 @@ resolveRawTarget sma allLocs (ri, rt) =
       | Just gp <- Map.lookup name globals =
           case gp of
               GlobalPackage _ -> pure $ deferToConstructPlan name
-              ReplacedGlobalPackage -> hackageLatest name
+              ReplacedGlobalPackage _ -> hackageLatest name
       | otherwise = hackageLatest name
 
     -- Note that we use CFILatest below, even though it's
@@ -448,7 +448,7 @@ parseTargets needTargets haddockDeps boptscli smActual = do
 
   let deps = smaDeps smActual
       globals = smaGlobal smActual
-      latestGlobal _ ReplacedGlobalPackage = pure Nothing
+      latestGlobal _ (ReplacedGlobalPackage _) = pure Nothing
       latestGlobal name (GlobalPackage version) = do
         mrev <- getLatestHackageRevision name version
         forM mrev $ \(_rev, cfKey, treeKey) -> do

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -211,7 +211,7 @@ data ResolveResult = ResolveResult
 -- the module).
 resolveRawTarget ::
        (HasLogFunc env, HasPantryConfig env, HasProcessContext env)
-    => SMActual
+    => SMActual GlobalPackage
     -> Map PackageName PackageLocation
     -> (RawInput, RawTarget)
     -> RIO env (Either Text ResolveResult)
@@ -434,7 +434,7 @@ parseTargets :: HasBuildConfig env
     => NeedTargets
     -> Bool
     -> BuildOptsCLI
-    -> SMActual
+    -> SMActual GlobalPackage
     -> RIO env SMTargets
 parseTargets needTargets haddockDeps boptscli smActual = do
   logDebug "Parsing the targets"

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -198,7 +198,7 @@ ghci opts@GhciOpts{..} = do
 preprocessTargets
     :: HasEnvConfig env
     => BuildOptsCLI
-    -> SMActual
+    -> SMActual GlobalPackage
     -> [Text]
     -> RIO env (Either [Path Abs File] (Map PackageName Target))
 preprocessTargets buildOptsCLI sma rawTargets = do
@@ -229,7 +229,7 @@ preprocessTargets buildOptsCLI sma rawTargets = do
 parseMainIsTargets
      :: HasEnvConfig env
      => BuildOptsCLI
-     -> SMActual
+     -> SMActual GlobalPackage
      -> Maybe Text
      -> RIO env (Maybe (Map PackageName Target))
 parseMainIsTargets buildOptsCLI sma mtarget = forM mtarget $ \target -> do

--- a/src/Stack/SourceMap.hs
+++ b/src/Stack/SourceMap.hs
@@ -149,8 +149,9 @@ toActual smw downloadCompiler ac = do
             WithDownloadCompiler -> globalsFromDump ac
             SkipDownloadCompiler -> globalsFromHints (actualToWanted ac)
     check <- globalCondCheck
+    let wantedPackages = Map.keysSet (smwDeps smw) <> Map.keysSet (smwProject smw)
     (prunedGlobals, keptGlobals) <-
-        partitionReplacedDependencies allGlobals (Map.keysSet $ smwDeps smw) check
+        partitionReplacedDependencies allGlobals wantedPackages check
     let globals = Map.map GlobalPackage keptGlobals <>
                   Map.map ReplacedGlobalPackage prunedGlobals
     return

--- a/src/Stack/Types/SourceMap.hs
+++ b/src/Stack/Types/SourceMap.hs
@@ -16,6 +16,7 @@ module Stack.Types.SourceMap
   , DepPackage (..)
   , ProjectPackage (..)
   , CommonPackage (..)
+  , GlobalPackageVersion (..)
   , GlobalPackage (..)
   , isReplacedGlobal
   , SourceMapHash (..)
@@ -92,12 +93,14 @@ data SMWanted = SMWanted
 -- the contents of the global package database.
 --
 -- Invariant: a @PackageName@ appears in only one of the @Map@s.
-data SMActual = SMActual
+data SMActual a = SMActual
   { smaCompiler :: !ActualCompiler
   , smaProject :: !(Map PackageName ProjectPackage)
   , smaDeps :: !(Map PackageName DepPackage)
-  , smaGlobal :: !(Map PackageName GlobalPackage)
+  , smaGlobal :: !(Map PackageName a)
   }
+
+newtype GlobalPackageVersion = GlobalPackageVersion Version
 
 -- | How a package is intended to be built
 data Target

--- a/src/Stack/Types/SourceMap.hs
+++ b/src/Stack/Types/SourceMap.hs
@@ -17,6 +17,7 @@ module Stack.Types.SourceMap
   , ProjectPackage (..)
   , CommonPackage (..)
   , GlobalPackage (..)
+  , isReplacedGlobal
   , SourceMapHash (..)
   ) where
 
@@ -66,8 +67,12 @@ data ProjectPackage = ProjectPackage
 -- because of a replaced dependency)
 data GlobalPackage
   = GlobalPackage !Version
-  | ReplacedGlobalPackage
+  | ReplacedGlobalPackage ![PackageName]
   deriving Eq
+
+isReplacedGlobal :: GlobalPackage -> Bool
+isReplacedGlobal (ReplacedGlobalPackage _) = True
+isReplacedGlobal (GlobalPackage _) = False
 
 -- | A source map with information on the wanted (but not actual)
 -- compiler. This is derived by parsing the @stack.yaml@ file for

--- a/src/Stack/Types/SourceMap.hs
+++ b/src/Stack/Types/SourceMap.hs
@@ -61,10 +61,13 @@ data ProjectPackage = ProjectPackage
   , ppResolvedDir :: !(ResolvedPath Dir)
   }
 
--- | A view of a package installed in the global package database.
-newtype GlobalPackage = GlobalPackage
-  { gpVersion :: Version
-  }
+-- | A view of a package installed in the global package database also
+-- could include marker for a replaced global package (could be replaced
+-- because of a replaced dependency)
+data GlobalPackage
+  = GlobalPackage !Version
+  | ReplacedGlobalPackage
+  deriving Eq
 
 -- | A source map with information on the wanted (but not actual)
 -- compiler. This is derived by parsing the @stack.yaml@ file for

--- a/src/Stack/Types/SourceMap.hs
+++ b/src/Stack/Types/SourceMap.hs
@@ -93,11 +93,11 @@ data SMWanted = SMWanted
 -- the contents of the global package database.
 --
 -- Invariant: a @PackageName@ appears in only one of the @Map@s.
-data SMActual a = SMActual
+data SMActual global = SMActual
   { smaCompiler :: !ActualCompiler
   , smaProject :: !(Map PackageName ProjectPackage)
   , smaDeps :: !(Map PackageName DepPackage)
-  , smaGlobal :: !(Map PackageName a)
+  , smaGlobal :: !(Map PackageName global)
   }
 
 newtype GlobalPackageVersion = GlobalPackageVersion Version

--- a/subs/curator/src/Curator/Snapshot.hs
+++ b/subs/curator/src/Curator/Snapshot.hs
@@ -159,7 +159,7 @@ checkDependencyGraph constraints snapshot = do
         let depTree =
               Map.map (piVersion &&& piTreeDeps) pkgInfos
               <> Map.map ((, []) . Just) ghcBootPackages
-        return $ Map.mapWithKey (validateDeps constraints depTree cabalVersion) pkgInfos
+        return $ Map.mapWithKey (validatePackage constraints depTree cabalVersion) pkgInfos
     let (rangeErrors, otherErrors) = splitErrors pkgErrors
         rangeErrors' =
           Map.mapWithKey (\(pname, _, _) bs -> (Map.member pname ghcBootPackages0, bs)) rangeErrors
@@ -399,14 +399,14 @@ getPkgInfo constraints compilerVer pname rsp = do
       , piGithubPings = applyGithubMapping constraints $ getGithubPings gpd
       }
 
-validateDeps ::
+validatePackage ::
        Constraints
     -> Map PackageName (Maybe Version, [PackageName])
     -> Version
     -> PackageName
     -> PkgInfo
     -> [DependencyError]
-validateDeps constraints depTree cabalVersion pname pkg =
+validatePackage constraints depTree cabalVersion pname pkg =
     checkCabalVersion <> checkCycles <>
     catMaybes [ checkDependency component dep
               | (component, deps) <- piAllDeps pkg

--- a/subs/pantry/package.yaml
+++ b/subs/pantry/package.yaml
@@ -61,6 +61,7 @@ dependencies:
 - text-metrics
 - resourcet
 - rio-prettyprint
+- mtl
 
 # FIXME remove when we drop store
 - integer-gmp

--- a/subs/pantry/pantry.cabal
+++ b/subs/pantry/pantry.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 097f1c956c3050b63f58c0a2ce38f9eebb02d7e1bfabc081d945a42936608f8b
+-- hash: e07cbc430962c6f97d47cabc25ad162a437b0286c8c77ff49ce54337ebedac86
 
 name:           pantry
 version:        0.1.0.0
@@ -82,6 +82,7 @@ library
     , integer-gmp
     , memory
     , mono-traversable
+    , mtl
     , network
     , network-uri
     , path
@@ -181,6 +182,7 @@ test-suite spec
     , integer-gmp
     , memory
     , mono-traversable
+    , mtl
     , network
     , network-uri
     , pantry

--- a/subs/pantry/src/Pantry.hs
+++ b/subs/pantry/src/Pantry.hs
@@ -159,10 +159,12 @@ module Pantry
   , getLatestHackageRevision
   , getHackageTypoCorrections
   , loadGlobalHints
+  , partitionReplacedDependencies
   ) where
 
 import RIO
 import Conduit
+import Control.Monad.State.Strict (get, execStateT, modify', StateT)
 import qualified RIO.Map as Map
 import qualified RIO.Set as Set
 import qualified RIO.ByteString as B
@@ -180,6 +182,7 @@ import Path (Path, Abs, File, toFilePath, Dir, (</>), filename, parseAbsDir, par
 import Path.IO (doesFileExist, resolveDir', listDir)
 import Distribution.PackageDescription (GenericPackageDescription, FlagName)
 import qualified Distribution.PackageDescription as D
+import Distribution.Types.Dependency (depPkgName)
 import Distribution.Parsec.Common (PWarning (..), showPos)
 import qualified Hpack
 import qualified Hpack.Config as Hpack
@@ -1467,3 +1470,50 @@ loadGlobalHints dest wc =
     inner2 = liftIO
            $ Map.lookup wc . fmap (fmap unCabalString . unCabalStringMap)
          <$> Yaml.decodeFileThrow (toFilePath dest)
+
+-- | Partition map of global packages with its versions into a Set of
+-- replaced packages and its dependencies and other (untouched) packages.
+--
+-- @since 0.1.0.0
+partitionReplacedDependencies ::
+       (HasPantryConfig env, HasLogFunc env, HasProcessContext env)
+    => Map PackageName Version
+    -> Set PackageName
+    -> RIO env (Set PackageName, Map PackageName Version)
+partitionReplacedDependencies globals overrides =
+  fmap (first Map.keysSet) . flip execStateT (replaced, mempty) $
+    for (Map.keys globals) $ prunePackageWithDeps globals
+  where
+    replaced = Map.restrictKeys globals overrides
+
+prunePackageWithDeps ::
+       (HasPantryConfig env, HasLogFunc env, HasProcessContext env)
+    => Map PackageName Version
+    -> PackageName
+    -> StateT (Map PackageName Version, Map PackageName Version) (RIO env) Bool
+prunePackageWithDeps pkgs pname = do
+  (pruned, kept) <- get
+  if Map.member pname pruned
+  then return True
+  else if Map.member pname kept
+    then return False
+    else do
+      version <- case Map.lookup pname pkgs of
+        Just v -> return v
+        Nothing -> error $ "Missing package version" ++ show (pname, pruned, kept, pkgs)
+      mrev <- lift $ getLatestHackageRevision pname version
+      prune <- case mrev of
+        Nothing -> do
+          -- wired-in package
+          return False
+        Just (_, blobKey, treeKey) -> do
+          gpd <- lift $ loadCabalFileImmutable $
+                 PLIHackage (PackageIdentifier pname version) blobKey treeKey
+          let deps = maybe mempty D.condTreeConstraints $ D.condLibrary gpd
+          fmap or . for deps $ prunePackageWithDeps pkgs . depPkgName
+      if prune
+      then do
+        modify' $ first (Map.insert pname version)
+      else do
+        modify' $ second (Map.insert pname version)
+      return prune

--- a/subs/pantry/src/Pantry.hs
+++ b/subs/pantry/src/Pantry.hs
@@ -1476,11 +1476,11 @@ loadGlobalHints dest wc =
 -- @since 0.1.0.0
 partitionReplacedDependencies ::
        Ord id
-    => Map PackageName a
-    -> (a -> PackageName)
-    -> (a -> id)
-    -> (a -> [id])
-    -> Set PackageName
+    => Map PackageName a -- ^ global packages
+    -> (a -> PackageName) -- ^ package name getter
+    -> (a -> id) -- ^ returns unique package id used for dependency pruning
+    -> (a -> [id]) -- ^ returns unique package ids of direct package dependencies
+    -> Set PackageName -- ^ overrides which global dependencies should get pruned
     -> (Map PackageName [PackageName], Map PackageName a)
 partitionReplacedDependencies globals getName getId getDeps overrides =
   flip execState (replaced, mempty) $

--- a/test/integration/tests/345-override-bytestring/files/stack.yaml
+++ b/test/integration/tests/345-override-bytestring/files/stack.yaml
@@ -1,5 +1,6 @@
 resolver: lts-11.22
 extra-deps:
 - bytestring-0.10.6.0
+- binary-0.7.5.0
 packages:
 - .


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Tested manually, plan to run integration tests.
Failure to build global packages as targets results in 2 errors (using `stack.yaml` from #4510 with `time` overriden):
```
$ stack build directory --dry-run

Error: While constructing the build plan, the following exceptions were encountered:

Can't use GHC boot package directory when it has an overriden dependency, you need to add the following as explicit dependencies to the
project: 
 unix

Some different approaches to resolving this:

  * Consider trying 'stack solver', which uses the cabal-install solver to attempt to find some working build configuration. This can be
    convenient when dealing with many complicated constraint errors, but results may be unpredictable.


Plan construction failed.
```
or
```
$ stack build process --dry-run

Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for process-1.6.5.0:
    directory must match >=1.1 && <1.4, but the stack configuration has no specified version  (latest matching version is 1.3.3.2)
    unix must match >=2.5 && <2.9, but the stack configuration has no specified version  (latest matching version is 2.7.2.2)
needed since process is a build target.

Some different approaches to resolving this:

  * Consider trying 'stack solver', which uses the cabal-install solver to attempt to find some working build configuration. This can be
    convenient when dealing with many complicated constraint errors, but results may be unpredictable.

  * Recommended action: try adding the following to your extra-deps in /home/qrilka/ws/h/stack4510/stack.yaml:

directory-1.3.3.2@sha256:79e15a62f90cb9f20f46b2b56fe67d00d71ed54cfad07ea337695f9ebb74baa4,2829
unix-2.7.2.2@sha256:4ef1d010d70a4a07a717e853d4a440c105dad38c6199316e320fdd4c48dacd34,3495

Plan construction failed.
```
Fixes #4510

Also I plan to update curator to take these details into account (probably as a separate PR)