### PR TITLE
Use GHC_ENVIRONMENT to resolve module name ambiguity in doctests

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -131,6 +131,9 @@ Other enhancements:
   variables. See [#620](https://github.com/commercialhaskell/stack/issues/620).
 * Less verbose output from `stack setup` on Windows. See
   [#1212](https://github.com/commercialhaskell/stack/issues/1212).
+* environment variable `GHC_ENVIRONMENT` is set to specify dependency
+  packages explicitly when running test. This is done to prevent
+  ambiguous module name errors in `doctest` tests.
 
 Bug fixes:
 

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TupleSections         #-}
 -- | Perform a build
 module Stack.Build.Execute
@@ -1809,22 +1810,39 @@ singleTest topts testsToRun ac ee task installedMap = do
                 tixPath <- liftM (pkgDir </>) $ parseRelFile $ exeName ++ ".tix"
                 exePath <- liftM (buildDir </>) $ parseRelFile $ "build/" ++ testName' ++ "/" ++ exeName
                 exists <- doesFileExist exePath
+                -- doctest relies on template-haskell in QuickCheck-based tests
+                thGhcId <- case find ((== "template-haskell") . pkgName . dpPackageIdent. snd)
+                                (Map.toList $ eeGlobalDumpPkgs ee) of
+                  Just (ghcId, _) -> return ghcId
+                  Nothing -> error "template-haskell is a wired-in GHC boot library but it wasn't found"
                 packageIds <- forMaybeM (M.toList $ packageDeps package) $ \(name, dv) -> do
                     let pkgId = PackageIdentifier name nullVersion
                     case Map.lookupGT pkgId allDepsMap of
                         Just (PackageIdentifier name' version, ghcPkgId)
                             | name' == name && dvType dv == AsLibrary &&
                               version `withinRange` dvVersionRange dv ->
-                            return $ Just (unGhcPkgId ghcPkgId)
+                            return $ Just ghcPkgId
                         _ -> do
                             logWarn $ "Could not find GHC package id for dependency " <> fromString (packageNameString name)
                             return Nothing
-                -- env var HASKELL_PACKAGE_IDS is used by doctest so module names for
+                -- env variable GHC_ENVIRONMENT is set for doctest so module names for
                 -- packages with proper dependencies should no longer get ambiguous
                 -- see e.g. https://github.com/doctest/issues/119
-                let usePackageIds pc = modifyEnvVars pc $ \envVars ->
-                      Map.insert "HASKELL_PACKAGE_IDS" (T.unwords packageIds) envVars
-                menv <- liftIO $ usePackageIds =<< configProcessContextSettings config EnvSettings
+                let setEnv f pc = modifyEnvVars pc $ \envVars ->
+                      Map.insert "GHC_ENVIRONMENT" (T.pack f) envVars
+                    fp = toFilePath $ eeTempDir ee </> $(mkRelFile "test-ghc-env")
+                    snapDBPath = toFilePathNoTrailingSep (bcoSnapDB $ eeBaseConfigOpts ee)
+                    localDBPath = toFilePathNoTrailingSep (bcoLocalDB $ eeBaseConfigOpts ee)
+                    ghcEnv = mconcat $
+                        "clear-package-db\n" :
+                        "global-package-db\n" :
+                        "package-db " <> fromString snapDBPath <> "\n" :
+                        "package-db " <> fromString localDBPath <> "\n" :
+                        map (\ghcId -> "package-id " <> RIO.display (unGhcPkgId ghcId) <> "\n")
+                            (thGhcId:packageIds)
+                logInfo $  "package ids: " <> RIO.displayShow packageIds
+                writeFileUtf8Builder fp ghcEnv
+                menv <- liftIO $ setEnv fp =<< configProcessContextSettings config EnvSettings
                     { esIncludeLocals = taskLocation task == Local
                     , esIncludeGhcPackagePath = True
                     , esStackExe = True

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1833,12 +1833,12 @@ singleTest topts testsToRun ac ee task installedMap = do
                     fp = toFilePath $ eeTempDir ee </> $(mkRelFile "test-ghc-env")
                     snapDBPath = toFilePathNoTrailingSep (bcoSnapDB $ eeBaseConfigOpts ee)
                     localDBPath = toFilePathNoTrailingSep (bcoLocalDB $ eeBaseConfigOpts ee)
-                    ghcEnv = mconcat $
-                        "clear-package-db\n" :
-                        "global-package-db\n" :
-                        "package-db " <> fromString snapDBPath <> "\n" :
-                        "package-db " <> fromString localDBPath <> "\n" :
-                        map (\ghcId -> "package-id " <> RIO.display (unGhcPkgId ghcId) <> "\n")
+                    ghcEnv =
+                        "clear-package-db\n" <>
+                        "global-package-db\n" <>
+                        "package-db " <> fromString snapDBPath <> "\n" <>
+                        "package-db " <> fromString localDBPath <> "\n" <>
+                        foldMap (\ghcId -> "package-id " <> RIO.display (unGhcPkgId ghcId) <> "\n")
                             (thGhcId:packageIds)
                 logInfo $  "package ids: " <> RIO.displayShow packageIds
                 writeFileUtf8Builder fp ghcEnv


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Tested manually on an intermediate Stackage snapshot (`lens` vs `lenz` ambiguity in `language-nix` tests)
This overrides #4533 and makes  https://github.com/sol/doctest/pull/218 unnecessary
