### PR TITLE
Use RawCommand when launching pager found on PATH

### DIFF
--- a/src/System/Process/Pager.hs
+++ b/src/System/Process/Pager.hs
@@ -3,49 +3,63 @@
 
 -- | Run external pagers (@$PAGER@, @less@, @more@).
 module System.Process.Pager
-  (pageWriter
-  ,pageText
-  ,PagerException(..))
-  where
+  ( pageWriter
+  , pageText
+  , PagerException (..)
+  ) where
 
 import Stack.Prelude
 import System.Directory (findExecutable)
 import System.Environment (lookupEnv)
-import System.Process (createProcess,shell,waitForProcess,StdStream (CreatePipe)
-                      ,CreateProcess(std_in, close_fds, delegate_ctlc))
+import System.Process ( createProcess, cmdspec, shell, proc, waitForProcess
+                      , CmdSpec (ShellCommand, RawCommand)
+                      , StdStream (CreatePipe)
+                      , CreateProcess (std_in, close_fds, delegate_ctlc)
+                      )
 import System.IO (stdout)
+import Control.Applicative ((<|>))
+import Control.Monad.Trans.Maybe (MaybeT (runMaybeT, MaybeT))
 import qualified Data.Text.IO as T
 
 -- | Run pager, providing a function that writes to the pager's input.
 pageWriter :: (Handle -> IO ()) -> IO ()
 pageWriter writer =
-  do mpager <- lookupEnv "PAGER" `orElse`
-               findExecutable "less" `orElse`
-               findExecutable "more"
+  do mpager <- runMaybeT $ cmdspecFromEnvVar
+                       <|> cmdspecFromExeName "less"
+                       <|> cmdspecFromExeName "more"
      case mpager of
        Just pager ->
-         do (Just h,_,_,procHandle) <- createProcess (shell pager)
-                                                       {std_in = CreatePipe
-                                                       ,close_fds = True
-                                                       ,delegate_ctlc = True}
-            (_::Either IOException ()) <- try (do writer h
-                                                  hClose h)
+         do (Just h,_,_,procHandle) <- createProcess pager
+                                         { std_in = CreatePipe
+                                         , close_fds = True
+                                         , delegate_ctlc = True
+                                         }
+            (_ :: Either IOException ()) <- try (do writer h
+                                                    hClose h)
             exit <- waitForProcess procHandle
             case exit of
               ExitSuccess -> return ()
-              ExitFailure n -> throwIO (PagerExitFailure pager n)
+              ExitFailure n -> throwIO (PagerExitFailure (cmdspec pager) n)
             return ()
        Nothing -> writer stdout
   where
-    orElse a b = maybe b (return . Just) =<< a
+    cmdspecFromEnvVar = shell <$> MaybeT (lookupEnv "PAGER")
+    cmdspecFromExeName =
+      fmap (\path -> proc path []) . MaybeT . findExecutable
 
 -- | Run pager to display a 'Text'
 pageText :: Text -> IO ()
 pageText = pageWriter . flip T.hPutStr
 
 -- | Exception running pager.
-data PagerException = PagerExitFailure FilePath Int
+data PagerException = PagerExitFailure CmdSpec Int
   deriving Typeable
 instance Show PagerException where
-  show (PagerExitFailure p n) = "Pager (`" ++ p ++ "') exited with non-zero status: " ++ show n
+  show (PagerExitFailure cmd n) =
+    let
+      getStr (ShellCommand c) = c
+      getStr (RawCommand exePath _) = exePath
+    in
+      "Pager (`" ++ getStr cmd ++ "') exited with non-zero status: " ++ show n
+
 instance Exception PagerException


### PR DESCRIPTION
When we used ShellCommand to launch a pager found on PATH (`less' or
`more') the pager cannot be launched when its path contained spaces and
other shell-specific characters.  This commit fixes that by using
RawCommand to launch any pager discovered via findExecutable.

Signed-off-by: Fred Miller <fghzxm@outlook.com>

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
Put a `less` executable into a path containing spaces and add that path to the front of `PATH`, then run `stack ls snapshots`.  Master fails while this branch succeeds.
