### PR TITLE
New CI build rules

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,11 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - ci/*
+    - master
+    - stable
+
 variables:
   BASE_BRANCH: "master"
   CACHE_S3_PREFIX: "stack"


### PR DESCRIPTION
New rules are as follows:
• Run CI if commits are pushed to stable, master branch
• Run CI for all new PR's
• Run CI for branches starting with `ci/`
