### PR TITLE
Tell the user that a boot package was pruned

### DIFF
--- a/test/integration/tests/4897-boot-package-pruned/Main.hs
+++ b/test/integration/tests/4897-boot-package-pruned/Main.hs
@@ -1,0 +1,16 @@
+import Control.Monad (unless)
+import Data.List (isInfixOf)
+import StackTest
+
+planFailure :: String
+planFailure =
+  "but this GHC boot package has been pruned (issue #4510);"
+
+main :: IO ()
+main = do
+  stackErrStderr ["build"] (expectMessage planFailure)
+
+expectMessage :: String -> String -> IO ()
+expectMessage msg stderr = do
+  unless (words msg `isInfixOf` words stderr)
+         (error $ "Expected an error: \n" ++ show msg)

--- a/test/integration/tests/4897-boot-package-pruned/files/directory/directory.cabal
+++ b/test/integration/tests/4897-boot-package-pruned/files/directory/directory.cabal
@@ -1,0 +1,8 @@
+name:                directory
+version:             1.3.3.0
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  build-depends:       base
+  default-language:    Haskell2010

--- a/test/integration/tests/4897-boot-package-pruned/files/files.cabal
+++ b/test/integration/tests/4897-boot-package-pruned/files/files.cabal
@@ -1,0 +1,8 @@
+name:                files
+version:             0.1.0.0
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  build-depends:       base, directory, process
+  default-language:    Haskell2010

--- a/test/integration/tests/4897-boot-package-pruned/files/stack.yaml
+++ b/test/integration/tests/4897-boot-package-pruned/files/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-13.26
+packages: [.]
+extra-deps: [./directory]


### PR DESCRIPTION
Fixes #4897.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [N/A] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [N/A] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

---

Manual test:

```shell
cabal get process-1.6.5.0 &&

cd process-1.6.5.0 &&

cabal get unix-2.7.2.2 &&

cat >stack.yaml <<EOF &&
resolver: lts-13.26
packages: [.]
extra-deps: [./unix-2.7.2.2]
EOF

"${LOCALLY_BUILT_STACK}" build
```

```

Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for process-1.6.5.0:
    directory must match >=1.1 && <1.4, but this GHC boot package has been pruned (issue
              #4510); you need to add the package explicitly to extra-deps  (latest
              matching version is 1.3.3.2)
needed since process is a build target.

Some different approaches to resolving this:

  * Recommended action: try adding the following to your extra-deps
    in /tmp/ppc/process-1.6.5.0/stack.yaml:

- directory-1.3.3.2@sha256:79e15a62f90cb9f20f46b2b56fe67d00d71ed54cfad07ea337695f9ebb74baa4,2829

Plan construction failed.
```