### PR TITLE
stack clean does not need ghc-pkg (fixes #4480)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -113,6 +113,9 @@ Other enhancements:
   downside to this, however: if you have a multifile script, and
   change one of the dependency modules, Stack will not automatically
   detect and recompile.
+* `stack clean` will delete the entire `.stack-work/dist` directory,
+  not just the relevant subdirectory for the current GHC version. See
+  [#4480](https://github.com/commercialhaskell/stack/issues/4480).
 
 Bug fixes:
 

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -660,7 +660,6 @@ loadBuildConfig mproject maresolver mcompiler = do
                 LCSProject _ -> False
                 LCSNoConfig _extraDeps -> False
         , bcCurator = projectCurator project
-        , bcDownloadCompiler = WithDownloadCompiler
         }
   where
     getEmptyProject :: Maybe RawSnapshotLocation -> [PackageIdentifierRevision] -> RIO Config Project

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -83,8 +83,6 @@ module Stack.Types.Config
   ,LoadConfig(..)
   -- ** WithDocker
   ,WithDocker(..)
-  -- ** WithDownloadCompiler
-  ,WithDownloadCompiler(..)
 
   -- ** Project & ProjectAndConfigMonoid
   ,Project(..)
@@ -495,16 +493,11 @@ data BuildConfig = BuildConfig
       -- ^ Are we loading from the implicit global stack.yaml? This is useful
       -- for providing better error messages.
     , bcCurator :: !(Maybe Curator)
-    , bcDownloadCompiler :: !WithDownloadCompiler
     }
 
 data WithDocker
   = SkipDocker
   | WithDocker
-
-data WithDownloadCompiler
-  = SkipDownloadCompiler
-  | WithDownloadCompiler
 
 stackYamlL :: HasBuildConfig env => Lens' env (Path Abs File)
 stackYamlL = buildConfigL.lens bcStackYaml (\x y -> x { bcStackYaml = y })

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -658,12 +658,7 @@ setupCmd sco@SetupCmdOpts{..} go@GlobalOpts{..} = loadConfigWithOpts go $ \lc ->
           (Just $ munlockFile lk)
 
 cleanCmd :: CleanOpts -> GlobalOpts -> IO ()
-cleanCmd opts go =
-  -- See issues #2010 and #3468 for why "stack clean --full" is not used
-  -- within docker.
-  case opts of
-    CleanFull{} -> withBuildConfigAndLockNoDockerInClean go (const (clean opts))
-    CleanShallow{} -> withBuildConfigAndLockInClean go (const (clean opts))
+cleanCmd opts go = withCleanConfig go (clean opts)
 
 -- | Helper for build and install commands
 buildCmd :: BuildOptsCLI -> GlobalOpts -> IO ()
@@ -998,7 +993,6 @@ imgDockerCmd (rebuild,images) go@GlobalOpts{..} = loadConfigWithOpts go $ \lc ->
     let mProjectRoot = lcProjectRoot lc
     withBuildConfigExt
         WithDocker
-        WithDownloadCompiler
         go
         NeedTargets
         defaultBuildOptsCLI


### PR DESCRIPTION
When running `stack clean`, the entire .stack-work/dist directory will
now be deleted, not just the subdirectory for the current GHC/Cabal
combination.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
