### PR TITLE
Fix typo that prevents flags from being enabled

### DIFF
--- a/src/Options/Applicative/Builder/Extra.hs
+++ b/src/Options/Applicative/Builder/Extra.hs
@@ -82,7 +82,7 @@ firstBoolFlagsTrue name helpSuffix =
 -- | Flag with a Semigroup instance and a default of False
 firstBoolFlagsFalse :: String -> String -> Mod FlagFields FirstFalse -> Parser FirstFalse
 firstBoolFlagsFalse name helpSuffix =
-  enableDisableFlags mempty (FirstFalse (Just False)) (FirstFalse (Just False))
+  enableDisableFlags mempty (FirstFalse (Just True)) (FirstFalse (Just False))
   name $ helpSuffix ++ " (default: disabled)"
 
 -- | Enable/disable flags for any type.

--- a/test/integration/tests/copy-bins-works/Main.hs
+++ b/test/integration/tests/copy-bins-works/Main.hs
@@ -1,0 +1,14 @@
+import StackTest
+import System.Directory
+import Control.Monad (unless)
+
+main :: IO ()
+main = do
+  let test args = do
+        removeDirIgnore "bin"
+        stack ["clean", "--full"]
+        stack args
+        exists <- doesDirectoryExist "bin"
+        unless exists $ error $ "Failed with: " ++ show args
+  test ["install", "--local-bin-path", "bin"]
+  test ["build", "--copy-bins", "--local-bin-path", "bin"]

--- a/test/integration/tests/copy-bins-works/files/package.yaml
+++ b/test/integration/tests/copy-bins-works/files/package.yaml
@@ -1,0 +1,9 @@
+name: foo
+version: 0
+
+executables:
+  bar:
+    source-dirs: src
+    main: Main.hs
+    dependencies:
+    - base

--- a/test/integration/tests/copy-bins-works/files/src/Main.hs
+++ b/test/integration/tests/copy-bins-works/files/src/Main.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = pure ()

--- a/test/integration/tests/copy-bins-works/files/stack.yaml
+++ b/test/integration/tests/copy-bins-works/files/stack.yaml
@@ -1,0 +1,2 @@
+resolver: ghc-8.2.2
+copy-bins: true


### PR DESCRIPTION
Discovered with --copy-bins, so I wrote the test based on that.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
