### PR TITLE
No latest global revisions for target parsing

### DIFF
--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -325,7 +325,7 @@ resolveRawTarget sma allLocs (ri, rt) =
                     , rrPackageType = PTDependency
                     }
 
-    -- Note that we use CFILatest below, even though it's
+    -- Note that we use getLatestHackageRevision below, even though it's
     -- non-reproducible, to avoid user confusion. In any event,
     -- reproducible builds should be done by updating your config
     -- files!

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -444,19 +444,10 @@ parseTargets needTargets haddockDeps boptscli smActual = do
   (errs1, concat -> rawTargets) <- fmap partitionEithers $ forM rawInput $
     parseRawTargetDirs workingDir locals
 
-  let deps = smaDeps smActual
-      globals = smaGlobal smActual
-      latestGlobal name gp = do
-        let version = gpVersion gp
-        mrev <- getLatestHackageRevision name version
-        forM mrev $ \(_rev, cfKey, treeKey) -> do
-          let ident = PackageIdentifier name version
-          pure $ PLImmutable (PLIHackage ident cfKey treeKey)
-  globalLocs <- Map.traverseMaybeWithKey latestGlobal globals
-  let allLocs = Map.union globalLocs (Map.map dpLocation deps)
+  let depLocs = Map.map dpLocation $ smaDeps smActual
 
   (errs2, resolveResults) <- fmap partitionEithers $ forM rawTargets $
-    resolveRawTarget smActual allLocs
+    resolveRawTarget smActual depLocs
 
   (errs3, targets, addedDeps) <- combineResolveResults resolveResults
 


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Tested manually.
This change assumes #4547 to get merged soon.
Excluding these revisions shaves off some time from Stack invocation, e.g. without it I see for `time stack path`:
```
real	0m3,561s
user	0m3,292s
sys	0m0,321s
```
and after applying it:
```
real	0m1,628s
user	0m1,602s
sys	0m0,077s
```
