### PR TITLE
Use patched filelock with CLOEXEC

### DIFF
--- a/snapshot-lts-12.yaml
+++ b/snapshot-lts-12.yaml
@@ -10,8 +10,8 @@ packages:
 - yaml-0.10.4.0@rev:0 #for hpack-0.31
 - persistent-2.9.2@rev:0
 - persistent-sqlite-2.9.3@rev:0
-- github: nh2/filelock
-  commit: 7008cde39887131c7ca91ad1bad19e2c528c5ced
+- github: snoyberg/filelock
+  commit: 97e83ecc133cd60a99df8e1fa5a3c2739ad007dc
 
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712

--- a/snapshot-nightly.yaml
+++ b/snapshot-nightly.yaml
@@ -4,8 +4,8 @@ name: snapshot-for-building-stack-with-ghc-8.6.2
 packages:
 - persistent-2.9.2@rev:0
 - persistent-sqlite-2.9.3@rev:0
-- github: nh2/filelock
-  commit: 7008cde39887131c7ca91ad1bad19e2c528c5ced
+- github: snoyberg/filelock
+  commit: 97e83ecc133cd60a99df8e1fa5a3c2739ad007dc
 
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -19,8 +19,8 @@ packages:
 - process-1.6.3.0@sha256:fc77cfe75a9653b8c54ae455ead8c06cb8adc4d7a340984d84d8ca880b579919,2370 #because of https://github.com/haskell/process/pull/101
 - persistent-2.9.2@rev:0
 - persistent-sqlite-2.9.3@rev:0
-- github: nh2/filelock
-  commit: 7008cde39887131c7ca91ad1bad19e2c528c5ced
+- github: snoyberg/filelock
+  commit: 97e83ecc133cd60a99df8e1fa5a3c2739ad007dc
 
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712


### PR DESCRIPTION
Specifically, we're adding in this commit:

https://github.com/snoyberg/filelock/commit/4f080496d8bf153fbe26e64d1f52cf73c7db25f6

Without this change, very often on large builds we end up in a situation
where:

* Multiple threads are working in parallel
* Thread A needs to work with the database
* Thread A takes a file lock on the database
* Thread B forks a child process, which inherits the database lock
* Thread A releases the file lock
* Thread C attempts to take the file lock, but is blocked by B's child

As a demonstration, lsof showed me this on my system:

```
COMMAND     PID    USER   FD   TYPE DEVICE SIZE/OFF       NODE NAME
stack     20216 michael   12w   REG    1,4        0 8613331527 stack.sqlite3.pantry-write-lock
Cabal-sim 22736 michael   12w   REG    1,4        0 8613331527 stack.sqlite3.pantry-write-lock
ghc       22800 michael   12w   REG    1,4        0 8613331527 stack.sqlite3.pantry-write-lock
```

With this change in place, I witnessed 0 cases of the file lock not
acquired message from Stack on a large build.