### PR TITLE
Azure CI: bump macOS to Mojave (10.14)

### DIFF
--- a/azure-nightly-pipeline.yml
+++ b/azure-nightly-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
 - template: ./.azure/azure-nightly-template-osx.yml
   parameters:
     name: macOS
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
     os: osx
 
 - template: ./.azure/azure-nightly-template-linux.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
 - template: ./.azure/azure-osx-template.yml
   parameters:
     name: macOS
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
     os: osx
 
 - template: ./.azure/azure-linux-template.yml

--- a/doc/azure/azure-pipelines.yml
+++ b/doc/azure/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
 - template: ./.azure/azure-osx-template.yml
   parameters:
     name: macOS
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
     os: osx
 
 - template: ./.azure/azure-windows-template.yml


### PR DESCRIPTION
This fixes an integration test failure (see
https://github.com/commercialhaskell/stack/pull/4939#issuecomment-510066631)
