### PR TITLE
Rename duplicated System.Permissions module

### DIFF
--- a/subs/pantry/src/Pantry/Repo.hs
+++ b/subs/pantry/src/Pantry/Repo.hs
@@ -19,7 +19,7 @@ import RIO.Process
 import Database.Persist (Entity (..))
 import qualified RIO.Text as T
 import System.Console.ANSI (hSupportsANSIWithoutEmulation)
-import System.Permissions (osIsWindows)
+import System.IsWindows (osIsWindows)
 
 fetchReposRaw
   :: (HasPantryConfig env, HasLogFunc env, HasProcessContext env)

--- a/subs/pantry/src/unix/System/IsWindows.hs
+++ b/subs/pantry/src/unix/System/IsWindows.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-module System.Permissions
+module System.IsWindows
   ( osIsWindows
   ) where
 

--- a/subs/pantry/src/windows/System/IsWindows.hs
+++ b/subs/pantry/src/windows/System/IsWindows.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-module System.Permissions
+module System.IsWindows
   ( osIsWindows
   ) where
 


### PR DESCRIPTION
Both the pantry and stack packages had the same module name, which
prevented `stack ghci` from working. This rename resolves the problem.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
