### PR TITLE
Make dot and ls dependencies not require GHC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -120,6 +120,9 @@ Other enhancements:
   [#4480](https://github.com/commercialhaskell/stack/issues/4480).
 * Add `stack purge` as a shortcut for `stack clean --full`. See
   [#3863](https://github.com/commercialhaskell/stack/issues/3863).
+* Both `stack dot` and `stack ls dependencies` accept a
+  `--global-hints` flag to bypass the need for an installed GHC. See
+  [#4390](https://github.com/commercialhaskell/stack/issues/4390).
 
 Bug fixes:
 

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -252,7 +252,7 @@ mkBaseConfigOpts boptsCli = do
 
 -- | Provide a function for loading package information from the package index
 loadPackage
-  :: HasEnvConfig env
+  :: (HasBuildConfig env, HasSourceMap env)
   => PackageLocationImmutable
   -> Map FlagName Bool
   -> [Text]

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1480,7 +1480,7 @@ singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} installedMap
         case taskType of
             TTLocalMutable lp -> do
                 when enableTests $ unsetTestSuccess pkgDir
-                caches <- runMemoized $ lpNewBuildCaches lp
+                caches <- runMemoizedWith $ lpNewBuildCaches lp
                 mapM_ (uncurry (writeBuildCache pkgDir))
                       (Map.toList caches)
             TTRemotePackage{} -> return ()
@@ -1722,7 +1722,7 @@ checkExeStatus compiler platform distDir name = do
 -- | Check if any unlisted files have been found, and add them to the build cache.
 checkForUnlistedFiles :: HasEnvConfig env => TaskType -> CTime -> Path Abs Dir -> RIO env [PackageWarning]
 checkForUnlistedFiles (TTLocalMutable lp) preBuildTime pkgDir = do
-    caches <- runMemoized $ lpNewBuildCaches lp
+    caches <- runMemoizedWith $ lpNewBuildCaches lp
     (addBuildCache,warnings) <-
         addUnlistedToBuildCache
             preBuildTime

--- a/src/Stack/Options/DotParser.hs
+++ b/src/Stack/Options/DotParser.hs
@@ -24,6 +24,7 @@ dotOptsParser externalDefault =
           <*> flagsParser
           <*> testTargets
           <*> benchTargets
+          <*> globalHints
   where includeExternal = boolFlags externalDefault
                                     "external"
                                     "inclusion of external dependencies"
@@ -51,6 +52,9 @@ dotOptsParser externalDefault =
 
         splitNames :: String -> [String]
         splitNames = map (takeWhile (not . isSpace) . dropWhile isSpace) . splitOn ","
+
+        globalHints = switch (long "global-hints" <>
+                              help "Do not require an install GHC; instead, use a hints file for global packages")
 
 -- | Parser for arguments to `stack list-dependencies`.
 listDepsOptsParser :: Parser ListDepsOpts

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -98,12 +98,6 @@ instance HasProcessContext Ctx where
     processContextL = configL.processContextL
 instance HasBuildConfig Ctx where
     buildConfigL = lens ctxBuildConfig (\x y -> x { ctxBuildConfig = y })
-    {-
-instance HasSourceMap Ctx where
-    sourceMapL = envConfigL.sourceMapL
-instance HasEnvConfig Ctx where
-    envConfigL = lens ctxEnvConfig (\x y -> x { ctxEnvConfig = y })
-    -}
 
 -- | Read @<package>.buildinfo@ ancillary files produced by some Setup.hs hooks.
 -- The file includes Cabal file syntax to be merged into the package description

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -77,7 +77,7 @@ import qualified RIO.PrettyPrint as PP (Style (Module))
 
 data Ctx = Ctx { ctxFile :: !(Path Abs File)
                , ctxDistDir :: !(Path Abs Dir)
-               , ctxEnvConfig :: !EnvConfig
+               , ctxBuildConfig :: !BuildConfig
                }
 
 instance HasPlatform Ctx
@@ -96,9 +96,14 @@ instance HasPantryConfig Ctx where
     pantryConfigL = configL.pantryConfigL
 instance HasProcessContext Ctx where
     processContextL = configL.processContextL
-instance HasBuildConfig Ctx
+instance HasBuildConfig Ctx where
+    buildConfigL = lens ctxBuildConfig (\x y -> x { ctxBuildConfig = y })
+    {-
+instance HasSourceMap Ctx where
+    sourceMapL = envConfigL.sourceMapL
 instance HasEnvConfig Ctx where
     envConfigL = lens ctxEnvConfig (\x y -> x { ctxEnvConfig = y })
+    -}
 
 -- | Read @<package>.buildinfo@ ancillary files produced by some Setup.hs hooks.
 -- The file includes Cabal file syntax to be merged into the package description
@@ -213,10 +218,10 @@ packageFromPackageDescription packageConfig pkgFlags (PackageDescriptionPair pkg
         \cabalfp -> debugBracket ("getPackageFiles" <+> pretty cabalfp) $ do
              let pkgDir = parent cabalfp
              distDir <- distDirFromDir pkgDir
-             env <- view envConfigL
+             bc <- view buildConfigL
              (componentModules,componentFiles,dataFiles',warnings) <-
                  runRIO
-                     (Ctx cabalfp distDir env)
+                     (Ctx cabalfp distDir bc)
                      (packageDescModulesAndFiles pkg)
              setupFiles <-
                  if buildType pkg == Custom

--- a/src/Stack/SourceMap.hs
+++ b/src/Stack/SourceMap.hs
@@ -14,6 +14,7 @@ module Stack.SourceMap
     , checkFlagsUsedThrowing
     , globalCondCheck
     , pruneGlobals
+    , globalsFromHints
     ) where
 
 import qualified Data.Conduit.List as CL

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -312,7 +312,7 @@ instance Show (MemoizedWith env a) where
   show _ = "<<MemoizedWith>>"
 
 lpFiles :: HasEnvConfig env => LocalPackage -> RIO env (Set.Set (Path Abs File))
-lpFiles lp = runMemoizedWith $ fmap (Set.unions . M.elems) $ lpComponentFiles lp
+lpFiles = runMemoizedWith . fmap (Set.unions . M.elems) . lpComponentFiles
 
 -- | A location to install a package into, either snapshot or local
 data InstallLocation = Snap | Local

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -338,7 +338,7 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
             (sdistOptsParser False)
         addCommand' "dot"
                     "Visualize your project's dependency graph using Graphviz dot"
-                    dotCmd
+                    dot
                     (dotOptsParser False) -- Default for --external is False.
         addCommand' "ghc"
                     "Run ghc"
@@ -417,7 +417,7 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                     (cleanOptsParser Purge)
         addCommand' "list-dependencies"
                     "List the dependencies"
-                    (withConfig . listDependenciesCmd True)
+                    (listDependenciesCmd True)
                     listDepsOptsParser
         addCommand' "query"
                     "Query general build information (experimental)"
@@ -1026,10 +1026,6 @@ solverCmd :: Bool -- ^ modify stack.yaml automatically?
 solverCmd fixStackYaml =
     withConfig $
     withDefaultEnvConfigAndLock (\_ -> solveExtraDeps fixStackYaml)
-
--- | Visualize dependencies
-dotCmd :: DotOpts -> RIO Runner ()
-dotCmd dotOpts = withConfig $ withEnvConfigDot dotOpts $ dot dotOpts
 
 -- | Query build information
 queryCmd :: [String] -> RIO Runner ()


### PR DESCRIPTION
The previous approach in #4405 would no longer work, due to @qrilka's explanation in https://github.com/commercialhaskell/stack/pull/4405#issuecomment-473820049. This implementation adds a new flag `--global-hints` which allows the user to bypass the need for an installation of GHC. We could arguably flip the default to not requiring GHC to be installed.

This will close #4390.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
