### PR TITLE
Don't change directories when cloning a repo

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,8 @@ Behavior changes:
 Other enhancements:
 
 Bug fixes:
+* Fix to allow dependencies on specific versions of local git repositories. See
+  [#4862](https://github.com/commercialhaskell/stack/pull/4862)
 
 
 ## v2.1.1.1

--- a/subs/pantry/ChangeLog.md
+++ b/subs/pantry/ChangeLog.md
@@ -1,5 +1,14 @@
 # Changelog for pantry
 
+## Unreleased changes
+
+**Changes since 0.1.0.0**
+
+Bug fixes:
+
+* Fix to allow dependencies on specific versions of local git repositories. See
+  [#4862](https://github.com/commercialhaskell/stack/pull/4862)
+
 ## 0.1.0.0
 
 * Initial release


### PR DESCRIPTION
This was [making it impossible to pin to a specific commit when using relative file paths as repo URLs](https://stackoverflow.com/a/56573316/625403).

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I tested this change by running `stack test` three times:

1. Before I made any changes, tests pass
1. After intentionally implementing my change incorrectly, tests fail
1. After a correct implementation of my change, tests pass again