### PR TITLE
MX linux support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -127,6 +127,8 @@ Behavior changes:
 
 Other enhancements:
 
+* Support MX Linux in get-stack.sh. Fixes
+  [#4769](https://github.com/commercialhaskell/stack/issues/4769).
 * Defer loading up of files for local packages. This allows us to get
   plan construction errors much faster, and avoid some unnecessary
   work when only building a subset of packages. This is especially

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -611,7 +611,8 @@ try_install_pkgs() {
 apt_get_install_pkgs() {
   # Grepping the output of dpkg-query and checking the overall status of the pipeline
   # causes differing behaviors across various shell versions. So it is more portable to
-  # just check the staus of dpkg-query
+  # just check the staus of dpkg-query.
+  # See https://github.com/commercialhaskell/stack/pull/4770#pullrequestreview-229732166
   if dpkg-query -W "$@" > /dev/null 2>&1; then
     info "Already installed!"
   elif ! sudocmd "install required system dependencies" apt-get install -y ${QUIET:+-qq} "$@"; then

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -609,7 +609,10 @@ try_install_pkgs() {
 
 # Install packages using apt-get
 apt_get_install_pkgs() {
-  if dpkg-query -W "$@" > /dev/null; then
+  # Grepping the output of dpkg-query and checking the overall status of the pipeline
+  # causes differing behaviors across various shell versions. So it is more portable to
+  # just check the staus of dpkg-query
+  if dpkg-query -W "$@" > /dev/null 2>&1; then
     info "Already installed!"
   elif ! sudocmd "install required system dependencies" apt-get install -y ${QUIET:+-qq} "$@"; then
     die "Installing apt packages failed.  Please run 'apt-get update' and try again."

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -447,7 +447,7 @@ GETDISTRO
     ubuntu|linuxmint|elementary|neon)
       do_ubuntu_install "$VERSION"
       ;;
-    debian|kali|raspbian)
+    debian|kali|raspbian|mx)
       do_debian_install "$VERSION"
       ;;
     fedora)
@@ -609,7 +609,7 @@ try_install_pkgs() {
 
 # Install packages using apt-get
 apt_get_install_pkgs() {
-  if ! dpkg-query -W "$@"|grep -v '^\S\+\s\+.\+$' > /dev/null; then
+  if dpkg-query -W "$@" > /dev/null; then
     info "Already installed!"
   elif ! sudocmd "install required system dependencies" apt-get install -y ${QUIET:+-qq} "$@"; then
     die "Installing apt packages failed.  Please run 'apt-get update' and try again."


### PR DESCRIPTION
Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Tested this by running the script against MX Linux 18.2 and Debian Stretch.

During testing I noticed that the dpkg-query check in apt_get_install_pkgs always assumes
that the packages are installed even when they aren't. This happens only on MX and not on
Debian and is probably a subtle behavior change between the /bin/sh versions in MX and Debian testing (I am not entirely sure though). This check was introduced in commit b46e5a7 a few days
back, reverting that to the previous version works fine in MX and Debian stretch. Please let me know if this is a problem, I'll try to find an alternative fix.