### PR TITLE
Show warning about `local-programs-path` with spaces on windows when running scripts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,10 @@ Behavior changes:
 
 Other enhancements:
 
+* Show warning about `local-programs-path` with spaces on windows
+  when running scripts. See 
+  [#5013](https://github.com/commercialhaskell/stack/pull/5013)
+
 * Add `ls dependencies json` which will print dependencies as JSON.
   `ls dependencies --tree`  is now `ls dependencies tree`. See
   [#4424](https://github.com/commercialhaskell/stack/pull/4424)

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -281,7 +281,7 @@ configFromConfigMonoid
        shortLocalProgramsFilePath <-
          liftIO $ getShortPathName localProgramsFilePath
        when (' ' `elem` shortLocalProgramsFilePath) $ do
-         logWarn $ "Stack's 'programs' path contains a space character and " <>
+         logError $ "Stack's 'programs' path contains a space character and " <>
            "has no alternative short ('8 dot 3') name. This will cause " <>
            "problems with packages that use the GNU project's 'configure' " <>
            "shell script. Use the 'local-programs-path' configuation option " <>

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -285,8 +285,8 @@ configFromConfigMonoid
            "has no alternative short ('8 dot 3') name. This will cause " <>
            "problems with packages that use the GNU project's 'configure' " <>
            "shell script. Use the 'local-programs-path' configuration option " <>
-           "to specify an alternative path. The current 'shortest' path is: " <>
-           display (T.pack shortLocalProgramsFilePath)
+           "to specify an alternative path. The current path is: " <>
+           display (T.pack localProgramsFilePath)
      platformOnlyDir <- runReaderT platformOnlyRelDir (configPlatform, configPlatformVariant)
      let configLocalPrograms = configLocalProgramsBase </> platformOnlyDir
 

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -284,7 +284,7 @@ configFromConfigMonoid
          logError $ "Stack's 'programs' path contains a space character and " <>
            "has no alternative short ('8 dot 3') name. This will cause " <>
            "problems with packages that use the GNU project's 'configure' " <>
-           "shell script. Use the 'local-programs-path' configuation option " <>
+           "shell script. Use the 'local-programs-path' configuration option " <>
            "to specify an alternative path. The current 'shortest' path is: " <>
            display (T.pack shortLocalProgramsFilePath)
      platformOnlyDir <- runReaderT platformOnlyRelDir (configPlatform, configPlatformVariant)


### PR DESCRIPTION
Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

It seems that warn messages are [not shown when running a script](https://github.com/commercialhaskell/stack/issues/3007) so the more straigthforward way is change the log level of the relevant message. Not sure it it could have a unwanted consequence.
It fixes #5001.

I've tested the change manually running a script to check the message is actually shown.
