### PR TITLE
Proper relative paths for script resolvers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -56,6 +56,9 @@ Behavior changes:
   directory could affect interpretation of the script. See
   [#4538](https://github.com/commercialhaskell/stack/pull/4538)
 
+* When using `stack script`, custom snapshot files will be resolved
+  relative to the directory containing the script.
+
 Other enhancements:
 
 * Defer loading up of files for local packages. This allows us to get

--- a/src/Options/Applicative/Complicated.hs
+++ b/src/Options/Applicative/Complicated.hs
@@ -79,11 +79,12 @@ addCommand :: String   -- ^ command string
            -> String   -- ^ title of command
            -> String   -- ^ footer of command help
            -> (a -> b) -- ^ constructor to wrap up command in common data type
+           -> (a -> c -> c) -- ^ extend common settings from local settings
            -> Parser c -- ^ common parser
            -> Parser a -- ^ command parser
            -> ExceptT b (Writer (Mod CommandFields (b,c))) ()
-addCommand cmd title footerStr constr =
-  addCommand' cmd title footerStr (\a c -> (constr a,c))
+addCommand cmd title footerStr constr extendCommon =
+  addCommand' cmd title footerStr (\a c -> (constr a,extendCommon a c))
 
 -- | Add a command that takes sub-commands to the options dispatcher.
 addSubCommands

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -60,7 +60,7 @@ cfgCmdSet go cmd = do
                      case mstackYaml of
                          LCSProject stackYaml -> return stackYaml
                          LCSNoProject -> liftM (</> stackDotYaml) (getImplicitGlobalProjectDir conf)
-                         LCSNoConfig _ -> throwString "config command used when no local configuration available"
+                         LCSNoConfig -> throwString "config command used when no local configuration available"
                  CommandScopeGlobal -> return (configUserConfigPath conf)
     -- We don't need to worry about checking for a valid yaml here
     (config :: Yaml.Object) <-

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -40,7 +40,7 @@ scriptCmd opts go' = do
             { globalConfigMonoid = (globalConfigMonoid go')
                 { configMonoidInstallGHC = First $ Just True
                 }
-            , globalStackYaml = SYLNoConfig scriptDir
+            , globalStackYaml = SYLNoConfig
             }
     withDefaultBuildConfigAndLock go $ \lk -> do
       -- Some warnings in case the user somehow tries to set a
@@ -53,7 +53,7 @@ scriptCmd opts go' = do
           "Ignoring override stack.yaml file for script command: " <>
           fromString fp
         SYLDefault -> return ()
-        SYLNoConfig _ -> assert False (return ())
+        SYLNoConfig -> assert False (return ())
 
       config <- view configL
       menv <- liftIO $ configProcessContextSettings config defaultEnvSettings

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -444,6 +444,7 @@ data GlobalOptsMonoid = GlobalOptsMonoid
     , globalMonoidTimeInLog    :: !(First Bool) -- ^ Whether to include timings in logs.
     , globalMonoidConfigMonoid :: !ConfigMonoid -- ^ Config monoid, for passing into 'loadConfig'
     , globalMonoidResolver     :: !(First (Unresolved AbstractResolver)) -- ^ Resolver override
+    , globalMonoidResolverRoot :: !(First FilePath) -- ^ root directory for resolver relative path
     , globalMonoidCompiler     :: !(First WantedCompiler) -- ^ Compiler override
     , globalMonoidTerminal     :: !(First Bool) -- ^ We're in a terminal?
     , globalMonoidStyles       :: !StylesUpdate -- ^ Stack's output styles

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -430,9 +430,7 @@ data GlobalOpts = GlobalOpts
 data StackYamlLoc filepath
     = SYLDefault
     | SYLOverride !filepath
-    | SYLNoConfig !(Path Abs Dir)
-    -- ^ FilePath is the directory containing the script file, used
-    -- for resolving custom snapshot files.
+    | SYLNoConfig
     deriving (Show,Functor,Foldable,Traversable)
 
 -- | Parsed global command-line options monoid.

--- a/test/integration/tests/relative-script-snapshots/Main.hs
+++ b/test/integration/tests/relative-script-snapshots/Main.hs
@@ -1,0 +1,4 @@
+import StackTest
+
+main :: IO ()
+main = stack ["subdir/script.hs"]

--- a/test/integration/tests/relative-script-snapshots/files/subdir/script.hs
+++ b/test/integration/tests/relative-script-snapshots/files/subdir/script.hs
@@ -1,0 +1,6 @@
+#!/usr/bin/env stack
+-- stack --resolver snapshot.yaml script
+import Acme.Missiles
+
+main :: IO ()
+main = launchMissiles

--- a/test/integration/tests/relative-script-snapshots/files/subdir/snapshot.yaml
+++ b/test/integration/tests/relative-script-snapshots/files/subdir/snapshot.yaml
@@ -1,0 +1,4 @@
+resolver: ghc-8.2.2
+name: snapshot
+packages:
+- acme-missiles-0.3@rev:0


### PR DESCRIPTION
Previously, any relative paths in a script's --resolver flag would be
considered relative to the current working directory. It's more logical
and consistent to have it relative to the directory the script lives in.
This makes the change.

Possible argument: it's a bit weird to put the resolver root into the
GlobalOptsMonoid value. Overall it seems like the best option to me, but
I'm open to other approaches.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
