### PR TITLE
stack upgrade: Call getExecutablePath before overwriting ourself

### DIFF
--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -1957,12 +1957,16 @@ downloadStackExe platforms0 archiveInfo destDir checkPath testExe = do
 
     platform <- view platformL
 
+    -- We need to call getExecutablePath before we overwrite the
+    -- currently running binary: after that, Linux will append
+    -- (deleted) to the filename.
+    currExe <- liftIO getExecutablePath
+
     liftIO $ do
       setFileExecutable (toFilePath tmpFile)
 
       testExe tmpFile
 
-      currExe <- getExecutablePath
       case platform of
           Platform _ Cabal.Windows | FP.equalFilePath (toFilePath destFile) currExe -> do
               old <- parseAbsFile (toFilePath destFile ++ ".old")
@@ -1975,7 +1979,7 @@ downloadStackExe platforms0 archiveInfo destDir checkPath testExe = do
 
     logInfo $ "New stack executable available at " <> fromString (toFilePath destFile)
 
-    when checkPath $ performPathChecking destFile
+    when checkPath $ performPathChecking destFile currExe
       `catchAny` (logError . displayShow)
   where
 
@@ -2034,9 +2038,9 @@ downloadStackExe platforms0 archiveInfo destDir checkPath testExe = do
 performPathChecking
     :: HasConfig env
     => Path Abs File -- ^ location of the newly downloaded file
+    -> String -- ^ currently running executable
     -> RIO env ()
-performPathChecking newFile = do
-  executablePath <- liftIO getExecutablePath
+performPathChecking newFile executablePath = do
   executablePath' <- parseAbsFile executablePath
   unless (toFilePath newFile == executablePath) $ do
     logInfo $ "Also copying stack executable to " <> fromString executablePath


### PR DESCRIPTION
Fixes: #4462

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Tested with

```console
$ stack install
Copying from /home/anders/haskell/stack/.stack-work/install/x86_64-linux-tinfo6/custom-snapshot-for-building-stack-with-ghc-8.2.2-kf0nGp8fCCJ3/8.2.2/bin/curator to /home/anders/.local/bin/curator
Copying from /home/anders/haskell/stack/.stack-work/install/x86_64-linux-tinfo6/custom-snapshot-for-building-stack-with-ghc-8.2.2-kf0nGp8fCCJ3/8.2.2/bin/stack to /home/anders/.local/bin/stack

Copied executables to /home/anders/.local/bin:
- curator
- stack

$ stack upgrade --force-download --verbose
Version 1.10.0, Git revision fce9fe335b902776b683420ea2ee45461b0fd97c (6718 commits) x86_64 hpack-0.31.1
2019-03-26 00:03:26.077371: [info] Current Stack version: 1.10.0, available download version: 1.9.3
2019-03-26 00:03:26.077749: [info] Forcing binary upgrade
2019-03-26 00:03:26.077909: [info] Querying for archive location for platform: linux-x86_64-static
2019-03-26 00:03:26.078131: [info] Downloading from: https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64-static.tar.gz
2019-03-26 00:03:28.390036: [info] Download complete, testing executable
Version 1.9.3, Git revision 40cf7b37526b86d1676da82167ea8758a854953b (6211 commits) x86_64 hpack-0.31.1
2019-03-26 00:03:28.401838: [info] New stack executable available at /home/anders/.local/bin/stack

$ ls ~/.local/bin/stack*
/home/anders/.local/bin/stack
```
