### PR TITLE
stack init works for internal libs (fixes #4408)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -218,6 +218,8 @@ Bug fixes:
   [#2159](https://github.com/commercialhaskell/stack/issues/2159).
 * Warnings are dumped from logs even when color is enabled. See
   [#2997](https://github.com/commercialhaskell/stack/issues/2997)
+* `stack init` will now work for cabal files with sublibraries. See
+  [#4408](https://github.com/commercialhaskell/stack/issues/4408)
 
 ## v1.9.3
 

--- a/test/integration/tests/4408-init-internal-libs/Main.hs
+++ b/test/integration/tests/4408-init-internal-libs/Main.hs
@@ -1,0 +1,4 @@
+import StackTest
+
+main :: IO ()
+main = stack ["init", "--resolver", "ghc-8.2.2", "--force"]

--- a/test/integration/tests/4408-init-internal-libs/files/.gitignore
+++ b/test/integration/tests/4408-init-internal-libs/files/.gitignore
@@ -1,0 +1,1 @@
+stack.yaml

--- a/test/integration/tests/4408-init-internal-libs/files/foo.cabal
+++ b/test/integration/tests/4408-init-internal-libs/files/foo.cabal
@@ -1,0 +1,15 @@
+cabal-version: 2.0
+name:          foo
+version:       0
+build-type:    Simple
+
+library
+  hs-source-dirs:      src
+  build-depends:       base, some-internal-lib
+  default-language:    Haskell2010
+
+library some-internal-lib
+  hs-source-dirs:      src-internal
+  exposed-modules:     Internal
+  build-depends:       base
+  default-language:    Haskell2010


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
