### PR TITLE
Fix some misplaced parse warnings #4789

### DIFF
--- a/subs/pantry/src/Pantry/Types.hs
+++ b/subs/pantry/src/Pantry/Types.hs
@@ -1532,7 +1532,7 @@ instance FromJSON (WithJSONWarnings (Unresolved PackageLocationImmutable)) where
           repoObject :: Value -> Parser (WithJSONWarnings (Unresolved PackageLocationImmutable))
           repoObject = withObjectWarnings "UnresolvedPackageLocationImmutable.PLIRepo" $ \o -> do
             pm <- parsePackageMetadata o
-            repoSubdir <- o ..: "subdir"
+            repoSubdir <- o ..:? "subdir" ..!= ""
             repoCommit <- o ..: "commit"
             (repoType, repoUrl) <-
                 (o ..: "git" >>= \url -> pure (RepoGit, url)) <|>
@@ -1573,7 +1573,7 @@ instance FromJSON (WithJSONWarnings (Unresolved PackageLocationImmutable)) where
                     ]
               archiveHash <- o ..: "sha256"
               archiveSize <- o ..: "size"
-              archiveSubdir <- o ..: "subdir"
+              archiveSubdir <- o ..:? "subdir" ..!= ""
               pure $ pure $ PLIArchive Archive {..} pm) value
 
 instance FromJSON (WithJSONWarnings (Unresolved (NonEmpty RawPackageLocationImmutable))) where

--- a/subs/pantry/test/Pantry/TypesSpec.hs
+++ b/subs/pantry/test/Pantry/TypesSpec.hs
@@ -140,11 +140,10 @@ spec = do
       liftIO $
         Yaml.toJSON (nightlySnapshotLocation day) `shouldBe`
         Yaml.String (T.pack $ "nightly-" ++ show day)
-    it "FromJSON instance for Repo" $ do
-      repValue <-
-        case Yaml.decodeThrow samplePLIRepo of
-          Just x -> pure x
-          Nothing -> fail "Can't parse Repo"
+    it "FromJSON instance for PLIRepo" $ do
+      WithJSONWarnings unresolvedPli warnings <- Yaml.decodeThrow samplePLIRepo
+      warnings `shouldBe` []
+      pli <- resolvePaths Nothing unresolvedPli
       let repoValue =
               Repo
                   { repoSubdir = "wai"
@@ -153,13 +152,7 @@ spec = do
                         "d11d63f1a6a92db8c637a8d33e7953ce6194a3e0"
                   , repoUrl = "https://github.com/yesodweb/wai.git"
                   }
-      repValue `shouldBe` repoValue
-    it "FromJSON instance for PackageMetadata" $ do
-      pkgMeta <-
-        case Yaml.decodeThrow samplePLIRepo of
-          Just x -> pure x
-          Nothing -> fail "Can't parse Repo"
-      let cabalSha =
+          cabalSha =
               SHA256.fromHexBytes
                   "eea52c4967d8609c2f79213d6dffe6d6601034f1471776208404781de7051410"
           pantrySha =
@@ -177,7 +170,7 @@ spec = do
                   , pmTreeKey = TreeKey (BlobKey psha (FileSize 714))
                   , pmCabal = BlobKey csha (FileSize 1765)
                   }
-      pkgMeta `shouldBe` pkgValue
+      pli `shouldBe` PLIRepo repoValue pkgValue
     it "parseHackageText parses" $ do
       let txt =
               "persistent-2.8.2@sha256:df118e99f0c46715e932fe82d787fc09689d87898f3a8b13f5954d25af6b46a1,5058"


### PR DESCRIPTION
This fixes the warnings about extraneous fields, by having `PackageMetadata` content parsed within the `WarningParser` which tracks which fields are used. This does _not_ fully address #4789, please do not close that issue when merging this.