### PR TITLE
Prefer compilers including the version number

### DIFF
--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -698,11 +698,21 @@ ensureSandboxedCompiler sopts getSetupInfo' = do
               ensureGhcjsBooted cv (soptsInstallIfMissing sopts) (soptsGHCJSBootOpts sopts)
             _ -> pure ()
 
-          let name =
-                case wc of
-                  Ghc -> "ghc"
-                  Ghcjs -> "ghcjs"
-          withProcessContext menv $ findExecutable name >>= either throwIO parseAbsFile
+          let names =
+                case wanted of
+                  WCGhc version -> ["ghc-" ++ versionString version, "ghc"]
+                  WCGhcGit{} -> ["ghc"]
+                  WCGhcjs{} -> ["ghcjs"]
+              loop [] = do
+                logError $ "Looked for sandboxed compiler named one of: " <> displayShow names
+                logError $ "Could not find it on the paths " <> displayShow (edBins paths)
+                throwString "Could not find sandboxed compiler"
+              loop (x:xs) = do
+                res <- findExecutable x
+                case res of
+                  Left _ -> loop xs
+                  Right y -> parseAbsFile y
+          withProcessContext menv $ loop names
 
     when (soptsSanityCheck sopts) $ sanityCheck compiler
     cp <- pathsFromCompiler wc compilerBuild isSandboxed compiler


### PR DESCRIPTION
This should hopefully fix #4727, by finding the Haddock executable even
though the copy without a version suffix is unavailable.