### PR TITLE
Haddock use relative paths in output (fixed #4971)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,9 @@ Other enhancements:
 
 Bug fixes:
 
+* Fix using relative links in haddocks output.  See
+  [#4971](https://github.com/commercialhaskell/stack/issues/4971).
+
 
 ## v2.1.3.1
 

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -229,8 +229,10 @@ generateHaddockIndex descr bco dumpPackages docRelFP destDir = do
                         docRelFP FP.</>
                         packageIdentifierString dpPackageIdent FP.</>
                         (packageNameString name FP.<.> "haddock")
+                    docPathRelFP =
+                        fmap ((docRelFP FP.</>) . FP.takeFileName) dpHaddockHtml
                     interfaces = intercalate "," $
-                      maybeToList dpHaddockHtml ++ [srcInterfaceFP]
+                        maybeToList docPathRelFP ++ [srcInterfaceFP]
 
                 destInterfaceAbsFile <- parseCollapsedAbsFile (toFilePath destDir FP.</> destInterfaceRelFP)
                 esrcInterfaceModTime <- tryGetModificationTime srcInterfaceAbsFile


### PR DESCRIPTION
* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [N/A] The documentation has been updated, if necessary.

Tested by generating haddocks for a package and confirming by`grep`ing all the output that no absolute links are generated.  Also spot checked that links are correct.

@qrilka It looks like the links changed to absolute in !4596.  I don't understand the original bug that fixed well enough to know whether my changes here will cause any problems, so please test it.