### PR TITLE
Avoid a warning for names in snapshots

### DIFF
--- a/subs/pantry/src/Pantry/Types.hs
+++ b/subs/pantry/src/Pantry/Types.hs
@@ -1954,6 +1954,7 @@ instance ToJSON RawSnapshotLayer where
 
 instance FromJSON (WithJSONWarnings (Unresolved RawSnapshotLayer)) where
   parseJSON = withObjectWarnings "Snapshot" $ \o -> do
+    _ :: Maybe Text <- o ..:? "name" -- avoid warnings for old snapshot format
     mcompiler <- o ..:? "compiler"
     mresolver <- jsonSubWarningsT $ o ...:? ["snapshot", "resolver"]
     unresolvedSnapshotParent <-


### PR DESCRIPTION
Since we no longer require this field, the previous code would spit out
a warning if it was present. This is extremely noisy for a field that
used to be required. Instead: just ignore the field if present.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
