### PR TITLE
package.yaml: bump stack version to 2.0.0

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stack
-version: '1.10.0'
+version: '2.0.0'
 synopsis: The Haskell Tool Stack
 description: ! 'Please see the README.md for usage information, and
   the wiki on Github for more details.  Also, note that


### PR DESCRIPTION
This will be the unstable Stack 2 development branch.  Release candidate branch will be cut as v2.1.0, and first Stack 2 full release will be v2.1.1.  See [version scheme](https://docs.haskellstack.org/en/stable/maintainers/releases/#version-scheme).