### PR TITLE
Add note about installing SDK headers on macOs >= 10.14

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -89,6 +89,11 @@ After installation, running `stack setup` might fail with `configure: error: can
 
     xcode-select --install
 
+Starting with macOs 10.14 (Mojave) running `xcode-select --install` [might not be enough](https://forums.developer.apple.com/thread/104296). You will need to install additional headers by running:
+
+    cd /Library/Developer/CommandLineTools/Packages/
+    open macOS_SDK_headers_for_macOS_10.14.pkg
+
 If you are on OS X 10.11 ("El Capitan") and encounter either of these
 problems, see the linked FAQ entries:
 

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -291,8 +291,9 @@ do_osx_install() {
   info "Using generic bindist..."
   info ""
   install_64bit_osx_binary
-  info "NOTE: You may need to run 'xcode-select --install' to set"
-  info "      up the Xcode command-line tools, which Stack uses."
+  info "NOTE: You may need to run 'xcode-select --install' and/or"
+  info "      'open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg'"
+  info "      to set up the Xcode command-line tools, which Stack uses."
   info ""
 }
 


### PR DESCRIPTION
Adds a note about installing additional headers on more recent macOs versions, when `xcode-select --install` is not enough. Follow up from https://github.com/commercialhaskell/stack/issues/4426#issuecomment-488641809

