### PR TITLE
Enable docker-auto-pull by default (fixes #3332)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -256,6 +256,8 @@ Behavior changes:
   download a template, stack will check whether that template had
   been downloaded before. In that case, the cached version will be
   used. See [#3850](https://github.com/commercialhaskell/stack/issues/3850).
+* The new default for `--docker-auto-pull` is enabled. See
+  [#3332](https://github.com/commercialhaskell/stack/issues/3332).
 
 Other enhancements:
 

--- a/doc/docker_integration.md
+++ b/doc/docker_integration.md
@@ -199,7 +199,7 @@ otherwise noted.
       # If true, the image will be pulled from the registry automatically, without
       # needing to run `stack docker pull`.  See the "security" section of this
       # document for implications of enabling this.
-      auto-pull: false
+      auto-pull: true
 
       # If true, the container will be run "detached" (in the background).  Refer
       # to the Docker users guide for information about how to manage containers.

--- a/src/Stack/Config/Docker.hs
+++ b/src/Stack/Config/Docker.hs
@@ -69,7 +69,7 @@ dockerOptsFromMonoid mproject stackRoot maresolver DockerOptsMonoid{..} = do
                 dockerMonoidRegistryLogin
         dockerRegistryUsername = emptyToNothing (getFirst dockerMonoidRegistryUsername)
         dockerRegistryPassword = emptyToNothing (getFirst dockerMonoidRegistryPassword)
-        dockerAutoPull = fromFirstFalse dockerMonoidAutoPull
+        dockerAutoPull = fromFirstTrue dockerMonoidAutoPull
         dockerDetach = fromFirstFalse dockerMonoidDetach
         dockerPersist = fromFirstFalse dockerMonoidPersist
         dockerContainerName = emptyToNothing (getFirst dockerMonoidContainerName)

--- a/src/Stack/Options/DockerParser.hs
+++ b/src/Stack/Options/DockerParser.hs
@@ -46,7 +46,7 @@ dockerOptsParser hide0 =
                         hide <>
                         metavar "PASSWORD" <>
                         help "Docker registry password")
-    <*> firstBoolFlagsFalse
+    <*> firstBoolFlagsTrue
                        (dockerOptName dockerAutoPullArgName)
                        "automatic pulling latest version of image"
                        hide

--- a/src/Stack/Types/Docker.hs
+++ b/src/Stack/Types/Docker.hs
@@ -75,7 +75,7 @@ data DockerOptsMonoid = DockerOptsMonoid
     -- ^ Optional username for Docker registry.
   ,dockerMonoidRegistryPassword :: !(First String)
     -- ^ Optional password for Docker registry.
-  ,dockerMonoidAutoPull :: !FirstFalse
+  ,dockerMonoidAutoPull :: !FirstTrue
     -- ^ Automatically pull new images.
   ,dockerMonoidDetach :: !FirstFalse
     -- ^ Whether to run a detached container
@@ -114,7 +114,7 @@ instance FromJSON (WithJSONWarnings DockerOptsMonoid) where
               dockerMonoidRegistryLogin    <- First <$> o ..:? dockerRegistryLoginArgName
               dockerMonoidRegistryUsername <- First <$> o ..:? dockerRegistryUsernameArgName
               dockerMonoidRegistryPassword <- First <$> o ..:? dockerRegistryPasswordArgName
-              dockerMonoidAutoPull         <- FirstFalse <$> o ..:? dockerAutoPullArgName
+              dockerMonoidAutoPull         <- FirstTrue <$> o ..:? dockerAutoPullArgName
               dockerMonoidDetach           <- FirstFalse <$> o ..:? dockerDetachArgName
               dockerMonoidPersist          <- FirstFalse <$> o ..:? dockerPersistArgName
               dockerMonoidContainerName    <- First <$> o ..:? dockerContainerNameArgName


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
