### PR TITLE
Build GHC from source (#4567)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -55,6 +55,11 @@ Major changes:
   builds, this functionality is no longer useful. For an example, please see
   [Building Haskell Apps with
   Docker](https://www.fpcomplete.com/blog/2017/12/building-haskell-apps-with-docker).
+* Support building GHC from source (experimental)
+    * Stack now supports building and installing GHC from source. The built GHC
+      is uniquely identified by a commit id and an Hadrian "flavour" (Hadrian is
+      the newer GHC build system), hence `compiler` can be set to use a GHC
+      built from source with `ghc-git-COMMIT-FLAVOUR`
 
 Behavior changes:
 * `stack.yaml` now supports `snapshot`: a synonym for `resolver`. See [#4256](https://github.com/commercialhaskell/stack/issues/4256)

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -450,6 +450,80 @@ compiler: ghcjs-0.1.0.20150924_ghc-7.10.2
 compiler-check: match-exact
 ```
 
+#### Building GHC from source (experimental)
+
+(Since 2.0)
+
+Stack supports building the GHC compiler from source. The version to build and
+to use is defined by a a Git commit ID and an Hadrian "flavour" (Hadrian is the
+build system of GHC) with the following syntax:
+
+```yaml
+compiler: ghc-git-COMMIT-FLAVOUR
+```
+
+In the following example the commit ID is "5be7ad..." and the flavour is
+"quick":
+
+```yaml
+compiler: ghc-git-5be7ad7861c8d39f60b7101fd8d8e816ff50353a-quick
+```
+
+By default the code is retrieved from the main GHC repository. If you want to
+select another repository, set the "compiler-repository" option:
+
+```yaml
+compiler-repository: git://my/ghc/repository
+# default
+# compiler-repository: https://gitlab.haskell.org/ghc/ghc.git
+```
+
+Note that Stack doesn't check the compiler version when it uses a compiler built
+from source. Moreover it is assumed that the built compiler is recent enough as
+Stack doesn't enable any known workaround to make older compilers work.
+
+Building the compiler can take a very long time (more than one hour). Hint: for
+faster build times, use Hadrian flavours that disable documentation generation.
+
+#### Global packages
+
+The GHC compiler you build from sources may depend on unreleased versions of
+some global packages (e.g. Cabal). It may be an issue if a package you try to
+build with this compiler depends on such global packages because Stack may not
+be able to find versions of those packages (on Hackage, etc.) that are
+compatible with the compiler.
+
+The easiest way to deal with this issue is to drop the offending packages as
+follows. Instead of using the packages specified in the resolver, the global
+packages bundled with GHC will be used.
+
+```yaml
+drop-packages:
+- Cabal
+- ...
+```
+
+Another way to deal with this issue is to add the relevant packages as
+`extra-deps` built from source. To avoid mismatching versions, you can use
+exactly the same commit id you used to build GHC as follows:
+
+```
+extra-deps:
+- git: https://gitlab.haskell.org/ghc/ghc.git
+  commit: 5be7ad7861c8d39f60b7101fd8d8e816ff50353a
+  subdirs:
+    - libraries/Cabal/Cabal
+    - libraries/...
+```
+
+#### Bootstrapping compiler
+
+Building GHC from source requires a working GHC (known as the bootstrap
+compiler). As we use a Stack based version of Hadrian (`hadrian/build.stack.sh` in
+GHC sources), the bootstrap compiler is configured into `hadrian/stack.yaml` and
+fully managed by Stack.
+
+
 ### ghc-options
 
 (Since 0.1.4)

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -65,6 +65,7 @@ import           Stack.Build.Haddock (shouldHaddockDeps)
 import           Stack.Storage (initStorage)
 import           Stack.SourceMap
 import           Stack.Types.Build
+import           Stack.Types.Compiler
 import           Stack.Types.Config
 import           Stack.Types.Docker
 import           Stack.Types.Nix
@@ -207,6 +208,9 @@ configFromConfigMonoid
          configHideTHLoading = fromFirstTrue configMonoidHideTHLoading
 
          configGHCVariant = getFirst configMonoidGHCVariant
+         configCompilerRepository = fromFirst
+            defaultCompilerRepository
+            configMonoidCompilerRepository
          configGHCBuild = getFirst configMonoidGHCBuild
          configInstallGHC = fromFirstTrue configMonoidInstallGHC
          configSkipGHCCheck = fromFirstFalse configMonoidSkipGHCCheck

--- a/src/Stack/Config/Nix.hs
+++ b/src/Stack/Config/Nix.hs
@@ -75,6 +75,7 @@ nixCompiler compilerVersion =
             _ -> "haskell.compiler.ghc" <> T.concat (x : y : minor)
         _ -> Left $ stringException "GHC major version not specified"
     WCGhcjs{} -> Left $ stringException "Only GHC is supported by stack --nix"
+    WCGhcGit{} -> Left $ stringException "Only GHC is supported by stack --nix"
 
 -- Exceptions thown specifically by Stack.Nix
 data StackNixException

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -254,6 +254,8 @@ allExposedModules gpd = do
       checkCond (PD.Impl compiler range) = case curCompiler of
         ACGhc version ->
           pure $ compiler == GHC && version `withinRange` range
+        ACGhcGit {} ->
+          pure $ compiler == GHC
         ACGhcjs version _ghcVersion ->
           pure $ compiler == GHCJS && version `withinRange` range
       -- currently we don't do flag checking here

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -728,12 +728,6 @@ buildGhcFromSource getSetupInfo' installed (CompilerRepository url) commitId fla
          -- RIO.Process doesn't wrap process' "shell".
          -- Instead we use "proc" with the "sh" command
          proc "sh" hadrianArgs runProcess_
-           `catch` \(e :: ExitCodeException) -> do
-              let dispLBS = displayBytesUtf8 . BL8.toStrict
-              logDebug ("Hadrian failed with " <> displayShow (eceExitCode e))
-              logDebug ("stdout: " <> dispLBS (eceStdout e))
-              logDebug ("stderr: " <> dispLBS (eceStderr e))
-              throwM e
 
          -- find the bindist and install it
          bindistPath <- parseRelDir "_build/bindist"

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -39,17 +39,22 @@ import           RIO.Process
 data Tool
     = Tool PackageIdentifier -- ^ e.g. ghc-7.8.4, msys2-20150512
     | ToolGhcjs ActualCompiler -- ^ e.g. ghcjs-0.1.0_ghc-7.10.2
+    | ToolGhcGit !Text !Text   -- ^ e.g. ghc-git-COMMIT_ID-FLAVOUR
+    deriving (Eq)
 
 toolString :: Tool -> String
 toolString (Tool ident) = packageIdentifierString ident
 toolString (ToolGhcjs cv) = compilerVersionString cv
+toolString (ToolGhcGit commit flavour) = "ghc-git-" ++ T.unpack commit ++ "-" ++ T.unpack flavour
 
 toolNameString :: Tool -> String
 toolNameString (Tool ident) = packageNameString $ pkgName ident
 toolNameString ToolGhcjs{} = "ghcjs"
+toolNameString ToolGhcGit{} = "ghc-git"
 
 parseToolText :: Text -> Maybe Tool
 parseToolText (parseWantedCompiler -> Right (WCGhcjs x y)) = Just (ToolGhcjs (ACGhcjs x y))
+parseToolText (parseWantedCompiler -> Right (WCGhcGit c f)) = Just (ToolGhcGit c f)
 parseToolText (parsePackageIdentifier . T.unpack -> Just pkgId) = Just (Tool pkgId)
 parseToolText _ = Nothing
 

--- a/src/Stack/SetupCmd.hs
+++ b/src/Stack/SetupCmd.hs
@@ -105,6 +105,7 @@ setup SetupCmdOpts{..} wantedCompiler compilerCheck mstack = do
         }
     let compiler = case wantedCompiler of
             WCGhc _ -> "GHC"
+            WCGhcGit{} -> "GHC (built from source)"
             WCGhcjs {} -> "GHCJS"
     if sandboxedGhc
         then logInfo $ "stack will use a sandboxed " <> compiler <> " it installed"

--- a/src/Stack/Types/Compiler.hs
+++ b/src/Stack/Types/Compiler.hs
@@ -9,6 +9,8 @@
 module Stack.Types.Compiler
   ( ActualCompiler (..)
   , WhichCompiler (..)
+  , CompilerRepository (..)
+  , defaultCompilerRepository
   , getGhcVersion
   , whichCompiler
   , compilerVersionText
@@ -21,8 +23,10 @@ module Stack.Types.Compiler
 
 import           Data.Aeson
 import qualified Data.Text as T
+import           Data.Text (Text)
 import           Stack.Prelude
 import           Stack.Types.Version
+import           Distribution.Version (mkVersion)
 
 -- | Variety of compiler to use.
 data WhichCompiler
@@ -36,6 +40,7 @@ data WhichCompiler
 -- support compilers other than GHC.
 data ActualCompiler
     = ACGhc !Version
+    | ACGhcGit !Text !Text
     | ACGhcjs
         !Version -- GHCJS version
         !Version -- GHC version
@@ -44,6 +49,7 @@ instance NFData ActualCompiler
 instance Display ActualCompiler where
     display (ACGhc x) = display (WCGhc x)
     display (ACGhcjs x y) = display (WCGhcjs x y)
+    display (ACGhcGit x y) = display (WCGhcGit x y)
 instance ToJSON ActualCompiler where
     toJSON = toJSON . compilerVersionText
 instance FromJSON ActualCompiler where
@@ -58,10 +64,12 @@ instance FromJSONKey ActualCompiler where
 wantedToActual :: WantedCompiler -> ActualCompiler
 wantedToActual (WCGhc x) = ACGhc x
 wantedToActual (WCGhcjs x y) = ACGhcjs x y
+wantedToActual (WCGhcGit x y) = ACGhcGit x y
 
 actualToWanted :: ActualCompiler -> WantedCompiler
 actualToWanted (ACGhc x) = WCGhc x
 actualToWanted (ACGhcjs x y) = WCGhcjs x y
+actualToWanted (ACGhcGit x y) = WCGhcGit x y
 
 parseActualCompiler :: T.Text -> Either PantryException ActualCompiler
 parseActualCompiler = fmap wantedToActual . parseWantedCompiler
@@ -74,6 +82,7 @@ compilerVersionString = T.unpack . compilerVersionText
 
 whichCompiler :: ActualCompiler -> WhichCompiler
 whichCompiler ACGhc{} = Ghc
+whichCompiler ACGhcGit{} = Ghc
 whichCompiler ACGhcjs{} = Ghcjs
 
 isWantedCompiler :: VersionCheck -> WantedCompiler -> ActualCompiler -> Bool
@@ -81,8 +90,27 @@ isWantedCompiler check (WCGhc wanted) (ACGhc actual) =
     checkVersion check wanted actual
 isWantedCompiler check (WCGhcjs wanted wantedGhc) (ACGhcjs actual actualGhc) =
     checkVersion check wanted actual && checkVersion check wantedGhc actualGhc
+isWantedCompiler _check (WCGhcGit wCommit wFlavour) (ACGhcGit aCommit aFlavour) =
+    wCommit == aCommit && wFlavour == aFlavour
 isWantedCompiler _ _ _ = False
 
 getGhcVersion :: ActualCompiler -> Version
 getGhcVersion (ACGhc v) = v
 getGhcVersion (ACGhcjs _ v) = v
+getGhcVersion (ACGhcGit _ _) =
+   -- We can't return the actual version without running the installed ghc.
+   -- For now we assume that users of ghc-git use it with a recent commit so we
+   -- return a version far in the future. This disables our hacks for older
+   -- versions and passes version checking when we use newer features.
+   mkVersion [999,0,0]
+
+-- | Repository containing the compiler sources
+newtype CompilerRepository
+  = CompilerRepository Text
+  deriving (Show)
+
+instance FromJSON CompilerRepository where
+  parseJSON = withText "CompilerRepository" (return . CompilerRepository)
+
+defaultCompilerRepository :: CompilerRepository
+defaultCompilerRepository = CompilerRepository "https://gitlab.haskell.org/ghc/ghc.git"

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -295,6 +295,8 @@ data Config =
          -- ^ On Windows: don't use a sandboxed MSYS
          ,configCompilerCheck       :: !VersionCheck
          -- ^ Specifies which versions of the compiler are acceptable.
+         ,configCompilerRepository  :: !CompilerRepository
+         -- ^ Specifies the repository containing the compiler sources
          ,configLocalBin            :: !(Path Abs Dir)
          -- ^ Directory we should install executables into
          ,configRequireStackVersion :: !VersionRange
@@ -692,6 +694,8 @@ data ConfigMonoid =
     -- ^ See: 'configSkipMsys'
     ,configMonoidCompilerCheck       :: !(First VersionCheck)
     -- ^ See: 'configCompilerCheck'
+    ,configMonoidCompilerRepository  :: !(First CompilerRepository)
+    -- ^ See: 'configCompilerRepository'
     ,configMonoidRequireStackVersion :: !IntersectingVersionRange
     -- ^ See: 'configRequireStackVersion'
     ,configMonoidArch                :: !(First String)
@@ -824,6 +828,7 @@ parseConfigMonoidObject rootDir obj = do
           params <- tobj ..:? configMonoidTemplateParametersName
           return (First scmInit,fromMaybe M.empty params)
     configMonoidCompilerCheck <- First <$> obj ..:? configMonoidCompilerCheckName
+    configMonoidCompilerRepository <- First <$> (obj ..:? configMonoidCompilerRepositoryName)
 
     options <- Map.map unGhcOptions <$> obj ..:? configMonoidGhcOptionsName ..!= mempty
 
@@ -962,6 +967,9 @@ configMonoidTemplateParametersName = "params"
 
 configMonoidCompilerCheckName :: Text
 configMonoidCompilerCheckName = "compiler-check"
+
+configMonoidCompilerRepositoryName :: Text
+configMonoidCompilerRepositoryName = "compiler-repository"
 
 configMonoidGhcOptionsName :: Text
 configMonoidGhcOptionsName = "ghc-options"
@@ -1314,6 +1322,7 @@ compilerVersionDir = do
     parseRelDir $ case compilerVersion of
         ACGhc version -> versionString version
         ACGhcjs {} -> compilerVersionString compilerVersion
+        ACGhcGit {} -> compilerVersionString compilerVersion
 
 -- | Package database for installing dependencies into
 packageDatabaseDeps :: (HasEnvConfig env) => RIO env (Path Abs Dir)

--- a/subs/curator/src/Curator/Snapshot.hs
+++ b/subs/curator/src/Curator/Snapshot.hs
@@ -137,6 +137,7 @@ checkDependencyGraph constraints snapshot = do
     let compiler = rsCompiler snapshot
         compilerVer = case compiler of
           WCGhc v -> v
+          WCGhcGit {} -> error "GHC-GIT is not supported"
           WCGhcjs _ _ -> error "GHCJS is not supported"
     let snapshotPackages =
             Map.fromList

--- a/subs/pantry/src/Pantry.hs
+++ b/subs/pantry/src/Pantry.hs
@@ -63,6 +63,7 @@ module Pantry
     -- ** Repos
   , Repo (..)
   , RepoType (..)
+  , withRepo
 
     -- ** Package location
   , RawPackageLocation (..)

--- a/test/integration/lib/StackTest.hs
+++ b/test/integration/lib/StackTest.hs
@@ -290,4 +290,7 @@ superslow inner = do
     Just "SUPERSLOW" -> do
       logInfo "Running superslow test, hold on to your butts"
       inner
-    _ -> error $ "Invalid value for STACK_TEST_SPEED env var: " ++ show mres
+    Nothing -> do
+      logInfo "No STACK_TEST_SPEED specified. Executing superslow test, hold on to your butts"
+      inner
+    Just x -> error $ "Invalid value for STACK_TEST_SPEED env var: " ++ show x

--- a/test/integration/tests/build-ghc/Main.hs
+++ b/test/integration/tests/build-ghc/Main.hs
@@ -1,0 +1,28 @@
+import StackTest
+import System.Directory (withCurrentDirectory)
+
+main :: IO ()
+main = do
+    -- cleanup previous failing test...
+    removeDirIgnore "tmpPackage"
+
+    stack ["new", "--resolver=lts-13.11", "tmpPackage"]
+
+    -- use a commit which is known to succeed with hadrian binary-dist
+    let commitId = "33b0a291898b6a35d822fde59864c5c94a53d039"
+        flavour  = "quick"
+
+    withCurrentDirectory "tmpPackage" $ do
+       appendFile "stack.yaml" $ unlines
+         [ "compiler-repository: https://gitlab.haskell.org/ghc/ghc.git"
+         , "compiler: ghc-git-" ++ commitId ++ "-" ++ flavour
+         ]
+
+       -- Setup the package
+       stack ["setup"]
+
+       -- build it with the built GHC
+       stack ["build"]
+
+    -- cleanup
+    removeDirIgnore "tmpPackage"

--- a/test/integration/tests/build-ghc/Main.hs
+++ b/test/integration/tests/build-ghc/Main.hs
@@ -2,14 +2,14 @@ import StackTest
 import System.Directory (withCurrentDirectory)
 
 main :: IO ()
-main = do
+main = superslow $ do
     -- cleanup previous failing test...
     removeDirIgnore "tmpPackage"
 
     stack ["new", "--resolver=lts-13.11", "tmpPackage"]
 
     -- use a commit which is known to succeed with hadrian binary-dist
-    let commitId = "33b0a291898b6a35d822fde59864c5c94a53d039"
+    let commitId = "be0dde8e3c27ca56477d1d1801bb77621f3618e1"
         flavour  = "quick"
 
     withCurrentDirectory "tmpPackage" $ do


### PR DESCRIPTION
This patch adds the experimental support for building GHC from source. We can now specify a specific GHC to build from source in `stack.yaml` with the following syntax:

```
compiler-build:
   git: GHC_GIT_REPO
   commit: COMMIT
   flavour: FLAVOUR
```

In the setup phase Stack uses Hadrian to build a GHC binary distribution
with the specified flavour and installs it into
STACK_ROOT/programs/ARCH/ghc-git-COMMIT-FLAVOUR.

The built compiler can be used with the following configuration:

```
compiler: ghc-git-COMMIT-FLAVOUR
```

As GHC may rely on unreleased version of the global packages (e.g.
Cabal), you may have to add some extra-deps as follows:

```
extra-deps:
- git: GHC_GIT_REPO
  commit: COMMIT
  subdirs:
    - libraries/Cabal/Cabal
    - libraries/...
```

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.
* [X] A test has been added but it takes a long time to run as it builds GHC. [Also note that currently GHC head builds non-installable bindists, cf [GHC#16498](https://gitlab.haskell.org/ghc/ghc/issues/16498)]
