### PR TITLE
Suppress haddock-dependent paths

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,10 @@ Release notes:
 Major changes:
 
 Behavior changes:
+* `stack path` no longer outputs haddock-dependent paths unless `--haddock` is
+  specified. [#4892](https://github.com/commercialhaskell/stack/issues/4892).
+  Current list of affected paths: `local-doc-root`, `local-hoogle-root`,
+  `dist-dir`.
 
 Other enhancements:
 


### PR DESCRIPTION
https://github.com/commercialhaskell/stack/issues/4892

I did my best, let me know any feedback!

Verified by hand:

```bash
➜  stack git:(master) stack exec stack -- path --local-doc-root          
➜  stack git:(master) stack exec stack -- --haddock path --local-doc-root
/Users/dan/tvision/git/stack/.stack-work/install/x86_64-osx/95706d9a7eb5a51fa4f678a8b9b1b45f1c109a287d472625bc347d888d9a84f7/8.2.2/doc
```

@snoyberg @qrilka 