### PR TITLE
Generate legacy snapshots

### DIFF
--- a/subs/curator/app/Main.hs
+++ b/subs/curator/app/Main.hs
@@ -77,6 +77,10 @@ options =
                  "Upload list of snapshot packages on Hackage as a distro"
                  hackageDistro
                  parseTarget
+      addCommand "legacy-bulk"
+                 "Bulk convert all new snapshots to the legacy LTS/Nightly directories"
+                 legacyBulk
+                 parseLegacyBulkArgs
     parseTarget =
       option (nightly <|> lts) ( long "target"
                               <> metavar "TARGET"
@@ -96,6 +100,10 @@ options =
                            <> value 1
                            <> help "Number of jobs to run Stackage build with"
                               )
+    parseLegacyBulkArgs = LegacyBulkArgs
+      <$> strOption (long "stackage-snapshots" <> metavar "DIR")
+      <*> strOption (long "lts-haskell" <> metavar "DIR")
+      <*> strOption (long "stackage-nightly" <> metavar "DIR")
 
 main :: IO ()
 main = runPantryApp $ do

--- a/subs/curator/app/Main.hs
+++ b/subs/curator/app/Main.hs
@@ -53,6 +53,10 @@ options =
                  "Check snapshot consistency"
                  (const checkSnapshot)
                  (pure ())
+      addCommand "legacy-snapshot"
+                 "Generate a legacy-format snapshot file"
+                 (const legacySnapshot)
+                 (pure ())
       addCommand "unpack"
                  "Unpack snapshot packages and create a Stack project for it"
                  (const unpackFiles)
@@ -167,6 +171,13 @@ checkSnapshot = do
   decodeFileThrow constraintsFilename >>= \constraints' -> do
     snapshot' <- loadSnapshotYaml
     checkDependencyGraph constraints' snapshot'
+
+legacySnapshot :: RIO PantryApp ()
+legacySnapshot = do
+  logInfo "Generating legacy-style snapshot file in legacy-snapshot.yaml"
+  snapshot' <- loadSnapshotYaml
+  legacy <- toLegacySnapshot snapshot'
+  liftIO $ encodeFile "legacy-snapshot.yaml" legacy
 
 unpackDir :: FilePath
 unpackDir = "unpack-dir"

--- a/subs/curator/src/Curator.hs
+++ b/subs/curator/src/Curator.hs
@@ -5,6 +5,7 @@ module Curator
 
 import Curator.Constants as Export
 import Curator.HackageDistro as Export
+import Curator.Legacy as Export
 import Curator.Repo as Export
 import Curator.StackageConstraints as Export
 import Curator.Snapshot as Export

--- a/subs/curator/src/Curator/Legacy.hs
+++ b/subs/curator/src/Curator/Legacy.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+-- | Legacy-style snapshot files
+module Curator.Legacy
+  ( LegacySnapshot
+  , toLegacySnapshot
+  ) where
+
+import RIO
+import RIO.PrettyPrint (HasTerm)
+import Pantry
+import Data.Yaml
+
+data LegacySnapshot = LegacySnapshot
+  { lsGhcVersion :: !Version
+  , lsCorePackages :: !(Map PackageName Version)
+  , lsPackages :: !(Map PackageName PackageInfo)
+  }
+
+data PackageInfo = PackageInfo
+  { piVersion :: !Version
+  , piCabalSha :: !SHA256
+  , piCabalSize :: !FileSize
+  , piFlags :: !(Map FlagName Bool)
+  , piHidden :: !Bool
+  }
+
+toLegacySnapshot
+  :: (HasPantryConfig env, HasTerm env)
+  => Snapshot
+  -> RIO env LegacySnapshot
+toLegacySnapshot Snapshot {..} = do
+  lsGhcVersion <-
+    case snapshotCompiler of
+      WCGhc v -> pure v
+      x -> error $ "Unexpected snapshotCompiler: " ++ show x
+  mglobalHints <- loadGlobalHints snapshotCompiler
+  lsCorePackages <-
+    case mglobalHints of
+      Nothing -> error $ "Could not load global hints for: " ++ show snapshotCompiler
+      Just x -> pure x
+  lsPackages <- traverse toPackageInfo snapshotPackages
+  pure LegacySnapshot {..}
+
+toPackageInfo
+  :: HasPantryConfig env
+  => SnapshotPackage
+  -> RIO env PackageInfo
+toPackageInfo (SnapshotPackage loc piFlags piHidden ghcOptions) = do
+  unless (null ghcOptions) $ error "ghc-options not supported"
+  (piVersion, BlobKey piCabalSha piCabalSize) <-
+    case loc of
+      PLIHackage (PackageIdentifier _name version) cabalFile _treekey ->
+        pure (version, cabalFile)
+      x -> error $ "Unsupported package location: " ++ show x
+  pure PackageInfo {..}
+
+instance ToJSON LegacySnapshot where
+  toJSON LegacySnapshot {..} = object
+    [ "system-info" .= object
+        [ "ghc-version" .= CabalString lsGhcVersion
+        , "core-packages" .= toCabalStringMap (CabalString <$> lsCorePackages)
+        ]
+    , "packages" .= toCabalStringMap lsPackages
+    ]
+
+instance ToJSON PackageInfo where
+  toJSON PackageInfo {..} = object
+    [ "version" .= CabalString piVersion
+    , "cabal-file-info" .= object
+        [ "size" .= piCabalSize
+        , "hashes" .= object
+            [ "SHA256" .= piCabalSha
+            ]
+        ]
+    , "constraints" .= object
+        [ "flags" .= toCabalStringMap piFlags
+        , "hidden" .= piHidden
+        ]
+    ]


### PR DESCRIPTION
I've checked that this provides enough information for Stack 1.9.3 to parse and use the generated snapshot files, and do not believe we need to produce any of the additional information that was in these files. I wanted to check with you @qrilka: where do you believe is the most logical place to put the code for adding the legacy snapshot file to the lts-haskell and stackage-nightly repos?