### PR TITLE
Fix integration test for mutable-deps

### DIFF
--- a/test/integration/tests/mutable-deps/files/filepath-1.4.1.2/System/FilePath/Internal.hs
+++ b/test/integration/tests/mutable-deps/files/filepath-1.4.1.2/System/FilePath/Internal.hs
@@ -1,4 +1,3 @@
-{-# ANN module "HLint: ignore" #-}
 #if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
 #endif

--- a/test/integration/tests/mutable-deps/files/filepath-1.4.1.2/System/FilePath/Internal.hs
+++ b/test/integration/tests/mutable-deps/files/filepath-1.4.1.2/System/FilePath/Internal.hs
@@ -1,6 +1,3 @@
-#if __GLASGOW_HASKELL__ >= 704
-{-# LANGUAGE Safe #-}
-#endif
 {-# LANGUAGE PatternGuards #-}
 
 -- This template expects CPP definitions for:
@@ -146,6 +143,7 @@ pathSeparator = if isWindows then '\\' else '/'
 -- > Windows: pathSeparators == ['\\', '/']
 -- > Posix:   pathSeparators == ['/']
 -- > pathSeparator `elem` pathSeparators
+{-# ANN pathSeparators "HLint: ignore" #-}
 pathSeparators :: [Char]
 pathSeparators = if isWindows then "\\/" else "/"
 
@@ -1025,5 +1023,6 @@ breakEnd p = spanEnd (not . p)
 -- | The stripSuffix function drops the given suffix from a list. It returns
 -- Nothing if the list did not end with the suffix given, or Just the list
 -- before the suffix, if it does.
+{-# ANN stripSuffix "HLint: ignore" #-}
 stripSuffix :: Eq a => [a] -> [a] -> Maybe [a]
 stripSuffix xs ys = fmap reverse $ stripPrefix (reverse xs) (reverse ys)


### PR DESCRIPTION
Without this, this results in an build error like this:

``` shellsession
$ ./run-single-test.sh mutable-deps
Running test mutable-deps
Running: /home/sibi/.local/bin/stack build
directory-1.3.0.2: unregistering (missing dependencies: filepath)
filemanip-0.3.6.3: unregistering (missing dependencies: directory, filepath)
filepath-1.4.1.2: unregistering (local file changes: System/FilePath/Internal.hs)
files-1.0.0: unregistering (missing dependencies: filemanip)
filepath-1.4.1.2: configure (lib)
filepath-1.4.1.2: build (lib)

--  While building package filepath-1.4.1.2 using:
      /home/sibi/.stack/setup-exe-cache/x86_64-linux/Cabal-simple_mPHDZzAJ_2.0.1.0_ghc-8.2.2 --builddir=.stack-work/dist/x86_64-linux/Cabal-2.0.1.0 build lib:filepath --ghc-options " -ddump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1
    Logs have been written to: /home/sibi/github/stack/test/integration/tests/mutable-deps/files/.stack-work/logs/filepath-1.4.1.2.log

    Configuring filepath-1.4.1.2...
    Preprocessing library for filepath-1.4.1.2..
    Building library for filepath-1.4.1.2..

    /home/sibi/github/stack/test/integration/tests/mutable-deps/files/filepath-1.4.1.2/System/FilePath/Posix.hs:1:1: error:
        File name does not match module name:
        Saw: ‘Main’
        Expected: ‘System.FilePath.Posix’
      |
    1 | {-# LANGUAGE CPP #-}
      | ^
Main.hs: Exited with exit code: ExitFailure 1
CallStack (from HasCallStack):
  error, called at ../../../lib/StackTest.hs:132:14 in main:StackTest
```

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
