### PR TITLE
Remove `list-dependencies` command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -131,6 +131,8 @@ Behavior changes:
   `recommend-stack-upgrade: false` to bypass this. See
   [#1681](https://github.com/commercialhaskell/stack/issues/1681).
 
+* `stack list-dependencies` has been removed in favour of `stack ls dependencies`.
+
 Other enhancements:
 
 * Support MX Linux in get-stack.sh. Fixes

--- a/src/Stack/Options/DotParser.hs
+++ b/src/Stack/Options/DotParser.hs
@@ -56,7 +56,7 @@ dotOptsParser externalDefault =
         globalHints = switch (long "global-hints" <>
                               help "Do not require an install GHC; instead, use a hints file for global packages")
 
--- | Parser for arguments to `stack list-dependencies`.
+-- | Parser for arguments to `stack ls dependencies`.
 listDepsOptsParser :: Parser ListDepsOpts
 listDepsOptsParser = ListDepsOpts
                  <$> dotOptsParser True -- Default for --external is True.

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1964,7 +1964,7 @@ data CompilerPaths = CompilerPaths
   --
   -- Note that this is not necessarily the same version as the one that stack
   -- depends on as a library and which is displayed when running
-  -- @stack list-dependencies | grep Cabal@ in the stack project.
+  -- @stack ls dependencies | grep Cabal@ in the stack project.
   , cpGlobalDB :: !(Path Abs Dir)
   -- ^ Global package database
   , cpGhcInfo :: !ByteString

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -352,10 +352,6 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                     "Delete the project stack working directories (.stack-work by default). Shortcut for 'stack clean --full'"
                     cleanCmd
                     (cleanOptsParser Purge)
-        addCommand' "list-dependencies"
-                    "List the dependencies"
-                    (listDependenciesCmd True)
-                    listDepsOptsParser
         addCommand' "query"
                     "Query general build information (experimental)"
                     queryCmd


### PR DESCRIPTION
This PR makes good on the warning originally threatened in `stack-1.7.1`. 