### PR TITLE
Compare package names to be pruned correctly

### DIFF
--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -53,7 +53,7 @@ data DotOpts = DotOpts
     -- ^ Include dependencies on base
     , dotDependencyDepth :: !(Maybe Int)
     -- ^ Limit the depth of dependency resolution to (Just n) or continue until fixpoint
-    , dotPrune :: !(Set String)
+    , dotPrune :: !(Set PackageName)
     -- ^ Package names to prune from the graph
     , dotTargets :: [Text]
     -- ^ stack TARGETs to trace dependencies for
@@ -215,14 +215,14 @@ payloadText opts payload =
 -- unless they are in @dontPrune@
 pruneGraph :: (F.Foldable f, F.Foldable g, Eq a)
            => f PackageName
-           -> g String
+           -> g PackageName
            -> Map PackageName (Set PackageName, a)
            -> Map PackageName (Set PackageName, a)
 pruneGraph dontPrune names =
   pruneUnreachable dontPrune . Map.mapMaybeWithKey (\pkg (pkgDeps,x) ->
-    if packageNameString pkg `F.elem` names
+    if pkg `F.elem` names
       then Nothing
-      else let filtered = Set.filter (\n -> packageNameString n `F.notElem` names) pkgDeps
+      else let filtered = Set.filter (\n -> n `F.notElem` names) pkgDeps
            in if Set.null filtered && not (Set.null pkgDeps)
                 then Nothing
                 else Just (filtered,x))
@@ -342,7 +342,7 @@ printGraph dotOpts locals graph = do
   void (Map.traverseWithKey printEdges (fst <$> graph))
   liftIO $ Text.putStrLn "}"
   where filteredLocals = Set.filter (\local' ->
-          packageNameString local' `Set.notMember` dotPrune dotOpts) locals
+          local' `Set.notMember` dotPrune dotOpts) locals
 
 -- | Print the local nodes with a different style depending on options
 printLocalNodes :: (F.Foldable t, MonadIO m)

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -220,9 +220,9 @@ pruneGraph :: (F.Foldable f, F.Foldable g, Eq a)
            -> Map PackageName (Set PackageName, a)
 pruneGraph dontPrune names =
   pruneUnreachable dontPrune . Map.mapMaybeWithKey (\pkg (pkgDeps,x) ->
-    if show pkg `F.elem` names
+    if packageNameString pkg `F.elem` names
       then Nothing
-      else let filtered = Set.filter (\n -> show n `F.notElem` names) pkgDeps
+      else let filtered = Set.filter (\n -> packageNameString n `F.notElem` names) pkgDeps
            in if Set.null filtered && not (Set.null pkgDeps)
                 then Nothing
                 else Just (filtered,x))

--- a/src/Stack/Options/DotParser.hs
+++ b/src/Stack/Options/DotParser.hs
@@ -7,6 +7,7 @@ import           Data.Char (isSpace)
 import           Data.List.Split (splitOn)
 import qualified Data.Set as Set
 import qualified Data.Text as T
+import           Distribution.Types.PackageName(PackageName, mkPackageName)
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
 import           Stack.Dot
@@ -50,8 +51,8 @@ dotOptsParser externalDefault =
         benchTargets = switch (long "bench" <>
                                help "Consider dependencies of benchmark components")
 
-        splitNames :: String -> [String]
-        splitNames = map (takeWhile (not . isSpace) . dropWhile isSpace) . splitOn ","
+        splitNames :: String -> [PackageName]
+        splitNames = map (mkPackageName . takeWhile (not . isSpace) . dropWhile isSpace) . splitOn ","
 
         globalHints = switch (long "global-hints" <>
                               help "Do not require an install GHC; instead, use a hints file for global packages")

--- a/src/test/Stack/DotSpec.hs
+++ b/src/test/Stack/DotSpec.hs
@@ -53,14 +53,14 @@ spec = do
 
     prop "requested packages are pruned" $ do
       let resolvedGraph = runIdentity (resolveDependencies Nothing graph stubLoader)
-          allPackages g = Set.map packageNameString (Map.keysSet g `Set.union`  fold (fmap fst g))
+          allPackages g = Map.keysSet g `Set.union`  fold (fmap fst g)
       forAll (sublistOf (Set.toList (allPackages resolvedGraph))) $ \toPrune ->
         let pruned = pruneGraph [pkgName "one", pkgName "two"] toPrune resolvedGraph
         in Set.null (allPackages pruned `Set.intersection` Set.fromList toPrune)
 
     prop "pruning removes orhpans" $ do
       let resolvedGraph = runIdentity (resolveDependencies Nothing graph stubLoader)
-          allPackages g = Set.map packageNameString (Map.keysSet g `Set.union` fold (fmap fst g))
+          allPackages g = Map.keysSet g `Set.union` fold (fmap fst g)
           orphans g = Map.filterWithKey (\k _ -> not (graphElem k g)) g
       forAll (sublistOf (Set.toList (allPackages resolvedGraph))) $ \toPrune ->
         let pruned = pruneGraph [pkgName "one", pkgName "two"] toPrune resolvedGraph

--- a/src/test/Stack/DotSpec.hs
+++ b/src/test/Stack/DotSpec.hs
@@ -53,14 +53,14 @@ spec = do
 
     prop "requested packages are pruned" $ do
       let resolvedGraph = runIdentity (resolveDependencies Nothing graph stubLoader)
-          allPackages g = Set.map show (Map.keysSet g `Set.union`  fold (fmap fst g))
+          allPackages g = Set.map packageNameString (Map.keysSet g `Set.union`  fold (fmap fst g))
       forAll (sublistOf (Set.toList (allPackages resolvedGraph))) $ \toPrune ->
         let pruned = pruneGraph [pkgName "one", pkgName "two"] toPrune resolvedGraph
         in Set.null (allPackages pruned `Set.intersection` Set.fromList toPrune)
 
     prop "pruning removes orhpans" $ do
       let resolvedGraph = runIdentity (resolveDependencies Nothing graph stubLoader)
-          allPackages g = Set.map show (Map.keysSet g `Set.union` fold (fmap fst g))
+          allPackages g = Set.map packageNameString (Map.keysSet g `Set.union` fold (fmap fst g))
           orphans g = Map.filterWithKey (\k _ -> not (graphElem k g)) g
       forAll (sublistOf (Set.toList (allPackages resolvedGraph))) $ \toPrune ->
         let pruned = pruneGraph [pkgName "one", pkgName "two"] toPrune resolvedGraph


### PR DESCRIPTION
Fixes #4845 

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

**Please also shortly describe how you tested your change. Bonus points for added tests!**

The tests and the implementation both were wrong, I fixed both. However I have found that the behaviour of `pruneGraph` function is a bit weird. But that is how it has been since the beginning, so I am not very sure if I should report a bug. Here are my observations:

1. The `dontPrune` parameter is not always respected. I wrote this property to verify what I thought should've been the behaviour and it does not pass:
    ```haskell
    prop "dontPrune packages are not pruned" $ do
      let resolvedGraph = runIdentity (resolveDependencies Nothing graph stubLoader)
          allPackages g = Set.map packageNameString (Map.keysSet g `Set.union`  fold (fmap fst g))
      forAll (sublistOf (Set.toList (allPackages resolvedGraph))) $ \toPrune ->
        let pruned = pruneGraph [pkgName "one", pkgName "two"] toPrune resolvedGraph
        in if "one" `elem` allPackages pruned
              then if "two" `elem` allPackages pruned
                      then succeeded
                      else failed {reason = "expected `two` to not be pruned but did not find it in pruned packages: " ++ show (allPackages pruned)}
              else failed {reason = "expected `one` to not be pruned did not find it in pruned packages: " ++ show (allPackages pruned)}
    ```
1. If package a depends only on package b, and we're running `stack dot --prune b`, package a will also get pruned. For e.g., Running `stack dot --no-include-base` in stack repository also prunes `array`.

I am not sure if this is expected, if not feel free to create bugs. I will try to fix them.


