### PR TITLE
Update list of files created by 'stack new' in README

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -77,18 +77,21 @@ The `stack new` command should have created the following files:
 
 ```
 .
-├── LICENSE
-├── Setup.hs
 ├── app
 │   └── Main.hs
+├── ChangeLog.md
+├── LICENSE
 ├── my-project.cabal
+├── package.yaml
+├── README.md
+├── Setup.hs
 ├── src
 │   └── Lib.hs
 ├── stack.yaml
 └── test
     └── Spec.hs
 
-    3 directories, 7 files
+    3 directories, 10 files
 ```
 
 So to manage your library:


### PR DESCRIPTION
Update the tree of files created by running `stack new` in the README. In particular, include `package.yaml`, which is referenced in the text below.

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.