### PR TITLE
Remove the --plain option for the exec family

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -76,6 +76,8 @@ Behavior changes:
   never been used yet, and there are no plans to implement signature
   verification.
 
+* Remove the `--plain` option for the `exec` family of commands
+
 Other enhancements:
 
 * Defer loading up of files for local packages. This allows us to get

--- a/doc/docker_integration.md
+++ b/doc/docker_integration.md
@@ -347,7 +347,7 @@ and publish port 3000.
 If you do want to do all your work, including editing, in the container, it
 might be better to use a persistent container in which you can install Ubuntu
 packages. You could get that by running something like
-`stack --docker-container-name=NAME --docker-persist exec --plain bash`. This
+`stack --docker-container-name=NAME --docker-persist exec bash`. This
 means when the container exits, it won't be deleted. You can then restart it
 using `docker start -a -i NAME`. It's also possible to detach from a container
 while it continues running in the background using by pressing Ctrl-P Ctrl-Q,

--- a/src/Stack/Options/ExecParser.hs
+++ b/src/Stack/Options/ExecParser.hs
@@ -39,8 +39,7 @@ evalOptsParser meta =
 
 -- | Parser for extra options to exec command
 execOptsExtraParser :: Parser ExecOptsExtra
-execOptsExtraParser = eoPlainParser <|>
-                      ExecOptsEmbellished
+execOptsExtraParser = ExecOptsExtra
                          <$> eoEnvSettingsParser
                          <*> eoPackagesParser
                          <*> eoRtsOptionsParser
@@ -68,11 +67,6 @@ execOptsExtraParser = eoPlainParser <|>
         ( long "rts-options"
         <> help "Explicit RTS options to pass to application"
         <> metavar "RTSFLAG"))
-
-    eoPlainParser :: Parser ExecOptsExtra
-    eoPlainParser = flag' ExecOptsPlain
-                          (long "plain" <>
-                           help "Use an unmodified environment (only useful with Docker)")
 
     eoCwdParser :: Parser (Maybe FilePath)
     eoCwdParser = optional

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -429,15 +429,13 @@ data SpecialExecCmd
     | ExecRunGhc
     deriving (Show, Eq)
 
-data ExecOptsExtra
-    = ExecOptsPlain
-    | ExecOptsEmbellished
-        { eoEnvSettings :: !EnvSettings
-        , eoPackages :: ![String]
-        , eoRtsOptions :: ![String]
-        , eoCwd :: !(Maybe FilePath)
-        }
-    deriving (Show)
+data ExecOptsExtra = ExecOptsExtra
+  { eoEnvSettings :: !EnvSettings
+  , eoPackages :: ![String]
+  , eoRtsOptions :: ![String]
+  , eoCwd :: !(Maybe FilePath)
+  }
+  deriving (Show)
 
 data EvalOpts = EvalOpts
     { evalArg :: !String


### PR DESCRIPTION
Perhaps the purpose for `--plain` was lost over time with refactorings, but I haven't been able to understand from the codebase what the flag is supposed to be doing.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
