### PR TITLE
Remove the MiniConfig and LoadConfig data types

### DIFF
--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -474,3 +474,9 @@ parseTargets needTargets haddockDeps boptscli smActual = do
     { smtTargets = targets
     , smtDeps = addedDeps'
     }
+  where
+    bcImplicitGlobal bconfig =
+      case configProject $ bcConfig bconfig of
+        PCProject _ -> False
+        PCNoProject -> True
+        PCNoConfig _ -> False

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveFoldable #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -21,14 +18,11 @@
 -- probably default to behaving like cabal, possibly with spitting out
 -- a warning that "you should run `stk init` to make things better".
 module Stack.Config
-  (MiniConfig
-  ,loadConfig
+  (loadConfig
   ,loadConfigMaybeProject
-  ,loadMiniConfig
   ,loadConfigYaml
   ,packagesParser
   ,getImplicitGlobalProjectDir
-  ,getStackYaml
   ,getSnapshots
   ,makeConcreteResolver
   ,checkOwnership
@@ -36,7 +30,7 @@ module Stack.Config
   ,getInNixShell
   ,defaultConfigYaml
   ,getProjectConfig
-  ,LocalConfigStatus(..)
+  ,loadBuildConfig
   ) where
 
 import           Control.Monad.Extra (firstJustM)
@@ -57,7 +51,7 @@ import           Distribution.System (OS (..), Platform (..), buildPlatform, Arc
 import qualified Distribution.Text
 import           Distribution.Version (simplifyVersionRange, mkVersion')
 import           GHC.Conc (getNumProcessors)
-import           Lens.Micro ((.~), lens)
+import           Lens.Micro ((.~))
 import           Network.HTTP.StackClient (httpJSON, parseUrlThrow, getResponseBody)
 import           Options.Applicative (Parser, strOption, long, help)
 import qualified Pantry.SHA256 as SHA256
@@ -85,7 +79,6 @@ import           System.Console.ANSI (hSupportsANSIWithoutEmulation)
 import           System.Environment
 import           System.PosixCompat.Files (fileOwner, getFileStatus)
 import           System.PosixCompat.User (getEffectiveUserID)
-import           RIO.PrettyPrint
 import           RIO.Process
 
 -- | If deprecated path exists, use it and print a warning.
@@ -132,15 +125,6 @@ getImplicitGlobalProjectDir config =
         (implicitGlobalProjectDirDeprecated stackRoot)
   where
     stackRoot = view stackRootL config
-
--- | This is slightly more expensive than @'asks' ('bcStackYaml' '.' 'getBuildConfig')@
--- and should only be used when no 'BuildConfig' is at hand.
-getStackYaml :: HasConfig env => RIO env (Path Abs File)
-getStackYaml = do
-    config <- view configL
-    case configMaybeProject config of
-        Just (_project, stackYaml) -> return stackYaml
-        Nothing -> liftM (</> stackDotYaml) (getImplicitGlobalProjectDir config)
 
 -- | Download the 'Snapshots' value from stackage.org.
 getSnapshots :: HasConfig env => RIO env Snapshots
@@ -198,17 +182,18 @@ configNoLocalConfig
     => Path Abs Dir -- ^ stack root
     -> Maybe AbstractResolver
     -> ConfigMonoid
+    -> [PackageIdentifierRevision]
     -> (Config -> RIO env a)
     -> RIO env a
-configNoLocalConfig _ Nothing _ _ = throwIO NoResolverWhenUsingNoLocalConfig
-configNoLocalConfig stackRoot (Just resolver) configMonoid inner = do
+configNoLocalConfig _ Nothing _ _ _ = throwIO NoResolverWhenUsingNoLocalConfig
+configNoLocalConfig stackRoot (Just resolver) configMonoid extraDeps inner = do
     userConfigPath <- liftIO $ getFakeConfigPath stackRoot resolver
     configFromConfigMonoid
       stackRoot
       userConfigPath
       False
       (Just resolver)
-      Nothing -- project
+      (PCNoConfig extraDeps)
       configMonoid
       inner
 
@@ -219,16 +204,21 @@ configFromConfigMonoid
     -> Path Abs File -- ^ user config file path, e.g. ~/.stack/config.yaml
     -> Bool -- ^ allow locals?
     -> Maybe AbstractResolver
-    -> Maybe (Project, Path Abs File)
+    -> ProjectConfig (Project, Path Abs File)
     -> ConfigMonoid
     -> (Config -> RIO env a)
     -> RIO env a
 configFromConfigMonoid
-    configStackRoot configUserConfigPath configAllowLocals mresolver
-    mproject ConfigMonoid{..} inner = do
+    configStackRoot configUserConfigPath configAllowLocals configResolver
+    configProject ConfigMonoid{..} inner = do
      -- If --stack-work is passed, prefer it. Otherwise, if STACK_WORK
      -- is set, use that. If neither, use the default ".stack-work"
      mstackWorkEnv <- liftIO $ lookupEnv stackWorkEnvVar
+     let mproject =
+           case configProject of
+             PCProject pair -> Just pair
+             PCNoProject -> Nothing
+             PCNoConfig _deps -> Nothing
      configWorkDir0 <- maybe (return relDirStackWork) (liftIO . parseRelDir) mstackWorkEnv
      let configWorkDir = fromFirst configWorkDir0 configMonoidWorkDir
          configLatestSnapshot = fromFirst
@@ -237,7 +227,7 @@ configFromConfigMonoid
          clConnectionCount = fromFirst 8 configMonoidConnectionCount
          configHideTHLoading = fromFirst True configMonoidHideTHLoading
 
-         configGHCVariant0 = getFirst configMonoidGHCVariant
+         configGHCVariant = getFirst configMonoidGHCVariant
          configGHCBuild = getFirst configMonoidGHCBuild
          configInstallGHC = fromFirst True configMonoidInstallGHC
          configSkipGHCCheck = fromFirst False configMonoidSkipGHCCheck
@@ -271,7 +261,7 @@ configFromConfigMonoid
 
      let configBuild = buildOptsFromMonoid configMonoidBuildOpts
      configDocker <-
-         dockerOptsFromMonoid (fmap fst mproject) configStackRoot mresolver configMonoidDockerOpts
+         dockerOptsFromMonoid (fmap fst mproject) configStackRoot configResolver configMonoidDockerOpts
      configNix <- nixOptsFromMonoid configMonoidNixOpts os
 
      configSystemGHC <-
@@ -284,7 +274,7 @@ configFromConfigMonoid
                          (dockerEnable configDocker || nixEnable configNix)
                          configMonoidSystemGHC)
 
-     when (isJust configGHCVariant0 && configSystemGHC) $
+     when (isJust configGHCVariant && configSystemGHC) $
          throwM ManualGHCVariantSettingsAreIncompatibleWithSystemGHC
 
      rawEnv <- liftIO getEnvironment
@@ -344,8 +334,6 @@ configFromConfigMonoid
             Just True -> return True
             _ -> getInContainer
 
-     let configMaybeProject = mproject
-
      configRunner' <- view runnerL
 
      useAnsi <- liftIO $ fromMaybe True <$>
@@ -402,40 +390,6 @@ getDefaultLocalProgramsBase configStackRoot configPlatform override =
           Nothing -> return defaultBase
       _ -> return defaultBase
 
--- | An environment with a subset of BuildConfig used for setup.
-data MiniConfig = MiniConfig -- TODO do we really need a whole extra data type?
-    { mcGHCVariant :: !GHCVariant
-    , mcConfig :: !Config
-    }
-instance HasConfig MiniConfig where
-    configL = lens mcConfig (\x y -> x { mcConfig = y })
-instance HasProcessContext MiniConfig where
-    processContextL = configL.processContextL
-instance HasPantryConfig MiniConfig where
-    pantryConfigL = configL.pantryConfigL
-instance HasPlatform MiniConfig
-instance HasGHCVariant MiniConfig where
-    ghcVariantL = lens mcGHCVariant (\x y -> x { mcGHCVariant = y })
-instance HasRunner MiniConfig where
-    runnerL = configL.runnerL
-instance HasLogFunc MiniConfig where
-    logFuncL = configL.logFuncL
-instance HasStylesUpdate MiniConfig where
-  stylesUpdateL = runnerL.stylesUpdateL
-instance HasTerm MiniConfig where
-  useColorL = runnerL.useColorL
-  termWidthL = runnerL.termWidthL
-
--- | Load the 'MiniConfig'.
-loadMiniConfig :: Config -> MiniConfig
-loadMiniConfig config = MiniConfig
-  { mcGHCVariant = configGHCVariantDefault config
-  , mcConfig = config
-  }
-
-configGHCVariantDefault :: Config -> GHCVariant -- FIXME why not just use this as the HasGHCVariant instance for Config?
-configGHCVariantDefault = fromMaybe GHCStandard . configGHCVariant0
-
 -- Load the configuration, using environment variables, and defaults as
 -- necessary.
 loadConfigMaybeProject
@@ -444,14 +398,19 @@ loadConfigMaybeProject
     -- ^ Config monoid from parsed command-line arguments
     -> Maybe AbstractResolver
     -- ^ Override resolver
-    -> LocalConfigStatus (Project, Path Abs File, ConfigMonoid)
+    -> ProjectConfig (Project, Path Abs File, ConfigMonoid)
     -- ^ Project config to use, if any
-    -> (LoadConfig -> RIO env a)
+    -> (Config -> RIO env a)
     -> RIO env a
 loadConfigMaybeProject configArgs mresolver mproject inner = do
     (stackRoot, userOwnsStackRoot) <- determineStackRootAndOwnership configArgs
 
-    let loadHelper mproject' inner2 = do
+    let (mproject', addConfigMonoid) =
+          case mproject of
+            PCProject (proj, fp, cm) -> (PCProject (proj, fp), (cm:))
+            PCNoProject -> (PCNoProject, id)
+            PCNoConfig deps -> (PCNoConfig deps, id)
+    let loadHelper inner2 = do
           userConfigPath <- getDefaultUserConfigPath stackRoot
           extraConfigs0 <- getExtraConfigs userConfigPath >>=
               mapM (\file -> loadConfigYaml (parseConfigMonoid (parent file)) file)
@@ -467,36 +426,24 @@ loadConfigMaybeProject configArgs mresolver mproject inner = do
             userConfigPath
             True -- allow locals
             mresolver
-            (fmap (\(x, y, _) -> (x, y)) mproject')
-            (mconcat $ configArgs
-            : maybe id (\(_, _, projectConfig) -> (projectConfig:)) mproject' extraConfigs)
+            mproject'
+            (mconcat $ configArgs : addConfigMonoid extraConfigs)
             inner2
 
     let withConfig = case mproject of
-          LCSNoConfig _extraDeps -> configNoLocalConfig stackRoot mresolver configArgs
-          LCSProject project -> loadHelper $ Just project
-          LCSNoProject -> loadHelper Nothing
+          PCNoConfig extraDeps -> configNoLocalConfig stackRoot mresolver configArgs extraDeps
+          PCProject _project -> loadHelper
+          PCNoProject -> loadHelper
 
     withConfig $ \config -> do
       unless (mkVersion' Meta.version `withinRange` configRequireStackVersion config)
           (throwM (BadStackVersionException (configRequireStackVersion config)))
-
-      let mprojectRoot = fmap (\(_, fp, _) -> parent fp) mproject
       unless (configAllowDifferentUser config) $ do
           unless userOwnsStackRoot $
               throwM (UserDoesn'tOwnDirectory stackRoot)
-          forM_ mprojectRoot $ \dir ->
+          forM_ (configProjectRoot config) $ \dir ->
               checkOwnership (dir </> configWorkDir config)
-
-      inner LoadConfig
-          { lcConfig          = config
-          , lcLoadBuildConfig = runRIO config . loadBuildConfig mproject mresolver
-          , lcProjectRoot     =
-              case mprojectRoot of
-                LCSProject fp -> Just fp
-                LCSNoProject  -> Nothing
-                LCSNoConfig _extraDeps -> Nothing
-          }
+      inner config
 
 -- | Load the configuration, using current directory, environment variables,
 -- and defaults as necessary. The passed @Maybe (Path Abs File)@ is an
@@ -508,40 +455,38 @@ loadConfig :: HasRunner env
            -- ^ Override resolver
            -> StackYamlLoc (Path Abs File)
            -- ^ Override stack.yaml
-           -> (LoadConfig -> RIO env a)
+           -> (Config -> RIO env a)
            -> RIO env a
 loadConfig configArgs mresolver mstackYaml inner =
     loadProjectConfig mstackYaml >>= \x -> loadConfigMaybeProject configArgs mresolver x inner
 
 -- | Load the build configuration, adds build-specific values to config loaded by @loadConfig@.
 -- values.
-loadBuildConfig :: LocalConfigStatus (Project, Path Abs File, ConfigMonoid)
-                -> Maybe AbstractResolver -- override resolver
-                -> Maybe WantedCompiler -- override compiler
+loadBuildConfig :: Maybe WantedCompiler -- override compiler
                 -> RIO Config BuildConfig
-loadBuildConfig mproject maresolver mcompiler = do
+loadBuildConfig mcompiler = do
     config <- ask
 
     -- If provided, turn the AbstractResolver from the command line
     -- into a Resolver that can be used below.
 
-    -- The maresolver and mcompiler are provided on the command
+    -- The configResolver and mcompiler are provided on the command
     -- line. In order to properly deal with an AbstractResolver, we
     -- need a base directory (to deal with custom snapshot relative
     -- paths). We consider the current working directory to be the
     -- correct base. Let's calculate the mresolver first.
-    mresolver <- forM maresolver $ \aresolver -> do
+    mresolver <- forM (configResolver config) $ \aresolver -> do
       logDebug ("Using resolver: " <> display aresolver <> " specified on command line")
       makeConcreteResolver aresolver
 
-    (project', stackYamlFP) <- case mproject of
-      LCSProject (project, fp, _) -> do
+    (project', stackYamlFP) <- case configProject config of
+      PCProject (project, fp) -> do
           forM_ (projectUserMsg project) (logWarn . fromString)
           return (project, fp)
-      LCSNoConfig extraDeps -> do
+      PCNoConfig extraDeps -> do
           p <- assert (isJust mresolver) (getEmptyProject mresolver extraDeps)
           return (p, configUserConfigPath config)
-      LCSNoProject -> do
+      PCNoProject -> do
             logDebug "Run from outside a project, using implicit global project config"
             destDir <- getImplicitGlobalProjectDir config
             let dest :: Path Abs File
@@ -555,7 +500,7 @@ loadBuildConfig mproject maresolver mcompiler = do
                    iopc <- loadConfigYaml (parseProjectAndConfigMonoid destDir) dest
                    ProjectAndConfigMonoid project _ <- liftIO iopc
                    when (view terminalL config) $
-                       case maresolver of
+                       case configResolver config of
                            Nothing ->
                                logDebug $
                                  "Using resolver: " <>
@@ -652,14 +597,8 @@ loadBuildConfig mproject maresolver mcompiler = do
     return BuildConfig
         { bcConfig = config
         , bcSMWanted = wanted
-        , bcGHCVariant = configGHCVariantDefault config
         , bcExtraPackageDBs = extraPackageDBs
         , bcStackYaml = stackYamlFP
-        , bcImplicitGlobal =
-            case mproject of
-                LCSNoProject -> True
-                LCSProject _ -> False
-                LCSNoConfig _extraDeps -> False
         , bcCurator = projectCurator project
         }
   where
@@ -829,17 +768,17 @@ loadYaml parser path = do
 getProjectConfig :: HasLogFunc env
                  => StackYamlLoc (Path Abs File)
                  -- ^ Override stack.yaml
-                 -> RIO env (LocalConfigStatus (Path Abs File))
-getProjectConfig (SYLOverride stackYaml) = return $ LCSProject stackYaml
+                 -> RIO env (ProjectConfig (Path Abs File))
+getProjectConfig (SYLOverride stackYaml) = return $ PCProject stackYaml
 getProjectConfig SYLDefault = do
     env <- liftIO getEnvironment
     case lookup "STACK_YAML" env of
         Just fp -> do
             logInfo "Getting project config file from STACK_YAML environment"
-            liftM LCSProject $ resolveFile' fp
+            liftM PCProject $ resolveFile' fp
         Nothing -> do
             currDir <- getCurrentDir
-            maybe LCSNoProject LCSProject <$> findInParents getStackDotYaml currDir
+            maybe PCNoProject PCProject <$> findInParents getStackDotYaml currDir
   where
     getStackDotYaml dir = do
         let fp = dir </> stackDotYaml
@@ -849,14 +788,7 @@ getProjectConfig SYLDefault = do
         if exists
             then return $ Just fp
             else return Nothing
-getProjectConfig (SYLNoConfig extraDeps) = return $ LCSNoConfig extraDeps
-
-data LocalConfigStatus a
-    = LCSNoProject
-    | LCSProject a
-    | LCSNoConfig ![PackageIdentifierRevision]
-    -- ^ Extra dependencies
-    deriving (Show,Functor,Foldable,Traversable)
+getProjectConfig (SYLNoConfig extraDeps) = return $ PCNoConfig extraDeps
 
 -- | Find the project config file location, respecting environment variables
 -- and otherwise traversing parents. If no config is found, we supply a default
@@ -864,21 +796,21 @@ data LocalConfigStatus a
 loadProjectConfig :: HasLogFunc env
                   => StackYamlLoc (Path Abs File)
                   -- ^ Override stack.yaml
-                  -> RIO env (LocalConfigStatus (Project, Path Abs File, ConfigMonoid))
+                  -> RIO env (ProjectConfig (Project, Path Abs File, ConfigMonoid))
 loadProjectConfig mstackYaml = do
     mfp <- getProjectConfig mstackYaml
     case mfp of
-        LCSProject fp -> do
+        PCProject fp -> do
             currDir <- getCurrentDir
             logDebug $ "Loading project config file " <>
                         fromString (maybe (toFilePath fp) toFilePath (stripProperPrefix currDir fp))
-            LCSProject <$> load fp
-        LCSNoProject -> do
+            PCProject <$> load fp
+        PCNoProject -> do
             logDebug "No project config file found, using defaults."
-            return LCSNoProject
-        LCSNoConfig extraDeps -> do
+            return PCNoProject
+        PCNoConfig extraDeps -> do
             logDebug "Ignoring config files"
-            return $ LCSNoConfig extraDeps
+            return $ PCNoConfig extraDeps
   where
     load fp = do
         iopc <- loadConfigYaml (parseProjectAndConfigMonoid (parent fp)) fp

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -22,7 +22,7 @@ import qualified Options.Applicative as OA
 import qualified Options.Applicative.Types as OA
 import           Path
 import           Path.IO
-import           Stack.Config (makeConcreteResolver, getProjectConfig, getImplicitGlobalProjectDir, LocalConfigStatus(..))
+import           Stack.Config (makeConcreteResolver, getProjectConfig, getImplicitGlobalProjectDir)
 import           Stack.Constants
 import           Stack.Snapshot (loadResolver)
 import           Stack.Types.Config
@@ -58,9 +58,9 @@ cfgCmdSet go cmd = do
                      mstackYamlOption <- forM (globalStackYaml go) resolveFile'
                      mstackYaml <- getProjectConfig mstackYamlOption
                      case mstackYaml of
-                         LCSProject stackYaml -> return stackYaml
-                         LCSNoProject -> liftM (</> stackDotYaml) (getImplicitGlobalProjectDir conf)
-                         LCSNoConfig _extraDeps -> throwString "config command used when no local configuration available"
+                         PCProject stackYaml -> return stackYaml
+                         PCNoProject -> liftM (</> stackDotYaml) (getImplicitGlobalProjectDir conf)
+                         PCNoConfig _extraDeps -> throwString "config command used when no local configuration available"
                  CommandScopeGlobal -> return (configUserConfigPath conf)
     -- We don't need to worry about checking for a valid yaml here
     (config :: Yaml.Object) <-

--- a/src/Stack/Freeze.hs
+++ b/src/Stack/Freeze.hs
@@ -22,10 +22,12 @@ newtype FreezeOpts = FreezeOpts
 
 freeze :: HasEnvConfig env => FreezeOpts -> RIO env ()
 freeze (FreezeOpts mode) = do
-  mproject <- view $ configL.to configMaybeProject
+  mproject <- view $ configL.to configProject
+  let warn = logWarn "No project was found: nothing to freeze"
   case mproject of
-    Just (p, _) -> doFreeze p mode
-    Nothing -> logWarn "No project was found: nothing to freeze"
+    PCProject (p, _) -> doFreeze p mode
+    PCNoProject -> warn
+    PCNoConfig _ -> warn
 
 doFreeze ::
        (HasProcessContext env, HasLogFunc env, HasPantryConfig env)

--- a/src/Stack/Ls.hs
+++ b/src/Stack/Ls.hs
@@ -310,7 +310,7 @@ lsViewRemoteCmd =
         (OA.info (pure Remote) (OA.progDesc "View remote snapshot"))
 
 -- | List stack's output styles
-listStylesCmd :: ListStylesOpts -> LoadConfig -> IO ()
+listStylesCmd :: ListStylesOpts -> Config -> IO ()
 listStylesCmd opts lc = do
     -- This is the same test as is used in Stack.Types.Runner.withRunner
     let useColor = view useColorL lc

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -20,6 +20,7 @@ import qualified Distribution.Types.UnqualComponentName as C
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
 import           Stack.Build.Target (NeedTargets(..))
+import           Stack.Config (loadBuildConfig)
 import           Stack.Constants (ghcShowOptionsOutput)
 import           Stack.Options.GlobalParser (globalOptsFromMonoid)
 import           Stack.Runners (loadConfigWithOpts)
@@ -53,8 +54,8 @@ buildConfigCompleter inner = mkCompleter $ \inputRaw -> do
         _ -> do
             go' <- globalOptsFromMonoid False mempty
             let go = go' { globalLogLevel = LevelOther "silent" }
-            loadConfigWithOpts go $ \lc -> do
-              bconfig <- liftIO $ lcLoadBuildConfig lc (globalCompiler go)
+            loadConfigWithOpts go $ \config -> do
+              bconfig <- runRIO config $ loadBuildConfig (globalCompiler go)
               envConfig <- runRIO bconfig (setupEnv AllowNoTargets defaultBuildOptsCLI Nothing)
               runRIO envConfig (inner input)
 
@@ -87,8 +88,11 @@ flagCompleter = buildConfigCompleter $ \input -> do
         flagString name fl =
             let flname = C.unFlagName $ C.flagName fl
              in (if flagEnabled name fl then "-" else "") ++ flname
-        prjFlags = maybe mempty (projectFlags . fst) $
-                   configMaybeProject (bcConfig bconfig)
+        prjFlags =
+          case configProject (bcConfig bconfig) of
+            PCProject (p, _) -> projectFlags p
+            PCNoProject -> mempty
+            PCNoConfig _ -> mempty
         flagEnabled name fl =
             fromMaybe (C.flagDefault fl) $
             Map.lookup (C.flagName fl) $

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -133,6 +133,7 @@ instance HasStylesUpdate PathInfo where
 instance HasTerm PathInfo where
   useColorL = runnerL.useColorL
   termWidthL = runnerL.termWidthL
+instance HasGHCVariant PathInfo
 instance HasConfig PathInfo
 instance HasPantryConfig PathInfo where
     pantryConfigL = configL.pantryConfigL

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -8,7 +8,6 @@
 module Stack.Runners
     ( withGlobalConfigAndLock
     , withConfigAndLock
-    , withMiniConfigAndLock
     , withBuildConfigAndLock
     , withDefaultBuildConfigAndLock
     , withCleanConfig
@@ -40,12 +39,12 @@ import           System.IO
 import           System.FileLock
 import           Stack.Dot
 
--- FIXME it seems wrong that we call lcLoadBuildConfig multiple times
+-- FIXME it seems wrong that we call loadBuildConfig multiple times
 loadCompilerVersion :: GlobalOpts
-                    -> LoadConfig
+                    -> Config
                     -> IO WantedCompiler
-loadCompilerVersion go lc =
-    view wantedCompilerVersionL <$> lcLoadBuildConfig lc (globalCompiler go)
+loadCompilerVersion go config =
+    view wantedCompilerVersionL <$> runRIO config (loadBuildConfig (globalCompiler go))
 
 -- | Enforce mutual exclusion of every action running via this
 -- function, on this path, on this users account.
@@ -91,13 +90,13 @@ withConfigAndLock
     :: GlobalOpts
     -> RIO Config ()
     -> IO ()
-withConfigAndLock go@GlobalOpts{..} inner = loadConfigWithOpts go $ \lc -> do
-    withUserFileLock go (view stackRootL lc) $ \lk ->
-        runRIO (lcConfig lc) $
+withConfigAndLock go@GlobalOpts{..} inner = loadConfigWithOpts go $ \config -> do
+    withUserFileLock go (view stackRootL config) $ \lk ->
+        runRIO config $
             Docker.reexecWithOptionalContainer
-                (lcProjectRoot lc)
+                (configProjectRoot config)
                 Nothing
-                (runRIO (lcConfig lc) inner)
+                (runRIO config inner)
                 Nothing
                 (Just $ munlockFile lk)
 
@@ -111,10 +110,10 @@ withGlobalConfigAndLock go@GlobalOpts{..} inner =
     withRunnerGlobal go $ \runner ->
     runRIO runner $ loadConfigMaybeProject
       globalConfigMonoid
-      Nothing
-      LCSNoProject $ \lc ->
+      globalResolver
+      PCNoProject $ \lc ->
         withUserFileLock go (view stackRootL lc) $ \_lk ->
-          runRIO (lcConfig lc) inner
+          runRIO lc inner
 
 -- For now the non-locking version just unlocks immediately.
 -- That is, there's still a serialization point.
@@ -165,9 +164,9 @@ withBuildConfigAndLock go needTargets boptsCLI inner =
 -- see issue #2010.
 withCleanConfig :: GlobalOpts -> RIO BuildConfig () -> IO ()
 withCleanConfig go inner =
-  loadConfigWithOpts go $ \lc ->
-  withUserFileLock go (view stackRootL lc) $ \_lk0 -> do
-    bconfig <- lcLoadBuildConfig lc $ globalCompiler go
+  loadConfigWithOpts go $ \config ->
+  withUserFileLock go (view stackRootL config) $ \_lk0 -> do
+    bconfig <- runRIO config $ loadBuildConfig $ globalCompiler go
     runRIO bconfig inner
 
 withBuildConfigExt
@@ -188,8 +187,8 @@ withBuildConfigExt
     -- available in this action, since that would require build tools to be
     -- installed on the host OS.
     -> IO ()
-withBuildConfigExt go@GlobalOpts{..} needTargets boptsCLI mbefore inner mafter = loadConfigWithOpts go $ \lc -> do
-    withUserFileLock go (view stackRootL lc) $ \lk0 -> do
+withBuildConfigExt go@GlobalOpts{..} needTargets boptsCLI mbefore inner mafter = loadConfigWithOpts go $ \config -> do
+    withUserFileLock go (view stackRootL config) $ \lk0 -> do
       -- A local bit of state for communication between callbacks:
       curLk <- newIORef lk0
       let inner' lk =
@@ -205,17 +204,17 @@ withBuildConfigExt go@GlobalOpts{..} needTargets boptsCLI mbefore inner mafter =
                  inner lk2
 
       let inner'' lk = do
-              bconfig <- lcLoadBuildConfig lc globalCompiler
+              bconfig <- runRIO config $ loadBuildConfig globalCompiler
               envConfig <- runRIO bconfig (setupEnv needTargets boptsCLI Nothing)
               runRIO envConfig (inner' lk)
 
-      let getCompilerVersion = loadCompilerVersion go lc
-      runRIO (lcConfig lc) $
+      let getCompilerVersion = loadCompilerVersion go config
+      runRIO config $
         Docker.reexecWithOptionalContainer
-          (lcProjectRoot lc)
+          (configProjectRoot config)
           mbefore
-          (runRIO (lcConfig lc) $
-              Nix.reexecWithOptionalShell (lcProjectRoot lc) getCompilerVersion (inner'' lk0))
+          (runRIO config $
+              Nix.reexecWithOptionalShell (configProjectRoot config) getCompilerVersion (inner'' lk0))
           mafter
           (Just $ liftIO $
                 do lk' <- readIORef curLk
@@ -225,17 +224,17 @@ withBuildConfigExt go@GlobalOpts{..} needTargets boptsCLI mbefore inner mafter =
 -- throughout this module.
 loadConfigWithOpts
   :: GlobalOpts
-  -> (LoadConfig -> IO a)
+  -> (Config -> IO a)
   -> IO a
 loadConfigWithOpts go@GlobalOpts{..} inner = withRunnerGlobal go $ \runner -> do
     mstackYaml <- forM globalStackYaml resolveFile'
     runRIO runner $
-      loadConfig globalConfigMonoid globalResolver mstackYaml $ \lc -> do
+      loadConfig globalConfigMonoid globalResolver mstackYaml $ \config -> do
         -- If we have been relaunched in a Docker container, perform in-container initialization
         -- (switch UID, etc.).  We do this after first loading the configuration since it must
         -- happen ASAP but needs a configuration.
-        forM_ globalDockerEntrypoint $ Docker.entrypoint (lcConfig lc)
-        liftIO $ inner lc
+        forM_ globalDockerEntrypoint $ Docker.entrypoint config
+        liftIO $ inner config
 
 withRunnerGlobal :: GlobalOpts -> (Runner -> IO a) -> IO a
 withRunnerGlobal GlobalOpts{..} inner = do
@@ -251,17 +250,6 @@ withRunnerGlobal GlobalOpts{..} inner = do
         globalTermWidth
         (isJust globalReExecVersion)
         inner
-
-withMiniConfigAndLock
-    :: GlobalOpts
-    -> RIO MiniConfig ()
-    -> IO ()
-withMiniConfigAndLock go@GlobalOpts{..} inner =
-  withRunnerGlobal go $ \runner ->
-  runRIO runner $
-  loadConfigMaybeProject globalConfigMonoid globalResolver LCSNoProject $ \lc -> do
-    let miniConfig = loadMiniConfig $ lcConfig lc
-    runRIO miniConfig inner
 
 -- | Unlock a lock file, if the value is Just
 munlockFile :: MonadIO m => Maybe FileLock -> m ()

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -83,7 +83,7 @@ import              Stack.Build (build)
 import              Stack.Build.Haddock (shouldHaddockDeps)
 import              Stack.Build.Source (loadSourceMap)
 import              Stack.Build.Target (NeedTargets(..), parseTargets)
-import              Stack.Config (loadConfig)
+import              Stack.Config (loadConfig, loadBuildConfig)
 import              Stack.Constants
 import              Stack.Constants.Config (distRelativeDir)
 import              Stack.GhcPkg (createDatabase, getCabalPkgVer, getGlobalDB, mkGhcPackagePath, ghcPkgPathEnvVar)
@@ -1415,7 +1415,7 @@ loadGhcjsEnvConfig stackYaml binPath inner = do
         })
       Nothing
       (SYLOverride stackYaml) $ \lc -> do
-        bconfig <- liftIO $ lcLoadBuildConfig lc Nothing
+        bconfig <- runRIO lc $ loadBuildConfig Nothing
         envConfig <- runRIO bconfig $ setupEnv AllowNoTargets defaultBuildOptsCLI Nothing
         inner envConfig
 

--- a/src/Stack/Solver.hs
+++ b/src/Stack/Solver.hs
@@ -658,9 +658,13 @@ solveExtraDeps modStackYaml = do
         Nothing -> throwM (SolverGiveUp giveUpMsg)
         Just x -> return x
 
-    mOldResolver <- view $ configL.to (fmap (projectResolver . fst) . configMaybeProject)
+    config <- view configL
+    let mOldResolver =
+          case configProject config of
+            PCProject (p, _) -> Just $ projectResolver p
+            PCNoProject -> Nothing
+            PCNoConfig _deps -> Nothing
 
-    let
         flags = removeSrcPkgDefaultFlags gpds (fmap snd (Map.union srcs edeps))
         versions = fmap fst edeps
 

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -22,7 +22,6 @@ import           Stack.Config
 import           Stack.Constants
 import           Stack.Setup
 import           Stack.Types.Config
-import           Stack.Types.Resolver
 import           System.Console.ANSI (hSupportsANSIWithoutEmulation)
 import           System.Exit                 (ExitCode (ExitSuccess))
 import           System.Process              (rawSystem, readProcess)
@@ -93,11 +92,10 @@ data UpgradeOpts = UpgradeOpts
 
 upgrade :: HasConfig env
         => ConfigMonoid
-        -> Maybe AbstractResolver
         -> Maybe String -- ^ git hash at time of building, if known
         -> UpgradeOpts
         -> RIO env ()
-upgrade gConfigMonoid mresolver builtHash (UpgradeOpts mbo mso) =
+upgrade gConfigMonoid builtHash (UpgradeOpts mbo mso) =
     case (mbo, mso) of
         -- FIXME It would be far nicer to capture this case in the
         -- options parser itself so we get better error messages, but
@@ -117,7 +115,7 @@ upgrade gConfigMonoid mresolver builtHash (UpgradeOpts mbo mso) =
             source so
   where
     binary bo = binaryUpgrade bo
-    source so = sourceUpgrade gConfigMonoid mresolver builtHash so
+    source so = sourceUpgrade gConfigMonoid builtHash so
 
 binaryUpgrade :: HasConfig env => BinaryOpts -> RIO env ()
 binaryUpgrade (BinaryOpts mplatform force' mver morg mrepo) = do
@@ -172,11 +170,10 @@ binaryUpgrade (BinaryOpts mplatform force' mver morg mrepo) = do
 sourceUpgrade
   :: HasConfig env
   => ConfigMonoid
-  -> Maybe AbstractResolver
   -> Maybe String
   -> SourceOpts
   -> RIO env ()
-sourceUpgrade gConfigMonoid mresolver builtHash (SourceOpts gitRepo) =
+sourceUpgrade gConfigMonoid builtHash (SourceOpts gitRepo) =
   withSystemTempDir "stack-upgrade" $ \tmp -> do
     mdir <- case gitRepo of
       Just (repo, branch) -> do
@@ -237,9 +234,9 @@ sourceUpgrade gConfigMonoid mresolver builtHash (SourceOpts gitRepo) =
     forM_ mdir $ \dir ->
       loadConfig
       gConfigMonoid
-      mresolver
+      Nothing -- always use the resolver settings in the stack.yaml file
       (SYLOverride $ dir </> stackDotYaml) $ \lc -> do
-        bconfig <- liftIO $ lcLoadBuildConfig lc Nothing
+        bconfig <- runRIO lc $ loadBuildConfig Nothing
         let boptsCLI = defaultBuildOptsCLI
                 { boptsCLITargets = ["stack"]
                 }

--- a/src/test/Stack/ConfigSpec.hs
+++ b/src/test/Stack/ConfigSpec.hs
@@ -147,19 +147,19 @@ spec = beforeAll setup $ do
 
     it "parses config option with-hpack" $ inTempDir $ do
       writeFile (toFilePath stackDotYaml) hpackConfig
-      loadConfig' $ \lc ->
-        liftIO $ configOverrideHpack (lcConfig lc) `shouldBe`
+      loadConfig' $ \config ->
+        liftIO $ configOverrideHpack config `shouldBe`
         HpackCommand "/usr/local/bin/hpack"
 
     it "parses config bundled hpack" $ inTempDir $ do
       writeFile (toFilePath stackDotYaml) sampleConfig
-      loadConfig' $ \lc ->
-        liftIO $ configOverrideHpack (lcConfig lc) `shouldBe` HpackBundled
+      loadConfig' $ \config ->
+        liftIO $ configOverrideHpack config `shouldBe` HpackBundled
 
     it "parses build config options" $ inTempDir $ do
      writeFile (toFilePath stackDotYaml) buildOptsConfig
-     loadConfig' $ \lc -> liftIO $ do
-      let BuildOpts{..} = configBuild  $ lcConfig lc
+     loadConfig' $ \config -> liftIO $ do
+      let BuildOpts{..} = configBuild  config
       boptsLibProfile `shouldBe` True
       boptsExeProfile `shouldBe` True
       boptsHaddock `shouldBe` True
@@ -188,8 +188,8 @@ spec = beforeAll setup $ do
       let childDir = "child"
       createDirectory childDir
       setCurrentDirectory childDir
-      loadConfig' $ \LoadConfig{..} -> liftIO $ do
-        bc <- lcLoadBuildConfig Nothing
+      loadConfig' $ \config -> liftIO $ do
+        bc <- runRIO config $ loadBuildConfig Nothing
         view projectRootL bc `shouldBe` parentDir
 
     it "respects the STACK_YAML env variable" $ inTempDir $ do
@@ -197,8 +197,8 @@ spec = beforeAll setup $ do
         let stackYamlFp = toFilePath (dir </> stackDotYaml)
         writeFile stackYamlFp sampleConfig
         writeFile (toFilePath dir ++ "/package.yaml") "name: foo"
-        withEnvVar "STACK_YAML" stackYamlFp $ loadConfig' $ \LoadConfig{..} -> liftIO $ do
-          BuildConfig{..} <- lcLoadBuildConfig Nothing
+        withEnvVar "STACK_YAML" stackYamlFp $ loadConfig' $ \config -> liftIO $ do
+          BuildConfig{..} <- runRIO config $ loadBuildConfig Nothing
           bcStackYaml `shouldBe` dir </> stackDotYaml
           parent bcStackYaml `shouldBe` dir
 
@@ -211,8 +211,8 @@ spec = beforeAll setup $ do
         createDirectoryIfMissing True $ toFilePath $ parent yamlAbs
         writeFile (toFilePath yamlAbs) "resolver: ghc-7.8"
         writeFile (toFilePath packageYaml) "name: foo"
-        withEnvVar "STACK_YAML" (toFilePath yamlRel) $ loadConfig' $ \LoadConfig{..} -> liftIO $ do
-            BuildConfig{..} <- lcLoadBuildConfig Nothing
+        withEnvVar "STACK_YAML" (toFilePath yamlRel) $ loadConfig' $ \config -> liftIO $ do
+            BuildConfig{..} <- runRIO config $ loadBuildConfig Nothing
             bcStackYaml `shouldBe` yamlAbs
 
   describe "defaultConfigYaml" $

--- a/src/test/Stack/NixSpec.hs
+++ b/src/test/Stack/NixSpec.hs
@@ -40,7 +40,7 @@ setup = unsetEnv "STACK_YAML"
 
 spec :: Spec
 spec = beforeAll setup $ do
-  let loadConfig' :: ConfigMonoid -> (LoadConfig -> IO ()) -> IO ()
+  let loadConfig' :: ConfigMonoid -> (Config -> IO ()) -> IO ()
       loadConfig' cmdLineArgs inner =
         withRunner LevelDebug True False ColorAuto mempty Nothing False $ \runner ->
         runRIO runner $ loadConfig cmdLineArgs Nothing SYLDefault (liftIO . inner)
@@ -61,43 +61,43 @@ spec = beforeAll setup $ do
   let trueOnNonWindows = not osIsWindows
   describe "nix disabled in config file" $
     around_ (withStackDotYaml sampleConfigNixDisabled) $ do
-      it "sees that the nix shell is not enabled" $ loadConfig' mempty $ \lc ->
-        nixEnable (configNix $ lcConfig lc) `shouldBe` False
+      it "sees that the nix shell is not enabled" $ loadConfig' mempty $ \config ->
+        nixEnable (configNix config) `shouldBe` False
       describe "--nix given on command line" $
         it "sees that the nix shell is enabled" $
-          loadConfig' (parseOpts ["--nix"]) $ \lc ->
-          nixEnable (configNix $ lcConfig lc) `shouldBe` trueOnNonWindows
+          loadConfig' (parseOpts ["--nix"]) $ \config ->
+          nixEnable (configNix config) `shouldBe` trueOnNonWindows
       describe "--nix-pure given on command line" $
         it "sees that the nix shell is enabled" $
-          loadConfig' (parseOpts ["--nix-pure"]) $ \lc ->
-          nixEnable (configNix $ lcConfig lc) `shouldBe` trueOnNonWindows
+          loadConfig' (parseOpts ["--nix-pure"]) $ \config ->
+          nixEnable (configNix config) `shouldBe` trueOnNonWindows
       describe "--no-nix given on command line" $
         it "sees that the nix shell is not enabled" $
-          loadConfig' (parseOpts ["--no-nix"]) $ \lc ->
-          nixEnable (configNix $ lcConfig lc) `shouldBe` False
+          loadConfig' (parseOpts ["--no-nix"]) $ \config ->
+          nixEnable (configNix config) `shouldBe` False
       describe "--no-nix-pure given on command line" $
         it "sees that the nix shell is not enabled" $
-          loadConfig' (parseOpts ["--no-nix-pure"]) $ \lc ->
-          nixEnable (configNix $ lcConfig lc) `shouldBe` False
+          loadConfig' (parseOpts ["--no-nix-pure"]) $ \config ->
+          nixEnable (configNix config) `shouldBe` False
   describe "nix enabled in config file" $
     around_ (withStackDotYaml sampleConfigNixEnabled) $ do
       it "sees that the nix shell is enabled" $
-        loadConfig' mempty $ \lc ->
-        nixEnable (configNix $ lcConfig lc) `shouldBe` trueOnNonWindows
+        loadConfig' mempty $ \config ->
+        nixEnable (configNix config) `shouldBe` trueOnNonWindows
       describe "--no-nix given on command line" $
         it "sees that the nix shell is not enabled" $
-          loadConfig' (parseOpts ["--no-nix"]) $ \lc ->
-          nixEnable (configNix $ lcConfig lc) `shouldBe` False
+          loadConfig' (parseOpts ["--no-nix"]) $ \config ->
+          nixEnable (configNix config) `shouldBe` False
       describe "--nix-pure given on command line" $
         it "sees that the nix shell is enabled" $
-          loadConfig' (parseOpts ["--nix-pure"]) $ \lc ->
-          nixEnable (configNix $ lcConfig lc) `shouldBe` trueOnNonWindows
+          loadConfig' (parseOpts ["--nix-pure"]) $ \config ->
+          nixEnable (configNix config) `shouldBe` trueOnNonWindows
       describe "--no-nix-pure given on command line" $
         it "sees that the nix shell is enabled" $
-          loadConfig' (parseOpts ["--no-nix-pure"]) $ \lc ->
-          nixEnable (configNix $ lcConfig lc) `shouldBe` trueOnNonWindows
-      it "sees that the only package asked for is glpk and asks for the correct GHC derivation" $ loadConfig' mempty $ \lc -> do
-        nixPackages (configNix $ lcConfig lc) `shouldBe` ["glpk"]
+          loadConfig' (parseOpts ["--no-nix-pure"]) $ \config ->
+          nixEnable (configNix config) `shouldBe` trueOnNonWindows
+      it "sees that the only package asked for is glpk and asks for the correct GHC derivation" $ loadConfig' mempty $ \config -> do
+        nixPackages (configNix config) `shouldBe` ["glpk"]
         v <- parseVersionThrowing "7.10.3"
         ghc <- either throwIO return $ nixCompiler (WCGhc v)
         ghc `shouldBe` "haskell.compiler.ghc7103"


### PR DESCRIPTION
This is an internal cleanup that removes some unneeded data types and
paves the way for future simplifications. There should be no behavior
changes from this change.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
