### PR TITLE
Fix nightly test for git-submodules

### DIFF
--- a/.azure/azure-nightly-template-osx.yml
+++ b/.azure/azure-nightly-template-osx.yml
@@ -24,6 +24,7 @@ jobs:
       cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack work --base-branch="${BASE_BRANCH}"
       etc/scripts/ci-setup.sh
       brew install mercurial
+      brew install gnu-tar
       export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.7/bin:$PATH
     env:
       OS_NAME: ${{ parameters.os }}
@@ -32,8 +33,8 @@ jobs:
       curl https://nixos.org/nix/install | sh
       . ~/.nix-profile/etc/profile.d/nix.sh
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root;
-      export PATH=$HOME/.local/bin:$PATH;
       set -ex
+      export PATH=/usr/local/opt/gnu-tar/libexec/gnubin:$HOME/.local/bin:$PATH;
       stack test --flag stack:integration-tests stack:test:stack-integration-test
       set +ex
     displayName: Integration Test

--- a/package.yaml
+++ b/package.yaml
@@ -311,6 +311,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - hspec
+    - filepath
     when:
     - condition: ! '!(flag(integration-tests))'
       buildable: false

--- a/subs/pantry/src/Pantry/Repo.hs
+++ b/subs/pantry/src/Pantry/Repo.hs
@@ -111,7 +111,7 @@ createRepoArchive
   -> RIO env ()
 createRepoArchive repo tarball = do
   let runCommand cmd args = void $ proc cmd args readProcess_
-  
+
   withRepo repo $ case repoType repo of
     RepoGit -> do
        runCommand "git" ["-c", "core.autocrlf=false", "archive", "-o", tarball, "HEAD"]
@@ -121,7 +121,7 @@ createRepoArchive repo tarball = do
        runCommand "git"
          [ "submodule", "foreach", "--recursive"
          , "git -c core.autocrlf=false archive --prefix=$displaypath/ -o bar.tar HEAD"
-           <> " && if [ -f bar.tar ]; then tar -Af " <> tarball <> " bar.tar ; fi"
+           <> " && if [ -f bar.tar ]; then tar --force-local -Af " <> tarball <> " bar.tar ; fi"
          ]
     RepoHg  -> runCommand "hg"  ["archive", tarball, "-X", ".hg_archival.txt"]
 

--- a/test/integration/lib/StackTest.hs
+++ b/test/integration/lib/StackTest.hs
@@ -32,6 +32,14 @@ runShell cmd = do
     ec <- waitForProcess ph
     unless (ec == ExitSuccess) $ error $ "Exited with exit code: " ++ show ec
 
+runWithCwd :: HasCallStack => FilePath -> String -> [String] -> IO String
+runWithCwd cwdPath cmd args = do
+    logInfo $ "Running: " ++ cmd
+    let cp = proc cmd args
+    (ec, stdoutStr, _) <- readCreateProcessWithExitCode (cp { cwd = Just cwdPath }) ""
+    unless (ec == ExitSuccess) $ error $ "Exited with exit code: " ++ show ec
+    return stdoutStr
+
 stackExe :: IO String
 stackExe = getEnv "STACK_EXE"
 

--- a/test/integration/tests/git-submodules/Main.hs
+++ b/test/integration/tests/git-submodules/Main.hs
@@ -1,5 +1,9 @@
 import StackTest
-import System.Directory (createDirectoryIfMissing,withCurrentDirectory)
+import System.Directory (createDirectoryIfMissing,withCurrentDirectory, getCurrentDirectory)
+import System.Exit (exitFailure)
+import System.FilePath ((</>))
+import Data.List (filter)
+import System.IO (hPutStrLn, withFile, IOMode(..))
 
 main :: IO ()
 main = do
@@ -30,13 +34,14 @@ main = do
 
     stack ["new", defaultResolverArg, "tmpPackage"]
 
+    curDir <- getCurrentDirectory
+    let tmpRepoDir = curDir </> "tmpRepo"
+    gitHead <- runWithCwd tmpRepoDir "git" ["rev-parse", "HEAD"]
+    let gitHeadCommit = stripNewline gitHead
+
     withCurrentDirectory "tmpPackage" $ do
       -- add git dependency on repo with recursive submodules
-      runShell "echo 'extra-deps:' >> stack.yaml"
-      runShell "echo \"- git: $(cd ../tmpRepo && pwd)\" >> stack.yaml"
-      runShell "echo \"  commit: $(cd ../tmpRepo && git rev-parse HEAD)\" >> stack.yaml"
-      runShell "echo '  subdir: sub/sub/pkg' >> stack.yaml"
-
+      writeToStackFile (tmpRepoDir, gitHeadCommit)
       -- Setup the package
       stack ["setup"]
 
@@ -45,3 +50,24 @@ main = do
     removeDirIgnore "tmpSubRepo"
     removeDirIgnore "tmpSubSubRepo"
     removeDirIgnore "tmpPackage"
+
+writeToStackFile :: (String, String) -> IO ()
+writeToStackFile (tmpRepoDir, gitCommit) = do
+  curDir <- getCurrentDirectory
+  let stackFile = curDir </> "stack.yaml"
+  let line1 = "extra-deps:"
+      line2 = "- git: " ++ tmpRepoDir
+      line3 = "  commit: " ++ gitCommit
+      line4 = "  subdir: sub/sub/pkg"
+  withFile stackFile AppendMode (\handle -> do
+                                   hPutStrLn handle line1
+                                   hPutStrLn handle line2
+                                   hPutStrLn handle line3
+                                   hPutStrLn handle line4
+                                )
+
+newline :: Char
+newline = '\n'
+
+stripNewline :: String -> String
+stripNewline str = filter (\x -> x /= newline) str


### PR DESCRIPTION
Summary of changes:
* Brings GNU Tar in the OSX environment
* Add --force-local option to the Tar args.
* Make the test code portable. ( I was guessing that the code was failing in Windows because of all the `runShell` and converted it to proper Haskell code. But I guess that's not necessarily required)

I tested the code changes in another CI and this code seems to work fine: https://dev.azure.com/psibi2000/stack-issue-debug/_build/results?buildId=758
