### PR TITLE
Perform CI on the v2.1 branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ trigger:
     - ci/*
     - master
     - stable
+    - v2.1
 
 variables:
   BASE_BRANCH: "master"


### PR DESCRIPTION
CC @psibi @borsboom. It makes me wonder if we need a different release
branch naming scheme so that we can have the default be to check all PRs
against release branches.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
