### PR TITLE
Use lock file locations when resolving project dependencies

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,6 +37,10 @@ Bug fixes:
   avoiding a SIGTERM screwing up GHC installation. See
   [#4888](https://github.com/commercialhaskell/stack/issues/4888).
 
+* Use package complete locations from lock files when resolving dependencies
+  in `extra-deps`. See
+  [#4887](https://github.com/commercialhaskell/stack/issues/4887).
+
 ## v2.1.1.1
 
 Hackage-only release that removes `stack.yaml` from the sdist.  This is because

--- a/src/Stack/Lock.hs
+++ b/src/Stack/Lock.hs
@@ -121,7 +121,7 @@ lockCachedWanted stackFile resolver fillWanted = do
         loadAndCompleteSnapshotRaw resolver slocCache pkgLocCache
     let compiler = snapshotCompiler snap
         snPkgs = Map.mapWithKey (\n p h -> snapToDepPackage h n p) (snapshotPackages snap)
-    (wanted, prjCompleted) <- fillWanted Map.empty compiler snPkgs
+    (wanted, prjCompleted) <- fillWanted pkgLocCache compiler snPkgs
     let lockLocations = map (\(CompletedPLI r c) -> LockedLocation r c)
         differentSnapLocs (CompletedSL raw complete)
           | raw == toRawSL complete = Nothing


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Fixes #4887
Tested manually, I don't think that we need an integration test for this change.
