### PR TITLE
Allow nix mode commands to run outside of a project

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,10 @@ Other enhancements:
 
 Bug fixes:
 
+* Allow Stack commands to be run in Nix mode without having a project file
+  available. See
+  [#4854](https://github.com/commercialhaskell/stack/issues/4864).
+
 
 ## v2.1.1.1
 

--- a/src/Stack/Nix.hs
+++ b/src/Stack/Nix.hs
@@ -24,7 +24,6 @@ import           Stack.Constants (platformVariantEnvVar,inNixShellEnvVar,inConta
 import           Stack.Types.Config
 import           Stack.Types.Docker
 import           Stack.Types.Nix
-import           Stack.Docker (getProjectRoot)
 import           System.Environment (getArgs,getExecutablePath,lookupEnv)
 import qualified System.FilePath  as F
 import           RIO.Process (processContextL, exec)
@@ -43,10 +42,11 @@ runShellAndExit = do
    local (set processContextL envOverride) $ do
      let cmnd = escape exePath
          args' = map escape args
-     projectRoot <- getProjectRoot
-     mshellFile <-
-         traverse (resolveFile projectRoot) $
-         nixInitFile (configNix config)
+
+     mshellFile <- case configProjectRoot config of
+         Just projectRoot ->
+             traverse (resolveFile projectRoot) $ nixInitFile (configNix config)
+         Nothing -> pure Nothing
 
      -- This will never result in double loading the build config, since:
      --


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
Tested running `stack new --nix` manually
Fixes #4864 
