### PR TITLE
Add configure-options settings (fixes #1438)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -60,6 +60,9 @@ Major changes:
       is uniquely identified by a commit id and an Hadrian "flavour" (Hadrian is
       the newer GHC build system), hence `compiler` can be set to use a GHC
       built from source with `ghc-git-COMMIT-FLAVOUR`
+* `stack.yaml` now supports a `configure-options`, which are passed directly to
+  the `configure` step in the Cabal build process. See
+  [#1438](https://github.com/commercialhaskell/stack/issues/1438)
 
 Behavior changes:
 * `stack.yaml` now supports `snapshot`: a synonym for `resolver`. See [#4256](https://github.com/commercialhaskell/stack/issues/4256)

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -585,6 +585,24 @@ on an options change, but this behavior can be changed back with the following:
 rebuild-ghc-options: true
 ```
 
+### configure-options
+
+Options which are passed to the configure step of the Cabal build process.
+These can either be set by package name, or using the `$everything`,
+`$targets`, and `$locals` special keys. These special keys have the same
+meaning as in `ghc-options`.
+
+```yaml
+configure-options:
+  $everything:
+  - --with-gcc
+  - /some/path
+  my-package:
+  - --another-flag
+```
+
+(Since 2.0)
+
 ### ghc-variant
 
 (Since 0.1.5)

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -244,9 +244,10 @@ loadPackage
   :: (HasBuildConfig env, HasSourceMap env)
   => PackageLocationImmutable
   -> Map FlagName Bool
-  -> [Text]
+  -> [Text] -- ^ GHC options
+  -> [Text] -- ^ Cabal configure options
   -> RIO env Package
-loadPackage loc flags ghcOptions = do
+loadPackage loc flags ghcOptions cabalConfigOpts = do
   compiler <- view actualCompilerVersionL
   platform <- view platformL
   let pkgConfig = PackageConfig
@@ -254,6 +255,7 @@ loadPackage loc flags ghcOptions = do
         , packageConfigEnableBenchmarks = False
         , packageConfigFlags = flags
         , packageConfigGhcOptions = ghcOptions
+        , packageConfigCabalConfigOpts = cabalConfigOpts
         , packageConfigCompilerVersion = compiler
         , packageConfigPlatform = platform
         }

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -118,7 +118,7 @@ type M = RWST -- TODO replace with more efficient WS stack on top of StackT
 
 data Ctx = Ctx
     { baseConfigOpts :: !BaseConfigOpts
-    , loadPackage    :: !(PackageLocationImmutable -> Map FlagName Bool -> [Text] -> M Package)
+    , loadPackage    :: !(PackageLocationImmutable -> Map FlagName Bool -> [Text] -> [Text] -> M Package)
     , combinedMap    :: !CombinedMap
     , ctxEnvConfig   :: !EnvConfig
     , callStack      :: ![PackageName]
@@ -171,7 +171,7 @@ instance HasEnvConfig Ctx where
 constructPlan :: forall env. HasEnvConfig env
               => BaseConfigOpts
               -> [DumpPackage] -- ^ locally registered
-              -> (PackageLocationImmutable -> Map FlagName Bool -> [Text] -> RIO EnvConfig Package) -- ^ load upstream package
+              -> (PackageLocationImmutable -> Map FlagName Bool -> [Text] -> [Text] -> RIO EnvConfig Package) -- ^ load upstream package
               -> SourceMap
               -> InstalledMap
               -> Bool
@@ -231,8 +231,8 @@ constructPlan baseConfigOpts0 localDumpPkgs loadPackage0 sourceMap installedMap 
 
     mkCtx econfig globalCabalVersion sources mcur pathEnvVar' = Ctx
         { baseConfigOpts = baseConfigOpts0
-        , loadPackage = \x y z -> runRIO econfig $
-            applyForceCustomBuild globalCabalVersion <$> loadPackage0 x y z
+        , loadPackage = \w x y z -> runRIO econfig $
+            applyForceCustomBuild globalCabalVersion <$> loadPackage0 w x y z
         , combinedMap = combineMap sources installedMap
         , ctxEnvConfig = econfig
         , callStack = []
@@ -469,7 +469,7 @@ tellExecutablesUpstream name retrievePkgLoc loc flags = do
     when (name `Set.member` wanted ctx) $ do
         mPkgLoc <- retrievePkgLoc
         forM_ mPkgLoc $ \pkgLoc -> do
-            p <- loadPackage ctx pkgLoc flags []
+            p <- loadPackage ctx pkgLoc flags [] []
             tellExecutablesPackage loc p
 
 tellExecutablesPackage :: InstallLocation -> Package -> M ()
@@ -505,7 +505,7 @@ installPackage name ps minstalled = do
     case ps of
         PSRemote pkgLoc _version _fromSnaphot cp -> do
             planDebug $ "installPackage: Doing all-in-one build for upstream package " ++ show name
-            package <- loadPackage ctx pkgLoc (cpFlags cp) (cpGhcOptions cp)
+            package <- loadPackage ctx pkgLoc (cpFlags cp) (cpGhcOptions cp) (cpCabalConfigOpts cp)
             resolveDepsAndInstall True (cpHaddocks cp) ps package minstalled
         PSFilePath lp -> do
             case lpTestBench lp of

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -165,6 +165,7 @@ gpdPackageDeps gpd ac platform flags =
             , packageConfigEnableBenchmarks = True
             , packageConfigFlags = flags
             , packageConfigGhcOptions = []
+            , packageConfigCabalConfigOpts = []
             , packageConfigCompilerVersion = ac
             , packageConfigPlatform = platform
             }

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -296,6 +296,7 @@ configFromConfigMonoid
 
      let configTemplateParams = configMonoidTemplateParameters
          configScmInit = getFirst configMonoidScmInit
+         configCabalConfigOpts = coerce configMonoidCabalConfigOpts
          configGhcOptionsByName = coerce configMonoidGhcOptionsByName
          configGhcOptionsByCat = coerce configMonoidGhcOptionsByCat
          configSetupInfoLocations = configMonoidSetupInfoLocations

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -627,12 +627,17 @@ loadGhciPkgDesc buildOptsCLI name cabalfp target = do
           (cpGhcOptions . ppCommon <$> M.lookup name smProject)
           <|>
           (cpGhcOptions . dpCommon <$> M.lookup name smDeps)
+        sourceMapCabalConfigOpts = fromMaybe [] $
+          (cpCabalConfigOpts . ppCommon <$> M.lookup name smProject)
+          <|>
+          (cpCabalConfigOpts . dpCommon <$> M.lookup name smDeps)
         config =
             PackageConfig
             { packageConfigEnableTests = True
             , packageConfigEnableBenchmarks = True
             , packageConfigFlags = getLocalFlags buildOptsCLI name
             , packageConfigGhcOptions = sourceMapGhcOptions
+            , packageConfigCabalConfigOpts = sourceMapCabalConfigOpts
             , packageConfigCompilerVersion = compilerVersion
             , packageConfigPlatform = view platformL econfig
             }

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -135,6 +135,7 @@ packageFromPackageDescription packageConfig pkgFlags (PackageDescriptionPair pkg
     , packageFiles = pkgFiles
     , packageUnknownTools = unknownTools
     , packageGhcOptions = packageConfigGhcOptions packageConfig
+    , packageCabalConfigOpts = packageConfigCabalConfigOpts packageConfig
     , packageFlags = packageConfigFlags packageConfig
     , packageDefaultFlags = M.fromList
       [(flagName flag, flagDefault flag) | flag <- pkgFlags]

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -511,6 +511,7 @@ getDefaultPackageConfig = do
     , packageConfigEnableBenchmarks = False
     , packageConfigFlags = mempty
     , packageConfigGhcOptions = []
+    , packageConfigCabalConfigOpts = []
     , packageConfigCompilerVersion = compilerVersion
     , packageConfigPlatform = platform
     }

--- a/src/Stack/SourceMap.hs
+++ b/src/Stack/SourceMap.hs
@@ -56,6 +56,7 @@ mkProjectPackage printWarnings dir buildHaddocks = do
                   , cpName = name
                   , cpFlags = mempty
                   , cpGhcOptions = mempty
+                  , cpCabalConfigOpts = mempty
                   , cpHaddocks = buildHaddocks
                   }
      }
@@ -86,6 +87,7 @@ additionalDepPackage buildHaddocks pl = do
                   , cpName = name
                   , cpFlags = mempty
                   , cpGhcOptions = mempty
+                  , cpCabalConfigOpts = mempty
                   , cpHaddocks = buildHaddocks
                   }
     }
@@ -107,6 +109,7 @@ snapToDepPackage buildHaddocks name SnapshotPackage{..} = do
                   , cpName = name
                   , cpFlags = spFlags
                   , cpGhcOptions = spGhcOptions
+                  , cpCabalConfigOpts = [] -- No spCabalConfigOpts, not present in snapshots
                   , cpHaddocks = buildHaddocks
                   }
     }

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -625,6 +625,7 @@ configureOptsNoDir econfig bco deps isLocal package = concat
                            else "-") <>
                        flagNameString name)
                     (Map.toList flags)
+    , map T.unpack $ packageCabalConfigOpts package
     , concatMap (\x -> [compilerOptionsCabalFlag wc, T.unpack x]) (packageGhcOptions package)
     , map ("--extra-include-dirs=" ++) (configExtraIncludeDirs config)
     , map ("--extra-lib-dirs=" ++) (configExtraLibDirs config)

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -102,6 +102,7 @@ data Package =
           ,packageUnknownTools :: !(Set ExeName)          -- ^ Build tools specified in the legacy manner (build-tools:) that failed the hard-coded lookup.
           ,packageAllDeps :: !(Set PackageName)           -- ^ Original dependencies (not sieved).
           ,packageGhcOptions :: ![Text]                   -- ^ Ghc options used on package.
+          ,packageCabalConfigOpts :: ![Text]              -- ^ Additional options passed to ./Setup.hs configure
           ,packageFlags :: !(Map FlagName Bool)           -- ^ Flags used on package.
           ,packageDefaultFlags :: !(Map FlagName Bool)    -- ^ Defaults for unspecified flags.
           ,packageLibraries :: !PackageLibraries          -- ^ does the package have a buildable library stanza?
@@ -216,6 +217,7 @@ data PackageConfig =
                 ,packageConfigEnableBenchmarks :: !Bool           -- ^ Are benchmarks enabled?
                 ,packageConfigFlags :: !(Map FlagName Bool)       -- ^ Configured flags.
                 ,packageConfigGhcOptions :: ![Text]               -- ^ Configured ghc options.
+                ,packageConfigCabalConfigOpts :: ![Text]          -- ^ ./Setup.hs configure options
                 ,packageConfigCompilerVersion :: ActualCompiler   -- ^ GHC version
                 ,packageConfigPlatform :: !Platform               -- ^ host platform
                 }

--- a/src/Stack/Types/SourceMap.hs
+++ b/src/Stack/Types/SourceMap.hs
@@ -38,6 +38,7 @@ data CommonPackage = CommonPackage
   , cpFlags :: !(Map FlagName Bool)
   -- ^ overrides default flags
   , cpGhcOptions :: ![Text] -- also lets us know if we're doing profiling
+  , cpCabalConfigOpts :: ![Text]
   , cpHaddocks :: !Bool
   }
 

--- a/test/integration/tests/1438-configure-options/Main.hs
+++ b/test/integration/tests/1438-configure-options/Main.hs
@@ -1,0 +1,18 @@
+import StackTest
+import Control.Monad (unless)
+import Data.Foldable (for_)
+import Data.List (isInfixOf)
+
+main :: IO ()
+main = do
+  stack ["clean", "--full"]
+  let stackYamlFiles = words "stack-locals.yaml stack-everything.yaml stack-targets.yaml stack-name.yaml"
+  for_ stackYamlFiles $ \stackYaml ->
+    stackErrStderr ["build", "--stack-yaml", stackYaml] $ \str ->
+      unless ("this is an invalid option" `isInfixOf` str) $
+      error "Configure option is not present"
+
+  stack ["build", "--stack-yaml", "stack-locals.yaml", "acme-missiles"]
+  stack ["build", "--stack-yaml", "stack-targets.yaml", "acme-missiles"]
+  stackErr ["build", "--stack-yaml", "stack-name.yaml", "acme-missiles"]
+  stackErr ["build", "--stack-yaml", "stack-everything.yaml", "acme-missiles"]

--- a/test/integration/tests/1438-configure-options/files/.gitignore
+++ b/test/integration/tests/1438-configure-options/files/.gitignore
@@ -1,0 +1,1 @@
+name.cabal

--- a/test/integration/tests/1438-configure-options/files/package.yaml
+++ b/test/integration/tests/1438-configure-options/files/package.yaml
@@ -1,0 +1,5 @@
+name: name
+version: 0
+
+dependencies: base
+library: {}

--- a/test/integration/tests/1438-configure-options/files/stack-everything.yaml
+++ b/test/integration/tests/1438-configure-options/files/stack-everything.yaml
@@ -1,0 +1,8 @@
+resolver: ghc-8.2.2
+
+extra-deps:
+- acme-missiles-0.3@rev:0
+
+configure-options:
+  $everything:
+  - this is an invalid option

--- a/test/integration/tests/1438-configure-options/files/stack-locals.yaml
+++ b/test/integration/tests/1438-configure-options/files/stack-locals.yaml
@@ -1,0 +1,8 @@
+resolver: ghc-8.2.2
+
+extra-deps:
+- acme-missiles-0.3@rev:0
+
+configure-options:
+  $locals:
+  - this is an invalid option

--- a/test/integration/tests/1438-configure-options/files/stack-name.yaml
+++ b/test/integration/tests/1438-configure-options/files/stack-name.yaml
@@ -1,0 +1,10 @@
+resolver: ghc-8.2.2
+
+extra-deps:
+- acme-missiles-0.3@rev:0
+
+configure-options:
+  name:
+  - this is an invalid option
+  acme-missiles:
+  - this is an invalid option

--- a/test/integration/tests/1438-configure-options/files/stack-targets.yaml
+++ b/test/integration/tests/1438-configure-options/files/stack-targets.yaml
@@ -1,0 +1,8 @@
+resolver: ghc-8.2.2
+
+extra-deps:
+- acme-missiles-0.3@rev:0
+
+configure-options:
+  $targets:
+  - this is an invalid option


### PR DESCRIPTION
Addresses #1438

Two points for discussion on this PR:

* Should we also be adding `configure-options` to Pantry snapshots, like we have support for `ghc-options`?
* Should we attempt to fold the `ghc-options` values into this field? I think not, since some commands use `ghc-options` but don't use `configure-options` (like `ghci`)

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
