### PR TITLE
Allow local installs of mutable snapshot packages

### DIFF
--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -75,7 +75,6 @@ combineSourceInstalled :: PackageSource
                        -> PackageInfo
 combineSourceInstalled ps (location, installed) =
     assert (psVersion ps == installedVersion installed) $
-    assert (psLocation ps == location) $
     case location of
         -- Always trust something in the snapshot
         Snap -> PIOnlyInstalled location installed
@@ -330,10 +329,6 @@ mkUnregisterLocal tasks dirtyReason localDumpPkgs sourceMap initialBuildSteps =
           = if initialBuildSteps && taskIsTarget task && taskProvides task == ident
               then Nothing
               else Just $ fromMaybe "" $ Map.lookup name dirtyReason
-      -- Check if we're no longer using the local version
-      | Just (dpLocation -> PLImmutable _) <- Map.lookup name (smDeps sourceMap)
-          -- FIXME:qrilka do git/archive count as snapshot installed?
-          = Just "Switching to snapshot installed package"
       -- Check if a dependency is going to be unregistered
       | (dep, _):_ <- mapMaybe (`Map.lookup` toUnregister) deps
           = Just $ "Dependency being unregistered: " <> T.pack (packageIdentifierString dep)

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -207,7 +207,7 @@ constructPlan baseConfigOpts0 localDumpPkgs loadPackage0 sourceMap installedMap 
             return $ takeSubset Plan
                 { planTasks = tasks
                 , planFinals = M.fromList finals
-                , planUnregisterLocal = mkUnregisterLocal tasks dirtyReason localDumpPkgs sourceMap initialBuildSteps
+                , planUnregisterLocal = mkUnregisterLocal tasks dirtyReason localDumpPkgs initialBuildSteps
                 , planInstallExes =
                     if boptsInstallExes (bcoBuildOpts baseConfigOpts0) ||
                        boptsInstallCompilerTool (bcoBuildOpts baseConfigOpts0)
@@ -275,12 +275,11 @@ mkUnregisterLocal :: Map PackageName Task
                   -- ^ Reasons why packages are dirty and must be rebuilt
                   -> [DumpPackage () () ()]
                   -- ^ Local package database dump
-                  -> SourceMap
                   -> Bool
                   -- ^ If true, we're doing a special initialBuildSteps
                   -- build - don't unregister target packages.
                   -> Map GhcPkgId (PackageIdentifier, Text)
-mkUnregisterLocal tasks dirtyReason localDumpPkgs sourceMap initialBuildSteps =
+mkUnregisterLocal tasks dirtyReason localDumpPkgs initialBuildSteps =
     -- We'll take multiple passes through the local packages. This
     -- will allow us to detect that a package should be unregistered,
     -- as well as all packages directly or transitively depending on

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -105,11 +105,15 @@ getInstalled opts installMap = do
                 Nothing -> m
                 Just (iLoc, iVersion)
                     -- Not the version we want, ignore it
-                    | version /= iVersion || loc /= iLoc -> Map.empty
+                    | version /= iVersion || mismatchingLoc loc iLoc -> Map.empty
 
                     | otherwise -> m
           where
             m = Map.singleton name (loc, Executable $ PackageIdentifier name version)
+            mismatchingLoc installed target | target == installed = False
+                                            | installed == Local = False -- snapshot dependency could end up
+                                                                         -- in a local install as being mutable
+                                            | otherwise = True
     exesSnap <- getInstalledExes Snap
     exesLocal <- getInstalledExes Local
     let installedMap = Map.unions

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -261,7 +261,7 @@ isAllowed opts mcache installMap mloc dp
     PackageIdentifier name version = dpPackageIdent dp
     -- Ensure that the installed location matches where the sourceMap says it
     -- should be installed
-    checkLocation Snap = mloc /= Just (InstalledTo Local) -- we can allow either global or snap
+    checkLocation Snap = True -- snapshot deps could become mutable after getting any mutable dependency
     checkLocation Local = mloc == Just (InstalledTo Local) || mloc == Just ExtraGlobal -- 'locally' installed snapshot packages can come from extra dbs
     -- Check if a package is allowed if it is found in the sourceMap
     checkFound (installLoc, installVer)


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Tested manually.
Fixes #4578 

With https://github.com/commercialhaskell/stack/blob/master/doc/build-overview.md being implemented we now have local installs of snapshot packages getting marked as mutable, i.e. having mutable (local) dependencies. This change removes reinstallation of those packages from snapshots.