### PR TITLE
get-stack.sh: fix apt package detection (fixes #4816)

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -612,7 +612,7 @@ try_install_pkgs() {
 apt_get_install_pkgs() {
   missing=
   for pkg in $*; do
-    if ! dpkg -s $pkg 2>/dev/null |grep Status >/dev/null; then
+    if ! dpkg -s $pkg 2>/dev/null |grep '^Status:.*installed' >/dev/null; then
       missing="$missing $pkg"
     fi
   done

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -610,9 +610,15 @@ try_install_pkgs() {
 
 # Install packages using apt-get
 apt_get_install_pkgs() {
-  if ! dpkg-query -W "$@"|grep -v '^\S\+\s\+.\+$' > /dev/null; then
+  missing=
+  for pkg in $*; do
+    if ! dpkg -s $pkg 2>/dev/null |grep Status >/dev/null; then
+      missing="$missing $pkg"
+    fi
+  done
+  if [ "$missing" = "" ]; then
     info "Already installed!"
-  elif ! sudocmd "install required system dependencies" apt-get install -y ${QUIET:+-qq} "$@"; then
+  elif ! sudocmd "install required system dependencies" apt-get install -y ${QUIET:+-qq}$missing; then
     die "Installing apt packages failed.  Please run 'apt-get update' and try again."
   fi
 }


### PR DESCRIPTION
This checks each dependency individually and then only `apt-get install`s the ones that are missing.

@rkaippully Can you please try this out on MX Linux and let me know if it works?  You ran into trouble with the last fix I attempted.