### PR TITLE
GHC Hide Source Paths

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -101,6 +101,10 @@ Behavior changes:
   addition, the `packagename> ` prefix is no longer included in
   interelaved mode when only building a single target.
 
+* The `-fhide-source-paths` GHC option is now enabled by default and
+  can be disabled via the `hide-source-paths` configuration option in
+  `stack.yaml`. See [#3784](https://github.com/commercialhaskell/stack/issues/3784)
+
 Other enhancements:
 
 * Defer loading up of files for local packages. This allows us to get

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -1045,3 +1045,25 @@ a yaml configuration file.
 
 (The British English spelling (colour) is also accepted. In yaml configuration
 files, the American spelling is the alternative that has priority.)
+
+### hide-source-directories
+
+Stack will use the `-fhide-source-paths` option by default for GHC >= 8.2, unless this
+option is set to `false`. 
+
+When enabled:
+
+```
+...
+[1 of 2] Compiling Lib
+[2 of 2] Compiling Paths_test_pr
+...
+```
+
+When disabled:
+
+```
+...
+[1 of 2] Compiling Lib              ( src/Lib.hs, .stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/Lib.o )
+...
+```

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -1046,12 +1046,16 @@ a yaml configuration file.
 (The British English spelling (colour) is also accepted. In yaml configuration
 files, the American spelling is the alternative that has priority.)
 
-### hide-source-directories
+### hide-source-paths
 
 Stack will use the `-fhide-source-paths` option by default for GHC >= 8.2, unless this
-option is set to `false`. 
+option is set to `false` as in the following example:
 
-When enabled:
+```yaml
+hide-source-paths: false
+```
+
+Build output when enabled:
 
 ```
 ...
@@ -1060,10 +1064,12 @@ When enabled:
 ...
 ```
 
-When disabled:
+Build output when disabled:
 
 ```
 ...
 [1 of 2] Compiling Lib              ( src/Lib.hs, .stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/Lib.o )
 ...
 ```
+
+Since 2.0

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -309,6 +309,7 @@ configFromConfigMonoid
          configDumpLogs = fromFirst DumpWarningLogs configMonoidDumpLogs
          configSaveHackageCreds = fromFirst True configMonoidSaveHackageCreds
          configHackageBaseUrl = fromFirst "https://hackage.haskell.org/" configMonoidHackageBaseUrl
+         configHideSourcePaths = fromFirstTrue configMonoidHideSourcePaths
 
      configAllowDifferentUser <-
         case getFirst configMonoidAllowDifferentUser of

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -629,9 +629,14 @@ configureOptsNoDir econfig bco deps isLocal package = concat
     , maybe [] (\customGcc -> ["--with-gcc=" ++ toFilePath customGcc]) (configOverrideGccPath config)
     , ["--ghcjs" | wc == Ghcjs]
     , ["--exact-configuration"]
+    , ["--ghc-option=-fhide-source-paths" | hideSourcePaths cv]
     ]
   where
     wc = view (actualCompilerVersionL.to whichCompiler) econfig
+    cv = view (actualCompilerVersionL.to getGhcVersion) econfig
+
+    hideSourcePaths ghcVersion = ghcVersion >= mkVersion [8, 2] && configHideSourcePaths config
+
     config = view configL econfig
     bopts = bcoBuildOpts bco
 

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -883,6 +883,8 @@ parseConfigMonoidObject rootDir obj = do
     let configMonoidStyles = fromMaybe mempty $   configMonoidStylesUS
                                               <|> configMonoidStylesGB
 
+    configMonoidHideSourcePaths <- FirstTrue <$> obj ..:? configMonoidHideSourcePathsName
+
     return ConfigMonoid {..}
   where
     handleExplicitSetupDep :: Monad m => (Text, Bool) -> m (Maybe PackageName, Bool)
@@ -1032,6 +1034,9 @@ configMonoidStylesUSName = "stack-colors"
 
 configMonoidStylesGBName :: Text
 configMonoidStylesGBName = "stack-colours"
+
+configMonoidHideSourcePathsName :: Text
+configMonoidHideSourcePathsName = "hide-source-paths"
 
 data ConfigException
   = ParseConfigFileException (Path Abs File) ParseException

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -360,6 +360,8 @@ data Config =
          -- ^ Any resolver override from the command line
          ,configStorage             :: !Storage
          -- ^ Database connection pool for Stack database
+         ,configHideSourcePaths     :: !Bool
+         -- ^ Enable GHC hiding source paths?
          }
 
 -- | The project root directory, if in a project.
@@ -764,6 +766,8 @@ data ConfigMonoid =
     , configMonoidColorWhen          :: !(First ColorWhen)
     -- ^ When to use 'ANSI' colors
     , configMonoidStyles             :: !StylesUpdate
+    , configMonoidHideSourcePaths    :: !FirstTrue
+    -- ^ See 'configHideSourcePaths'
     }
   deriving (Show, Generic)
 


### PR DESCRIPTION
Add `ghc-option` to hide source paths when using ghc >= 8.2 as detailed in #3784.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

# To test
- The default output for compiling modules should hide the source paths
- The entry `hide-source-paths` in `stack.yaml` set to `false` should restore including the source paths
- The entry `hide-source-paths` in `stack.yaml` set to `true` should hide the source paths (as the default behavior)

E.g.:
When enabled:

```
...
[1 of 2] Compiling Lib
[2 of 2] Compiling Paths_test_pr
...
```

When disabled:

```
...
[1 of 2] Compiling Lib              ( src/Lib.hs, .stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/Lib.o )
...
```