### PR TITLE
Print "try adding ... to your extra-deps" as YAML

### DIFF
--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -1041,7 +1041,7 @@ pprintExceptions exceptions stackYaml stackRoot parentMap wanted' prunedGlobalDe
     pprintExtra (name, (version, BlobKey cabalHash cabalSize)) =
       let cfInfo = CFIHash cabalHash (Just cabalSize)
           packageIdRev = PackageIdentifierRevision name version cfInfo
-       in fromString $ T.unpack $ utf8BuilderToText $ RIO.display packageIdRev
+       in "- " <+> (fromString $ T.unpack $ utf8BuilderToText $ RIO.display packageIdRev)
 
     allNotInBuildPlan = Set.fromList $ concatMap toNotInBuildPlan exceptions'
     toNotInBuildPlan (DependencyPlanFailures _ pDeps) =

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -1041,7 +1041,7 @@ pprintExceptions exceptions stackYaml stackRoot parentMap wanted' prunedGlobalDe
     pprintExtra (name, (version, BlobKey cabalHash cabalSize)) =
       let cfInfo = CFIHash cabalHash (Just cabalSize)
           packageIdRev = PackageIdentifierRevision name version cfInfo
-       in "- " <+> (fromString $ T.unpack $ utf8BuilderToText $ RIO.display packageIdRev)
+       in "- " <+> fromString (T.unpack (utf8BuilderToText (RIO.display packageIdRev)))
 
     allNotInBuildPlan = Set.fromList $ concatMap toNotInBuildPlan exceptions'
     toNotInBuildPlan (DependencyPlanFailures _ pDeps) =


### PR DESCRIPTION
* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Before:

```
  * Recommended action: try adding the following to your extra-deps in /Users/yom/forks/servant/stack.yaml:

aeson-1.4.2.0@sha256:8166752a9669597db375343df19805069595fed9c613f98504e418849f40fe18
attoparsec-iso8601-1.0.1.0@sha256:acba3fc2fcd8b9b3177219c44ca26c0dc0f32e4af9cfaafc0845786fc5f488ef
free-5.1@sha256:71aa48c5a5dde71ed2a7f3d1d23c6d3a66580859444f55c8b38dd1bb205aa298
http-types-0.12.3@sha256:f35229edb1bc7b3ae27f961b2407dadb5bfa69d43a8f5337ab46cdc79ca4afe9
lens-4.17@sha256:534febcd710980b3c30efe12813e865b09fc6086a4ed6b7a6a8885f27caee3a6
semigroupoids-5.3.2@sha256:7a00aa24d8129b153f19991b96341e6f725ba77cef46b151c84d6dac1d12b47e
tagged-0.8.6@sha256:b5e1de3b14ff198b548928f686e5e8783301dc231413f751c23f4ee10cd47a7c
```

After:

```
  * Recommended action: try adding the following to your extra-deps in /Users/yom/forks/servant/stack.yaml:

- aeson-1.4.2.0@sha256:8166752a9669597db375343df19805069595fed9c613f98504e418849f40fe18
- attoparsec-iso8601-1.0.1.0@sha256:acba3fc2fcd8b9b3177219c44ca26c0dc0f32e4af9cfaafc0845786fc5f488ef
- free-5.1@sha256:71aa48c5a5dde71ed2a7f3d1d23c6d3a66580859444f55c8b38dd1bb205aa298
- http-types-0.12.3@sha256:f35229edb1bc7b3ae27f961b2407dadb5bfa69d43a8f5337ab46cdc79ca4afe9
- lens-4.17@sha256:534febcd710980b3c30efe12813e865b09fc6086a4ed6b7a6a8885f27caee3a6
- semigroupoids-5.3.2@sha256:7a00aa24d8129b153f19991b96341e6f725ba77cef46b151c84d6dac1d12b47e
- tagged-0.8.6@sha256:b5e1de3b14ff198b548928f686e5e8783301dc231413f751c23f4ee10cd47a7c
```

Warning: untested.