### PR TITLE
Disable interleaved output when building Stackage with curator

### DIFF
--- a/subs/curator/app/Main.hs
+++ b/subs/curator/app/Main.hs
@@ -214,7 +214,7 @@ build jobs = do
   logInfo "Building"
   withWorkingDir unpackDir $ proc
     "stack"
-    (words $ "build --test --bench --test-suite-timeout=600 --no-rerun-tests --no-run-benchmarks --haddock --color never --jobs=" ++ show jobs)
+    (words $ "build --test --bench --test-suite-timeout=600 --no-rerun-tests --no-run-benchmarks --haddock --color never --no-interleaved-output --jobs=" ++ show jobs)
     runProcess_
 
 hackageDistro :: Target -> RIO PantryApp ()


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Curator-only fix
