### PR TITLE
stack ghci: Make shown options easily copy-pastable.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -83,6 +83,8 @@ Other enhancements:
 * Stack parses and respects the `preferred-versions` information from
   Hackage for choosing latest version of a package in some cases,
   e.g. `stack unpack packagename`.
+* The components output in the `The main module to load is ambiguous` message
+  now include package names so they can be more easily copy-pasted.
 * Git repos are shared across multiple projects. See
   [#3551](https://github.com/commercialhaskell/stack/issues/3551)
 * Use en_US.UTF-8 locale by default in pure Nix mode so programs won't

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -561,10 +561,13 @@ figureOutMainFile bopts mainIsTargets targets0 packages = do
                     wantedPackageComponents bopts target (ghciPkgPackage pkg)
     renderCandidate c@(pkgName,namedComponent,mainIs) =
         let candidateIndex = T.pack . show . (+1) . fromMaybe 0 . elemIndex c
+            pkgNameText = T.pack (packageNameString pkgName)
         in  candidateIndex candidates <> ". Package `" <>
-            T.pack (packageNameString pkgName) <>
+            pkgNameText <>
             "' component " <>
-            renderComp namedComponent <>
+            -- This is the format that can be directly copy-pasted as
+            -- an argument to `stack ghci`.
+            pkgNameText <> ":" <> renderComp namedComponent <>
             " with main-is file: " <>
             T.pack (toFilePath mainIs)
     candidateIndices = take (length candidates) [1 :: Int ..]


### PR DESCRIPTION
Turns

		1. Package `p' component exe:myexe with main-is file ...

into

		1. Package `p' component p:exe:myexe with main-is file ...

so that you can easily copy-paste it into

    stack ghci p:exe:myexe


Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary (not necessary).

---

* [x] I haven't tested the change yet, as it's still compiling. **Now tested.**