### PR TITLE
No user file locks #4636

### DIFF
--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -88,7 +88,6 @@ module Stack.Constants
     ,relFileDockerfile
     ,relDirHaskellStackGhci
     ,relFileGhciScript
-    ,relFileLockfile
     ,relDirCombined
     ,relFileHpcIndexHtml
     ,relDirCustom
@@ -493,9 +492,6 @@ relDirHaskellStackGhci = $(mkRelDir "haskell-stack-ghci")
 
 relFileGhciScript :: Path Rel File
 relFileGhciScript = $(mkRelFile "ghci-script")
-
-relFileLockfile :: Path Rel File
-relFileLockfile = $(mkRelFile "lockfile")
 
 relDirCombined :: Path Rel Dir
 relDirCombined = $(mkRelDir "combined")

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -22,11 +22,11 @@ module Stack.Docker
   ,entrypoint
   ,preventInContainer
   ,pull
-  ,reexecWithOptionalContainer
   ,reset
   ,reExecArgName
   ,StackDockerException(..)
   ,getProjectRoot
+  ,runContainerAndExit
   ) where
 
 import           Stack.Prelude
@@ -174,21 +174,6 @@ getCmdArgs docker imageInfo isRemoteDocker = do
     cmdArgs args exePath = do
         let mountPath = hostBinDir FP.</> FP.takeBaseName exePath
         return (mountPath, args, [], [Mount exePath mountPath])
-
--- | If Docker is enabled, re-runs the currently running OS command in a Docker container.
--- Otherwise, runs the inner action.
-reexecWithOptionalContainer
-    :: HasConfig env
-    => RIO env a
-    -> RIO env a
-reexecWithOptionalContainer inner =
-  do config <- view configL
-     inContainer <- getInContainer
-     isReExec <- view reExecL
-     if | inContainer && not isReExec -> throwIO OnlyOnHostException
-        | inContainer -> inner
-        | not (dockerEnable (configDocker config)) -> inner
-        | otherwise -> runContainerAndExit
 
 -- | Error if running in a container.
 preventInContainer :: MonadIO m => m () -> m ()

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -66,7 +66,6 @@ import           Stack.Setup (ensureDockerStackExe)
 import           System.Directory (canonicalizePath,getHomeDirectory)
 import           System.Environment (getEnv,getEnvironment,getProgName,getArgs,getExecutablePath)
 import           System.Exit (exitSuccess, exitWith, ExitCode(..))
-import           System.FileLock (FileLock, unlockFile)
 import qualified System.FilePath as FP
 import           System.IO (stderr,stdin,stdout)
 import           System.IO.Error (isDoesNotExistError)
@@ -178,33 +177,18 @@ getCmdArgs docker imageInfo isRemoteDocker = do
 
 -- | If Docker is enabled, re-runs the currently running OS command in a Docker container.
 -- Otherwise, runs the inner action.
---
--- This takes an optional release action which should be taken IFF control is
--- transferring away from the current process to the intra-container one.  The main use
--- for this is releasing a lock.  After launching reexecution, the host process becomes
--- nothing but an manager for the call into docker and thus may not hold the lock.
 reexecWithOptionalContainer
     :: HasConfig env
-    => Maybe (RIO env ())
-    -> IO (Maybe FileLock)
+    => RIO env a
     -> RIO env a
-    -> RIO env a
-reexecWithOptionalContainer mbefore mrelease inner =
+reexecWithOptionalContainer inner =
   do config <- view configL
      inContainer <- getInContainer
      isReExec <- view reExecL
-     if | inContainer && not isReExec && isJust mbefore ->
-            throwIO OnlyOnHostException
+     if | inContainer && not isReExec -> throwIO OnlyOnHostException
         | inContainer -> inner
-        | not (dockerEnable (configDocker config)) ->
-            fromMaybeAction mbefore *> inner
-        | otherwise ->
-            do liftIO $ mrelease >>= traverse_ unlockFile
-               runContainerAndExit
-                 (fromMaybeAction mbefore)
-  where
-    fromMaybeAction Nothing = return ()
-    fromMaybeAction (Just hook) = hook
+        | not (dockerEnable (configDocker config)) -> inner
+        | otherwise -> runContainerAndExit
 
 -- | Error if running in a container.
 preventInContainer :: MonadIO m => m () -> m ()
@@ -215,11 +199,8 @@ preventInContainer inner =
         else inner
 
 -- | Run a command in a new Docker container, then exit the process.
-runContainerAndExit
-  :: HasConfig env
-  => RIO env ()  -- ^ Action to run before
-  -> RIO env void
-runContainerAndExit before = do
+runContainerAndExit :: HasConfig env => RIO env void
+runContainerAndExit = do
      config <- view configL
      let docker = configDocker config
      checkDockerVersion docker
@@ -332,7 +313,6 @@ runContainerAndExit before = do
          ,[image]
          ,[cmnd]
          ,args])
-     before
 -- MSS 2018-08-30 can the CPP below be removed entirely, and instead exec the
 -- `docker` process so that it can handle the signals directly?
 #ifndef WINDOWS

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -99,7 +99,7 @@ createPrunedDependencyGraph :: DotOpts
                             -> RIO Runner
                                  (Set PackageName,
                                   Map PackageName (Set PackageName, DotPayload))
-createPrunedDependencyGraph dotOpts = withConfig $ withDotConfig dotOpts $ do
+createPrunedDependencyGraph dotOpts = withDotConfig dotOpts $ do
   localNames <- view $ buildConfigL.to (Map.keysSet . smwProject . bcSMWanted)
   logDebug "Creating dependency graph"
   resultGraph <- createDependencyGraph dotOpts
@@ -383,12 +383,12 @@ localPackageToPackage lp =
 withDotConfig
     :: DotOpts
     -> RIO DotConfig a
-    -> RIO Config a
+    -> RIO Runner a
 withDotConfig opts inner =
   local (over globalOptsL modifyGO) $
     if dotGlobalHints opts
-      then withBuildConfig withGlobalHints
-      else withReal
+      then withConfig NoReexec $ withBuildConfig withGlobalHints
+      else withConfig YesReexec withReal
   where
     withGlobalHints = do
       bconfig <- view buildConfigL

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -343,7 +343,7 @@ buildDepsAndInitialSteps GhciOpts{..} localTargets = do
     -- 'initialBuildSteps'.
     when (not ghciNoBuild && not (null targets)) $ do
         -- only new local targets could appear here
-        eres <- tryAny $ withNewLocalBuildTargets targets $ build Nothing Nothing
+        eres <- tryAny $ withNewLocalBuildTargets targets $ build Nothing
         case eres of
             Right () -> return ()
             Left err -> do

--- a/src/Stack/Hoogle.hs
+++ b/src/Stack/Hoogle.hs
@@ -27,7 +27,7 @@ import           RIO.Process
 hoogleCmd :: ([String],Bool,Bool,Bool) -> RIO Runner ()
 hoogleCmd (args,setup,rebuild,startServer) =
   local (over globalOptsL modifyGO) $
-  withConfig $
+  withConfig YesReexec $
   withDefaultEnvConfig $ do
     hooglePath <- ensureHoogleInPath
     generateDbIfNeeded hooglePath

--- a/src/Stack/Hoogle.hs
+++ b/src/Stack/Hoogle.hs
@@ -69,7 +69,7 @@ hoogleCmd (args,setup,rebuild,startServer) =
     buildHaddocks = do
       config <- view configL
       runRIO config $ -- a bit weird that we have to drop down like this
-        catch (withDefaultEnvConfigAndLock $ Stack.Build.build Nothing)
+        catch (withDefaultEnvConfig $ Stack.Build.build Nothing)
               (\(_ :: ExitCode) -> return ())
     hooglePackageName = mkPackageName "hoogle"
     hoogleMinVersion = mkVersion [5, 0]
@@ -112,7 +112,7 @@ hoogleCmd (args,setup,rebuild,startServer) =
                     hooglePackageIdentifier
                 }
         runRIO config $ catch -- Also a bit weird
-                 (withEnvConfigAndLock
+                 (withEnvConfig
                       NeedTargets
                       boptsCLI $
                       Stack.Build.build Nothing

--- a/src/Stack/Ls.hs
+++ b/src/Stack/Ls.hs
@@ -31,7 +31,7 @@ import RIO.PrettyPrint.DefaultStyles (defaultStyles)
 import RIO.PrettyPrint.Types (StyleSpec)
 import RIO.PrettyPrint.StylesUpdate (StylesUpdate (..), stylesUpdateL)
 import Stack.Dot
-import Stack.Runners (withConfig, withDefaultEnvConfig)
+import Stack.Runners
 import Stack.Options.DotParser (listDepsOptsParser)
 import Stack.Types.Config
 import System.Console.ANSI.Codes (SGR (Reset), setSGRCode, sgrToCode)
@@ -225,7 +225,7 @@ localSnaptoText xs = T.intercalate "\n" $ L.map T.pack xs
 
 handleLocal :: LsCmdOpts -> RIO Runner ()
 handleLocal lsOpts = do
-    (instRoot :: Path Abs Dir) <- withConfig $ withDefaultEnvConfig installationRootDeps
+    (instRoot :: Path Abs Dir) <- withConfig YesReexec $ withDefaultEnvConfig installationRootDeps
     isStdoutTerminal <- view terminalL
     let snapRootDir = parent $ parent instRoot
     snapData' <- liftIO $ listDirectory $ toFilePath snapRootDir
@@ -279,7 +279,7 @@ lsCmd lsOpts =
                 Local -> handleLocal lsOpts
                 Remote -> handleRemote lsOpts
         LsDependencies depOpts -> listDependenciesCmd False depOpts
-        LsStyles stylesOpts -> withConfig $ listStylesCmd stylesOpts
+        LsStyles stylesOpts -> withConfig NoReexec $ listStylesCmd stylesOpts
 
 -- | List the dependencies
 listDependenciesCmd :: Bool -> ListDepsOpts -> RIO Runner ()

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -19,12 +19,10 @@ import qualified Distribution.PackageDescription as C
 import qualified Distribution.Types.UnqualComponentName as C
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
-import           Stack.Build.Target (NeedTargets(..))
 import           Stack.Constants (ghcShowOptionsOutput)
 import           Stack.Options.GlobalParser (globalOptsFromMonoid)
 import           Stack.Runners
 import           Stack.Prelude
-import           Stack.Setup
 import           Stack.Types.Config
 import           Stack.Types.NamedComponent
 import           Stack.Types.SourceMap
@@ -53,10 +51,7 @@ buildConfigCompleter inner = mkCompleter $ \inputRaw -> do
         _ -> do
             go' <- globalOptsFromMonoid False mempty
             let go = go' { globalLogLevel = LevelOther "silent" }
-            withRunnerGlobal go $ withConfig NoReexec $ withBuildConfig $ do
-              -- FIXME should this just be withDefaultEnvConfig? Should we be using YesReexec instead?
-              envConfig <- setupEnv AllowNoTargets defaultBuildOptsCLI Nothing
-              runRIO envConfig (inner input)
+            withRunnerGlobal go $ withConfig NoReexec $ withDefaultEnvConfig $ inner input
 
 targetCompleter :: Completer
 targetCompleter = buildConfigCompleter $ \input -> do

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -20,10 +20,9 @@ import qualified Distribution.Types.UnqualComponentName as C
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
 import           Stack.Build.Target (NeedTargets(..))
-import           Stack.Config (loadBuildConfig)
 import           Stack.Constants (ghcShowOptionsOutput)
 import           Stack.Options.GlobalParser (globalOptsFromMonoid)
-import           Stack.Runners (withConfig, withRunnerGlobal)
+import           Stack.Runners
 import           Stack.Prelude
 import           Stack.Setup
 import           Stack.Types.Config
@@ -54,9 +53,9 @@ buildConfigCompleter inner = mkCompleter $ \inputRaw -> do
         _ -> do
             go' <- globalOptsFromMonoid False mempty
             let go = go' { globalLogLevel = LevelOther "silent" }
-            withRunnerGlobal go $ withConfig $ do
-              bconfig <- loadBuildConfig
-              envConfig <- runRIO bconfig (setupEnv AllowNoTargets defaultBuildOptsCLI Nothing)
+            withRunnerGlobal go $ withConfig NoReexec $ withBuildConfig $ do
+              -- FIXME should this just be withDefaultEnvConfig? Should we be using YesReexec instead?
+              envConfig <- setupEnv AllowNoTargets defaultBuildOptsCLI Nothing
               runRIO envConfig (inner input)
 
 targetCompleter :: Completer

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -54,7 +54,7 @@ path keys =
                T.putStrLn $ prefix <> extractPath pathInfo
            runHaddock x = local
              (set (globalOptsL.globalOptsBuildOptsMonoidL.buildOptsMonoidHaddockL) (Just x)) .
-             withConfig .
+             withConfig YesReexec . -- FIXME this matches previous behavior, but doesn't make a lot of sense
              withDefaultEnvConfig
        -- MSS 2019-03-17 Not a huge fan of rerunning withConfig and
        -- withDefaultEnvConfig each time, need to figure out what

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -5,23 +5,15 @@
 
 -- | Utilities for running stack commands.
 module Stack.Runners
-    ( withGlobalConfigAndLock
-    , withConfigAndLock
-    , withEnvConfigAndLock
-    , withDefaultEnvConfigAndLock
-    , withBuildConfig
-    , withCleanConfig
+    ( withBuildConfig
     , withEnvConfig
     , withDefaultEnvConfig
     , withConfig
-    , withUserFileLock
-    , munlockFile
+    , withGlobalConfig
     , withRunnerGlobal
     ) where
 
 import           Stack.Prelude
-import           Path
-import           Path.IO
 import           RIO.Process (mkDefaultProcessContext)
 import           Stack.Build.Target(NeedTargets(..))
 import           Stack.Config
@@ -32,68 +24,16 @@ import qualified Stack.Nix as Nix
 import           Stack.Setup
 import           Stack.Types.Config
 import           System.Console.ANSI (hSupportsANSIWithoutEmulation)
-import           System.Environment (getEnvironment)
-import           System.FileLock
 import           System.Terminal (getTerminalWidth)
-
--- | Enforce mutual exclusion of every action running via this
--- function, on this path, on this users account.
---
--- A lock file is created inside the given directory.  Currently,
--- stack uses locks per-snapshot.  In the future, stack may refine
--- this to an even more fine-grain locking approach.
---
-withUserFileLock :: HasRunner env
-                 => Path Abs Dir
-                 -> (Maybe FileLock -> RIO env a)
-                 -> RIO env a
-withUserFileLock dir act = withRunInIO $ \run -> do
-    env <- getEnvironment
-    let toLock = lookup "STACK_LOCK" env == Just "true"
-    if toLock
-        then do
-            let lockfile = relFileLockfile
-            let pth = dir </> lockfile
-            ensureDir dir
-            -- Just in case of asynchronous exceptions, we need to be careful
-            -- when using tryLockFile here:
-            bracket (tryLockFile (toFilePath pth) Exclusive)
-                    munlockFile
-                    (\fstTry ->
-                        case fstTry of
-                          Just lk -> run $ act $ Just lk
-                          Nothing ->
-                            do run $ logError $
-                                 "Failed to grab lock (" <>
-                                 displayShow pth <>
-                                 "); other stack instance running.  Waiting..."
-                               bracket (lockFile (toFilePath pth) Exclusive)
-                                       unlockFile
-                                       (\lk -> run $ do
-                                            logError "Lock acquired, proceeding."
-                                            act $ Just lk))
-        else run $ act Nothing
-
-withConfigAndLock
-    :: RIO Config ()
-    -> RIO Runner ()
-withConfigAndLock inner = withConfig $ do
-    stackRoot <- view stackRootL
-    withUserFileLock stackRoot $ \lk ->
-      Docker.reexecWithOptionalContainer
-        Nothing
-        (pure lk)
-        inner
 
 -- | Loads global config, ignoring any configuration which would be
 -- loaded due to $PWD.
-withGlobalConfigAndLock
+withGlobalConfig
     :: RIO Config ()
     -> RIO Runner ()
-withGlobalConfigAndLock inner =
+withGlobalConfig inner =
     local (set stackYamlLocL SYLNoProject) $
     loadConfig $ \config ->
-    withUserFileLock (view stackRootL config) $ \_lk ->
     runRIO config inner
 
 -- For now the non-locking version just unlocks immediately.
@@ -101,75 +41,26 @@ withGlobalConfigAndLock inner =
 withDefaultEnvConfig
     :: RIO EnvConfig a
     -> RIO Config a
-withDefaultEnvConfig inner =
-    withEnvConfigAndLock AllowNoTargets defaultBuildOptsCLI (\lk -> do munlockFile lk
-                                                                       inner)
-
-withEnvConfig
-    :: NeedTargets
-    -> BuildOptsCLI
-    -> RIO EnvConfig a
-    -> RIO Config a
-withEnvConfig needTargets boptsCLI inner =
-    withEnvConfigAndLock needTargets boptsCLI (\lk -> do munlockFile lk
-                                                         inner)
-
-withDefaultEnvConfigAndLock
-    :: (Maybe FileLock -> RIO EnvConfig a)
-    -> RIO Config a
-withDefaultEnvConfigAndLock = withEnvConfigAndLock AllowNoTargets defaultBuildOptsCLI
-
--- | A runner specially built for the "stack clean" use case. For some
--- reason (hysterical raisins?), all of the functions in this module
--- which say BuildConfig actually work on an EnvConfig, while the
--- clean command legitimately only needs a BuildConfig. At some point
--- in the future, we could consider renaming everything for more
--- consistency.
---
--- /NOTE/ This command always runs outside of the Docker environment,
--- since it does not need to run any commands to get information on
--- the project. This is a change as of #4480. For previous behavior,
--- see issue #2010.
-withCleanConfig :: RIO BuildConfig a -> RIO Config a
-withCleanConfig inner = do
-    root <- view stackRootL
-    withUserFileLock root $ \_lk0 -> do
-      bconfig <- loadBuildConfig
-      runRIO bconfig inner
+withDefaultEnvConfig = withEnvConfig AllowNoTargets defaultBuildOptsCLI
 
 withBuildConfig :: RIO BuildConfig a -> RIO Config a
 withBuildConfig inner = do
   bconfig <- loadBuildConfig
   runRIO bconfig inner
 
-withEnvConfigAndLock
+withEnvConfig
     :: NeedTargets
     -> BuildOptsCLI
-    -> (Maybe FileLock -> RIO EnvConfig a)
+    -> RIO EnvConfig a
     -- ^ Action that uses the build config.  If Docker is enabled for builds,
     -- this will be run in a Docker container.
     -> RIO Config a
-withEnvConfigAndLock needTargets boptsCLI inner = do
-    config <- ask
-    withUserFileLock (view stackRootL config) $ \lk0 -> do
-      -- A local bit of state for communication between callbacks:
-      curLk <- newIORef lk0
-
-      Docker.reexecWithOptionalContainer Nothing (readIORef curLk) $
-        Nix.reexecWithOptionalShell $ withBuildConfig $ do
-          envConfig <- setupEnv needTargets boptsCLI Nothing
-          runRIO envConfig $ do
-            -- Locking policy:  This is only used for build commands, which
-            -- only need to lock the snapshot, not the global lock.  We
-            -- trade in the lock here.
-            dir <- installationRootDeps
-            -- Hand-over-hand locking:
-            withUserFileLock dir $ \lk2 -> do
-              lk1 <- readIORef curLk
-              munlockFile lk1
-              writeIORef curLk lk2
-              logDebug "Starting to execute command inside EnvConfig"
-              inner lk2
+withEnvConfig needTargets boptsCLI inner =
+  Docker.reexecWithOptionalContainer $
+  Nix.reexecWithOptionalShell $ withBuildConfig $ do
+    envConfig <- setupEnv needTargets boptsCLI Nothing
+    logDebug "Starting to execute command inside EnvConfig"
+    runRIO envConfig inner
 
 -- | Load the configuration. Convenience function used
 -- throughout this module.
@@ -219,8 +110,3 @@ withRunnerGlobal go inner = do
           | w < minTerminalWidth = minTerminalWidth
           | w > maxTerminalWidth = maxTerminalWidth
           | otherwise = w
-
--- | Unlock a lock file, if the value is Just
-munlockFile :: MonadIO m => Maybe FileLock -> m ()
-munlockFile Nothing = return ()
-munlockFile (Just lk) = liftIO $ unlockFile lk

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -36,7 +36,11 @@ import           System.Terminal (getTerminalWidth)
 
 -- | Ensure that no project settings are used when running 'withConfig'.
 withNoProject :: RIO Runner a -> RIO Runner a
-withNoProject = local (set stackYamlLocL SYLNoProject) -- FIXME consider adding a warning when overriding, or using SYLNoConfig
+withNoProject inner = do
+  oldSYL <- view stackYamlLocL
+  case oldSYL of
+    SYLDefault -> local (set stackYamlLocL SYLNoProject) inner
+    _ -> throwString "Cannot use this command with options which override the stack.yaml location"
 
 -- | Helper for 'withEnvConfig' which passes in some default arguments:
 --

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -457,7 +457,7 @@ buildExtractedTarball pkgDir = do
         in set envConfigL updatedEnvConfig env
       updatePackagesInSourceMap sm =
         sm {smProject = Map.insert (cpName $ ppCommon pp) pp pathsToKeep}
-  local adjustEnvForBuild $ build Nothing Nothing
+  local adjustEnvForBuild $ build Nothing
 
 -- | Version of 'checkSDistTarball' that first saves lazy bytestring to
 -- temporary directory and then calls 'checkSDistTarball' on it.

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -85,7 +85,7 @@ scriptCmd opts = do
 
   longWay file scriptDir =
     withConfig $
-    withDefaultEnvConfigAndLock $ \lk -> do
+    withDefaultEnvConfig $ do
       -- Some warnings in case the user somehow tries to set a
       -- stack.yaml location. Note that in this functions we use
       -- logError instead of logWarn because, when using the
@@ -133,7 +133,7 @@ scriptCmd opts = do
                 else do
                     logDebug "Missing packages, performing installation"
                     let targets = map (T.pack . packageNameString) $ Set.toList targetsSet
-                    withNewLocalBuildTargets targets $ Stack.Build.build Nothing lk
+                    withNewLocalBuildTargets targets $ Stack.Build.build Nothing
 
         let ghcArgs = concat
                 [ ["-i", "-i" ++ toFilePath scriptDir]
@@ -149,7 +149,6 @@ scriptCmd opts = do
                     SEOptimize -> ["-O2"]
                 , soGhcOptions opts
                 ]
-        munlockFile lk -- Unlock before transferring control away.
         case soCompile opts of
           SEInterpret -> exec ("run" ++ compilerExeName wc)
                 (ghcArgs ++ toFilePath file : soArgs opts)

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -84,7 +84,7 @@ scriptCmd opts = do
       else longWay file scriptDir
 
   longWay file scriptDir =
-    withConfig $
+    withConfig YesReexec $
     withDefaultEnvConfig $ do
       -- Some warnings in case the user somehow tries to set a
       -- stack.yaml location. Note that in this functions we use

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -1374,7 +1374,7 @@ buildInGhcjsEnv :: (HasEnvConfig env, MonadIO m) => env -> m ()
 buildInGhcjsEnv envConfig = do
     runRIO (set (buildOptsL.buildOptsInstallExesL) True $
             set (buildOptsL.buildOptsHaddockL) False envConfig) $
-        build Nothing Nothing
+        build Nothing
 
 getCabalInstallVersion :: (HasProcessContext env, HasLogFunc env) => RIO env (Maybe Version)
 getCabalInstallVersion = do

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -244,4 +244,4 @@ sourceUpgrade builtHash (SourceOpts gitRepo) =
             "Try rerunning with --install-ghc to install the correct GHC into " <>
             T.pack (toFilePath (configLocalPrograms (view configL bconfig)))
         runRIO (set (buildOptsL.buildOptsInstallExesL) True envConfig1) $
-            build Nothing Nothing
+            build Nothing

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -167,7 +167,7 @@ binaryUpgrade (BinaryOpts mplatform force' mver morg mrepo) = do
                     $ throwString "Non-success exit code from running newly downloaded executable"
 
 sourceUpgrade
-  :: HasConfig env
+  :: HasConfig env -- FIXME try knocking this down to HasRunner and initializing the Config appropriately here
   => Maybe String
   -> SourceOpts
   -> RIO env ()

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -677,7 +677,7 @@ upgradeCmd upgradeOpts' = do
       logError "You cannot use the --resolver option with the upgrade command"
       liftIO exitFailure
     Nothing ->
-      withNoProject $ withConfig NoReexec $
+      withNoProject $
       upgrade
 #ifdef USE_GIT_INFO
         (either (const Nothing) (Just . giHash) $$tGitInfoCwdTry)

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -683,7 +683,7 @@ upgradeCmd upgradeOpts' = do
       logError "You cannot use the --resolver option with the upgrade command"
       liftIO exitFailure
     Nothing ->
-      withGlobalConfig $
+      withNoProject $ withConfig $
       upgrade
 #ifdef USE_GIT_INFO
         (either (const Nothing) (Just . giHash) $$tGitInfoCwdTry)
@@ -940,12 +940,12 @@ initCmd :: InitOpts -> RIO Runner ()
 initCmd initOpts = do
     pwd <- getCurrentDir
     go <- view globalOptsL
-    withGlobalConfig (initProject IsInitCmd pwd initOpts (globalResolver go))
+    withNoProject $ withConfig (initProject IsInitCmd pwd initOpts (globalResolver go))
 
 -- | Create a project directory structure and initialize the stack config.
 newCmd :: (NewOpts,InitOpts) -> RIO Runner ()
 newCmd (newOpts,initOpts) =
-    withGlobalConfig $ do
+    withNoProject $ withConfig $ do
         dir <- new newOpts (forceOverwrite initOpts)
         exists <- doesFileExist $ dir </> stackDotYaml
         when (forceOverwrite initOpts || not exists) $ do


### PR DESCRIPTION
Following discussion on #4636, it looks like the user file locking is no longer needed, and we can make Docker/Nix an either/or choice. This PR does just this. Removing the file lock code unlocks a number of simplifications. Following that, I cleaned up the reexec logic to be a bit cleaner. Then I added a number of further simplifications.

At the end of this, we're much more explicit about when reexecing inside Docker/Nix is desired via a `ShouldReexec` parameter to `withConfig`, which I think is the best case scenario. There may still be some cases where we want to tweak the behavior, but that can occur in later PRs.