### PR TITLE
Remove names from snapshots

### DIFF
--- a/doc/pantry.md
+++ b/doc/pantry.md
@@ -306,8 +306,6 @@ directories is available in snapshots to ensure reproducibility.
 resolver: lts-8.21 # Inherits GHC version and package set
 compiler: ghc-8.0.1 # Overwrites GHC version in the resolver, optional
 
-name: my-snapshot # User-friendly name
-
 # Additional packages, follows extra-deps syntax
 packages:
 - unordered-containers-0.2.7.1
@@ -371,7 +369,6 @@ packages:
   pantry-tree:
     size: 7376
     sha256: ac2601c49cf7bc0f5d66b2793eddc8352f51a6ee989980827a0d0d8169700a03
-name: my-snapshot
 hidden:
   warp: false
   wai: true

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -645,7 +645,7 @@ loadBuildConfig mproject maresolver mcompiler = do
           { smwCompiler = fromMaybe (snapshotCompiler snapshot)  mcompiler
           , smwProject = packages
           , smwDeps = deps
-          , smwSnapshotName = snapshotName snapshot
+          , smwSnapshotLocation = projectResolver project
           }
 
     return BuildConfig

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -857,7 +857,9 @@ targetWarnings localTargets nonLocalTargets mfileTargets = do
       prettyNote $ vsep
           [ flow "No local targets specified, so a plain ghci will be started with no package hiding or package options."
           , ""
-          , flow $ "You are using snapshot: " ++ T.unpack (smwSnapshotName smWanted)
+          , flow $ T.unpack $ utf8BuilderToText $
+                   "You are using snapshot: " <>
+                   RIO.display (smwSnapshotLocation smWanted)
           , ""
           , flow "If you want to use package hiding and options, then you can try one of the following:"
           , ""

--- a/src/Stack/Types/BuildPlan.hs
+++ b/src/Stack/Types/BuildPlan.hs
@@ -57,10 +57,7 @@ instance Store SnapshotDef
 instance NFData SnapshotDef
 
 sdResolverName :: SnapshotDef -> Text
-sdResolverName sd =
-  case sdSnapshot sd of
-    Nothing -> utf8BuilderToText $ display $ sdWantedCompilerVersion sd
-    Just (snapshot, _) -> rslName snapshot
+sdResolverName = utf8BuilderToText . display . sdResolver
 
 sdSnapshots :: SnapshotDef -> [RawSnapshotLayer]
 sdSnapshots sd =

--- a/src/Stack/Types/SourceMap.hs
+++ b/src/Stack/Types/SourceMap.hs
@@ -87,7 +87,8 @@ data SMWanted = SMWanted
   { smwCompiler :: !WantedCompiler
   , smwProject :: !(Map PackageName ProjectPackage)
   , smwDeps :: !(Map PackageName DepPackage)
-  , smwSnapshotName :: !Text
+  , smwSnapshotLocation :: !RawSnapshotLocation
+  -- ^ Where this snapshot is loaded from.
   }
 
 -- | Adds in actual compiler information to 'SMWanted', in particular

--- a/subs/curator/app/Main.hs
+++ b/subs/curator/app/Main.hs
@@ -54,7 +54,7 @@ snapshotIncomplete :: RIO PantryApp ()
 snapshotIncomplete = do
   logInfo "Writing snapshot-incomplete.yaml"
   decodeFileThrow "constraints.yaml" >>= \constraints' ->
-    makeSnapshot constraints' "my-test-snapshot-2" >>=
+    makeSnapshot constraints' >>=
     liftIO . encodeFile "snapshot-incomplete.yaml"
 
 snapshot :: RIO PantryApp ()

--- a/subs/curator/src/Curator/Snapshot.hs
+++ b/subs/curator/src/Curator/Snapshot.hs
@@ -41,9 +41,8 @@ import qualified RIO.Text.Partial as TP
 makeSnapshot
   :: (HasPantryConfig env, HasLogFunc env, HasProcessContext env)
   => Constraints
-  -> Text -- ^ name
   -> RIO env RawSnapshotLayer
-makeSnapshot cons name = do
+makeSnapshot cons = do
     locs <-
         traverseValidate (\(pn, pc) -> (pn,) <$> toLoc pn pc) $
         Map.toList $ consPackages cons
@@ -53,7 +52,6 @@ makeSnapshot cons name = do
         RawSnapshotLayer
         { rslParent = RSLCompiler $ WCGhc $ consGhcVersion cons
         , rslCompiler = Nothing
-        , rslName = name
         , rslLocations = mapMaybe snd locs
         , rslDropPackages = mempty
         , rslFlags = Map.mapMaybeWithKey (\pn pc -> if (inSnapshot pn) then getFlags pc else Nothing)

--- a/subs/pantry/src/Pantry.hs
+++ b/subs/pantry/src/Pantry.hs
@@ -803,7 +803,6 @@ completeSnapshotLayer rsnapshot = do
     { slParent = parent'
     , slLocations = pls
     , slCompiler= rslCompiler rsnapshot
-    , slName = rslName rsnapshot
     , slDropPackages = rslDropPackages rsnapshot
     , slFlags = rslFlags rsnapshot
     , slHidden = rslHidden rsnapshot
@@ -893,7 +892,6 @@ loadSnapshotRaw loc = do
     Left wc ->
       pure RawSnapshot
         { rsCompiler = wc
-        , rsName = utf8BuilderToText $ display wc
         , rsPackages = mempty
         , rsDrop = mempty
         }
@@ -913,7 +911,6 @@ loadSnapshotRaw loc = do
       warnUnusedAddPackagesConfig (display loc) unused
       pure RawSnapshot
         { rsCompiler = fromMaybe (rsCompiler snap0) (rslCompiler rsl)
-        , rsName = rslName rsl
         , rsPackages = packages
         , rsDrop = apcDrop unused
         }
@@ -931,7 +928,6 @@ loadSnapshot loc = do
     Left wc ->
       pure RawSnapshot
         { rsCompiler = wc
-        , rsName = utf8BuilderToText $ display wc
         , rsPackages = mempty
         , rsDrop = mempty
         }
@@ -951,7 +947,6 @@ loadSnapshot loc = do
       warnUnusedAddPackagesConfig (display loc) unused
       pure RawSnapshot
         { rsCompiler = fromMaybe (rsCompiler snap0) (rslCompiler rsl)
-        , rsName = rslName rsl
         , rsPackages = packages
         , rsDrop = apcDrop unused
         }
@@ -983,7 +978,6 @@ loadAndCompleteSnapshotRaw loc = do
     Left wc ->
       let snapshot = Snapshot
             { snapshotCompiler = wc
-            , snapshotName = utf8BuilderToText $ display wc
             , snapshotPackages = mempty
             , snapshotDrop = mempty
             }
@@ -1004,7 +998,6 @@ loadAndCompleteSnapshotRaw loc = do
       warnUnusedAddPackagesConfig (display loc) unused
       let snapshot = Snapshot
             { snapshotCompiler = fromMaybe (snapshotCompiler snap0) (rslCompiler rsl)
-            , snapshotName = rslName rsl
             , snapshotPackages = packages
             , snapshotDrop = apcDrop unused
             }


### PR DESCRIPTION
It doesn't seem to match our overall approach to other config files.
Instead of giving a user-friendly name, I've modified the one place that
was displaying the name to instead display the location of the snapshot.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
