### PR TITLE
Find GHC on PATH via version suffixes (fixes #2433)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -149,6 +149,10 @@ Other enhancements:
 * Warn when a Docker image does not include a `PATH` environment
   variable. See
   [#2472](https://github.com/commercialhaskell/stack/issues/2742)
+* When using `system-ghc: true`, Stack will now find the appropriate GHC
+  installation based on the version suffix, allowing you to more easily switch
+  between various system-installed GHCs. See
+  [#2433](https://github.com/commercialhaskell/stack/issues/2433).
 
 Bug fixes:
 

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -147,7 +147,8 @@ instance HasProcessContext Ctx where
 instance HasBuildConfig Ctx
 instance HasSourceMap Ctx where
     sourceMapL = envConfigL.sourceMapL
-instance HasCompiler Ctx
+instance HasCompiler Ctx where
+    compilerPathsL = envConfigL.compilerPathsL
 instance HasEnvConfig Ctx where
     envConfigL = lens ctxEnvConfig (\x y -> x { ctxEnvConfig = y })
 

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -205,8 +205,6 @@ data ExecuteEnv = ExecuteEnv
     , eeSnapshotDumpPkgs :: !(TVar (Map GhcPkgId DumpPackage))
     , eeLocalDumpPkgs  :: !(TVar (Map GhcPkgId DumpPackage))
     , eeLogFiles       :: !(TChan (Path Abs Dir, Path Abs File))
-    , eeGetGhcPath     :: !(forall m. MonadIO m => m (Path Abs File))
-    , eeGetGhcjsPath   :: !(forall m. MonadIO m => m (Path Abs File))
     , eeCustomBuilt    :: !(IORef (Set PackageName))
     -- ^ Stores which packages with custom-setup have already had their
     -- Setup.hs built.
@@ -290,11 +288,11 @@ getSetupExe setupHs setupShimHs tmpdir = do
                     , toFilePath tmpOutputPath
                     ] ++
                     ["-build-runner" | wc == Ghcjs]
-            withWorkingDir (toFilePath tmpdir) (proc (compilerExeName wc) args $ \pc0 -> do
+            compilerPath <- getCompilerPath
+            withWorkingDir (toFilePath tmpdir) (proc (toFilePath compilerPath) args $ \pc0 -> do
               let pc = setStdout (useHandleOpen stderr) pc0
               runProcess_ pc)
-                `catch` \ece -> do
-                    compilerPath <- getCompilerPath wc
+                `catch` \ece ->
                     throwM $ SetupHsBuildFailure (eceExitCode ece) Nothing compilerPath args Nothing []
             when (wc == Ghcjs) $ renameDir tmpJsExePath jsExePath
             renameFile tmpExePath exePath
@@ -318,8 +316,6 @@ withExecuteEnv bopts boptsCli baseConfigOpts locals globalPackages snapshotPacka
         idMap <- liftIO $ newTVarIO Map.empty
         config <- view configL
 
-        getGhcPath <- memoizeRef $ getCompilerPath Ghc
-        getGhcjsPath <- memoizeRef $ getCompilerPath Ghcjs
         customBuiltRef <- newIORef Set.empty
 
         -- Create files for simple setup and setup shim, if necessary
@@ -338,7 +334,7 @@ withExecuteEnv bopts boptsCli baseConfigOpts locals globalPackages snapshotPacka
         setupExe <- getSetupExe setupHs setupShimHs tmpdir
 
         cabalPkgVer <- view cabalVersionL
-        globalDB <- getGlobalDB =<< view (actualCompilerVersionL.whichCompilerL)
+        globalDB <- cpGlobalDB
         snapshotPackagesTVar <- liftIO $ newTVarIO (toDumpPackagesByGhcPkgId snapshotPackages)
         localPackagesTVar <- liftIO $ newTVarIO (toDumpPackagesByGhcPkgId localPackages)
         logFilesTChan <- liftIO $ atomically newTChan
@@ -366,8 +362,6 @@ withExecuteEnv bopts boptsCli baseConfigOpts locals globalPackages snapshotPacka
             , eeSnapshotDumpPkgs = snapshotPackagesTVar
             , eeLocalDumpPkgs = localPackagesTVar
             , eeLogFiles = logFilesTChan
-            , eeGetGhcPath = runMemoized getGhcPath
-            , eeGetGhcjsPath = runMemoized getGhcjsPath
             , eeCustomBuilt = customBuiltRef
             } `finally` dumpLogs logFilesTChan totalWanted
   where
@@ -581,7 +575,6 @@ executePlan' :: HasEnvConfig env
 executePlan' installedMap0 targets plan ee@ExecuteEnv {..} = do
     when (toCoverage $ boptsTestOpts eeBuildOpts) deleteHpcReports
     cv <- view actualCompilerVersionL
-    let wc = view whichCompilerL cv
     case nonEmpty . Map.toList $ planUnregisterLocal plan of
         Nothing -> return ()
         Just ids -> do
@@ -636,9 +629,9 @@ executePlan' installedMap0 targets plan ee@ExecuteEnv {..} = do
     when (boptsHaddock eeBuildOpts) $ do
         snapshotDumpPkgs <- liftIO (readTVarIO eeSnapshotDumpPkgs)
         localDumpPkgs <- liftIO (readTVarIO eeLocalDumpPkgs)
-        generateLocalHaddockIndex wc eeBaseConfigOpts localDumpPkgs eeLocals
-        generateDepsHaddockIndex wc eeBaseConfigOpts eeGlobalDumpPkgs snapshotDumpPkgs localDumpPkgs eeLocals
-        generateSnapHaddockIndex wc eeBaseConfigOpts eeGlobalDumpPkgs snapshotDumpPkgs
+        generateLocalHaddockIndex eeBaseConfigOpts localDumpPkgs eeLocals
+        generateDepsHaddockIndex eeBaseConfigOpts eeGlobalDumpPkgs snapshotDumpPkgs localDumpPkgs eeLocals
+        generateSnapHaddockIndex eeBaseConfigOpts eeGlobalDumpPkgs snapshotDumpPkgs
         when (boptsOpenHaddocks eeBuildOpts) $ do
             let planPkgs, localPkgs, installedPkgs, availablePkgs
                     :: Map PackageName (PackageIdentifier, InstallLocation)
@@ -663,7 +656,6 @@ unregisterPackages ::
     -> NonEmpty (GhcPkgId, (PackageIdentifier, Text))
     -> RIO env ()
 unregisterPackages cv localDB ids = do
-    let wc = view whichCompilerL cv
     let logReason ident reason =
             logInfo $
             fromString (packageIdentifierString ident) <> ": unregistering" <>
@@ -672,7 +664,7 @@ unregisterPackages cv localDB ids = do
                 else " (" <> RIO.display reason <> ")"
     let unregisterSinglePkg select (gid, (ident, reason)) = do
             logReason ident reason
-            unregisterGhcPkgIds wc localDB $ select ident gid :| []
+            unregisterGhcPkgIds localDB $ select ident gid :| []
 
     case cv of
         -- GHC versions >= 8.0.1 support batch unregistering of packages. See
@@ -691,7 +683,7 @@ unregisterPackages cv localDB ids = do
                 let chunksOfNE size = mapMaybe nonEmpty . chunksOf size . NonEmpty.toList
                 for_ (chunksOfNE batchSize ids) $ \batch -> do
                     for_ batch $ \(_, (ident, reason)) -> logReason ident reason
-                    unregisterGhcPkgIds wc localDB $ fmap (Right . fst) batch
+                    unregisterGhcPkgIds localDB $ fmap (Right . fst) batch
 
         -- GHC versions >= 7.9 support unregistering of packages via their
         -- GhcPkgId.
@@ -862,10 +854,14 @@ ensureConfig newConfigCache pkgDir ExecuteEnv {..} announce cabal cabalfp task =
     when needConfig $ withMVar eeConfigureLock $ \_ -> do
         deleteCaches pkgDir
         announce
+        cp <- view compilerPathsL
         let programNames =
-                if eeCabalPkgVer < mkVersion [1, 22]
-                    then ["ghc", "ghc-pkg"]
-                    else ["ghc", "ghc-pkg", "ghcjs", "ghcjs-pkg"]
+              case cpWhich cp of
+                Ghc ->
+                  [ "--with-ghc=" ++ toFilePath (cpCompiler cp)
+                  , "--with-ghc-pkg=" ++ toFilePath (cpPkg cp)
+                  ]
+                Ghcjs -> []
         exes <- forM programNames $ \name -> do
             mpath <- findExecutable name
             return $ case mpath of
@@ -1226,10 +1222,7 @@ withSingleContext ActionContext {..} ExecuteEnv {..} task@Task {..} mdeps msuffi
                         else do
                             ensureDir setupDir
                             compiler <- view $ actualCompilerVersionL.whichCompilerL
-                            compilerPath <-
-                                case compiler of
-                                    Ghc -> eeGetGhcPath
-                                    Ghcjs -> eeGetGhcjsPath
+                            compilerPath <- view $ compilerPathsL.to cpCompiler
                             packageArgs <- getPackageArgs setupDir
                             runExe compilerPath $
                                 [ "--make"
@@ -1406,7 +1399,7 @@ singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} installedMap
                       (T.pack $ toFilePathNoTrailingSep $ bcoSnapDB eeBaseConfigOpts)
 
                 withModifyEnvVars modifyEnv $ do
-                  let ghcPkgExe = ghcPkgExeName wc
+                  ghcPkgExe <- view $ compilerPathsL.to cpPkg.to toFilePath
 
                   -- first unregister everything that needs to be unregistered
                   forM_ allToUnregister $ \packageName -> catchAny
@@ -1431,7 +1424,7 @@ singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} installedMap
         case mlib of
             Nothing -> return $ Just $ Executable taskProvides
             Just _ -> do
-                mpkgid <- loadInstalledPkg wc pkgDbs eeSnapshotDumpPkgs pname
+                mpkgid <- loadInstalledPkg pkgDbs eeSnapshotDumpPkgs pname
 
                 return $ Just $
                     case mpkgid of
@@ -1640,9 +1633,9 @@ singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} installedMap
                     let sublibName = T.concat ["z-", T.pack $ packageNameString $ packageName package, "-z-", sublib]
                     case parsePackageName $ T.unpack sublibName of
                       Nothing -> return Nothing -- invalid lib, ignored
-                      Just subLibName -> loadInstalledPkg wc [installedPkgDb] installedDumpPkgsTVar subLibName
+                      Just subLibName -> loadInstalledPkg [installedPkgDb] installedDumpPkgsTVar subLibName
 
-                mpkgid <- loadInstalledPkg wc [installedPkgDb] installedDumpPkgsTVar (packageName package)
+                mpkgid <- loadInstalledPkg [installedPkgDb] installedDumpPkgsTVar (packageName package)
                 case mpkgid of
                     Nothing -> throwM $ Couldn'tFindPkgId $ packageName package
                     Just pkgid -> return (Library ident pkgid Nothing, sublibsPkgIds)
@@ -1671,8 +1664,8 @@ singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} installedMap
 
         return mpkgid
 
-    loadInstalledPkg wc pkgDbs tvar name = do
-        dps <- ghcPkgDescribe name wc pkgDbs $ conduitDumpPackage .| CL.consume
+    loadInstalledPkg pkgDbs tvar name = do
+        dps <- ghcPkgDescribe name pkgDbs $ conduitDumpPackage .| CL.consume
         case dps of
             [] -> return Nothing
             [dp] -> do

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -117,7 +117,7 @@ loadDatabase :: HasEnvConfig env
              -> RIO env ([LoadHelper], [DumpPackage])
 loadDatabase installMap mdb lhs0 = do
     wc <- view $ actualCompilerVersionL.to whichCompiler
-    (lhs1', dps) <- ghcPkgDump wc (fmap snd (maybeToList mdb))
+    (lhs1', dps) <- ghcPkgDump (fmap snd (maybeToList mdb))
                 $ conduitDumpPackage .| sink
     let ghcjsHack = wc == Ghcjs && isNothing mdb
     lhs1 <- mapMaybeM (processLoadResult mdb ghcjsHack) lhs1'

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -35,7 +35,6 @@ import              Stack.Build.Target
 import              Stack.Package
 import              Stack.SourceMap
 import              Stack.Types.Build
-import              Stack.Types.Compiler (whichCompiler)
 import              Stack.Types.Config
 import              Stack.Types.NamedComponent
 import              Stack.Types.Package
@@ -142,9 +141,8 @@ hashSourceMapData
     -> SourceMap
     -> RIO env SourceMapHash
 hashSourceMapData boptsCli sm = do
-    let wc = whichCompiler $ smCompiler sm
-    compilerPath <- getUtf8Builder . fromString . toFilePath <$> getCompilerPath wc
-    compilerInfo <- getCompilerInfo wc
+    compilerPath <- getUtf8Builder . fromString . toFilePath <$> getCompilerPath
+    compilerInfo <- getCompilerInfo
     immDeps <- forM (Map.elems (smDeps sm)) depPackageHashableContent
     bc <- view buildConfigL
     let -- extra bytestring specifying GHC options supposed to be applied to

--- a/src/Stack/SetupCmd.hs
+++ b/src/Stack/SetupCmd.hs
@@ -88,7 +88,7 @@ setup
     -> RIO env ()
 setup SetupCmdOpts{..} wantedCompiler compilerCheck mstack = do
     Config{..} <- view configL
-    (_, _, sandboxedGhc) <- ensureCompiler SetupOpts
+    sandboxedGhc <- cpSandboxed <$> ensureCompiler SetupOpts
         { soptsInstallIfMissing = True
         , soptsUseSystem = configSystemGHC && not scoForceReinstall
         , soptsWantedCompiler = wantedCompiler

--- a/src/Stack/Snapshot.hs
+++ b/src/Stack/Snapshot.hs
@@ -414,7 +414,7 @@ loadCompiler :: forall env.
              => ActualCompiler
              -> RIO env LoadedSnapshot
 loadCompiler cv = do
-  m <- ghcPkgDump (whichCompiler cv) []
+  m <- ghcPkgDump []
     (conduitDumpPackage .| CL.foldMap (\dp -> Map.singleton (dpGhcPkgId dp) dp))
   return LoadedSnapshot
     { lsCompilerVersion = cv

--- a/src/Stack/Types/Compiler.hs
+++ b/src/Stack/Types/Compiler.hs
@@ -11,10 +11,8 @@ module Stack.Types.Compiler
   , WhichCompiler (..)
   , getGhcVersion
   , whichCompiler
-  , compilerExeName
   , compilerVersionText
   , compilerVersionString
-  , haddockExeName
   , isWantedCompiler
   , wantedToActual
   , actualToWanted
@@ -89,11 +87,3 @@ isWantedCompiler _ _ _ = False
 getGhcVersion :: ActualCompiler -> Version
 getGhcVersion (ACGhc v) = v
 getGhcVersion (ACGhcjs _ v) = v
-
-compilerExeName :: WhichCompiler -> String
-compilerExeName Ghc = "ghc"
-compilerExeName Ghcjs = "ghcjs"
-
-haddockExeName :: WhichCompiler -> String
-haddockExeName Ghc = "haddock"
-haddockExeName Ghcjs = "haddock-ghcjs"

--- a/test/integration/tests/2433-ghc-by-version/Main.hs
+++ b/test/integration/tests/2433-ghc-by-version/Main.hs
@@ -1,0 +1,5 @@
+import System.Process (rawSystem)
+import Control.Exception (throwIO)
+
+main :: IO ()
+main = rawSystem "./run.sh" [] >>= throwIO

--- a/test/integration/tests/2433-ghc-by-version/files/.gitignore
+++ b/test/integration/tests/2433-ghc-by-version/files/.gitignore
@@ -1,0 +1,1 @@
+/fake-root/

--- a/test/integration/tests/2433-ghc-by-version/files/fake-path/ghc
+++ b/test/integration/tests/2433-ghc-by-version/files/fake-path/ghc
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo I should not be used!
+exit 1

--- a/test/integration/tests/2433-ghc-by-version/files/fake-path/ghc-pkg
+++ b/test/integration/tests/2433-ghc-by-version/files/fake-path/ghc-pkg
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo I should not be used!
+exit 1

--- a/test/integration/tests/2433-ghc-by-version/files/foo.hs
+++ b/test/integration/tests/2433-ghc-by-version/files/foo.hs
@@ -1,0 +1,1 @@
+main = putStrLn "Looks like everything is working!"

--- a/test/integration/tests/2433-ghc-by-version/files/run.sh
+++ b/test/integration/tests/2433-ghc-by-version/files/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+export PATH=$(pwd)/fake-path:$($STACK_EXE path --resolver ghc-8.2.2 --compiler-bin):$($STACK_EXE path --resolver ghc-8.4.4 --compiler-bin):$PATH
+export STACK_ROOT=$(pwd)/fake-root
+
+which ghc
+
+$STACK_EXE --system-ghc --no-install-ghc --resolver ghc-8.2.2 ghc -- --info
+$STACK_EXE --system-ghc --no-install-ghc --resolver ghc-8.4.4 ghc -- --info
+
+$STACK_EXE --system-ghc --no-install-ghc --resolver ghc-8.2.2 runghc foo.hs


### PR DESCRIPTION
If you enable system-ghc, and have multiple versions of GHC available,
Stack will now find the appropriate one based on the version-suffixed
name.

Note: the code in Stack.Setup is _really_ difficult to follow at this
point. This PR makes the situation a bit worse, to avoid making this
diff larger than it has to be. A later PR to clean up Stack.Setup would
be a great idea.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
