### PR TITLE
Fix building haddocks for packages with internal libraries

### DIFF
--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -25,6 +25,7 @@ import           Data.Time (UTCTime)
 import           Path
 import           Path.Extra
 import           Path.IO
+import           RIO.List (intercalate)
 import           RIO.PrettyPrint
 import           Stack.Constants
 import           Stack.PackageDump
@@ -235,6 +236,9 @@ generateHaddockIndex descr wc bco dumpPackages docRelFP destDir = do
                         docRelFP FP.</>
                         packageIdentifierString dpPackageIdent FP.</>
                         (packageNameString name FP.<.> "haddock")
+                    interfaces = intercalate "," $
+                      maybeToList dpHaddockHtml ++ [srcInterfaceFP]
+
                 destInterfaceAbsFile <- parseCollapsedAbsFile (toFilePath destDir FP.</> destInterfaceRelFP)
                 esrcInterfaceModTime <- tryGetModificationTime srcInterfaceAbsFile
                 return $
@@ -242,11 +246,7 @@ generateHaddockIndex descr wc bco dumpPackages docRelFP destDir = do
                         Left _ -> Nothing
                         Right srcInterfaceModTime ->
                             Just
-                                ( [ "-i"
-                                  , concat
-                                        [ docRelFP FP.</> packageIdentifierString dpPackageIdent
-                                        , ","
-                                        , destInterfaceRelFP ]]
+                                ( [ "-i", interfaces ]
                                 , srcInterfaceModTime
                                 , srcInterfaceAbsFile
                                 , destInterfaceAbsFile )


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

I've tested it using https://github.com/qrilka/test-internal-haddock. Without this patch I get
```
Updating Haddock index for local packages and dependencies in
/home/qrilka/ws/h/stack-tests/test-internal/.stack-work/install/x86_64-linux-tinfo6/d542db1939a9b706609e6e30f7207fbc656b1f8b91ec7d78f8c9c350b2157d09/8.6.3/doc/all/index.html
Received ExitFailure 1 when running
Raw command: /home/qrilka/.stack/programs/x86_64-linux/ghc-tinfo6-8.6.3/bin/haddock --optghc=-package-db=/home/qrilka/.stack/snapshots/x86_64-linux-tinfo6/d542db1939a9b706609e6e30f7207fbc656b1f8b91ec7d78f8c9c350b2157d09/8.6.3/pkgdb --optghc=-package-db=/home/qrilka/ws/h/stack-tests/test-internal/.stack-work/install/x86_64-linux-tinfo6/d542db1939a9b706609e6e30f7207fbc656b1f8b91ec7d78f8c9c350b2157d09/8.6.3/pkgdb --gen-contents --gen-index -i ../ghc-prim-0.5.3,../ghc-prim-0.5.3/ghc-prim.haddock -i ../z-test-internal-haddock-z-internal-lib-0.1.0.0,../z-test-internal-haddock-z-internal-lib-0.1.0.0/z-test-internal-haddock-z-internal-lib.haddock -i ../test-internal-haddock-0.1.0.0,../test-internal-haddock-0.1.0.0/test-internal-haddock.haddock -i ../base-4.12.0.0,../base-4.12.0.0/base.haddock -i ../integer-gmp-1.0.2.0,../integer-gmp-1.0.2.0/integer-gmp.haddock
Run from: /home/qrilka/ws/h/stack-tests/test-internal/.stack-work/install/x86_64-linux-tinfo6/d542db1939a9b706609e6e30f7207fbc656b1f8b91ec7d78f8c9c350b2157d09/8.6.3/doc/all/
Standard output:

haddock: internal error: ../z-test-internal-haddock-z-internal-lib-0.1.0.0/z-test-internal-haddock-z-internal-lib.haddock: openBinaryFile: does not exist (No such file or directory)
```
While with this fix I get correct results.

Fixes #3989 