### PR TITLE
Add disabled 'docker:' section to 'stack*.yaml'

### DIFF
--- a/stack-lts-12.yaml
+++ b/stack-lts-12.yaml
@@ -8,13 +8,10 @@ packages:
 - subs/rio-prettyprint
 - subs/hi-file-parser
 
-# docker:
-#   enable: true
-#   repo: fpco/stack-full
-# image:
-#   containers:
-#     - base: "fpco/stack-base" # see ./etc/docker/stack-base/Dockerfile
-#       name: "fpco/stack-test"
+docker:
+  enable: false
+  repo: fpco/stack-build-small:lts-12.26
+
 nix:
   # --nix on the command-line to enable.
   enable: false

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -8,13 +8,10 @@ packages:
 - subs/rio-prettyprint
 - subs/hi-file-parser
 
-# docker:
-#   enable: true
-#   repo: fpco/stack-full
-# image:
-#   containers:
-#     - base: "fpco/stack-base" # see ./etc/docker/stack-base/Dockerfile
-#       name: "fpco/stack-test"
+docker:
+  enable: false
+  repo: fpco/stack-build-small:lts-13.26
+
 nix:
   # --nix on the command-line to enable.
   enable: false

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,13 +8,10 @@ packages:
 - subs/rio-prettyprint
 - subs/hi-file-parser
 
-# docker:
-#   enable: true
-#   repo: fpco/stack-full
-# image:
-#   containers:
-#     - base: "fpco/stack-base" # see ./etc/docker/stack-base/Dockerfile
-#       name: "fpco/stack-test"
+docker:
+  enable: false
+  repo: fpco/stack-build:lts-11.22
+
 nix:
   # --nix on the command-line to enable.
   packages:


### PR DESCRIPTION
This is for convenience of being able to use 'stack build --docker'
without needing to specify an image.
    
Also removed obsolete commented out 'image:' sections.
