### PR TITLE
Implemented "ignore-expiry" flag as in "cabal --ignore-expiry

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -118,6 +118,11 @@ Other enhancements:
   [#4480](https://github.com/commercialhaskell/stack/issues/4480).
 * Add `stack purge` as a shortcut for `stack clean --full`. See
   [#3863](https://github.com/commercialhaskell/stack/issues/3863).
+* Add an optional `ignore-expiry` flag to the `hackage-security`
+  section of the `~/.stack/config.yaml`. It allows to disable timestamp
+  expiration verification just like `cabal --ignore-expiry` does.
+  The flag is not enabled by default so that the default functionality
+  is not changed.
 
 Bug fixes:
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -354,6 +354,7 @@ package-indices:
     - aa315286e6ad281ad61182235533c41e806e5a787e0b6d1e7eef3f09d137d2e9
     - fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0
     key-threshold: 3 # number of keys required
+    ignore-expiry: no
 ```
 
 If you provide a replacement index which does not mirror Hackage, it

--- a/subs/pantry/src/Pantry.hs
+++ b/subs/pantry/src/Pantry.hs
@@ -254,6 +254,7 @@ defaultHackageSecurityConfig = HackageSecurityConfig
       ]
   , hscKeyThreshold = 3
   , hscDownloadPrefix = "https://s3.amazonaws.com/hackage.fpcomplete.com/"
+  , hscIgnoreExpiry = False
   }
 
 -- | Returns the latest version of the given package available from

--- a/subs/pantry/src/Pantry/Types.hs
+++ b/subs/pantry/src/Pantry/Types.hs
@@ -527,6 +527,7 @@ data HackageSecurityConfig = HackageSecurityConfig
   { hscKeyIds :: ![Text]
   , hscKeyThreshold :: !Int
   , hscDownloadPrefix :: !Text
+  , hscIgnoreExpiry :: !Bool
   }
   deriving Show
 instance FromJSON (WithJSONWarnings HackageSecurityConfig) where
@@ -535,6 +536,7 @@ instance FromJSON (WithJSONWarnings HackageSecurityConfig) where
     Object o <- o' ..: "hackage-security"
     hscKeyIds <- o ..: "keyids"
     hscKeyThreshold <- o ..: "key-threshold"
+    hscIgnoreExpiry <- o ..:? "ignore-expiry" ..!= False
     pure HackageSecurityConfig {..}
 
 -- | An environment which contains a 'PantryConfig'.


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

This change simply exposes the same functionality which cabal already implements and exposes using "--ignore-expiry" flag.