### PR TITLE
Fix DB name in migrate error message

### DIFF
--- a/subs/pantry/src/Pantry/Types.hs
+++ b/subs/pantry/src/Pantry/Types.hs
@@ -1019,7 +1019,7 @@ instance Display PantryException where
     "Encountered error while migrating " <> display desc <> " database:" <>
     "\n    " <> displayShow ex <>
     "\nPlease report this on https://github.com/commercialhaskell/stack/issues" <>
-    "\nAs a workaround you may delete Pantry database in " <>
+    "\nAs a workaround you may delete " <> display desc <> " database in " <>
     fromString (toFilePath fp) <> " triggering its recreation."
 
 data FuzzyResults


### PR DESCRIPTION
Noticed the error message "you may delete **Pantry** database" even for `stack.sqlite3`.  This fixes it.