### PR TITLE
Indicate where git-annex will lead to pantry error

### DIFF
--- a/doc/pantry.md
+++ b/doc/pantry.md
@@ -214,6 +214,26 @@ extra-deps:
   commit: 2f8a8e1b771829f4a8a77c0111352ce45a14c30f
 ```
 
+#### Limited [git-annex](https://git-annex.branchable.com) support
+
+Pantry does not support [git-annex](https://git-annex.branchable.com). This is
+because `git archive` does not handle symbolic links outside the work tree. It
+is still possible to use repositories which use git-annex but do not require the
+annex files for the package to be built.
+
+To do so, ensure that any files or directories stored by git-annex are marked
+[export-ignore](https://git-scm.com/docs/git-archive#Documentation/git-archive.txt-export-ignore)
+in the `.gitattributes` file in the repository. See
+[#4579](https://github.com/commercialhaskell/stack/issues/4579) for more
+information.
+
+For example, if the directory `fonts/` is controlled by git-annex, use the
+following line.
+
+```gitattributes
+fonts export-ignore
+```
+
 ### Archives (HTTP(S) or local filepath)
 
 You can use HTTP and HTTPS URLs and local filepaths referring to

--- a/subs/pantry/src/Pantry/Archive.hs
+++ b/subs/pantry/src/Pantry/Archive.hs
@@ -394,7 +394,9 @@ parseArchive rpli archive fp = do
                   ]
                 Right x -> Right x
             case Map.lookup dest files of
-              Nothing -> Left $ "Symbolic link dest not found from " ++ mePath me ++ " to " ++ relDest ++ ", looking for " ++ dest
+              Nothing -> Left $ "Symbolic link dest not found from " ++ mePath me ++ " to " ++ relDest ++ ", looking for " ++ dest ++ ".\n"
+                  ++ "This may indicate that the source is a git archive which uses git-annex.\n"
+                  ++ "See https://github.com/commercialhaskell/stack/issues/4579 for further information."
               Just me' ->
                 case meType me' of
                   METNormal -> Right $ SimpleEntry dest FTNormal


### PR DESCRIPTION
Fixes #4579.

I haven't updated the changelog; not sure where the update should go.

For tests, I could create an integration test which makes a git repo and creates a symbolic link out of the repo. It wouldn't need git-annex, but it would trigger the same error. Does that sound worthwhile?

---

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
