### PR TITLE
Modify the GHC_ENVIRONMENT env var in Stack.Setup

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -160,7 +160,7 @@ Other enhancements:
 * Include default values for most command line flags in the `--help`
   output. See
   [#893](https://github.com/commercialhaskell/stack/issues/893).
-* environment variable `GHC_ENVIRONMENT` is set to specify dependency
+* Set the `GHC_ENVIRONMENT` environment variable to specify dependency
   packages explicitly when running test. This is done to prevent
   ambiguous module name errors in `doctest` tests.
 - Document the way stack interacts with the Cabal library.
@@ -181,6 +181,13 @@ Other enhancements:
 * User config files are respected for the script command. See
   [#3705](https://github.com/commercialhaskell/stack/issues/3705),
   [#3887](https://github.com/commercialhaskell/stack/issues/3887).
+* Set the `GHC_ENVIRONMENT` environment variable to `-` to tell GHC to
+  ignore any such files when GHC is new enough (>= 8.4.4), otherwise
+  simply unset the variable. This allows Stack to have control of
+  package databases when running commands like `stack exec ghci`, even
+  in the presence of implicit environment files created by `cabal
+  new-build`. See
+  [#4706](https://github.com/commercialhaskell/stack/issues/4706).
 
 Bug fixes:
 

--- a/test/integration/tests/4706-ignore-ghc-env-files/Main.hs
+++ b/test/integration/tests/4706-ignore-ghc-env-files/Main.hs
@@ -1,0 +1,27 @@
+import StackTest
+import Control.Exception (bracket_)
+import Control.Monad (when)
+import System.Environment
+import System.Directory
+import System.Info (arch, os)
+
+main :: IO ()
+main = when False $ do -- skip this test until we start using GHC 8.4.4 or later for integration tests
+  let ghcVer = "8.4.4"
+      fp = concat
+        [ ".ghc.environment."
+        , arch
+        , "-"
+        , os
+        , "-"
+        , ghcVer
+        ]
+  writeFile "stack.yaml" $ "resolver: ghc-" ++ ghcVer
+  bracket_
+    (writeFile fp "This is an invalid GHC environment file")
+    (removeFile fp) $ do
+      envFile <- canonicalizePath fp
+      setEnv "GHC_ENVIRONMENT" envFile
+      stack ["clean"]
+      stack ["build"]
+      stack ["runghc", "Main.hs"]

--- a/test/integration/tests/4706-ignore-ghc-env-files/files/.gitignore
+++ b/test/integration/tests/4706-ignore-ghc-env-files/files/.gitignore
@@ -1,0 +1,2 @@
+foo.cabal
+stack.yaml

--- a/test/integration/tests/4706-ignore-ghc-env-files/files/Main.hs
+++ b/test/integration/tests/4706-ignore-ghc-env-files/files/Main.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = pure ()

--- a/test/integration/tests/4706-ignore-ghc-env-files/files/package.yaml
+++ b/test/integration/tests/4706-ignore-ghc-env-files/files/package.yaml
@@ -1,0 +1,7 @@
+name: foo
+version: 0
+
+dependencies:
+- base
+
+library: {}


### PR DESCRIPTION
CC @phadej @tfausak 

This fixes #4706. Since GHC 8.0, GHC will now implicitly read in from a
.ghc.environment.* file, which can cause commands like `stack exec ghci`
to fail. Due to the use case of `stack exec`, it doesn't make sense to
try to create our own environment file, but instead tell GHC to ignore
it. Unfortunately, the ability to ignore environment files was only
added in GHC 8.4.4. This patch:

* Unsets any `GHC_ENVIRONMENT` variable already set outside of Stack
* When using GHC 8.4.4 or later, sets the variable to `-`

This will help work around situations where `cabal new-build` creates an
environment file without the user's awareness. This may be somewhat
superfluous in the future depending on changes to either GHC or
cabal-install, but shouldn't present any harm for the foreseeable future
(unless GHC changes its understanding of `GHC_ENVIRONMENT`).

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
