### PR TITLE
Disable WAL mode for SQLite databases (fixes #4876)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,10 @@ Major changes:
 
 Behavior changes:
 
+* Disable WAL mode for SQLite3 databases, to improve compatibility with
+  some platforms and filesystems.  See
+  [#4876](https://github.com/commercialhaskell/stack/issues/4876).
+
 Other enhancements:
 
 * Do not rerun expected test failures. This is mostly a change that

--- a/subs/pantry/src/Pantry/SQLite.hs
+++ b/subs/pantry/src/Pantry/SQLite.hs
@@ -57,6 +57,7 @@ initStorage description migration fp inner = do
 
     sqinfo isMigration
            = set extraPragmas ["PRAGMA busy_timeout=2000;"]
+           $ set walEnabled False
 
            -- When doing a migration, we want to disable foreign key
            -- checking, since the order in which tables are created by


### PR DESCRIPTION
Tested both against existing databases that had WAL enabled before, and a new STACK_ROOT with new databases.  In the former case, WAL remained enabled on the existing databases, and in the latter case WAL was not enabled on the new databases.