### PR TITLE
Hackage creds are read-only (fixes #2159)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -196,6 +196,8 @@ Bug fixes:
 - Fix detection of aarch64 platform (this broke when we upgraded to a newer Cabal version).
 - Docker: fix detecting and pulling missing images with `--docker-auto-pull`, see
   [#4598](https://github.com/commercialhaskell/stack/issues/4598)
+* Hackage credentials are not world-readable. See
+  [#2159](https://github.com/commercialhaskell/stack/issues/2159).
 
 ## v1.9.3
 

--- a/src/test/Stack/UploadSpec.hs
+++ b/src/test/Stack/UploadSpec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Stack.UploadSpec (spec) where
+
+import RIO
+import RIO.Directory
+import RIO.FilePath ((</>))
+import Stack.Upload
+import Test.Hspec
+import System.Permissions (osIsWindows)
+import System.PosixCompat.Files (getFileStatus, fileMode)
+import Data.Bits ((.&.))
+
+spec :: Spec
+spec = do
+  it "writeFilePrivate" $ example $ withSystemTempDirectory "writeFilePrivate" $ \dir -> replicateM_ 2 $ do
+    let fp = dir </> "filename"
+        contents :: IsString s => s
+        contents = "These are the contents"
+    writeFilePrivate fp contents
+    actual <- readFileBinary fp
+    actual `shouldBe` contents
+    perms <- getPermissions fp
+    perms `shouldBe` setOwnerWritable True (setOwnerReadable True emptyPermissions)
+
+    unless osIsWindows $ do
+      status <- getFileStatus fp
+      (fileMode status .&. 0o777) `shouldBe` 0o600


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
