### PR TITLE
Add support for Git repositories with submodules

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,7 @@ Major changes:
     * Support for archives and repos in the `packages` section has
       been removed. Instead, you must use `extra-deps` for such
       dependencies. `packages` now only supports local filepaths.
+    * Add support for Git repositories containing (recursive) submodules.
     * Addition of new configuration options for specifying a "pantry
       tree" key, which provides more reproducibility around builds,
       and (in the future) will be used for more efficient package

--- a/test/integration/tests/git-submodules/Main.hs
+++ b/test/integration/tests/git-submodules/Main.hs
@@ -1,0 +1,47 @@
+import StackTest
+import System.Directory (createDirectoryIfMissing,withCurrentDirectory)
+
+main :: IO ()
+main = do
+    let
+      gitInit = do
+         runShell "git init ."
+         runShell "git config user.name Test"
+         runShell "git config user.email test@test.com"
+
+    createDirectoryIfMissing True "tmpSubSubRepo"
+    withCurrentDirectory "tmpSubSubRepo" $ do
+      gitInit
+      stack ["new", "pkg ", defaultResolverArg]
+      runShell "git add pkg"
+      runShell "git commit -m SubSubCommit"
+
+    createDirectoryIfMissing True "tmpSubRepo"
+    withCurrentDirectory "tmpSubRepo" $ do
+      gitInit
+      runShell "git submodule add ../tmpSubSubRepo sub"
+      runShell "git commit -a -m SubCommit"
+
+    createDirectoryIfMissing True "tmpRepo"
+    withCurrentDirectory "tmpRepo" $ do
+      gitInit
+      runShell "git submodule add ../tmpSubRepo sub"
+      runShell "git commit -a -m Commit"
+
+    stack ["new", defaultResolverArg, "tmpPackage"]
+
+    withCurrentDirectory "tmpPackage" $ do
+      -- add git dependency on repo with recursive submodules
+      runShell "echo 'extra-deps:' >> stack.yaml"
+      runShell "echo \"- git: $(cd ../tmpRepo && pwd)\" >> stack.yaml"
+      runShell "echo \"  commit: $(cd ../tmpRepo && git rev-parse HEAD)\" >> stack.yaml"
+      runShell "echo '  subdir: sub/sub/pkg' >> stack.yaml"
+
+      -- Setup the package
+      stack ["setup"]
+
+    -- cleanup
+    removeDirIgnore "tmpRepo"
+    removeDirIgnore "tmpSubRepo"
+    removeDirIgnore "tmpSubSubRepo"
+    removeDirIgnore "tmpPackage"


### PR DESCRIPTION
Add support for Git submodules (recursive or not) in Pantry. Useful when a git repository containing submodules is used as a Stack "extra-deps".

A test has been added: it tries to `stack setup` a package that has an "extra-deps" on a package contained in a sub-submodule of a Git repo.

Also export the function `withRepo` that I use to implement #4567.

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary: not necessary