### PR TITLE
Set empty input to sinkProcessStderrStdout

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1193,6 +1193,9 @@ withSingleContext ActionContext {..} ExecuteEnv {..} task@Task {..} mdeps msuffi
                         OTLogFile _ h ->
                             proc (toFilePath exeName) fullArgs
                           $ runProcess_
+                            -- Don't use closed, since that can break
+                            -- ./configure scripts. See:
+                            -- https://github.com/commercialhaskell/stack/pull/4722
                           . setStdin (byteStringInput "")
                           . setStdout (useHandleOpen h)
                           . setStderr (useHandleOpen h)

--- a/src/Stack/Prelude.hs
+++ b/src/Stack/Prelude.hs
@@ -37,7 +37,7 @@ import           System.IO.Echo (withoutInputEcho)
 
 import qualified Data.Conduit.Binary as CB
 import qualified Data.Conduit.List as CL
-import           Data.Conduit.Process.Typed (withLoggedProcess_, createSource)
+import           Data.Conduit.Process.Typed (withLoggedProcess_, createSource, byteStringInput)
 import           RIO.Process (HasProcessContext (..), ProcessContext, setStdin, closed, getStderr, getStdout, proc, withProcess_, setStdout, setStderr, ProcessConfig, readProcess_, workingDirL)
 import           Data.Text.Encoding (decodeUtf8With)
 import           Data.Text.Encoding.Error (lenientDecode)
@@ -70,6 +70,9 @@ sinkProcessStderrStdout name args sinkStderr sinkStdout =
   proc name args $ \pc0 -> do
     let pc = setStdout createSource
            $ setStderr createSource
+           -- Don't use closed, since that can break ./configure scripts
+           -- See https://github.com/commercialhaskell/stack/pull/4722
+           $ setStdin (byteStringInput "")
              pc0
     withProcess_ pc $ \p ->
       runConduit (getStderr p .| sinkStderr) `concurrently`


### PR DESCRIPTION
This is intended to address intermittent integration test failures,
which started as a result of the new integration test runner. This is a
weird corner case, but here goes:

* ./configure scripts will fail if run with `stdin` closed. We already
work around this in Stack.Build.Execute in the OTLogFile case

* However, in the OTConsole case, we use the sinkProcessStderrStdout
functions, which inherits stdin

* The current behavior can be classified as a bug: we don't want
subprocesses to be exposed to stdin in general.

    * Reviewer request: I've checked the other use cases for
      sinkProcessStderrStdout, and I believe in _all_ cases we do not want the
      subprocess to have such stdin access. Please confirm I haven't made a
      mistake.

* The new integration test runner explicit uses `setStdin closed`...

* And in some cases, the runner will try to build the `network` package,
which has a ./configure script. I don't know why this package isn't
built every time, but when it is built, it fails with a file descriptor
0 error