### PR TITLE
Cache GHC information in the SQLite database

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -202,6 +202,7 @@ Other enhancements:
   in the presence of implicit environment files created by `cabal
   new-build`. See
   [#4706](https://github.com/commercialhaskell/stack/issues/4706).
+* Use a database cache table to speed up discovery of installed GHCs
 
 Bug fixes:
 

--- a/src/Stack/Storage.hs
+++ b/src/Stack/Storage.hs
@@ -149,7 +149,7 @@ CompilerCache
   -- is very cheap, so we'll take the easy way out for now.
   globalDump Text
 
-  UniqueGhcInfo ghcPath
+  UniqueCompilerInfo ghcPath
 |]
 
 -- | Initialize the database.
@@ -468,7 +468,7 @@ loadCompilerPaths
   -> Bool -- ^ sandboxed?
   -> RIO env (Maybe CompilerPaths)
 loadCompilerPaths compiler build sandboxed = do
-  mres <- withStorage $ getBy $ UniqueGhcInfo $ toFilePath compiler
+  mres <- withStorage $ getBy $ UniqueCompilerInfo $ toFilePath compiler
   for mres $ \(Entity _ CompilerCache {..}) -> do
     compilerStatus <- liftIO $ getFileStatus $ toFilePath compiler
     when
@@ -520,7 +520,7 @@ saveCompilerPaths
   => CompilerPaths
   -> RIO env ()
 saveCompilerPaths CompilerPaths {..} = withStorage $ do
-  deleteBy $ UniqueGhcInfo $ toFilePath cpCompiler
+  deleteBy $ UniqueCompilerInfo $ toFilePath cpCompiler
   compilerStatus <- liftIO $ getFileStatus $ toFilePath cpCompiler
   globalDbStatus <- liftIO $ getFileStatus $ toFilePath $ cpGlobalDB </> $(mkRelFile "package.cache")
   let GhcPkgExe pkgexe = cpPkg

--- a/src/Stack/Types/Compiler.hs
+++ b/src/Stack/Types/Compiler.hs
@@ -22,6 +22,8 @@ module Stack.Types.Compiler
   ) where
 
 import           Data.Aeson
+import           Database.Persist
+import           Database.Persist.Sql
 import qualified Data.Text as T
 import           Data.Text (Text)
 import           Stack.Prelude
@@ -60,6 +62,11 @@ instance FromJSONKey ActualCompiler where
         case parseActualCompiler k of
             Left _ -> fail $ "Failed to parse CompilerVersion " ++ T.unpack k
             Right parsed -> return parsed
+instance PersistField ActualCompiler where
+  toPersistValue = toPersistValue . compilerVersionText
+  fromPersistValue = (mapLeft tshow . parseActualCompiler) <=< fromPersistValue
+instance PersistFieldSql ActualCompiler where
+  sqlType _ = SqlString
 
 wantedToActual :: WantedCompiler -> ActualCompiler
 wantedToActual (WCGhc x) = ACGhc x

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1881,6 +1881,7 @@ wantedCompilerVersionL = buildConfigL.to (smwCompiler . bcSMWanted)
 
 -- | Location of the ghc-pkg executable
 newtype GhcPkgExe = GhcPkgExe (Path Abs File)
+  deriving Show
 
 -- | Get the 'GhcPkgExe' from a 'HasCompiler' environment
 getGhcPkgExe :: HasCompiler env => RIO env GhcPkgExe
@@ -1901,7 +1902,7 @@ data DumpPackage = DumpPackage
     , dpHaddockHtml :: !(Maybe FilePath)
     , dpIsExposed :: !Bool
     }
-    deriving (Show, Eq)
+    deriving (Show, Read, Eq)
 
 -- | Paths on the filesystem for the compiler we're using
 data CompilerPaths = CompilerPaths
@@ -1930,6 +1931,7 @@ data CompilerPaths = CompilerPaths
   -- ^ Output of @ghc --info@
   , cpGlobalDump :: !(Map PackageName DumpPackage)
   }
+  deriving Show
 
 cpWhich :: (MonadReader env m, HasCompiler env) => m WhichCompiler
 cpWhich = view $ compilerPathsL.to (whichCompiler.cpCompilerVersion)

--- a/src/Stack/Types/GhcPkgId.hs
+++ b/src/Stack/Types/GhcPkgId.hs
@@ -18,6 +18,7 @@ import           Data.Aeson.Extended
 import           Data.Attoparsec.Text
 import qualified Data.Text as T
 import           Database.Persist.Sql (PersistField, PersistFieldSql)
+import           Prelude (Read (..))
 
 -- | A parse fail.
 newtype GhcPkgIdParseFail
@@ -36,6 +37,8 @@ instance NFData GhcPkgId
 
 instance Show GhcPkgId where
   show = show . ghcPkgIdString
+instance Read GhcPkgId where
+  readsPrec i = map (first (GhcPkgId . T.pack)) . readsPrec i
 
 instance FromJSON GhcPkgId where
   parseJSON = withText "GhcPkgId" $ \t ->


### PR DESCRIPTION
This bypasses a few relatively expensive external process executions on
each Stack invocation, namely `ghc --info` and `ghc-pkg dump`.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
