### PR TITLE
Fix #4726: On Windows, inform or warn about 'programs' path with space

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -239,6 +239,10 @@ Other enhancements:
   [#2226](https://github.com/commercialhaskell/stack/issues/2226)
 * Windows terminal width detection is now done. See
   [#3588](https://github.com/commercialhaskell/stack/issues/3588)
+* On Windows, informs users if the 'programs' path contains a space character
+  and further warns users if that path does not have an alternative short
+  ('8 dot 3') name, referencing the `local-programs-path` configuration option.
+  See [#4726](https://github.com/commercialhaskell/stack/issues/4726)
 
 Bug fixes:
 

--- a/package.yaml
+++ b/package.yaml
@@ -243,6 +243,7 @@ library:
   - Stack.Unpack
   - Stack.Upgrade
   - Stack.Upload
+  - System.Info.ShortPathName
   - System.Permissions
   - System.Process.Pager
   - System.Terminal

--- a/src/unix/System/Info/ShortPathName.hs
+++ b/src/unix/System/Info/ShortPathName.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module System.Info.ShortPathName
+  ( getShortPathName
+  ) where
+
+import RIO.FilePath (FilePath)
+import RIO.Prelude (pure)
+import RIO.Prelude.Types (IO)
+
+getShortPathName :: FilePath -> IO FilePath
+getShortPathName = pure

--- a/src/windows/System/Info/ShortPathName.hs
+++ b/src/windows/System/Info/ShortPathName.hs
@@ -1,0 +1,5 @@
+module System.Info.ShortPathName
+  ( getShortPathName
+  ) where
+
+import System.Win32.Info (getShortPathName)


### PR DESCRIPTION
In module `Stack.Config`, function `configFromConfigMonoid`, a stack user is informed if the stack 'programs' path contains a space character. If the path also does not have an alternative short ('8 dot 3') name, the user is further warned of the implications for packages that make use of the GNU project's `configure` shell script.

New modules `System.Info` are added to `src/windows` and `src/unix` to re-export `getShortPathName` from the `System.Win32.Info` module of the `Win32` package in the case of Windows and do nothing in the case of Unix-like operating systems. This avoids the need for C preprocessor (CPP) directives in `Stack.Config`.

`ChangeLog.md` is updated, accordingly.

Tested on Windows 10 with 'programs' paths that do and do not contain space characters and, in the latter case, with paths that do and do not have '8 dot 3' names. Tested with paths that do not yet exist when stack is first run.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary. N/A - documentation was the subject of #4798.

Please also shortly describe how you tested your change. Bonus points for added tests! See above.
