### PR TITLE
Fix test failure for relative-script-snapshots

### DIFF
--- a/test/integration/tests/relative-script-snapshots/files/subdir/snapshot.yaml
+++ b/test/integration/tests/relative-script-snapshots/files/subdir/snapshot.yaml
@@ -2,3 +2,4 @@ resolver: ghc-8.2.2
 name: snapshot
 packages:
 - acme-missiles-0.3@rev:0
+- stm-2.5.0.0@rev:0


### PR DESCRIPTION
`stm` package is one of the dependency of `acme-missiles`, so that
also needs to be added as part of `packages` section of the
`snapshot.yaml` file.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
