### PR TITLE
Postpone revision retrieval for executables until they're needed

### DIFF
--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -429,15 +429,13 @@ addDep treatAsDep' name = do
                             -- they likely won't affect executable
                             -- names. This code does not feel right.
                             let version = installedVersion installed
-                            mrev <- liftRIO $ getLatestHackageRevision name version
-                            case mrev of
-                              Nothing -> error $ "No package revision found for: " <> show name
-                              Just (_rev, cfKey, treeKey) ->
-                                tellExecutablesUpstream
-                                  name
-                                  (PLIHackage (PackageIdentifier name version) cfKey treeKey)
-                                  loc
-                                  Map.empty
+                                askPkgLoc = liftRIO $ do
+                                  mrev <- getLatestHackageRevision name version
+                                  case mrev of
+                                    Nothing -> error $ "No package revision found for: " <> show name
+                                    Just (_rev, cfKey, treeKey) ->
+                                      return $ PLIHackage (PackageIdentifier name version) cfKey treeKey
+                            tellExecutablesUpstream name askPkgLoc loc Map.empty
                             return $ Right $ ADRFound loc installed
                         Just (PIOnlySource ps) -> do
                             tellExecutables name ps
@@ -456,12 +454,13 @@ tellExecutables _name (PSFilePath lp)
 -- Ignores ghcOptions because they don't matter for enumerating
 -- executables.
 tellExecutables name (PSRemote pkgloc _version _fromSnaphot cp) =
-    tellExecutablesUpstream name pkgloc Snap (cpFlags cp)
+    tellExecutablesUpstream name (pure pkgloc) Snap (cpFlags cp)
 
-tellExecutablesUpstream :: PackageName -> PackageLocationImmutable -> InstallLocation -> Map FlagName Bool -> M ()
-tellExecutablesUpstream name pkgloc loc flags = do
+tellExecutablesUpstream :: PackageName -> M PackageLocationImmutable -> InstallLocation -> Map FlagName Bool -> M ()
+tellExecutablesUpstream name retrievePkgloc loc flags = do
     ctx <- ask
     when (name `Set.member` wanted ctx) $ do
+        pkgloc <- retrievePkgloc
         p <- loadPackage ctx pkgloc flags []
         tellExecutablesPackage loc p
 


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

This in addition to #4557 shaves off some added slowness in #4479 
On `master` I get locally for `time stack exec -- stack build --dry-run`:
```
real	0m17,832s
user	0m17,737s
sys	0m0,228s
```

With this applied:
```
real	0m5,300s
user	0m5,184s
sys	0m0,240s
```