### PR TITLE
Pre-release package and snapshot updates

### DIFF
--- a/doc/azure/azure-linux-template.yml
+++ b/doc/azure/azure-linux-template.yml
@@ -10,13 +10,13 @@ jobs:
       stack-lts-13:
         BUILD: stack
         STACK_YAML: stack-lts-13.yaml
-      cabal-8.4.3:
+      cabal-8.4.4:
         BUILD: cabal
-        GHCVER: 8.4.3
+        GHCVER: 8.4.4
         CABALVER: 2.4
-      cabal-8.6.3:
+      cabal-8.6.5:
         BUILD: cabal
-        GHCVER: 8.6.3
+        GHCVER: 8.6.5
         CABALVER: 2.4
       nightly:
         BUILD: stack

--- a/doc/azure_ci.md
+++ b/doc/azure_ci.md
@@ -168,13 +168,13 @@ strategy:
     stack-lts-13:
       BUILD: stack
       STACK_YAML: stack-lts-13.yaml
-    cabal-8.4.3:
+    cabal-8.4.4:
       BUILD: cabal
-      GHCVER: 8.4.3
+      GHCVER: 8.4.4
       CABALVER: 2.4
-    cabal-8.6.3:
+    cabal-8.6.5:
       BUILD: cabal
-      GHCVER: 8.6.3
+      GHCVER: 8.6.5
       CABALVER: 2.4
     nightly:
       BUILD: stack

--- a/doc/build-overview.md
+++ b/doc/build-overview.md
@@ -76,7 +76,7 @@ specific package) and _general_ (general option `*` for flags is only available 
     * A map from package name to package location, flags, GHC options,
       and if a package should be hidden. All package locations here
       are immutable.
-    * A wanted compiler version, e.g. `ghc-8.4.3`
+    * A wanted compiler version, e.g. `ghc-8.6.5`
 * If the `--compiler` CLI arg is set, or the `compiler` config value
   is set (and `--resolver` CLI arg is not set), ignore the wanted
   compiler from the snapshot and use the specified wanted compiler

--- a/doc/pantry.md
+++ b/doc/pantry.md
@@ -36,7 +36,7 @@ There are essentially four different ways of specifying a snapshot
 location:
 
 * Via a compiler version, which is a "compiler only" snapshot. This
-  could be, e.g., `resolver: ghc-8.4.3`.
+  could be, e.g., `resolver: ghc-8.6.5`.
 * Via a URL pointing to a snapshot configuration file, e.g. `resolver: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2018/8/21.yaml`
 * Via a local file path pointing to a snapshot configuration file, e.g. `resolver: my-local-snapshot.yaml`
 * Via a _convenience synonym_, which provides a short form for some

--- a/doc/travis-complex.yml
+++ b/doc/travis-complex.yml
@@ -63,9 +63,9 @@ matrix:
   - env: BUILD=cabal GHCVER=8.4.4 CABALVER=2.2 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.4.4"
     addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=8.6.3 CABALVER=2.4 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 8.6.3"
-    addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.6.5 CABALVER=2.4 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.6.5"
+    addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.5,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   # see below.
@@ -108,7 +108,7 @@ matrix:
     addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-13"
-    compiler: ": #stack 8.6.3"
+    compiler: ": #stack 8.6.5"
     addons: {apt: {packages: [libgmp-dev]}}
 
   # Nightly builds are allowed to fail
@@ -151,7 +151,7 @@ matrix:
     os: osx
 
   - env: BUILD=stack ARGS="--resolver lts-13"
-    compiler: ": #stack 8.6.3 osx"
+    compiler: ": #stack 8.6.5 osx"
     os: osx
 
   - env: BUILD=stack ARGS="--resolver nightly"

--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ homepage: http://haskellstack.org
 custom-setup:
   dependencies:
   - base >=4.10 && < 5
-  - Cabal >= 2.4
+  - Cabal
   - filepath
 extra-source-files:
 # note: leaving out 'package.yaml' because it causes confusion with hackage metadata revisions
@@ -38,10 +38,10 @@ ghc-options:
 - -fwarn-incomplete-record-updates
 - -optP-Wno-nonportable-include-path # workaround [Filename case on macOS · Issue #4739 · haskell/cabal](https://github.com/haskell/cabal/issues/4739)
 dependencies:
-- Cabal >= 2.4
+- Cabal
 - aeson
 - annotated-wl-pprint
-- ansi-terminal >= 0.8.1
+- ansi-terminal
 - array
 - async
 - attoparsec
@@ -77,8 +77,6 @@ dependencies:
 - memory
 - microlens
 - mintty
-# TODO remove dep when persistent drops monad-logger
-- monad-logger
 - mono-traversable
 - mtl
 - mustache
@@ -99,8 +97,8 @@ dependencies:
 - regex-applicative-text
 - resource-pool
 - resourcet
-- retry >= 0.7
-- rio >= 0.1.9.2
+- retry
+- rio
 - rio-prettyprint
 - semigroups
 - split
@@ -119,7 +117,7 @@ dependencies:
 - typed-process
 - unicode-transforms
 - unix-compat
-- unliftio >= 0.2.8.0
+- unliftio
 - unordered-containers
 - vector
 - yaml

--- a/snapshot-lts-12.yaml
+++ b/snapshot-lts-12.yaml
@@ -1,9 +1,8 @@
-resolver: lts-12.20
+resolver: lts-12.26
 name: snapshot-for-building-stack-with-ghc-8.4.4
 
 packages:
 - Cabal-2.4.0.1@rev:0
-- githash-0.1.3.0@rev:0
 - hpack-0.31.1@rev:0
 - infer-license-0.2.0@rev:0 #for hpack-0.31
 - tar-conduit-0.3.1@rev:0
@@ -11,6 +10,10 @@ packages:
 - persistent-2.9.2@rev:0
 - persistent-sqlite-2.9.3@rev:0
 - rio-0.1.9.2@rev:0
+- ansi-terminal-0.9@rev:0
+- ansi-wl-pprint-0.6.8.2@rev:1 # for ansi-terminal-0.9
+- hedgehog-0.6.1@rev:4 # for ansi-terminal-0.9
+- optparse-simple-0.1.1.2
 - github: snoyberg/filelock
   commit: 97e83ecc133cd60a99df8e1fa5a3c2739ad007dc
 

--- a/snapshot-nightly.yaml
+++ b/snapshot-nightly.yaml
@@ -1,10 +1,11 @@
-resolver: nightly-2018-12-01
-name: snapshot-for-building-stack-with-ghc-8.6.2
+resolver: nightly-2019-05-05
+name: snapshot-for-building-stack-with-ghc-8.6.5
 
 packages:
-- persistent-2.9.2@rev:0
-- persistent-sqlite-2.9.3@rev:0
-- rio-0.1.9.2@rev:0
+- amazonka-1.6.1@rev:0
+- amazonka-s3-1.6.1@rev:0
+- amazonka-core-1.6.1@rev:0
+- http-client-0.5.14@rev:0
 - github: snoyberg/filelock
   commit: 97e83ecc133cd60a99df8e1fa5a3c2739ad007dc
 

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -2,7 +2,7 @@ resolver: lts-11.22
 name: snapshot-for-building-stack-with-ghc-8.2.2
 
 packages:
-- ansi-terminal-0.8.1@sha256:4cebbd2034dcd9029369c0a49c72666be8dacd11a2827d33bcfa539f2933614a,3116
+- ansi-terminal-0.9@rev:0
 - Cabal-2.4.0.1@rev:0
 - infer-license-0.2.0@rev:0 #for hpack-0.31
 - hpack-0.31.1@rev:0
@@ -20,6 +20,8 @@ packages:
 - persistent-2.9.2@rev:0
 - persistent-sqlite-2.9.3@rev:0
 - rio-0.1.9.2@rev:0
+- ansi-wl-pprint-0.6.8.2@rev:1 # for ansi-terminal-0.9
+- hedgehog-0.6.1@rev:4 # for ansi-terminal-0.9
 - github: snoyberg/filelock
   commit: 97e83ecc133cd60a99df8e1fa5a3c2739ad007dc
 

--- a/subs/hi-file-parser/test-files/iface/x32/run.sh
+++ b/subs/hi-file-parser/test-files/iface/x32/run.sh
@@ -3,7 +3,7 @@
 set -eux
 
 go() {
-  for ver in 7.10.3 8.0.2 8.2.2 8.4.4 8.6.4
+  for ver in 7.10.3 8.0.2 8.2.2 8.4.4 8.6.5
   do
       stack --resolver ghc-$ver --arch i386 ghc -- -fforce-recomp Main.hs
       local DIR

--- a/subs/pantry/package.yaml
+++ b/subs/pantry/package.yaml
@@ -19,7 +19,7 @@ extra-source-files:
 
 dependencies:
 - base
-- ansi-terminal >= 0.8.1
+- ansi-terminal
 - digest
 - rio
 - aeson
@@ -45,16 +45,16 @@ dependencies:
 - cryptonite
 - cryptonite-conduit
 - persistent
-- persistent-sqlite >= 2.9.3
+- persistent-sqlite
 - persistent-template
-- Cabal >= 2.4
+- Cabal
 - path-io
 - rio-orphans
 - conduit-extra
-- tar-conduit >= 0.3.0
+- tar-conduit
 - time
 - unix-compat
-- hpack >= 0.29.6
+- hpack
 - yaml
 - zip-archive
 - text-metrics

--- a/subs/rio-prettyprint/src/Text/PrettyPrint/Leijen/Extended.hs
+++ b/subs/rio-prettyprint/src/Text/PrettyPrint/Leijen/Extended.hs
@@ -343,6 +343,7 @@ data SGRTag
     | TagColorForeground
     | TagColorBackground
     | TagRGBColor
+    | TagPaletteColor
     deriving (Eq, Ord)
 
 getSGRTag :: SGR -> SGRTag
@@ -356,6 +357,7 @@ getSGRTag SetSwapForegroundBackground{} = TagSwapForegroundBackground
 getSGRTag (SetColor Foreground _ _)     = TagColorForeground
 getSGRTag (SetColor Background _ _)     = TagColorBackground
 getSGRTag SetRGBColor{}                 = TagRGBColor
+getSGRTag SetPaletteColor{}             = TagPaletteColor
 
 (<+>) :: StyleDoc -> StyleDoc -> StyleDoc
 StyleDoc x <+> StyleDoc y = StyleDoc (x P.<+> y)


### PR DESCRIPTION
- Update to latest nightly and lts-12 snapshots
- Remove extraneous dependency constraints
- Update docs with current GHC versions
