### PR TITLE
Bump azure timeouts

### DIFF
--- a/.azure/azure-nightly-template-linux.yml
+++ b/.azure/azure-nightly-template-linux.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: ${{ parameters.name }}
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
   variables:
   - group: AWS_Keys
   pool:

--- a/.azure/azure-nightly-template-osx.yml
+++ b/.azure/azure-nightly-template-osx.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: ${{ parameters.name }}
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
   variables:
   - group: AWS_Keys
   pool:

--- a/.azure/azure-nightly-template-windows.yml
+++ b/.azure/azure-nightly-template-windows.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: ${{ parameters.name }}
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
   variables:
   - group: AWS_Keys
   pool:


### PR DESCRIPTION
Recently the integration test has been getting timeouts, so this PR bumps it to 4 hours (previously it was 3 hour).