### PR TITLE
Adds support for configuring version of stack installed.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,9 @@ Other enhancements:
 * Add `ls dependencies json` which will print dependencies as JSON.
   `ls dependencies --tree`  is now `ls dependencies tree`. See
   [#4424](https://github.com/commercialhaskell/stack/pull/4424)
+* Add ability to set which version of stack to be downloaded by
+  `get-stack.sh` with `--version` argument.
+
 
 Bug fixes:
 

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -25,7 +25,8 @@
 # https://docs.haskellstack.org/en/stable/install_and_upgrade/
 #
 
-STACK_VERSION="2.1.3"
+DEFAULT_STACK_VERSION="2.1.3"
+STACK_VERSION=""
 HOME_LOCAL_BIN="$HOME/.local/bin"
 DEFAULT_DEST="/usr/local/bin/stack"
 # Windows doesn't have a good place for DEST, but all CI systems (Appveyor, Travis, Azure) support /bin
@@ -469,6 +470,10 @@ set_default_dest() {
   [ "$DEST" != "" ] || DEST="$DEFAULT_DEST"
 }
 
+set_default_stack_version() {
+  [ "$STACK_VERSION" != "" ] || STACK_VERSION="$DEFAULT_STACK_VERSION"
+}
+
 # Determine operating system and attempt to install.
 do_os() {
   case "$(uname)" in
@@ -792,6 +797,10 @@ while [ $# -gt 0 ]; do
       DEST="$2/stack"
       shift 2
       ;;
+    -v|--version)
+      STACK_VERSION="$2"
+      shift 2
+      ;;
     *)
       echo "Invalid argument: $1" >&2
       exit 1
@@ -799,6 +808,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+set_default_stack_version
 check_stack_installed
 do_os
 check_home_local_bin_on_path


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

I tested this change on OS X by running:
`cat get-stack.sh | sh -s - -f`
`stack --version`
which outputs
`Version 2.1.3, Git revision 0fa51b9925decd937e4a993ad90cb686f88fa282 (7739 commits) x86_64 hpack-0.31.2`
then
`cat get-stack.sh | sh -s - -f -v 1.9.3`
which outputs
`Version 1.9.3, Git revision 40cf7b37526b86d1676da82167ea8758a854953b (6211 commits) x86_64 hpack-0.31.1`


The use case for this feature is to allow for using a deterministic version in our CI. It also helps provide a migration path from 1.9.x -> 2.x as we're currently using `stack container image`.  I hope you'll accept it. Thanks!
