### PR TITLE
Remove incorrect Git repo documentation (fixes #4425)

### DIFF
--- a/doc/nonstandard_project_init.md
+++ b/doc/nonstandard_project_init.md
@@ -79,17 +79,11 @@ default so as to avoid unnecessary recompilation time.
   - https://github.com/commercialhaskell/stack/issues/464
 
 ## Using git Repositories
-stack has support for packages that reside in remote git locations.
 
-Example:
-
-```
-packages:
-- '.'
-- location:
-    git: https://github.com/kolmodin/binary
-    commit: 8debedd3fcb6525ac0d7de2dd49217dce2abc0d9
-```
+Stack has support for packages that reside in remote git locations. Please see
+the [YAML configuration
+documentation](yaml_configuration.md#git-and-mercurial-repos) for more
+information.
 
 ### Issues Referenced
   - https://github.com/commercialhaskell/stack/issues/254


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
