### PR TITLE
Allow empty stack init (fixes #2465)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -168,6 +168,8 @@ Other enhancements:
   installation based on the version suffix, allowing you to more easily switch
   between various system-installed GHCs. See
   [#2433](https://github.com/commercialhaskell/stack/issues/2433).
+* `stack init` will now support create a `stack.yaml` file without any local
+  packages. See [#2465](https://github.com/commercialhaskell/stack/issues/2465)
 
 Bug fixes:
 

--- a/test/integration/tests/2465-init-no-packages/Main.hs
+++ b/test/integration/tests/2465-init-no-packages/Main.hs
@@ -1,0 +1,11 @@
+import StackTest
+import System.Directory
+import Control.Monad (unless)
+
+main :: IO ()
+main = do
+  removeFileIgnore "stack.yaml"
+  stack ["init"]
+  exists <- doesFileExist "stack.yaml"
+  unless exists $ error "stack.yaml not created!"
+  stack ["build"]

--- a/test/integration/tests/2465-init-no-packages/files/.gitignore
+++ b/test/integration/tests/2465-init-no-packages/files/.gitignore
@@ -1,0 +1,1 @@
+stack.yaml


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
