### PR TITLE
Reformat contributing information to increase inclusivity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,16 +59,21 @@ If you want to contribute to the source code, please take a look at the
 
 ## Contributing to Documentation
 
+[1]: https://github.com/commercialhaskell/stack/tree/stable
+
 If you would like to help with documentation, please note that for most cases
 the Wiki has been deprecated in favor of markdown files placed in a new `/doc`
-subdirectory of the repository itself. Please submit a
-[pull request](https://help.github.com/articles/using-pull-requests/) with your
-changes/additions based off the [the stable branch](https://github.com/commercialhaskell/stack/tree/stable).
+subdirectory of the repository itself. Please create a new branch off of the 
+project's [stable branch][1] and make your changes/additions on the new 
+branch. Once you are ready to submit your changes/additions, please submit a 
+pull request from your new branch to the project's [stable branch][1]. For 
+more information about pull requests, take a look at GitHub's overview of 
+[using pull requests](https://help.github.com/articles/using-pull-requests/).
 
 The documentation is rendered on [haskellstack.org](http://haskellstack.org) by
 readthedocs.org using Sphinx and CommonMark. Since links and formatting vary
-from GFM, please check the documentation there before submitting a PR to fix
-those.
+from GitHub Flavored Markdown, please check the documentation there before 
+submitting a pull request to fix those.
 
 If your changes move or rename files, or subsume Wiki content, please continue
 to leave a file/page in the old location temporarily, in addition to the new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,51 @@ issue. If you are not a member of the project, you will be asked for
 confirmation and we will close it.
 
 
-## Documentation
+## Contributing Overview
+
+Contributions to The Haskell Tool Stack are most welcome. To get started, we 
+suggest that you get the source code of the project onto your local machine by 
+following these steps (this assumes that you have already installed a version 
+of stack and have `git` installed on your machine).
+
+1. Clone `stack` from git with
+   `git clone https://github.com/commercialhaskell/stack.git`.
+2. Enter into the stack folder with `cd stack`.
+3. Build `stack` using a pre-existing `stack` install with
+   `stack setup && stack build`.
+4. Once `stack` finishes building, check the stack version with
+   `stack exec stack -- --version`. Make sure the version is the latest.
+5. Look for issues tagged with
+   [newcomer friendly](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3a%22newcomer+friendly%22)
+   and
+   [awaiting pull request](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3A%22awaiting+pull+request%22)
+   labels.
+
+Here is a one-line command that will execute steps 1 through 3 at once.
+```bash
+git clone https://github.com/commercialhaskell/stack.git && \
+cd stack && \
+stack setup && \
+stack build
+```
+
+If you need to check your changes quickly run:
+```bash
+stack ghci
+λ: :main --stack-root /path/to/root/ --stack-yaml /path/to/stack.yaml COMMAND
+```
+
+This allows you to set a special stack root (instead of `~/.stack/` or, on
+Windows, `%LOCALAPPDATA%\Programs\stack`) and to target your commands at a
+particular `stack.yaml` instead of the one found in the current directory.
+
+If you want to contribute to documentation, please take a look at the 
+[Contributing to Documentation](#contributing-to-documentation) section below. 
+If you want to contribute to the source code, please take a look at the 
+[Contributing to Code](#contributing-to-code) section below.
+
+
+## Contributing to Documentation
 
 If you would like to help with documentation, please note that for most cases
 the Wiki has been deprecated in favor of markdown files placed in a new `/doc`
@@ -33,7 +77,7 @@ location. Please also update any links in other files, or on the Wiki, to point
 to the new file location.
 
 
-## Code
+## Contributing to Code
 
 If you would like to contribute code to fix a bug, add a new feature, or
 otherwise improve `stack`, pull requests are most welcome. It's a good idea to

--- a/doc/README.md
+++ b/doc/README.md
@@ -116,41 +116,21 @@ If you want to go further, we highly recommend you to read the [`stack` guide](G
 
 #### How to contribute
 
-This assumes that you have already installed a version of stack, and have `git`
-installed.
+[1]: https://docs.haskellstack.org/en/stable/CONTRIBUTING/
+[2]: https://docs.haskellstack.org/en/stable/CONTRIBUTING/#contributing-overview
+[3]: https://docs.haskellstack.org/en/stable/CONTRIBUTING/#contributing-to-documentation
+[4]: https://docs.haskellstack.org/en/stable/CONTRIBUTING/#contributing-to-code
+[5]: https://github.com/commercialhaskell/stack/blob/master/CONTRIBUTING.md
+[6]: https://github.com/commercialhaskell/stack/blob/master/CONTRIBUTING.md#contributing-overview
+[7]: https://github.com/commercialhaskell/stack/blob/master/CONTRIBUTING.md#contributing-to-documentation
+[8]: https://github.com/commercialhaskell/stack/blob/master/CONTRIBUTING.md#contributing-to-code
 
-1. Clone `stack` from git with
-   `git clone https://github.com/commercialhaskell/stack.git`.
-2. Enter into the stack folder with `cd stack`.
-3. Build `stack` using a pre-existing `stack` install with
-   `stack setup && stack build`.
-4. Once `stack` finishes building, check the stack version with
-   `stack exec stack -- --version`. Make sure the version is the latest.
-5. Look for issues tagged with
-   [newcomer friendly](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3a%22newcomer+friendly%22)
-   and
-   [awaiting pull request](https://github.com/commercialhaskell/stack/issues?q=is%3Aopen+is%3Aissue+label%3A%22awaiting+pull+request%22)
-   labels.
-
-Build from source as a one-liner:
-
-```bash
-git clone https://github.com/commercialhaskell/stack.git && \
-cd stack && \
-stack setup && \
-stack build
-```
-
-If you need to check your changes quickly run:
-
-```bash
-stack ghci
-λ: :main --stack-root /path/to/root/ --stack-yaml /path/to/stack.yaml COMMAND
-```
-
-This allows you to set a special stack root (instead of `~/.stack/` or, on
-Windows, `%LOCALAPPDATA%\Programs\stack`) and to target your commands at a
-particular `stack.yaml` instead of the one found in the current directory.
+To begin your contribution, we suggest that you clone this repository to your 
+local machine and build the Haskell Tool Stack program - you can find the 
+specific steps for this in the [contributing overview section][2] 
+of the [contributors guide][1]. Also, please refer to the [contributing to documentation section][3]
+if you want to make changes to documentation, and the [contributing to code section][4]
+if you want to make changes to the source code.
 
 #### Complete guide to stack
 


### PR DESCRIPTION
Moved content under the How to contribute section of the doc/README.md document to CONTRIBUTING.md document and replaced that content with a quick overview* of contribution in order to localize contributing specifics to the CONTRIBUTING.md document and keep the doc/README.md document as a collection of quick overviews.
*The quick overview includes links to the contributing document, but specifically the contributing document rendered on http://haskellstack.org, not the source on GitHub.

Renamed Documentation and Code sections in CONTRIBUTING.md as Contributing to Documentation and Contributing to Code, respectively, to avoid possible confusion.

Rephrased the pull request requirements under the (now) Contributing to Documentation section to more clearly express where changes should be made and submitted to.


* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

