### PR TITLE
Bring cabal-install executable into $PATH for integration test

### DIFF
--- a/.azure/azure-nightly-template-linux.yml
+++ b/.azure/azure-nightly-template-linux.yml
@@ -34,6 +34,9 @@ jobs:
       export PATH=$HOME/.local/bin:$PATH;
       set -ex
       stack install cabal-install
+      # FIXME: Note that cabal-install might not be required once
+      # https://github.com/commercialhaskell/stack/issues/4410 get's
+      # fixed.
       stack test --flag stack:integration-tests stack:test:stack-integration-test
       set +ex
     displayName: Integration Test

--- a/.azure/azure-nightly-template-linux.yml
+++ b/.azure/azure-nightly-template-linux.yml
@@ -33,6 +33,7 @@ jobs:
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root;
       export PATH=$HOME/.local/bin:$PATH;
       set -ex
+      stack install cabal-install
       stack test --flag stack:integration-tests stack:test:stack-integration-test
       set +ex
     displayName: Integration Test

--- a/.azure/azure-nightly-template-osx.yml
+++ b/.azure/azure-nightly-template-osx.yml
@@ -34,6 +34,7 @@ jobs:
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root;
       export PATH=$HOME/.local/bin:$PATH;
       set -ex
+      stack install cabal-install
       stack test --flag stack:integration-tests stack:test:stack-integration-test
       set +ex
     displayName: Integration Test

--- a/.azure/azure-nightly-template-osx.yml
+++ b/.azure/azure-nightly-template-osx.yml
@@ -35,6 +35,9 @@ jobs:
       export PATH=$HOME/.local/bin:$PATH;
       set -ex
       stack install cabal-install
+      # FIXME: Note that cabal-install might not be required once
+      # https://github.com/commercialhaskell/stack/issues/4410 get's
+      # fixed.
       stack test --flag stack:integration-tests stack:test:stack-integration-test
       set +ex
     displayName: Integration Test

--- a/.azure/azure-nightly-template-windows.yml
+++ b/.azure/azure-nightly-template-windows.yml
@@ -39,6 +39,7 @@ jobs:
       export PATH=$PATH:"/C/Program Files/Mercurial/"
       export TMP=/D/tmp
       set -ex
+      stack install cabal-install
       stack test --flag stack:integration-tests stack:test:stack-integration-test
       set +ex
     displayName: Integration Test

--- a/.azure/azure-nightly-template-windows.yml
+++ b/.azure/azure-nightly-template-windows.yml
@@ -40,6 +40,9 @@ jobs:
       export TMP=/D/tmp
       set -ex
       stack install cabal-install
+      # FIXME: Note that cabal-install might not be required once
+      # https://github.com/commercialhaskell/stack/issues/4410 get's
+      # fixed.
       stack test --flag stack:integration-tests stack:test:stack-integration-test
       set +ex
     displayName: Integration Test


### PR DESCRIPTION
This will fix integration tests (like `stack-init-solver`)
which depends on the cabal executable.

I tested that this PR works on a separate CI job here:
https://dev.azure.com/psibi2000/stack-issue-debug/_build/results?buildId=737