### PR TITLE
Rewrite IntegrationSpec for streaming output

### DIFF
--- a/.azure/azure-nightly-template-linux.yml
+++ b/.azure/azure-nightly-template-linux.yml
@@ -37,7 +37,7 @@ jobs:
       # FIXME: Note that cabal-install might not be required once
       # https://github.com/commercialhaskell/stack/issues/4410 get's
       # fixed.
-      stack test --flag stack:integration-tests stack:test:stack-integration-test --interleaved-output
+      stack build --flag stack:integration-tests stack --interleaved-output --exec stack-integration-test
       set +ex
     displayName: Integration Test
   - script: |

--- a/.azure/azure-nightly-template-linux.yml
+++ b/.azure/azure-nightly-template-linux.yml
@@ -37,7 +37,7 @@ jobs:
       # FIXME: Note that cabal-install might not be required once
       # https://github.com/commercialhaskell/stack/issues/4410 get's
       # fixed.
-      stack build --flag stack:integration-tests stack --interleaved-output --exec stack-integration-test
+      etc/scripts/integration-tests.sh
       set +ex
     displayName: Integration Test
   - script: |

--- a/.azure/azure-nightly-template-osx.yml
+++ b/.azure/azure-nightly-template-osx.yml
@@ -39,7 +39,7 @@ jobs:
       # FIXME: Note that cabal-install might not be required once
       # https://github.com/commercialhaskell/stack/issues/4410 get's
       # fixed.
-      stack test --flag stack:integration-tests stack:test:stack-integration-test --interleaved-output
+      stack build --flag stack:integration-tests stack --interleaved-output --exec stack-integration-test
       set +ex
     displayName: Integration Test
   - script: |

--- a/.azure/azure-nightly-template-osx.yml
+++ b/.azure/azure-nightly-template-osx.yml
@@ -39,7 +39,7 @@ jobs:
       # FIXME: Note that cabal-install might not be required once
       # https://github.com/commercialhaskell/stack/issues/4410 get's
       # fixed.
-      stack build --flag stack:integration-tests stack --interleaved-output --exec stack-integration-test
+      etc/scripts/integration-tests.sh
       set +ex
     displayName: Integration Test
   - script: |

--- a/.azure/azure-nightly-template-windows.yml
+++ b/.azure/azure-nightly-template-windows.yml
@@ -43,7 +43,7 @@ jobs:
       # FIXME: Note that cabal-install might not be required once
       # https://github.com/commercialhaskell/stack/issues/4410 get's
       # fixed.
-      stack build --flag stack:integration-tests stack --interleaved-output --exec stack-integration-test
+      etc/scripts/integration-tests.sh
       set +ex
     displayName: Integration Test
   - powershell: |

--- a/.azure/azure-nightly-template-windows.yml
+++ b/.azure/azure-nightly-template-windows.yml
@@ -43,7 +43,7 @@ jobs:
       # FIXME: Note that cabal-install might not be required once
       # https://github.com/commercialhaskell/stack/issues/4410 get's
       # fixed.
-      stack test --flag stack:integration-tests stack:test:stack-integration-test --interleaved-output --no-terminal
+      stack build --flag stack:integration-tests stack --interleaved-output --exec stack-integration-test
       set +ex
     displayName: Integration Test
   - powershell: |

--- a/etc/scripts/integration-tests.sh
+++ b/etc/scripts/integration-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec stack build --flag stack:integration-tests stack --interleaved-output --exec stack-integration-test

--- a/package.yaml
+++ b/package.yaml
@@ -277,17 +277,6 @@ executables:
       cpp-options: -DHIDE_DEP_VERSIONS
     - condition: flag(supported-build)
       cpp-options: -DSUPPORTED_BUILD
-tests:
-  stack-test:
-    main: Spec.hs
-    source-dirs: src/test
-    ghc-options:
-    - -threaded
-    dependencies:
-    - QuickCheck
-    - hspec
-    - stack
-    - smallcheck
   stack-integration-test:
     main: IntegrationSpec.hs
     source-dirs:
@@ -303,6 +292,17 @@ tests:
     when:
     - condition: ! '!(flag(integration-tests))'
       buildable: false
+tests:
+  stack-test:
+    main: Spec.hs
+    source-dirs: src/test
+    ghc-options:
+    - -threaded
+    dependencies:
+    - QuickCheck
+    - hspec
+    - stack
+    - smallcheck
 flags:
   static:
     description: Pass -static/-pthread to ghc when linking the stack binary.

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -355,8 +355,16 @@ configFromConfigMonoid
          Nothing -> pure defaultHackageSecurityConfig
          Just [hsc] -> pure hsc
          Just x -> error $ "When overriding the default package index, you must provide exactly one value, received: " ++ show x
+     mpantryRoot <- liftIO $ lookupEnv "PANTRY_ROOT"
+     pantryRoot <-
+       case mpantryRoot of
+         Just dir ->
+           case parseAbsDir dir of
+             Nothing -> throwString $ "Failed to parse PANTRY_ROOT environment variable (expected absolute directory): " ++ show dir
+             Just x -> pure x
+         Nothing -> pure $ configStackRoot </> relDirPantry
      withPantryConfig
-       (configStackRoot </> relDirPantry)
+       pantryRoot
        hsc
        (maybe HpackBundled HpackCommand $ getFirst configMonoidOverrideHpack)
        clConnectionCount

--- a/test/integration/tests/2433-ghc-by-version/files/run.sh
+++ b/test/integration/tests/2433-ghc-by-version/files/run.sh
@@ -2,10 +2,10 @@
 
 set -exuo pipefail
 
-export PATH=$(pwd)/fake-path:$($STACK_EXE path --resolver ghc-8.2.2 --compiler-bin):$PATH
+export PATH=$(pwd)/fake-path:$("$STACK_EXE" path --resolver ghc-8.2.2 --compiler-bin):$PATH
 export STACK_ROOT=$(pwd)/fake-root
 
 which ghc
 
-$STACK_EXE --system-ghc --no-install-ghc --resolver ghc-8.2.2 ghc -- --info
-$STACK_EXE --system-ghc --no-install-ghc --resolver ghc-8.2.2 runghc foo.hs
+"$STACK_EXE" --system-ghc --no-install-ghc --resolver ghc-8.2.2 ghc -- --info
+"$STACK_EXE" --system-ghc --no-install-ghc --resolver ghc-8.2.2 runghc foo.hs


### PR DESCRIPTION
This makes a number of changes, including:

* stack-integration-tests is now an executable, not a test suite
* Output for test progress is displayed immediately
* Much smarter setup of the temporary home directory (just keep pantry)
* Modify the Azure scripts to call appropriately