### PR TITLE
Ignore hackage-security expiry by default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,9 @@ Behavior changes:
   some platforms and filesystems.  See
   [#4876](https://github.com/commercialhaskell/stack/issues/4876).
 
+* By default, do not perform expiry checks in Hackage Security. See
+  [#4928](https://github.com/commercialhaskell/stack/issues/4928).
+
 Other enhancements:
 
 * Do not rerun expected test failures. This is mostly a change that

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -337,12 +337,16 @@ package-indices:
     key-threshold: 3 # number of keys required
 
     # ignore expiration date, see https://github.com/commercialhaskell/stack/pull/4614
-    ignore-expiry: no
+    ignore-expiry: true
 ```
 
 If you provide a replacement index which does not mirror Hackage, it
 is likely that you'll end up with significant breakage, such as most
 snapshots failing to work.
+
+Note: since Stack v2.1.3, `ignore-expiry` was changed to `true` by
+default. For more information on this change, see [issue
+#4928](https://github.com/commercialhaskell/stack/issues/4928).
 
 ### system-ghc
 

--- a/subs/pantry/ChangeLog.md
+++ b/subs/pantry/ChangeLog.md
@@ -9,6 +9,11 @@ Bug fixes:
 * Fix to allow dependencies on specific versions of local git repositories. See
   [#4862](https://github.com/commercialhaskell/stack/pull/4862)
 
+Behavior changes:
+
+* By default, do not perform expiry checks in Hackage Security. See
+  [#4928](https://github.com/commercialhaskell/stack/issues/4928).
+
 ## 0.1.0.0
 
 * Initial release

--- a/subs/pantry/src/Pantry/Types.hs
+++ b/subs/pantry/src/Pantry/Types.hs
@@ -541,7 +541,7 @@ instance FromJSON (WithJSONWarnings HackageSecurityConfig) where
     Object o <- o' ..: "hackage-security"
     hscKeyIds <- o ..: "keyids"
     hscKeyThreshold <- o ..: "key-threshold"
-    hscIgnoreExpiry <- o ..:? "ignore-expiry" ..!= False
+    hscIgnoreExpiry <- o ..:? "ignore-expiry" ..!= True
     pure HackageSecurityConfig {..}
 
 


### PR DESCRIPTION
* Fixes #3731
* Fixes #4927
* Fixes #4928

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
