### PR TITLE
Update install_and_upgrade.md

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -71,7 +71,7 @@ Run:
 
 If you have the popular [brew](https://brew.sh/) tool installed, you can just do:
 
-    brew install stack
+    brew install haskell-stack
 
 * The Homebrew formula and bottles are **unofficial** and lag slightly behind new Stack releases,
 but tend to be updated within a day or two.


### PR DESCRIPTION
Mac homebrew's package name is no longer 'stack', it is 'haskell-stack'

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
