### PR TITLE
Take a write lock before using Pantry database #4471

### DIFF
--- a/snapshot-lts-12.yaml
+++ b/snapshot-lts-12.yaml
@@ -8,3 +8,5 @@ packages:
 - infer-license-0.2.0@rev:0 #for hpack-0.31
 - tar-conduit-0.3.1@rev:0
 - yaml-0.10.4.0@rev:0 #for hpack-0.31
+- persistent-2.9.2@rev:0
+- persistent-sqlite-2.9.3@rev:0

--- a/snapshot-nightly.yaml
+++ b/snapshot-nightly.yaml
@@ -1,2 +1,6 @@
 resolver: nightly-2018-12-01
 name: snapshot-for-building-stack-with-ghc-8.6.2
+
+packages:
+- persistent-2.9.2@rev:0
+- persistent-sqlite-2.9.3@rev:0

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -9,7 +9,6 @@ packages:
 - hpack-0.31.1@rev:0
 - githash-0.1.3.0@rev:0
 - rio-orphans-0.1.1.0@sha256:15600084c56ef4e1f22ac2091d10fa6ed62f01f531d819c6a5a19492212a76c9
-- persistent-sqlite-2.8.2@sha256:6874958eb2943c4567c30bc0069ce4868b2813c490402c22bb2e0efa5b4c4c71,3873
 - yaml-0.10.4.0@rev:0 #for hpack-0.31
 - tar-conduit-0.3.0@sha256:c220b7a74b986445d08706aed77f17f82807d0133a5f3a760f53d587d20865b2,2928
 - hackage-security-0.5.3.0@rev:2
@@ -19,6 +18,8 @@ packages:
 - happy-1.19.9@sha256:f8c774230735a390c287b2980cfcd2703d24d8dde85a01ea721b7b4b4c82944f,4667
 - fsnotify-0.3.0.1@rev:1
 - process-1.6.3.0@sha256:fc77cfe75a9653b8c54ae455ead8c06cb8adc4d7a340984d84d8ca880b579919,2370 #because of https://github.com/haskell/process/pull/101
+- persistent-2.9.2@rev:0
+- persistent-sqlite-2.9.3@rev:0
 
 flags:
   cabal-install:

--- a/src/Stack/Storage.hs
+++ b/src/Stack/Storage.hs
@@ -130,7 +130,7 @@ withStorage ::
     => ReaderT SqlBackend (RIO env) a
     -> RIO env a
 withStorage inner =
-    SQLite.withStorage inner =<< view (configL . to configStorage)
+    flip SQLite.withStorage_ inner =<< view (configL . to configStorage)
 
 -- | Key used to retrieve configuration or flag cache
 type ConfigCacheKey = Unique ConfigCacheParent

--- a/subs/pantry/package.yaml
+++ b/subs/pantry/package.yaml
@@ -47,7 +47,6 @@ dependencies:
 - persistent
 - persistent-sqlite >= 2.8.2
 - persistent-template
-- resource-pool
 - Cabal >= 2.4
 - path-io
 - rio-orphans
@@ -62,6 +61,7 @@ dependencies:
 - resourcet
 - rio-prettyprint
 - mtl
+- filelock
 
 # FIXME remove when we drop store
 - integer-gmp

--- a/subs/pantry/package.yaml
+++ b/subs/pantry/package.yaml
@@ -45,7 +45,7 @@ dependencies:
 - cryptonite
 - cryptonite-conduit
 - persistent
-- persistent-sqlite >= 2.8.2
+- persistent-sqlite >= 2.9.3
 - persistent-template
 - Cabal >= 2.4
 - path-io

--- a/subs/pantry/src/Pantry/SQLite.hs
+++ b/subs/pantry/src/Pantry/SQLite.hs
@@ -1,47 +1,93 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Pantry.SQLite
-  ( P.Storage
+  ( Storage (..)
   , initStorage
-  , withStorage
   ) where
 
 import RIO hiding (FilePath)
-import qualified Pantry.Types as P
 import Database.Persist.Sqlite
 import RIO.Orphans ()
 import Path (Path, Abs, File, toFilePath, parent)
 import Path.IO (ensureDir)
-import Data.Pool (destroyAllResources)
-import Pantry.Types (PantryException (MigrationFailure))
+import Pantry.Types (PantryException (MigrationFailure), Storage (..))
+import System.FileLock (withFileLock, withTryFileLock, SharedExclusive (..))
 
 initStorage
   :: HasLogFunc env
   => Text
   -> Migration
   -> Path Abs File -- ^ storage file
-  -> (P.Storage -> RIO env a)
+  -> (Storage -> RIO env a)
   -> RIO env a
 initStorage description migration fp inner = do
   ensureDir $ parent fp
-  bracket
-    (createSqlitePoolFromInfo (sqinfo False) 1)
-    (liftIO . destroyAllResources) $ \pool -> do
-    migrates <- wrapMigrationFailure $ runSqlPool (runMigrationSilent migration) pool
-    forM_ migrates $ \mig -> logDebug $ "Migration executed: " <> display mig
-  bracket
-    (createSqlitePoolFromInfo (sqinfo True) 1)
-    (liftIO . destroyAllResources) $ \pool -> inner (P.Storage pool)
+
+  migrates <- withWriteLock fp $ wrapMigrationFailure $
+    withSqliteConnInfo (sqinfo True) $ runReaderT $
+    runMigrationSilent migration
+  forM_ migrates $ \mig -> logDebug $ "Migration executed: " <> display mig
+
+  inner $ Storage
+    { withStorage_ = withSqliteConnInfo (sqinfo False) . runSqlConn
+    , withWriteLock_ = withWriteLock fp
+    }
   where
     wrapMigrationFailure = handleAny (throwIO . MigrationFailure description fp)
-    sqinfo fk = set extraPragmas ["PRAGMA busy_timeout=2000;"]
-           $ set fkEnabled fk
+
+    sqinfo isMigration
+           = set extraPragmas ["PRAGMA busy_timeout=2000;"]
+
+           -- When doing a migration, we want to disable foreign key
+           -- checking, since the order in which tables are created by
+           -- the migration scripts may not respect foreign keys. The
+           -- rest of the time: enforce those foreign keys.
+           $ set fkEnabled (not isMigration)
+
+           -- This one is subtle. Enabling Write-Ahead Logging (WAL)
+           -- mode is persistent: the next usage of the database is
+           -- still in WAL mode until explicitly disabled. Therefore,
+           -- when we're already migrated the database, there's no
+           -- need to waste time reenabling WAL. Skipping this also
+           -- allows us to get slightly more meaningful error messages
+           -- if we run into the SQLITE_BUSY bug again.
+           $ set walEnabled isMigration
+
            $ mkSqliteConnectionInfo (fromString $ toFilePath fp)
 
-withStorage
+-- | Ensure that only one process is trying to write to the database
+-- at a time. See
+-- https://github.com/commercialhaskell/stack/issues/4471 and comments
+-- above.
+withWriteLock
   :: HasLogFunc env
-  => ReaderT SqlBackend (RIO env) a
-  -> P.Storage
+  => Path Abs File -- ^ SQLite database file
   -> RIO env a
-withStorage action (P.Storage pool) =
-  runSqlPool action pool
+  -> RIO env a
+withWriteLock dbFile inner = do
+  let lockFile = toFilePath dbFile ++ ".pantry-write-lock"
+  withRunInIO $ \run -> do
+    mres <- withTryFileLock lockFile Exclusive $ const $ run inner
+    case mres of
+      Just res -> pure res
+      Nothing -> do
+        run $ logInfo "Unable to get a write lock on the Pantry database, waiting..."
+        shouldStopComplainingVar <- newTVarIO False
+        let complainer = fix $ \loop -> do
+              delay <- registerDelay $ 60 * 1000 * 1000 -- 1 minute
+              shouldComplain <-
+                atomically $
+                  -- Delay has triggered, time to complain again
+                  (readTVar delay >>= checkSTM >> pure True) <|>
+                  -- Time to stop complaining, ignore that delay immediately
+                  (readTVar shouldStopComplainingVar >>= checkSTM >> pure False)
+              when shouldComplain $ do
+                run $ logWarn "Still waiting on the Pantry database write lock..."
+                loop
+            stopComplaining = atomically $ writeTVar shouldStopComplainingVar True
+            worker = withFileLock lockFile Exclusive $ const $ do
+              run $ logInfo "Acquired the Pantry database write lock"
+              stopComplaining
+              run inner
+        runConcurrently $ Concurrently complainer
+                       *> Concurrently (worker `finally` stopComplaining)

--- a/subs/pantry/src/Pantry/Storage.hs
+++ b/subs/pantry/src/Pantry/Storage.hs
@@ -241,7 +241,7 @@ withStorage
   => ReaderT SqlBackend (RIO env) a
   -> RIO env a
 withStorage action =
-  SQLite.withStorage action =<< view (P.pantryConfigL.to P.pcStorage)
+  flip SQLite.withStorage_ action =<< view (P.pantryConfigL.to P.pcStorage)
 
 getPackageNameId
   :: (HasPantryConfig env, HasLogFunc env)


### PR DESCRIPTION
This makes two basic changes to the code:

* Avoids a connection pool, which forces the SQLite connection to be
closed at the end of each call to withStorage. This seems unfortunate;
we would like to be able to maintain connections. However, SQLite seems
to view such connections as holding a write lock even when not in the
middle of a database transaction.

* Uses an explicit file lock on the two longest-running write
operations: migration and Hackage population. Ideally the locking
mechanism in SQLite would be sufficient for this, but (1) Hackage
population can take a long time, and (2) evidence has shown that it
doesn't behave as we expect it to.

This may be insufficient for preventing the bug described in #4471, in
which case we may need to apply withWriteLock to more calls. However,
I'd like to start off small to avoid the additional overhead.