### PR TITLE
Fix test failure for script-extra-dep

### DIFF
--- a/test/integration/tests/script-extra-dep/files/script.hs
+++ b/test/integration/tests/script-extra-dep/files/script.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver ghc-8.2.2 script --extra-dep acme-missiles-0.3@rev:0
+-- stack --resolver ghc-8.2.2 script --extra-dep acme-missiles-0.3@rev:0 --extra-dep stm-2.5.0.0@rev:0
 import Acme.Missiles
 
 main :: IO ()


### PR DESCRIPTION
This PR fixes this failure:

``` shellsession
Running test script-extra-dep
Running: /home/sibi/.local/bin/stack script.hs

Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for acme-missiles-0.3:
    stm needed, but the stack configuration has no specified version  (latest matching version is 2.5.0.0)
needed since acme-missiles is a build target.

Some different approaches to resolving this:

  * Consider trying 'stack solver', which uses the cabal-install solver to attempt to find some working build configuration. This can be convenient when dealing with many
    complicated constraint errors, but results may be unpredictable.

  * Recommended action: try adding the following to your extra-deps in /home/sibi/.stack/script/048d6ed9f71bbafeb2cf702cda487d65dbd1010070852364425533166dcd99bc/config.yaml:

stm-2.5.0.0@sha256:1fb8bd117550d560d1b33a6404e27fdb090e70921e0f6434722cdbbce20d8256,2086

Plan construction failed.
Main.hs: Exited with exit code: ExitFailure 1
CallStack (from HasCallStack):
  error, called at ../../../lib/StackTest.hs:52:34 in main:StackTest
  stack, called at ../Main.hs:4:8 in main:Main
```

`stm` package is one of the dependency of acme-missiles, so that also
needs to be added as part of `extra-dep` for the test to run properly

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
