### PR TITLE
Prepare to cache GHC info

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -86,15 +86,15 @@ Behavior changes:
 * Always use the `--exact-configuration` Cabal configuration option when
   building (should mostly be a non-user-visible enhancement).
 
+* No longer supports Cabal versions older than `1.19.2`.  This means
+  projects using snapshots earlier than `lts-3.0` or
+  `nightly-2015-05-05` will no longer build.
+
 * Remove the `stack docker cleanup` command.  Docker itself now has
   [`docker image prune`](https://docs.docker.com/engine/reference/commandline/image_prune/)
   and
   [`docker container prune`](https://docs.docker.com/engine/reference/commandline/container_prune/),
   which you can use instead.
-
-* No longer supports Cabal versions older than `1.19.2`.  This means
-  projects using snapshots earlier than `lts-3.0` or
-  `nightly-2015-05-05` will no longer build.
 
 Other enhancements:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -92,6 +92,10 @@ Behavior changes:
   [`docker container prune`](https://docs.docker.com/engine/reference/commandline/container_prune/),
   which you can use instead.
 
+* No longer supports Cabal versions older than `1.19.2`.  This means
+  projects using snapshots earlier than `lts-3.0` or
+  `nightly-2015-05-05` will no longer build.
+
 Other enhancements:
 
 * Defer loading up of files for local packages. This allows us to get

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -121,6 +121,15 @@ checkCabalVersion = do
             "Error: --allow-newer requires at least Cabal version 1.22, but version " ++
             versionString cabalVer ++
             " was found."
+    -- Since --exact-configuration is always passed, some old cabal
+    -- versions can no longer be used. See the following link for why
+    -- it's 1.19.2:
+    -- https://github.com/haskell/cabal/blob/580fe6b6bf4e1648b2f66c1cb9da9f1f1378492c/cabal-install/Distribution/Client/Setup.hs#L592
+    when (cabalVer < mkVersion [1, 19, 2]) $ throwM $
+        CabalVersionException $
+            "Stack no longer supports Cabal versions older than 1.19.2, but version " ++
+            versionString cabalVer ++
+            " was found.  To fix this, consider updating the resolver to lts-3.0 or later / nightly-2015-05-05 or later."
 
 newtype CabalVersionException = CabalVersionException { unCabalVersionException :: String }
     deriving (Typeable)

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -181,7 +181,7 @@ constructPlan baseConfigOpts0 localDumpPkgs loadPackage0 sourceMap installedMap 
       prettyWarn $ flow "You are trying to upgrade/downgrade base, which is almost certainly not what you really want. Please, consider using another GHC version if you need a certain version of base, or removing base from extra-deps. See more at https://github.com/commercialhaskell/stack/issues/3940." <> line
 
     econfig <- view envConfigL
-    globalCabalVersion <- cpCabalVersion
+    globalCabalVersion <- view $ compilerPathsL.to cpCabalVersion
     sources <- getSources globalCabalVersion
     mcur <- view $ buildConfigL.to bcCurator
 

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1672,7 +1672,8 @@ singleBuild ac@ActionContext {..} ee@ExecuteEnv {..} task@Task {..} installedMap
         return mpkgid
 
     loadInstalledPkg pkgDbs tvar name = do
-        dps <- ghcPkgDescribe name pkgDbs $ conduitDumpPackage .| CL.consume
+        pkgexe <- getGhcPkgExe
+        dps <- ghcPkgDescribe pkgexe name pkgDbs $ conduitDumpPackage .| CL.consume
         case dps of
             [] -> return Nothing
             [dp] -> do

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -203,7 +203,7 @@ generateHaddockIndex descr bco dumpPackages docRelFP destDir = do
                   " in\n" <>
                   fromString (toFilePath destIndexFile)
                 liftIO (mapM_ copyPkgDocs interfaceOpts)
-                haddockExeName <- toFilePath <$> cpHaddock
+                haddockExeName <- view $ compilerPathsL.to (toFilePath . cpHaddock)
                 withWorkingDir (toFilePath destDir) $ readProcessNull
                     haddockExeName
                     (map (("--optghc=-package-db=" ++ ) . toFilePathNoTrailingSep)

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -117,7 +117,8 @@ loadDatabase :: HasEnvConfig env
              -> RIO env ([LoadHelper], [DumpPackage])
 loadDatabase installMap mdb lhs0 = do
     wc <- view $ actualCompilerVersionL.to whichCompiler
-    (lhs1', dps) <- ghcPkgDump (fmap snd (maybeToList mdb))
+    pkgexe <- getGhcPkgExe
+    (lhs1', dps) <- ghcPkgDump pkgexe (fmap snd (maybeToList mdb))
                 $ conduitDumpPackage .| sink
     let ghcjsHack = wc == Ghcjs && isNothing mdb
     lhs1 <- mapMaybeM (processLoadResult mdb ghcjsHack) lhs1'

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -11,7 +11,6 @@ module Stack.GhcPkg
   ,findGhcPkgField
   ,createDatabase
   ,unregisterGhcPkgIds
-  ,getCabalPkgVer
   ,ghcPkgPathEnvVar
   ,mkGhcPackagePath)
   where
@@ -27,7 +26,6 @@ import           Path (parent, (</>))
 import           Path.Extra (toFilePathNoTrailingSep)
 import           Path.IO
 import           Stack.Constants
-import           Stack.Types.Build
 import           Stack.Types.Config (GhcPkgExe (..))
 import           Stack.Types.GhcPkgId
 import           Stack.Types.Compiler
@@ -153,18 +151,6 @@ unregisterGhcPkgIds pkgexe pkgDb epgids = do
             (\ident -> [packageIdentifierString ident])
             (\gid -> ["--ipid", ghcPkgIdString gid]))
             epgids
-
--- | Get the version of Cabal from the global package database.
-getCabalPkgVer
-  :: (HasProcessContext env, HasLogFunc env)
-  => GhcPkgExe
-  -> RIO env Version
-getCabalPkgVer pkgexe = do
-    logDebug "Getting Cabal package version"
-
-    mv <- findGhcPkgField pkgexe [] (packageNameString cabalPackageName) "version"
-    maybe (throwIO $ Couldn'tFindPkgId cabalPackageName) pure $
-      mv >>= parseVersion . T.unpack
 
 -- | Get the value for GHC_PACKAGE_PATH
 mkGhcPackagePath :: Bool -> Path Abs Dir -> Path Abs Dir -> [Path Abs Dir] -> Path Abs Dir -> Text

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Functions for the GHC package database.

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -76,7 +76,7 @@ fillPathInfo = do
      piSnapDb <- packageDatabaseDeps
      piLocalDb <- packageDatabaseLocal
      piExtraDbs <- packageDatabaseExtra
-     piGlobalDb <- cpGlobalDB
+     piGlobalDb <- view $ compilerPathsL.to cpGlobalDB
      piSnapRoot <- installationRootDeps
      piLocalRoot <- installationRootLocal
      piToolsDir <- bindirCompilerTools

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -118,8 +118,8 @@ scriptCmd opts = do
             -- --simple-output to check which packages are installed
             -- already. If all needed packages are available, we can
             -- skip the (rather expensive) build call below.
-            pkg <- view $ compilerPathsL.to cpPkg.to toFilePath
-            bss <- sinkProcessStdout pkg
+            GhcPkgExe pkg <- view $ compilerPathsL.to cpPkg
+            bss <- sinkProcessStdout (toFilePath pkg)
                 ["list", "--simple-output"] CL.consume -- FIXME use the package info from envConfigPackages, or is that crazy?
             let installed = Set.fromList
                           $ map toPackageName
@@ -149,7 +149,7 @@ scriptCmd opts = do
                 ]
         case soCompile opts of
           SEInterpret -> do
-            interpret <- cpInterpreter
+            interpret <- view $ compilerPathsL.to cpInterpreter
             exec (toFilePath interpret)
                 (ghcArgs ++ toFilePath file : soArgs opts)
           _ -> do

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -31,9 +31,6 @@ module Stack.Setup
   , preferredPlatforms
   , downloadStackReleaseInfo
   , downloadStackExe
-  -- * WithGHC
-  , WithGHC (..)
-  , runWithGHC
   ) where
 
 import qualified    Codec.Archive.Tar as Tar

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -684,7 +684,7 @@ pathsFromCompiler wc compilerBuild menv needLocal compiler = handleAny onErr $ w
           getGlobalDB pkg
         Right x -> pure x
     return CompilerPaths
-      { cpBuild = Just compilerBuild -- FIXME is this always Just? Remove the Maybe?
+      { cpBuild = compilerBuild
       , cpSandboxed = needLocal
       , cpCompilerVersion = compilerVer
       , cpCompiler = compiler

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -1071,7 +1071,7 @@ sourceSystemCompilers wanted = do
           , "ghc"
           ]
         WCGhcjs{} -> ["ghcjs"]
-        WCGhcGit{} -> [] -- ^ only use sandboxed versions
+        WCGhcGit{} -> [] -- only use sandboxed versions
     addExe
       | osIsWindows = (++ ".exe")
       | otherwise = id

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -1060,7 +1060,7 @@ sourceSystemCompilers
 sourceSystemCompilers wanted = do
   searchPath <- view exeSearchPathL
   for_ names $ \name -> for_ searchPath $ \dir -> do
-    fp <- parseAbsFile $ addExe $ dir FP.</> name
+    fp <- resolveFile' $ addExe $ dir FP.</> name
     exists <- doesFileExist fp
     when exists $ yield fp
   where

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -799,6 +799,9 @@ pathsFromCompiler wc compilerBuild isSandboxed compiler = handleAny onErr $ do
           logWarn "Asking ghc-pkg directly"
           withProcessContext menv $ getGlobalDB pkg
         Right x -> pure x
+
+    globalDump <- withProcessContext menv $ globalsFromDump pkg
+
     return CompilerPaths
       { cpBuild = compilerBuild
       , cpArch = arch
@@ -811,6 +814,7 @@ pathsFromCompiler wc compilerBuild isSandboxed compiler = handleAny onErr $ do
       , cpCabalVersion = cabalPkgVer
       , cpGlobalDB = globaldb
       , cpGhcInfo = infobs
+      , cpGlobalDump = globalDump
       }
   where
     onErr = throwIO . InvalidGhcAt compiler

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -16,7 +16,7 @@
 
 module Stack.Setup
   ( setupEnv
-  , ensureCompiler
+  , ensureCompilerAndMsys
   , ensureDockerStackExe
   , getCabalInstallVersion
   , SetupOpts (..)
@@ -50,7 +50,7 @@ import qualified    Data.Conduit.Binary as CB
 import              Data.Conduit.Lazy (lazyConsume)
 import              Data.Conduit.Lift (evalStateC)
 import qualified    Data.Conduit.List as CL
-import              Data.Conduit.Process.Typed (eceStderr, createSource)
+import              Data.Conduit.Process.Typed (createSource)
 import              Data.Conduit.Zlib          (ungzip)
 import              Data.Foldable (maximumBy)
 import qualified    Data.HashMap.Strict as HashMap
@@ -244,7 +244,7 @@ setupEnv needTargets boptsCLI mResolveMissingGHC = do
             , soptsGHCJSBootOpts = ["--clean"]
             }
 
-    (compilerPaths, ghcBin) <- ensureCompiler sopts
+    (compilerPaths, ghcBin) <- ensureCompilerAndMsys sopts
     let compilerVer = cpCompilerVersion compilerPaths
 
     -- Modify the initial environment to include the GHC path, if a local GHC
@@ -461,11 +461,134 @@ addIncludeLib (ExtraDirs _bins includes libs) config = config
         map toFilePathNoTrailingSep libs
     }
 
--- | Ensure compiler (ghc or ghcjs) is installed and provide the PATHs to add if necessary
-ensureCompiler :: forall env. (HasConfig env, HasGHCVariant env)
-               => SetupOpts
-               -> RIO env (CompilerPaths, ExtraDirs)
-ensureCompiler sopts = do
+-- | Ensure both the compiler and the msys toolchain are installed and
+-- provide the PATHs to add if necessary
+ensureCompilerAndMsys
+  :: (HasConfig env, HasGHCVariant env)
+  => SetupOpts
+  -> RIO env (CompilerPaths, ExtraDirs)
+ensureCompilerAndMsys sopts = do
+  getSetupInfo' <- memoizeRef (getSetupInfo (soptsSetupInfoYaml sopts))
+  (cp, ghcPaths) <- ensureCompiler sopts getSetupInfo'
+  mmsys2Tool <- ensureMsys sopts getSetupInfo'
+  paths <-
+    case mmsys2Tool of
+      Nothing -> pure ghcPaths
+      Just msys2Tool -> do
+        msys2Paths <- extraDirs msys2Tool
+        pure $ ghcPaths <> msys2Paths
+  pure (cp, paths)
+
+-- | Ensure that the msys toolchain is installed if necessary and
+-- provide the PATHs to add if necessary
+ensureMsys
+  :: HasConfig env
+  => SetupOpts
+  -> Memoized SetupInfo
+  -> RIO env (Maybe Tool)
+ensureMsys sopts getSetupInfo' = do
+  platform <- view platformL
+  localPrograms <- view $ configL.to configLocalPrograms
+  installed <- listInstalled localPrograms
+
+  case platform of
+      Platform _ Cabal.Windows | not (soptsSkipMsys sopts) ->
+          case getInstalledTool installed (mkPackageName "msys2") (const True) of
+              Just tool -> return (Just tool)
+              Nothing
+                  | soptsInstallIfMissing sopts -> do
+                      si <- runMemoized getSetupInfo'
+                      osKey <- getOSKey platform
+                      config <- view configL
+                      VersionedDownloadInfo version info <-
+                          case Map.lookup osKey $ siMsys2 si of
+                              Just x -> return x
+                              Nothing -> throwString $ "MSYS2 not found for " ++ T.unpack osKey
+                      let tool = Tool (PackageIdentifier (mkPackageName "msys2") version)
+                      Just <$> downloadAndInstallTool (configLocalPrograms config) info tool (installMsys2Windows osKey si)
+                  | otherwise -> do
+                      logWarn "Continuing despite missing tool: msys2"
+                      return Nothing
+      _ -> return Nothing
+
+installGhcBindist
+  :: HasConfig env
+  => SetupOpts
+  -> Memoized SetupInfo
+  -> [Tool]
+  -> RIO env (Tool, CompilerBuild)
+installGhcBindist sopts getSetupInfo' installed = do
+    Platform expectedArch _ <- view platformL
+    let wanted = soptsWantedCompiler sopts
+        isWanted = isWantedCompiler (soptsCompilerCheck sopts) (soptsWantedCompiler sopts)
+        canUseCompiler (compilerVersion, arch, _dir)
+            | soptsSkipGhcCheck sopts = True
+            | otherwise = isWanted compilerVersion && arch == expectedArch
+    config <- view configL
+    ghcVariant <- view ghcVariantL
+    possibleCompilers <-
+            case whichCompiler $ wantedToActual wanted of
+                Ghc -> do
+                    ghcBuilds <- getGhcBuilds
+                    forM ghcBuilds $ \ghcBuild -> do
+                        ghcPkgName <- parsePackageNameThrowing ("ghc" ++ ghcVariantSuffix ghcVariant ++ compilerBuildSuffix ghcBuild)
+                        return (getInstalledTool installed ghcPkgName (isWanted . ACGhc), ghcBuild)
+                Ghcjs -> return [(getInstalledGhcjs installed isWanted, CompilerBuildStandard)]
+    let existingCompilers = concatMap
+            (\(installedCompiler, compilerBuild) ->
+                case (installedCompiler, soptsForceReinstall sopts) of
+                    (Just tool, False) -> [(tool, compilerBuild)]
+                    _ -> [])
+            possibleCompilers
+    logDebug $
+      "Found already installed GHC builds: " <>
+      mconcat (intersperse ", " (map (fromString . compilerBuildName . snd) existingCompilers))
+    case existingCompilers of
+        (tool, build_):_ -> return (tool, build_)
+        []
+            | soptsInstallIfMissing sopts -> do
+                si <- runMemoized getSetupInfo'
+                downloadAndInstallPossibleCompilers
+                    (map snd possibleCompilers)
+                    si
+                    (soptsWantedCompiler sopts)
+                    (soptsCompilerCheck sopts)
+                    (soptsGHCBindistURL sopts)
+            | otherwise -> do
+                recommendSystemGhc <-
+                    if soptsUseSystem sopts
+                        then return False
+                        else do
+                            msystemGhc <- getSystemCompiler wanted
+                            return (any canUseCompiler msystemGhc)
+                let suggestion = fromMaybe
+                        (mconcat
+                             ([ "To install the correct GHC into "
+                              , T.pack (toFilePath (configLocalPrograms config))
+                              , ", try running \"stack setup\" or use the \"--install-ghc\" flag."
+                              ] ++
+                              [ " To use your system GHC installation, run \"stack config set system-ghc --global true\", or use the \"--system-ghc\" flag."
+                              | recommendSystemGhc
+                              ]))
+                        (soptsResolveMissingGHC sopts)
+                throwM $ CompilerVersionMismatch
+                    Nothing -- FIXME ((\(x, y, _) -> (x, y)) <$> msystem)
+                    (soptsWantedCompiler sopts, expectedArch)
+                    ghcVariant
+                    (case possibleCompilers of
+                        [] -> CompilerBuildStandard
+                        (_, compilerBuild):_ -> compilerBuild)
+                    (soptsCompilerCheck sopts)
+                    (soptsStackYaml sopts)
+                    suggestion
+
+-- | Ensure compiler (ghc or ghcjs) is installed, without worrying about msys
+ensureCompiler
+  :: forall env. (HasConfig env, HasGHCVariant env)
+  => SetupOpts
+  -> Memoized SetupInfo
+  -> RIO env (CompilerPaths, ExtraDirs)
+ensureCompiler sopts getSetupInfo' = do
     let wanted = soptsWantedCompiler sopts
     when (getGhcVersion (wantedToActual wanted) < mkVersion [7, 8]) $ do
         logWarn "Stack will almost certainly fail with GHC below version 7.8"
@@ -486,150 +609,50 @@ ensureCompiler sopts = do
             | soptsSkipGhcCheck sopts = True
             | otherwise = isWanted compilerVersion && arch == expectedArch
         isWanted = isWantedCompiler (soptsCompilerCheck sopts) (soptsWantedCompiler sopts)
-        needLocal = not (any canUseCompiler msystem)
 
-    getSetupInfo' <- memoizeRef (getSetupInfo (soptsSetupInfoYaml sopts))
-
-    let getMmsys2Tool = do
-            platform <- view platformL
-            localPrograms <- view $ configL.to configLocalPrograms
-            installed <- listInstalled localPrograms
-
-            case platform of
-                Platform _ Cabal.Windows | not (soptsSkipMsys sopts) ->
-                    case getInstalledTool installed (mkPackageName "msys2") (const True) of
-                        Just tool -> return (Just tool)
-                        Nothing
-                            | soptsInstallIfMissing sopts -> do
-                                si <- runMemoized getSetupInfo'
-                                osKey <- getOSKey platform
-                                config <- view configL
-                                VersionedDownloadInfo version info <-
-                                    case Map.lookup osKey $ siMsys2 si of
-                                        Just x -> return x
-                                        Nothing -> throwString $ "MSYS2 not found for " ++ T.unpack osKey
-                                let tool = Tool (PackageIdentifier (mkPackageName "msys2") version)
-                                Just <$> downloadAndInstallTool (configLocalPrograms config) info tool (installMsys2Windows osKey si)
-                            | otherwise -> do
-                                logWarn "Continuing despite missing tool: msys2"
-                                return Nothing
-                _ -> return Nothing
-
-    let installGhcBindist installed = do
-            config <- view configL
-            ghcVariant <- view ghcVariantL
-            possibleCompilers <-
-                    case whichCompiler $ wantedToActual wanted of
-                        Ghc -> do
-                            ghcBuilds <- getGhcBuilds
-                            forM ghcBuilds $ \ghcBuild -> do
-                                ghcPkgName <- parsePackageNameThrowing ("ghc" ++ ghcVariantSuffix ghcVariant ++ compilerBuildSuffix ghcBuild)
-                                return (getInstalledTool installed ghcPkgName (isWanted . ACGhc), ghcBuild)
-                        Ghcjs -> return [(getInstalledGhcjs installed isWanted, CompilerBuildStandard)]
-            let existingCompilers = concatMap
-                    (\(installedCompiler, compilerBuild) ->
-                        case (installedCompiler, soptsForceReinstall sopts) of
-                            (Just tool, False) -> [(tool, compilerBuild)]
-                            _ -> [])
-                    possibleCompilers
-            logDebug $
-              "Found already installed GHC builds: " <>
-              mconcat (intersperse ", " (map (fromString . compilerBuildName . snd) existingCompilers))
-            (compilerTool, compilerBuild) <- case existingCompilers of
-                (tool, build_):_ -> return (tool, build_)
-                []
-                    | soptsInstallIfMissing sopts -> do
-                        si <- runMemoized getSetupInfo'
-                        downloadAndInstallPossibleCompilers
-                            (map snd possibleCompilers)
-                            si
-                            (soptsWantedCompiler sopts)
-                            (soptsCompilerCheck sopts)
-                            (soptsGHCBindistURL sopts)
-                    | otherwise -> do
-                        recommendSystemGhc <-
-                            if soptsUseSystem sopts
-                                then return False
-                                else do
-                                    msystemGhc <- getSystemCompiler wanted
-                                    return (any canUseCompiler msystemGhc)
-                        let suggestion = fromMaybe
-                                (mconcat
-                                     ([ "To install the correct GHC into "
-                                      , T.pack (toFilePath (configLocalPrograms config))
-                                      , ", try running \"stack setup\" or use the \"--install-ghc\" flag."
-                                      ] ++
-                                      [ " To use your system GHC installation, run \"stack config set system-ghc --global true\", or use the \"--system-ghc\" flag."
-                                      | recommendSystemGhc
-                                      ]))
-                                (soptsResolveMissingGHC sopts)
-                        throwM $ CompilerVersionMismatch
-                            ((\(x, y, _) -> (x, y)) <$> msystem)
-                            (soptsWantedCompiler sopts, expectedArch)
-                            ghcVariant
-                            (case possibleCompilers of
-                                [] -> CompilerBuildStandard
-                                (_, compilerBuild):_ -> compilerBuild)
-                            (soptsCompilerCheck sopts)
-                            (soptsStackYaml sopts)
-                            suggestion
-
-            return (Right compilerTool, compilerBuild)
-
-    -- If we need to install a GHC, try to do so
-    -- Return the additional directory paths of GHC.
-    (compilerTool, compilerBuild) <-
+    (compilerBuild, mcompiler, isSandboxed, paths, mcompilerTool) <-
       case msystem of
-        Just system | canUseCompiler system -> return (Left system, CompilerBuildStandard)
+        Just system@(_, _, compiler) | canUseCompiler system -> do
+          let paths = ExtraDirs { edBins = [parent compiler], edInclude = [], edLib = [] }
+          return (CompilerBuildStandard, Just compiler, False, paths, Nothing)
         _ -> do
             -- List installed tools
             config <- view configL
             let localPrograms = configLocalPrograms config
             installed <- listInstalled localPrograms
             logDebug $ "Installed tools: \n - " <> mconcat (intersperse "\n - " (map (fromString . toolString) installed))
-            case soptsWantedCompiler sopts of
+            (compilerTool, compilerBuild) <-
+              case soptsWantedCompiler sopts of
                -- shall we build GHC from source?
                WCGhcGit commitId flavour -> buildGhcFromSource getSetupInfo' installed  (configCompilerRepository config) commitId flavour
-               _ -> installGhcBindist installed
+               _ -> installGhcBindist sopts getSetupInfo' installed
+            paths <- extraDirs compilerTool
+            pure (compilerBuild, Nothing, True, paths, Just compilerTool)
 
+    let wc = whichCompiler $ wantedToActual wanted
+    compiler <-
+      case mcompiler of
+        Just compiler -> pure compiler
+        Nothing -> do
+          menv0 <- view processContextL
+          m <- either throwM return
+             $ augmentPathMap (toFilePath <$> edBins paths) (view envVarsL menv0)
+          menv <- mkProcessContext (removeHaskellEnvVars m)
 
-    -- Install msys2 on windows, if necessary
-    mmsys2Tool <- getMmsys2Tool
+          case mcompilerTool of
+            Just (ToolGhcjs cv) ->
+              withProcessContext menv $
+              ensureGhcjsBooted cv (soptsInstallIfMissing sopts) (soptsGHCJSBootOpts sopts)
+            _ -> pure ()
 
-    -- FIXME get the actual compiler path right here!
-    paths <- do
-      -- Add GHC's and MSYS's paths to the config.
-      compilerPath <-
-        case compilerTool of
-          Left (_, _, dir) -> pure ExtraDirs { edBins = [dir], edInclude = [], edLib = [] }
-          Right tool -> extraDirs tool
-      msysPath <- for mmsys2Tool extraDirs
-      return $ compilerPath <> fold msysPath
+          let name =
+                case wc of
+                  Ghc -> "ghc"
+                  Ghcjs -> "ghcjs"
+          withProcessContext menv $ findExecutable name >>= either throwIO parseAbsFile
 
-    menv <- do
-      let ed = paths
-      menv0 <- view processContextL
-      m <- either throwM return
-         $ augmentPathMap (toFilePath <$> edBins ed) (view envVarsL menv0)
-      mkProcessContext (removeHaskellEnvVars m)
-
-    case compilerTool of
-        Right (ToolGhcjs cv) ->
-            withProcessContext menv
-          $ ensureGhcjsBooted cv (soptsInstallIfMissing sopts) (soptsGHCJSBootOpts sopts)
-        _ -> pure ()
-
-    let findHelper getName = do -- FIXME remove
-          eres <- withProcessContext menv $ findExecutable $ getName $ whichCompiler $ wantedToActual wanted
-          case eres of
-            Left e -> throwIO e
-            Right res -> parseAbsFile res
-
-    compiler <- findHelper $ \case
-                               Ghc -> "ghc"
-                               Ghcjs -> "ghcjs"
     when (soptsSanityCheck sopts) $ sanityCheck compiler
-    cp <- pathsFromCompiler (whichCompiler (wantedToActual wanted)) compilerBuild needLocal compiler
+    cp <- pathsFromCompiler wc compilerBuild isSandboxed compiler
     pure (cp, paths)
 
 pathsFromCompiler
@@ -639,7 +662,7 @@ pathsFromCompiler
   -> Bool
   -> Path Abs File -- ^ executable filepath
   -> RIO env CompilerPaths
-pathsFromCompiler wc compilerBuild needLocal compiler = handleAny onErr $ do
+pathsFromCompiler wc compilerBuild isSandboxed compiler = handleAny onErr $ do
     let dir = toFilePath $ parent compiler
         suffixNoVersion
           | osIsWindows = ".exe"
@@ -667,7 +690,9 @@ pathsFromCompiler wc compilerBuild needLocal compiler = handleAny onErr $ do
                                Ghc -> ["ghc-pkg"]
                                Ghcjs -> ["ghcjs-pkg"]
 
-    cabalPkgVer <- getCabalPkgVer pkg
+    menv0 <- view processContextL
+    menv <- mkProcessContext (removeHaskellEnvVars (view envVarsL menv0))
+    cabalPkgVer <- withProcessContext menv $ getCabalPkgVer pkg
     compilerVer <- getCompilerVersion wc compiler
 
     interpreter <- findHelper $
@@ -697,11 +722,11 @@ pathsFromCompiler wc compilerBuild needLocal compiler = handleAny onErr $ do
           logWarn "Parsing global DB from GHC info failed"
           logWarn $ displayShow e
           logWarn "Asking ghc-pkg directly"
-          getGlobalDB pkg
+          withProcessContext menv $ getGlobalDB pkg
         Right x -> pure x
     return CompilerPaths
       { cpBuild = compilerBuild
-      , cpSandboxed = needLocal
+      , cpSandboxed = isSandboxed
       , cpCompilerVersion = compilerVer
       , cpCompiler = compiler
       , cpPkg = pkg
@@ -719,14 +744,14 @@ buildGhcFromSource :: forall env.
    , HasProcessContext env
    , HasConfig env
    ) => Memoized SetupInfo -> [Tool] -> CompilerRepository -> Text -> Text
-   -> RIO env (Either (ActualCompiler, Arch, Path Abs Dir) Tool, CompilerBuild)
+   -> RIO env (Tool, CompilerBuild)
 buildGhcFromSource getSetupInfo' installed (CompilerRepository url) commitId flavour = do
    config <- view configL
    let compilerTool = ToolGhcGit commitId flavour
 
    -- detect when the correct GHC is already installed
    if compilerTool `elem` installed
-     then return (Right compilerTool,CompilerBuildStandard)
+     then return (compilerTool,CompilerBuildStandard)
      else do
        let repo = Repo
             { repoCommit = commitId
@@ -789,7 +814,7 @@ buildGhcFromSource getSetupInfo' installed (CompilerRepository url) commitId fla
                  dlinfo
                  compilerTool
                  (installer si)
-               return (Right compilerTool, CompilerBuildStandard)
+               return (compilerTool, CompilerBuildStandard)
            _ -> do
               forM_ files (logDebug . fromString . (" - " ++) . toFilePath)
               error "Can't find hadrian generated bindist"
@@ -951,7 +976,7 @@ ensureDockerStackExe containerPlatform = do
 getSystemCompiler
   :: (HasProcessContext env, HasLogFunc env)
   => WantedCompiler
-  -> RIO env (Maybe (ActualCompiler, Arch, Path Abs Dir))
+  -> RIO env (Maybe (ActualCompiler, Arch, Path Abs File))
 getSystemCompiler wanted = do
     let actual = wantedToActual wanted
         wc = whichCompiler actual
@@ -965,7 +990,6 @@ getSystemCompiler wanted = do
       Right exe -> do
         logDebug $ "Found executable at " <> fromString exe
         exePath <- parseAbsFile exe
-        let exeDir = parent exePath
         eres <- proc exe ["--info"] $ tryAny . fmap fst . readProcess_
         logDebug $ "--info results: " <> displayShow eres
         let minfo = do
@@ -975,12 +999,12 @@ getSystemCompiler wanted = do
                 arch <- lookup "Target platform" pairs_ >>= simpleParse . takeWhile (/= '-')
                 return (version, arch)
         case (wc, minfo) of
-            (Ghc, Just (version, arch)) -> return (Just (ACGhc version, arch, exeDir))
+            (Ghc, Just (version, arch)) -> return (Just (ACGhc version, arch, exePath))
             (Ghcjs, Just (_, arch)) -> do
                 eversion <- tryAny $ getCompilerVersion Ghcjs exePath
                 case eversion of
                     Left _ -> return Nothing
-                    Right version -> return (Just (version, arch, exeDir))
+                    Right version -> return (Just (version, arch, exePath))
             (_, Nothing) -> return Nothing
 
 -- | Download the most recent SetupInfo

--- a/src/Stack/SetupCmd.hs
+++ b/src/Stack/SetupCmd.hs
@@ -88,7 +88,7 @@ setup
     -> RIO env ()
 setup SetupCmdOpts{..} wantedCompiler compilerCheck mstack = do
     Config{..} <- view configL
-    sandboxedGhc <- (cpSandboxed . fst) <$> ensureCompilerAndMsys SetupOpts
+    sandboxedGhc <- cpSandboxed . fst <$> ensureCompilerAndMsys SetupOpts
         { soptsInstallIfMissing = True
         , soptsUseSystem = configSystemGHC && not scoForceReinstall
         , soptsWantedCompiler = wantedCompiler

--- a/src/Stack/SetupCmd.hs
+++ b/src/Stack/SetupCmd.hs
@@ -88,7 +88,7 @@ setup
     -> RIO env ()
 setup SetupCmdOpts{..} wantedCompiler compilerCheck mstack = do
     Config{..} <- view configL
-    sandboxedGhc <- cpSandboxed <$> ensureCompiler SetupOpts
+    sandboxedGhc <- (cpSandboxed . fst) <$> ensureCompiler SetupOpts
         { soptsInstallIfMissing = True
         , soptsUseSystem = configSystemGHC && not scoForceReinstall
         , soptsWantedCompiler = wantedCompiler

--- a/src/Stack/SetupCmd.hs
+++ b/src/Stack/SetupCmd.hs
@@ -88,7 +88,7 @@ setup
     -> RIO env ()
 setup SetupCmdOpts{..} wantedCompiler compilerCheck mstack = do
     Config{..} <- view configL
-    sandboxedGhc <- (cpSandboxed . fst) <$> ensureCompiler SetupOpts
+    sandboxedGhc <- (cpSandboxed . fst) <$> ensureCompilerAndMsys SetupOpts
         { soptsInstallIfMissing = True
         , soptsUseSystem = configSystemGHC && not scoForceReinstall
         , soptsWantedCompiler = wantedCompiler

--- a/src/Stack/SourceMap.hs
+++ b/src/Stack/SourceMap.hs
@@ -21,7 +21,7 @@ module Stack.SourceMap
     , SnapshotCandidate
     ) where
 
-import Data.ByteString.Builder (byteString, lazyByteString)
+import Data.ByteString.Builder (byteString)
 import qualified Data.Conduit.List as CL
 import qualified Distribution.PackageDescription as PD
 import Distribution.System (Platform(..))
@@ -238,9 +238,7 @@ pruneGlobals globals deps =
      Map.map ReplacedGlobalPackage prunedGlobals
 
 getCompilerInfo :: (HasConfig env, HasCompiler env) => RIO env Builder
-getCompilerInfo = do
-    compilerExe <- view $ compilerPathsL.to cpCompiler.to toFilePath
-    lazyByteString . fst <$> proc compilerExe ["--info"] readProcess_
+getCompilerInfo = view $ compilerPathsL.to (byteString . cpGhcInfo)
 
 immutableLocSha :: PackageLocationImmutable -> Builder
 immutableLocSha = byteString . treeKeyToBs . locationTreeKey

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1262,7 +1262,7 @@ platformGhcRelDir
     => m (Path Rel Dir)
 platformGhcRelDir = do
     cp <- view compilerPathsL
-    let cbSuffix = maybe "" compilerBuildSuffix $ cpBuild cp
+    let cbSuffix = compilerBuildSuffix $ cpBuild cp
     verOnly <- platformGhcVerOnlyRelDirStr
     parseRelDir (mconcat [ verOnly, cbSuffix ])
 
@@ -1885,7 +1885,7 @@ getGhcPkgExe = view $ compilerPathsL.to cpPkg
 -- | Paths on the filesystem for the compiler we're using
 data CompilerPaths = CompilerPaths
   { cpCompilerVersion :: !ActualCompiler
-  , cpBuild :: !(Maybe CompilerBuild)
+  , cpBuild :: !CompilerBuild
   , cpCompiler :: !(Path Abs File)
   -- | ghc-pkg or equivalent
   , cpPkg :: !GhcPkgExe

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1895,7 +1895,6 @@ data CompilerPaths = CompilerPaths
   , cpHaddock :: !(Path Abs File)
   -- | Is this a Stack-sandboxed installation?
   , cpSandboxed :: !Bool
-  , cpExtraDirs :: !ExtraDirs
   , cpCabalVersion :: !Version
   -- ^ This is the version of Cabal that stack will use to compile Setup.hs files
   -- in the build process.

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -143,10 +143,8 @@ module Stack.Types.Config
   ,actualCompilerVersionL
   ,HasCompiler(..)
   ,CompilerPaths(..)
-  ,cpInterpreter
-  ,cpHaddock
-  ,cpCabalVersion
-  ,cpGlobalDB
+  ,GhcPkgExe(..)
+  ,getGhcPkgExe
   ,cpWhich
   ,ExtraDirs(..)
   ,buildOptsL
@@ -560,7 +558,6 @@ data EnvConfig = EnvConfig
     ,envConfigSourceMap :: !SourceMap
     ,envConfigSourceMapHash :: !SourceMapHash
     ,envConfigCompilerPaths :: !CompilerPaths
-    ,envConfigCabalVersion :: !Version
     }
 
 ppGPD :: MonadIO m => ProjectPackage -> m GenericPackageDescription
@@ -1878,54 +1875,39 @@ stackRootL = configL.lens configStackRoot (\x y -> x { configStackRoot = y })
 wantedCompilerVersionL :: HasBuildConfig s => Getting r s WantedCompiler
 wantedCompilerVersionL = buildConfigL.to (smwCompiler . bcSMWanted)
 
+-- | Location of the ghc-pkg executable
+newtype GhcPkgExe = GhcPkgExe (Path Abs File)
+
+-- | Get the 'GhcPkgExe' from a 'HasCompiler' environment
+getGhcPkgExe :: HasCompiler env => RIO env GhcPkgExe
+getGhcPkgExe = view $ compilerPathsL.to cpPkg
+
 -- | Paths on the filesystem for the compiler we're using
 data CompilerPaths = CompilerPaths
   { cpCompilerVersion :: !ActualCompiler
   , cpBuild :: !(Maybe CompilerBuild)
   , cpCompiler :: !(Path Abs File)
   -- | ghc-pkg or equivalent
-  , cpPkg :: !(Path Abs File)
-  -- | runghc, in 'IO' to allow deferring the lookup
-  , cpInterpreter' :: !(CompilerPaths -> IO (Path Abs File))
+  , cpPkg :: !GhcPkgExe
+  -- | runghc
+  , cpInterpreter :: !(Path Abs File)
   -- | haddock, in 'IO' to allow deferring the lookup
-  , cpHaddock' :: !(CompilerPaths -> IO (Path Abs File))
+  , cpHaddock :: !(Path Abs File)
   -- | Is this a Stack-sandboxed installation?
   , cpSandboxed :: !Bool
   , cpExtraDirs :: !ExtraDirs
-  , cpCabalVersion' :: !(CompilerPaths -> IO Version)
+  , cpCabalVersion :: !Version
   -- ^ This is the version of Cabal that stack will use to compile Setup.hs files
   -- in the build process.
   --
   -- Note that this is not necessarily the same version as the one that stack
   -- depends on as a library and which is displayed when running
   -- @stack list-dependencies | grep Cabal@ in the stack project.
-  , cpGlobalDB' :: !(CompilerPaths -> IO (Path Abs Dir))
+  , cpGlobalDB :: !(Path Abs Dir)
   -- ^ Global package database
+  , cpGhcInfo :: !ByteString
+  -- ^ Output of @ghc --info@
   }
-
--- | Helper for 'cpInterpreter''
-cpInterpreter :: HasCompiler env => RIO env (Path Abs File)
-cpInterpreter = do
-  env <- view compilerPathsL
-  liftIO $ cpInterpreter' env env
-
--- | Helper for 'cpHaddock''
-cpHaddock :: HasCompiler env => RIO env (Path Abs File)
-cpHaddock = do
-  env <- view compilerPathsL
-  liftIO $ cpHaddock' env env
-
--- | Helper for 'cpCabalVersion''
-cpCabalVersion :: HasCompiler env => RIO env Version
-cpCabalVersion = do
-  env <- view compilerPathsL
-  liftIO $ cpCabalVersion' env env
-
--- | Helper for 'cpGlobalDB''
-cpGlobalDB :: HasCompiler env => RIO env (Path Abs Dir)
-cpGlobalDB = do
-  env <- view compilerPathsL
-  liftIO $ cpGlobalDB' env env
 
 cpWhich :: (MonadReader env m, HasCompiler env) => m WhichCompiler
 cpWhich = view $ compilerPathsL.to (whichCompiler.cpCompilerVersion)
@@ -2001,8 +1983,8 @@ globalOptsBuildOptsMonoidL =
     configMonoidBuildOpts
     (\x y -> x { configMonoidBuildOpts = y })
 
-cabalVersionL :: HasEnvConfig env => SimpleGetter env Version
-cabalVersionL = envConfigL.to envConfigCabalVersion
+cabalVersionL :: HasCompiler env => SimpleGetter env Version
+cabalVersionL = compilerPathsL.to cpCabalVersion
 
 whichCompilerL :: Getting r ActualCompiler WhichCompiler
 whichCompilerL = to whichCompiler

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -194,7 +194,7 @@ import           Data.Yaml (ParseException)
 import qualified Data.Yaml as Yaml
 import           Distribution.PackageDescription (GenericPackageDescription)
 import qualified Distribution.PackageDescription as C
-import           Distribution.System (Platform)
+import           Distribution.System (Platform, Arch)
 import qualified Distribution.Text
 import qualified Distribution.Types.UnqualComponentName as C
 import           Distribution.Version (anyVersion, mkVersion', mkVersion)
@@ -1885,6 +1885,7 @@ getGhcPkgExe = view $ compilerPathsL.to cpPkg
 -- | Paths on the filesystem for the compiler we're using
 data CompilerPaths = CompilerPaths
   { cpCompilerVersion :: !ActualCompiler
+  , cpArch :: !Arch
   , cpBuild :: !CompilerBuild
   , cpCompiler :: !(Path Abs File)
   -- | ghc-pkg or equivalent

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -801,7 +801,8 @@ execCmd ExecOpts {..} =
 
       -- return the package-id of the first package in GHC_PACKAGE_PATH
       getPkgId name = do
-          mId <- findGhcPkgField [] name "id"
+          pkg <- getGhcPkgExe
+          mId <- findGhcPkgField pkg [] name "id"
           case mId of
               Just i -> return (head $ words (T.unpack i))
               -- should never happen as we have already installed the packages
@@ -838,7 +839,7 @@ execCmd ExecOpts {..} =
 
       getRunGhcCmd pkgs args = do
           pkgopts <- getPkgOpts pkgs
-          interpret <- cpInterpreter
+          interpret <- view $ compilerPathsL.to cpInterpreter
           return (toFilePath interpret, pkgopts ++ args)
 
       runWithPath :: Maybe FilePath -> RIO EnvConfig () -> RIO EnvConfig ()

--- a/src/test/Stack/PackageDumpSpec.hs
+++ b/src/test/Stack/PackageDumpSpec.hs
@@ -16,6 +16,7 @@ import           Stack.PackageDump
 import           Stack.Prelude
 import           Stack.Setup
 import           Stack.Types.Compiler          (ActualCompiler (..))
+import           Stack.Types.CompilerBuild     (CompilerBuild (..))
 import           Stack.Types.Config
 import           Stack.Types.GhcPkgId
 import           RIO.Process
@@ -271,7 +272,7 @@ runEnvNoLogging inner = do
   pkg <- find "ghc-pkg"
   let cp = CompilerPaths
         { cpCompilerVersion = ACGhc $ mkVersion [1, 2, 3]
-        , cpBuild = Nothing
+        , cpBuild = CompilerBuildStandard
         , cpCompiler = compiler
         , cpPkg = pkg
         , cpInterpreter' = const $ pure undefined


### PR DESCRIPTION
This is a refactoring of a bunch of code in Stack.Setup and related modules to make it possible to begin caching GHC information. These changes already improve the behavior of Stack slightly, such as

* Warning on untested or unsupported GHC/Cabal versions
* Avoiding redundant global package checks
* Checking for multiple system GHCs in a sensible order

I'm opening up this PR first for review, and once this is merged, I'll work on the caching logic, which will allow us to bypass a few expensive external process calls on each Stack invocation.