### PR TITLE
Use RIO Runner instead of explicit GlobalOpts

### DIFF
--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -21,7 +21,6 @@ import qualified Data.Yaml as Yaml
 import qualified Options.Applicative as OA
 import qualified Options.Applicative.Types as OA
 import           Path
-import           Path.IO
 import           Stack.Config (makeConcreteResolver, getProjectConfig, getImplicitGlobalProjectDir)
 import           Stack.Constants
 import           Stack.Snapshot (loadResolver)
@@ -49,13 +48,13 @@ configCmdSetScope (ConfigCmdSetInstallGhc scope _) = scope
 
 cfgCmdSet
     :: (HasConfig env, HasGHCVariant env)
-    => GlobalOpts -> ConfigCmdSet -> RIO env ()
-cfgCmdSet go cmd = do
+    => ConfigCmdSet -> RIO env ()
+cfgCmdSet cmd = do
     conf <- view configL
     configFilePath <-
              case configCmdSetScope cmd of
                  CommandScopeProject -> do
-                     mstackYamlOption <- forM (globalStackYaml go) resolveFile'
+                     mstackYamlOption <- view $ globalOptsL.to globalStackYaml
                      mstackYaml <- getProjectConfig mstackYamlOption
                      case mstackYaml of
                          PCProject stackYaml -> return stackYaml

--- a/src/Stack/FileWatch.hs
+++ b/src/Stack/FileWatch.hs
@@ -16,26 +16,29 @@ import System.FSNotify
 import System.IO (hPutStrLn, getLine)
 import System.Terminal
 
-fileWatch :: Handle
-          -> ((Set (Path Abs File) -> IO ()) -> IO ())
-          -> IO ()
+fileWatch
+  :: Handle
+  -> ((Set (Path Abs File) -> IO ()) -> RIO env ())
+  -> RIO env ()
 fileWatch = fileWatchConf defaultConfig
 
-fileWatchPoll :: Handle
-              -> ((Set (Path Abs File) -> IO ()) -> IO ())
-              -> IO ()
+fileWatchPoll
+  :: Handle
+  -> ((Set (Path Abs File) -> IO ()) -> RIO env ())
+  -> RIO env ()
 fileWatchPoll = fileWatchConf $ defaultConfig { confUsePolling = True }
 
 -- | Run an action, watching for file changes
 --
 -- The action provided takes a callback that is used to set the files to be
 -- watched. When any of those files are changed, we rerun the action again.
-fileWatchConf :: WatchConfig
-              -> Handle
-              -> ((Set (Path Abs File) -> IO ()) -> IO ())
-              -> IO ()
-fileWatchConf cfg out inner = withManagerConf cfg $ \manager -> do
-    let putLn = hPutStrLn out
+fileWatchConf
+  :: WatchConfig
+  -> Handle
+  -> ((Set (Path Abs File) -> IO ()) -> RIO env ())
+  -> RIO env ()
+fileWatchConf cfg out inner = withRunInIO $ \run -> withManagerConf cfg $ \manager -> do
+    let putLn = hPutStrLn out -- FIXME
     outputIsTerminal <- hIsTerminalDeviceOrMinTTY out
     let withColor color str = putLn $ do
             if outputIsTerminal
@@ -114,7 +117,7 @@ fileWatchConf cfg out inner = withManagerConf cfg $ \manager -> do
             dirty <- readTVar dirtyVar
             check dirty
 
-        eres <- tryAny $ inner setWatched
+        eres <- tryAny $ run $ inner setWatched
 
         -- Clear dirtiness flag after the build to avoid an infinite
         -- loop caused by the build itself triggering dirtiness. This

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -23,7 +23,7 @@ import           Stack.Build.Target (NeedTargets(..))
 import           Stack.Config (loadBuildConfig)
 import           Stack.Constants (ghcShowOptionsOutput)
 import           Stack.Options.GlobalParser (globalOptsFromMonoid)
-import           Stack.Runners (withConfig)
+import           Stack.Runners (withConfig, withRunnerGlobal)
 import           Stack.Prelude
 import           Stack.Setup
 import           Stack.Types.Config
@@ -54,7 +54,7 @@ buildConfigCompleter inner = mkCompleter $ \inputRaw -> do
         _ -> do
             go' <- globalOptsFromMonoid False mempty
             let go = go' { globalLogLevel = LevelOther "silent" }
-            withConfig go $ do
+            withRunnerGlobal go $ withConfig $ do
               bconfig <- loadBuildConfig
               envConfig <- runRIO bconfig (setupEnv AllowNoTargets defaultBuildOptsCLI Nothing)
               runRIO envConfig (inner input)

--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -5,7 +5,7 @@ module Stack.Options.GlobalParser where
 
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
-import           Path.IO (getCurrentDir, resolveDir')
+import           Path.IO (getCurrentDir, resolveDir', resolveFile')
 import qualified Stack.Docker                      as Docker
 import           Stack.Init
 import           Stack.Prelude
@@ -74,6 +74,10 @@ globalOptsFromMonoid defaultTerminal GlobalOptsMonoid{..} = do
         First Nothing -> getCurrentDir
         First (Just dir) -> resolveDir' dir
     resolvePaths (Just root) ur
+  stackYaml <-
+    case getFirst globalMonoidStackYaml of
+      Nothing -> pure SYLDefault
+      Just fp -> SYLOverride <$> resolveFile' fp
   pure GlobalOpts
     { globalReExecVersion = getFirst globalMonoidReExecVersion
     , globalDockerEntrypoint = getFirst globalMonoidDockerEntrypoint
@@ -85,7 +89,7 @@ globalOptsFromMonoid defaultTerminal GlobalOptsMonoid{..} = do
     , globalTerminal = fromFirst defaultTerminal globalMonoidTerminal
     , globalStylesUpdate = globalMonoidStyles
     , globalTermWidth = getFirst globalMonoidTermWidth
-    , globalStackYaml = maybe SYLDefault SYLOverride $ getFirst globalMonoidStackYaml
+    , globalStackYaml = stackYaml
     }
 
 initOptsParser :: Parser InitOpts

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -21,28 +21,22 @@ import           Path.Extra
 import           Stack.Constants
 import           Stack.Constants.Config
 import           Stack.GhcPkg as GhcPkg
+import           Stack.Runners
 import           Stack.Types.Config
 import qualified System.FilePath as FP
-import           System.IO (stderr)
 import           RIO.PrettyPrint
 import           RIO.Process (HasProcessContext (..), exeSearchPathL)
 
 -- | Print out useful path information in a human-readable format (and
 -- support others later).
-path ::
-       (HasEnvConfig envHaddocks, HasEnvConfig envNoHaddocks)
-    => (RIO envNoHaddocks () -> IO ())
-    -> (RIO envHaddocks () -> IO ())
-    -> [Text]
-    -> IO ()
-path runNoHaddocks runHaddocks keys =
+path :: [Text] -> RIO Runner ()
+path keys =
     do let deprecated = filter ((`elem` keys) . fst) deprecatedPathKeys
-       liftIO $ forM_ deprecated $ \(oldOption, newOption) -> T.hPutStrLn stderr $ T.unlines
-           [ ""
-           , "'--" <> oldOption <> "' will be removed in a future release."
-           , "Please use '--" <> newOption <> "' instead."
-           , ""
-           ]
+       forM_ deprecated $ \(oldOption, newOption) -> logWarn $
+           "\n" <>
+           "'--" <> display oldOption <> "' will be removed in a future release.\n" <>
+           "Please use '--" <> display newOption <> "' instead.\n" <>
+           "\n"
        let -- filter the chosen paths in flags (keys),
            -- or show all of them if no specific paths chosen.
            goodPaths = filter
@@ -53,13 +47,21 @@ path runNoHaddocks runHaddocks keys =
            toEither (_, k, UseHaddocks p) = Left (k, p)
            toEither (_, k, WithoutHaddocks p) = Right (k, p)
            (with, without) = partitionEithers $ map toEither goodPaths
-           printKeys runEnv extractors single = runEnv $ do
+           printKeys extractors single = do
              pathInfo <- fillPathInfo
              liftIO $ forM_ extractors $ \(key, extractPath) -> do
                let prefix = if single then "" else key <> ": "
                T.putStrLn $ prefix <> extractPath pathInfo
-       printKeys runHaddocks with singlePath
-       printKeys runNoHaddocks without singlePath
+           runHaddock x = local
+             (set (globalOptsL.globalOptsBuildOptsMonoidL.buildOptsMonoidHaddockL) (Just x)) .
+             withConfig .
+             withDefaultEnvConfig
+       -- MSS 2019-03-17 Not a huge fan of rerunning withConfig and
+       -- withDefaultEnvConfig each time, need to figure out what
+       -- purpose is served and whether we can achieve it without two
+       -- completely separate Config setups
+       runHaddock True $ printKeys with singlePath
+       runHaddock False $ printKeys without singlePath
 
 fillPathInfo :: HasEnvConfig env => RIO env PathInfo
 fillPathInfo = do

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -454,7 +454,7 @@ data GlobalOpts = GlobalOpts
     , globalTerminal     :: !Bool -- ^ We're in a terminal?
     , globalStylesUpdate :: !StylesUpdate -- ^ SGR (Ansi) codes for styles
     , globalTermWidth    :: !(Maybe Int) -- ^ Terminal width override
-    , globalStackYaml    :: !(StackYamlLoc FilePath) -- ^ Override project stack.yaml
+    , globalStackYaml    :: !(StackYamlLoc (Path Abs File)) -- ^ Override project stack.yaml
     } deriving (Show)
 
 -- | Location for the project's stack.yaml file.

--- a/src/test/Stack/ConfigSpec.hs
+++ b/src/test/Stack/ConfigSpec.hs
@@ -134,7 +134,7 @@ spec = beforeAll setup $ do
     let loadConfig' inner = do
           globalOpts <- globalOptsFromMonoid False mempty
           withRunnerGlobal globalOpts { globalLogLevel = logLevel } $
-            loadConfig mempty Nothing SYLDefault inner
+            loadConfig inner
     -- TODO(danburton): make sure parent dirs also don't have config file
     it "works even if no config file exists" $ example $
       loadConfig' $ const $ return ()

--- a/src/test/Stack/NixSpec.hs
+++ b/src/test/Stack/NixSpec.hs
@@ -43,9 +43,9 @@ spec :: Spec
 spec = beforeAll setup $ do
   let loadConfig' :: ConfigMonoid -> (Config -> IO ()) -> IO ()
       loadConfig' cmdLineArgs inner = do
-        globalOpts <- globalOptsFromMonoid False mempty
+        globalOpts <- globalOptsFromMonoid False mempty { globalMonoidConfigMonoid = cmdLineArgs }
         withRunnerGlobal globalOpts { globalLogLevel = LevelDebug } $
-          loadConfig cmdLineArgs Nothing SYLDefault (liftIO . inner)
+          loadConfig (liftIO . inner)
       inTempDir test = do
         currentDirectory <- getCurrentDirectory
         withSystemTempDirectory "Stack_ConfigSpec" $ \tempDir -> do


### PR DESCRIPTION
This yet again avoids behavioral changes, and opens the way for future
cleanups.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
