### PR TITLE
docs: update linux bindist links

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -24,7 +24,7 @@ future, we are open to supporting more OSes (to request one, please
 Binary packages are signed with this [signing key](SIGNING_KEY.md).
 
 If you are writing a script that needs to download the latest binary, you can
-use URLs like `https://get.haskellstack.org/stable/<PLATFORM>.<EXTENSION>` (e.g. https://get.haskellstack.org/stable/linux-x86_64.tar.gz) that always point to the latest stable release.
+use URLs like `https://get.haskellstack.org/stable/<PLATFORM>.<EXTENSION>` (e.g. https://get.haskellstack.org/stable/linux-x86_64-static.tar.gz) that always point to the latest stable release.
 
 ## Windows
 
@@ -238,17 +238,11 @@ or:
 
 * Download the latest release:
 
-    * [Linux 64-bit, standard](https://get.haskellstack.org/stable/linux-x86_64.tar.gz)
-
-    * [Linux 64-bit, libgmp4](https://get.haskellstack.org/stable/linux-x86_64-gmp4.tar.gz)
-      (if you are on an older 64-bit distribution that only includes libgmp4
-      (libgmp.so.3), such as CentOS/RHEL/Amazon Linux 6.)
+    * [Linux 64-bit, static](https://get.haskellstack.org/stable/linux-x86_64-static.tar.gz)
 
     * [Linux 32-bit, standard](https://get.haskellstack.org/stable/linux-i386.tar.gz)
-
-    * [Linux 32-bit, libgmp4](https://get.haskellstack.org/stable/linux-i386-gmp4.tar.gz)
-      (if you are on an older 32-bit distribution that only includes libgmp4
-      (libgmp.so.3), such as CentOS/RHEL/Amazon Linux 6.)
+      (note: requires libgmp.so.10, and will not work on some older
+      distributions that have libgmp.so.3, such as CentOS 6)
 
     * [Linux ARMv7](https://get.haskellstack.org/stable/linux-arm.tar.gz)
 


### PR DESCRIPTION
fixes #4881

Removes links to no-longer existing stack bindists (like linux-gmp4).  Also switches to static bindist where available.