### PR TITLE
Making the stack init and External Dependencies section clearer

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -549,6 +549,8 @@ stack init does quite a few things for you behind the scenes:
 Assuming it finds a match, it will write your `stack.yaml` file, and everything
 will work.
 
+(Note: yackage does not currently support hpack, but you can also hpack-convert should you need to generate a package.yaml).
+
 #### External Dependencies
 
 Given that LTS Haskell and Stackage Nightly have ~1400 of the most common
@@ -556,9 +558,9 @@ Haskell packages, this will often be enough to build most packages. However,
 at times, you may find that not all dependencies required may be available in
 the Stackage snapshots.
 
-Let's simulate an unsatisfied dependency by adding acme-missiles to the `.cabal` file
-(yackage does not currently support hpack, but you can also [hpack-convert](https://github.com/yamadapc/hpack-convert)
-should you need to generate a `package.yaml`) build-depends and then re-initing:
+Let's simulate an unsatisfied dependency by adding acme-missiles to the list of dependencies 
+the build requires. This is done by including it in the `Build-depends` section in the .cabal file 
+and then re-initing:
 
 ```
 cueball:~/yackage-0.8.0$ stack init --force


### PR DESCRIPTION
Changes include:

Moving the reference to hpack from the external dependencies section to the stack init section.

- Rationale: The section about adding acme-missiles is mainly about showing how to resolve external packages that is not found in the snapshots. Dropping the reference to hpack and packages.yml is out of place as that talks about the various files stack works with. Which is why I think moving it to the stack init section is more proper, as that section talks about initiating a project for stack usage.
Rework the section that talks about how to add acme-missile

- Rationale: The inclusion of hpack and how the sentence was structured did not make the instruction to update the build-depends section clear. The build-depends was also not highlighted, hence not making it super obvious it is a special term found in the cabal file. The rework sought to remedy these two issues.

Checklist items:

- Changes are purely textual, hence including it ChangeLog.md is not necessary.
- Changes are purely textual, hence no tests required.