### PR TITLE
Inform the user why sudo is necessary in get-stack (fixes #4672)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -17,7 +17,7 @@ It features:
 
 #### How to install
 
-For many Un*x operating systems, all you need to do is run:
+For most Un*x operating systems, the easiest way to install is to run:
 
     curl -sSL https://get.haskellstack.org/ | sh
 
@@ -28,9 +28,15 @@ or:
 On Windows, you can download and install the
 [Windows 64-bit Installer](https://get.haskellstack.org/stable/windows-x86_64-installer.exe).
 
-For detailed instructions and downloads, including many additional
-operating systems, check out the
-[install and upgrade page](install_and_upgrade.md).
+For other operating systems and direct downloads, check out the
+[install and upgrade guide](install_and_upgrade.md).
+
+Note that the [get.haskellstack.org](https://get.haskellstack.org/)
+script will ask for root access using `sudo` in order to use your
+platform's package manager to install dependencies and to install to
+`/usr/local/bin`.  If you prefer more control, follow the manual
+installation instructions in the
+[install and upgrade guide](install_and_upgrade.md).
 
 #### Quick Start Guide
 

--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -295,9 +295,9 @@ Run:
 
 ## Path
 
-You can install stack by copying it anywhere on your PATH environment variable. We recommend installing in the same directory where stack itself will install executables (that way stack is able to upgrade itself!). On Windows, that directory is `%APPDATA%\local\bin`, e.g. "c:\Users\Michael\AppData\Roaming\local\bin". For other systems, use `$HOME/.local/bin`.
+You can install stack by copying it anywhere on your PATH environment variable. A good place to install is the same directory where stack itself will install executables. On Windows, that directory is `%APPDATA%\local\bin`, e.g. `c:\Users\Michael\AppData\Roaming\local\bin`. For other systems, it's `$HOME/.local/bin`.
 
-If you don't have that directory in your PATH, you may need to update your PATH (such as by editing .bashrc).
+If you don't have that directory in your PATH, you may need to update your PATH (such as by editing `~/.bashrc`).
 
 If you're curious about the choice of these paths, see [issue #153](https://github.com/commercialhaskell/stack/issues/153)
 

--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -10,9 +10,12 @@ or:
 
     wget -qO- https://get.haskellstack.org/ | sh
 
-Distribution packages are available for [Ubuntu](#ubuntu), [Debian](#debian),
-[Fedora](#fedora),
-[Arch Linux](#arch-linux) and [FreeBSD](#freebsd).
+
+Note that this script will ask for root access using `sudo` in order
+to use your platform's package manager to install dependencies and to
+install to `/usr/local/bin`.  If you prefer more control, follow the
+manual installation instructions for your platform below.
+
 Binaries for other operating systems are listed below, and available on
 [the GitHub release page](https://github.com/fpco/stack/releases). For the
 future, we are open to supporting more OSes (to request one, please
@@ -249,7 +252,7 @@ or:
 * Extract the archive and place `stack` somewhere on your `$PATH` (see [Path section below](#path))
 
 * Ensure you have required system dependencies installed.  These include GCC, GNU make, xz, perl, libgmp, libffi, and zlib.  We also recommend Git and GPG.  To install these using your package manager:
-    * Debian / Ubuntu: `sudo apt-get install g++ gcc libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev git gnupg`
+    * Debian / Ubuntu: `sudo apt-get install g++ gcc libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev git gnupg netbase`
     * Fedora / CentOS: `sudo dnf install perl make automake gcc gmp-devel libffi zlib xz tar git gnupg` (use `yum` instead of `dnf` on CentOS and Fedora <= 21)
         * Fedora 24: In order to use `stack setup` on a 32-bit system, you may
           need to run `sudo dnf install ncurses-compat-libs`. If this package is


### PR DESCRIPTION
This also adds some extra text to the docs pointing people to the manual installation instructions if they prefer not to use the script.  (ping @jkachmar)
