### PR TITLE
Get package name from completed information #4789

### DIFF
--- a/subs/pantry/src/Pantry.hs
+++ b/subs/pantry/src/Pantry.hs
@@ -1175,9 +1175,9 @@ addAndCompletePackagesToSnapshot loc cachedPL newPackages (AddPackagesConfig dro
                  -> RawPackageLocationImmutable
                  -> RIO env ([(PackageName, SnapshotPackage)], [CompletedPLI])
       addPackage (ps, completed) rawLoc = do
-        name <- getPackageLocationName rawLoc
         complLoc <- cachedSnapshotCompletePackageLocation cachedPL rawLoc
-        let p = (name, SnapshotPackage
+        let PackageIdentifier name _ = pliIdent complLoc
+            p = (name, SnapshotPackage
               { spLocation = complLoc
               , spFlags = Map.findWithDefault mempty name flags
               , spHidden = Map.findWithDefault False name hiddens

--- a/subs/pantry/src/Pantry/Types.hs
+++ b/subs/pantry/src/Pantry/Types.hs
@@ -107,6 +107,7 @@ module Pantry.Types
   , SnapshotCacheHash (..)
   , getGlobalHintsFile
   , bsToBlobKey
+  , pliIdent
   ) where
 
 import RIO
@@ -2269,7 +2270,13 @@ getGlobalHintsFile = do
 
 -- | Creates BlobKey for an input ByteString
 --
--- @sinc 0.1.0.0
+-- @since 0.1.0.0
 bsToBlobKey :: ByteString -> BlobKey
 bsToBlobKey bs =
     BlobKey (SHA256.hashBytes bs) (FileSize (fromIntegral (B.length bs)))
+
+-- | Identifier from a 'PackageLocationImmutable'
+pliIdent :: PackageLocationImmutable -> PackageIdentifier
+pliIdent (PLIHackage ident _ _) = ident
+pliIdent (PLIArchive _ pm) = pmIdent pm
+pliIdent (PLIRepo _ pm) = pmIdent pm


### PR DESCRIPTION
The completed package information already contains the package name,
bypassing the need for a package completion call if the cache (lock
file) already contains that information. This bypasses a spurious
warning about lacking cryptographic hashes, and likely improves
performance, for the repo and archive cases.

This wasn't discovered initially because the Hackage use case never had
an overhead: the specification of a RPLIHackage already contains the
package name in all cases.