### PR TITLE
Setup-info configurability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 .stack-root/
 /.cabal-sandbox/
 TAGS
-Setup
+/Setup/
 cabal-dev/
 cabal.sandbox.config
 dist/

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ Release notes:
 
 Major changes:
 * `setup-info-locations` yaml configuration now allows overwriting the default locations of `stack-setup-2.yaml`.
+  [#5031](https://github.com/commercialhaskell/stack/pull/5031)
   [#2983](https://github.com/commercialhaskell/stack/issues/2983)
   [#2913](https://github.com/commercialhaskell/stack/issues/2913)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,6 +37,9 @@ Other enhancements:
 
 * Remove warning for using Stack with GHC 8.8 and Cabal 3.0.
 
+* Allow relative paths in `--setup-info-yaml` and tool paths
+  [#3394](https://github.com/commercialhaskell/stack/issues/3394)
+
 Bug fixes:
 
 * Upgrade `pantry`: module mapping insertions into the database are now atomic.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,11 +8,21 @@
 Release notes:
 
 Major changes:
+* `setup-info-locations` yaml configuration now allows overwriting the default locations of `stack-setup-2.yaml`.
+  [#2983](https://github.com/commercialhaskell/stack/issues/2983)
+  [#2913](https://github.com/commercialhaskell/stack/issues/2913)
+
+* The `setup-info` configuration key now allows overwriting parts of the default `setup-info`
+
+* The `--setup-info-yaml` command line flag now may be used in all stack commands such as `stack build`, and not only in `stack setup`
+
+* The `--setup-info-yaml` may specify multiple locations for `stack-setup.yaml` files.
 
 Behavior changes:
+* Remove the deprecated `--stack-setup-yaml` command line argument in favor of `--setup-info-yaml`
+  [#2647](https://github.com/commercialhaskell/stack/issues/2647)
 
 Other enhancements:
-
 * Add `build-output-timestamps` flag in yaml. Setting it to true
   prefixes each build log output line with a timestamp.
 

--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -319,11 +319,10 @@ If you're attempting to install stack from within China:
 
 ```
 ###ADD THIS IF YOU LIVE IN CHINA
-setup-info: "http://mirrors.tuna.tsinghua.edu.cn/stackage/stack-setup.yaml"
+setup-info-locations: 
+- "http://mirrors.tuna.tsinghua.edu.cn/stackage/stack-setup.yaml"
 urls:
   latest-snapshot: http://mirrors.tuna.tsinghua.edu.cn/stackage/snapshots.json
-  lts-build-plans: http://mirrors.tuna.tsinghua.edu.cn/stackage/lts-haskell/
-  nightly-build-plans: http://mirrors.tuna.tsinghua.edu.cn/stackage/stackage-nightly/
 package-indices:
  - name: Tsinghua
    download-prefix: http://mirrors.tuna.tsinghua.edu.cn/hackage/package/

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -707,8 +707,6 @@ ghc:
             url: "installs/ghc-8.2.2.tar.xz"
 ```
 
-Executing `stack setup` outside of a project will use the global `stack.yaml` to determine the relevant `setup-info` information and locations.
-
 ### setup-info
 
 (Since 0.1.5)

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -653,7 +653,8 @@ The first location which specifies the location of a tool `(Tool, Platform, Vers
 ```yaml
 setup-info-locations:
 - C:/stack-offline/my-stack-setup.yaml
-- \\smbServer\stack\my-stack-setup.yaml
+- relative/inside/my/project/setup-info.yaml
+- \\smbShare\stack\my-stack-setup.yaml
 - http://stack-mirror.com/stack-setup.yaml
 - https://github.com/commercialhaskell/stackage-content/raw/master/stack/stack-setup-2.yaml
 ```
@@ -668,6 +669,42 @@ setup-info-locations:
 
 ```yaml
 setup-info-locations: []
+```
+
+Relative paths are resolved relative to the `stack.yaml` file - either in the local project or the global `stack.yaml` in the stack directory.
+
+Relative paths may also be used inside paths to tool installs - such as for ghc or 7z, which allows vendoring the tools inside a monorepo.
+For example:
+
+Directory structure:
+```
+- src/
+- installs/
+  - my-stack-setup.yaml
+  - 7z.exe
+  - 7z.dll
+  - ghc-8.2.2.tar.xz
+- stack.yaml
+```
+
+In the project's `stack.yaml`:
+```yaml
+setup-info-locations:
+- installs/my-stack-setup.yaml
+```
+
+In `installs/my-stack-setup.yaml`:
+```yaml
+sevenzexe-info:
+    url: "installs/7z.exe"
+
+sevenzdll-info:
+    url: "installs/7z.dll"
+
+ghc:
+    windows64:
+        8.2.2:
+            url: "installs/ghc-8.2.2.tar.xz"
 ```
 
 ### setup-info

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -674,7 +674,7 @@ setup-info-locations: []
 
 (Since 0.1.5)
 
-Allows specifying from where tools like GHC and msys2 (on Windows) are
+Allows augmenting from where tools like GHC and msys2 (on Windows) are
 downloaded. Most useful for specifying locations of custom GHC binary
 distributions (for use with the [ghc-variant](#ghc-variant) option).
 
@@ -688,7 +688,14 @@ setup-info:
         url: "https://example.com/ghc-7.10.2-i386-unknown-mingw32-foo.tar.xz"
 ```
 
-Note that specifying this config *does not* the default `stack-setup-2.yaml` from being consulted as a fallback.
+This configuration **adds** the specified setup info metadata to the default;
+Specifying this config **does not** prevent the default `stack-setup-2.yaml` from being consulted as a fallback.
+
+If you need to **replace** the default setup-info, add the following:
+
+```yaml
+setup-info-locations: []
+```
 
 ### pvp-bounds
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -617,8 +617,9 @@ Specify a variant binary distribution of GHC to use.  Known values:
 * `integersimple`: Use a GHC bindist that uses
   [integer-simple instead of GMP](https://ghc.haskell.org/trac/ghc/wiki/ReplacingGMPNotes)
 * any other value: Use a custom GHC bindist. You should specify
-  [setup-info](#setup-info) so `stack setup` knows where to download it, or
-  pass the `stack setup --ghc-bindist` argument on the command-line
+  [setup-info](#setup-info) or [setup-info-locations](#setup-info-locations) 
+  so `stack setup` knows where to download it,
+  or pass the `stack setup --ghc-bindist` argument on the command-line
 
 This option is incompatible with `system-ghc: true`.
 
@@ -630,13 +631,54 @@ Specify a specialized architecture bindist to use.  Normally this is
 determined automatically, but you can override the autodetected value here.
 Possible arguments include `standard`, `gmp4`, `tinfo6`, and `nopie`.
 
+### setup-info-locations
+
+(Since 2.3)
+
+Possible usages of this config are:
+1. Using `stack` offline or behind a firewall
+2. Extending the tools known to `stack` such as cutting-edge versions of `ghc` or builds for custom linux distributions.
+
+The `setup-info` dictionary specifies locations for installation of Haskell-related tooling - it maps `(Tool, Platform, Version)` to the location where it can be obtained, such as `(GHC, Windows64, 8.6.5)` to the url hosting the `*.tar.xz` for GHC's installation.
+
+By default, it's obtained from [stack-setup-2.yaml](https://github.com/commercialhaskell/stackage-content/raw/master/stack/stack-setup-2.yaml).
+
+The `setup-info` dictionary is constructed in the following order:
+1. `setup-info` yaml configuration - inline config
+2. `--setup-info-yaml` command line arguments - urls or paths, multiple locations may be specified.
+3. `setup-info-locations` yaml configuration - urls or paths
+
+The first location which specifies the location of a tool `(Tool, Platform, Version)` takes precedence, so one can extend the default tools with a fallback to the default `setup-info` location:
+
+```yaml
+setup-info-locations:
+- C:/stack-offline/my-stack-setup.yaml
+- \\smbServer\stack\my-stack-setup.yaml
+- http://stack-mirror.com/stack-setup.yaml
+- https://github.com/commercialhaskell/stackage-content/raw/master/stack/stack-setup-2.yaml
+```
+
+The default `setup-info` location is included only if no locations in the `setup-info-locations` config or the  `--setup-info-yaml` command line argument were specified.
+
+Thus the following will cause `stack setup` not to consult github for the `setup-info`:
+```yaml
+setup-info-locations:
+- C:/stack-offline/my-stack-setup.yaml
+```
+
+```yaml
+setup-info-locations: []
+```
+
 ### setup-info
 
 (Since 0.1.5)
 
-Allows augmenting from where tools like GHC and msys2 (on Windows) are
+Allows specifying from where tools like GHC and msys2 (on Windows) are
 downloaded. Most useful for specifying locations of custom GHC binary
-distributions (for use with the [ghc-variant](#ghc-variant) option):
+distributions (for use with the [ghc-variant](#ghc-variant) option).
+
+The format of this field is the same as in the default [stack-setup-2.yaml](https://github.com/commercialhaskell/stackage-content/raw/master/stack/stack-setup-2.yaml):
 
 ```yaml
 setup-info:
@@ -646,18 +688,7 @@ setup-info:
         url: "https://example.com/ghc-7.10.2-i386-unknown-mingw32-foo.tar.xz"
 ```
 
-Or you can point to external setup-info:
-
-```yaml
-setup-info: "https://example.com/my-stack-setup-info.yaml"
-```
-
-This may be either URL or (since 1.2.0) absolute file path.
-
-Note that this **adds** the specified setup info metadata to the default.
-If you need to **replace** it, use the `stack --setup-info-yaml` command-line
-argument instead.  The default setup metadata is in
-[stack-setup-2.yaml](https://github.com/commercialhaskell/stackage-content/raw/master/stack/stack-setup-2.yaml).
+Note that specifying this config *does not* the default `stack-setup-2.yaml` from being consulted as a fallback.
 
 ### pvp-bounds
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -707,6 +707,8 @@ ghc:
             url: "installs/ghc-8.2.2.tar.xz"
 ```
 
+Executing `stack setup` outside of a project will use the global `stack.yaml` to determine the relevant `setup-info` information and locations.
+
 ### setup-info
 
 (Since 0.1.5)

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -320,6 +320,7 @@ configFromConfigMonoid
          configGhcOptionsByName = coerce configMonoidGhcOptionsByName
          configGhcOptionsByCat = coerce configMonoidGhcOptionsByCat
          configSetupInfoLocations = configMonoidSetupInfoLocations
+         configSetupInfoInline = configMonoidSetupInfoInline
          configPvpBounds = fromFirst (PvpBounds PvpBoundsNone False) configMonoidPvpBounds
          configModifyCodePage = fromFirstTrue configMonoidModifyCodePage
          configExplicitSetupDeps = configMonoidExplicitSetupDeps

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -132,7 +132,7 @@ configOptsParser currentDir hide0 =
     <*> many (
         strOption
             ( long "setup-info-yaml"
-           <> help "Alternate URL or absolute path for stack dependencies"
+           <> help "Alternate URL or relative / absolute path for stack dependencies"
            <> metavar "URL" ))
     <*> firstBoolFlagsTrue
             "modify-code-page"

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -130,17 +130,10 @@ configOptsParser currentDir hide0 =
             <> hide
              ))
     <*> many (
-        ( strOption
-            ( long "stack-setup-yaml"
-           <> help "DEPRECATED: Use 'setup-info-yaml' instead"
-           <> metavar "URL"
-           <> hidden )
-        ) <|>
-        ( strOption
+        strOption
             ( long "setup-info-yaml"
            <> help "Alternate URL or absolute path for stack dependencies"
-           <> metavar "URL" )
-        ))
+           <> metavar "URL" ))
     <*> firstBoolFlagsTrue
             "modify-code-page"
             "setting the codepage to support UTF-8 (Windows only)"

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -129,7 +129,7 @@ configOptsParser currentDir hide0 =
             <> help "Install binaries to DIR"
             <> hide
              ))
-    <*> many (SetupInfoFileOrURL <$> (
+    <*> many (
         ( strOption
             ( long "stack-setup-yaml"
            <> help "DEPRECATED: Use 'setup-info-yaml' instead"
@@ -140,7 +140,7 @@ configOptsParser currentDir hide0 =
             ( long "setup-info-yaml"
            <> help "Alternate URL or absolute path for stack dependencies"
            <> metavar "URL" )
-        )))
+        ))
     <*> firstBoolFlagsTrue
             "modify-code-page"
             "setting the codepage to support UTF-8 (Windows only)"

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -21,8 +21,8 @@ configOptsParser :: FilePath -> GlobalOptsContext -> Parser ConfigMonoid
 configOptsParser currentDir hide0 =
     (\stackRoot workDir buildOpts dockerOpts nixOpts systemGHC installGHC arch
         ghcVariant ghcBuild jobs includes libs overrideGccPath overrideHpack
-        skipGHCCheck skipMsys localBin modifyCodePage allowDifferentUser
-        dumpLogs colorWhen -> mempty
+        skipGHCCheck skipMsys localBin setupInfoLocations modifyCodePage
+        allowDifferentUser dumpLogs colorWhen -> mempty
             { configMonoidStackRoot = stackRoot
             , configMonoidWorkDir = workDir
             , configMonoidBuildOpts = buildOpts
@@ -41,6 +41,7 @@ configOptsParser currentDir hide0 =
             , configMonoidOverrideHpack = overrideHpack
             , configMonoidSkipMsys = skipMsys
             , configMonoidLocalBinPath = localBin
+            , configMonoidSetupInfoLocations = setupInfoLocations
             , configMonoidModifyCodePage = modifyCodePage
             , configMonoidAllowDifferentUser = allowDifferentUser
             , configMonoidDumpLogs = dumpLogs
@@ -128,6 +129,18 @@ configOptsParser currentDir hide0 =
             <> help "Install binaries to DIR"
             <> hide
              ))
+    <*> many (SetupInfoFileOrURL <$> (
+        ( strOption
+            ( long "stack-setup-yaml"
+           <> help "DEPRECATED: Use 'setup-info-yaml' instead"
+           <> metavar "URL"
+           <> hidden )
+        ) <|>
+        ( strOption
+            ( long "setup-info-yaml"
+           <> help "Alternate URL or absolute path for stack dependencies"
+           <> metavar "URL" )
+        )))
     <*> firstBoolFlagsTrue
             "modify-code-page"
             "setting the codepage to support UTF-8 (Windows only)"

--- a/src/Stack/SetupCmd.hs
+++ b/src/Stack/SetupCmd.hs
@@ -27,24 +27,10 @@ import           Stack.Types.Version
 data SetupCmdOpts = SetupCmdOpts
     { scoCompilerVersion :: !(Maybe WantedCompiler)
     , scoForceReinstall  :: !Bool
-    , scoSetupInfoYaml   :: !String
     , scoGHCBindistURL   :: !(Maybe String)
     , scoGHCJSBootOpts   :: ![String]
     , scoGHCJSBootClean  :: !Bool
     }
-
-setupYamlCompatParser :: OA.Parser String
-setupYamlCompatParser = stackSetupYaml <|> setupInfoYaml
-    where stackSetupYaml = OA.strOption (
-               OA.long "stack-setup-yaml"
-            <> OA.help "DEPRECATED: Use 'setup-info-yaml' instead"
-            <> OA.metavar "URL"
-            <> OA.hidden )
-          setupInfoYaml  = OA.strOption (
-               OA.long "setup-info-yaml"
-            <> OA.help "Alternate URL or absolute path for stack dependencies"
-            <> OA.metavar "URL"
-            <> OA.value defaultSetupInfoYaml )
 
 setupParser :: OA.Parser SetupCmdOpts
 setupParser = SetupCmdOpts
@@ -56,7 +42,6 @@ setupParser = SetupCmdOpts
             "reinstall"
             "reinstalling GHC, even if available (incompatible with --system-ghc)"
             OA.idm
-    <*> setupYamlCompatParser
     <*> OA.optional (OA.strOption
             (OA.long "ghc-bindist"
            <> OA.metavar "URL"
@@ -99,7 +84,6 @@ setup SetupCmdOpts{..} wantedCompiler compilerCheck mstack = do
         , soptsSkipGhcCheck = False
         , soptsSkipMsys = configSkipMsys
         , soptsResolveMissingGHC = Nothing
-        , soptsSetupInfoYaml = scoSetupInfoYaml
         , soptsGHCBindistURL = scoGHCBindistURL
         , soptsGHCJSBootOpts = scoGHCJSBootOpts ++ ["--clean" | scoGHCJSBootClean]
         }

--- a/src/Stack/SetupCmd.hs
+++ b/src/Stack/SetupCmd.hs
@@ -65,7 +65,7 @@ setupParser = SetupCmdOpts
             Right x -> return x
 
 setup
-    :: (HasConfig env, HasGHCVariant env)
+    :: (HasBuildConfig env, HasGHCVariant env)
     => SetupCmdOpts
     -> WantedCompiler
     -> VersionCheck

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1694,15 +1694,15 @@ instance FromJSON (WithJSONWarnings SetupInfo) where
         return SetupInfo {..}
 
 -- | For @siGHCs@ and @siGHCJSs@ fields maps are deeply merged.
--- For all fields the values from the last @SetupInfo@ win.
+-- For all fields the values from the first @SetupInfo@ win.
 instance Semigroup SetupInfo where
     l <> r =
         SetupInfo
-        { siSevenzExe = siSevenzExe r <|> siSevenzExe l
-        , siSevenzDll = siSevenzDll r <|> siSevenzDll l
-        , siMsys2 = siMsys2 r <> siMsys2 l
-        , siGHCs = Map.unionWith (<>) (siGHCs r) (siGHCs l)
-        , siGHCJSs = Map.unionWith (<>) (siGHCJSs r) (siGHCJSs l)
+        { siSevenzExe = siSevenzExe l <|> siSevenzExe r
+        , siSevenzDll = siSevenzDll l <|> siSevenzDll r
+        , siMsys2 = siMsys2 l <> siMsys2 r
+        , siGHCs = Map.unionWith (<>) (siGHCs l) (siGHCs r)
+        , siGHCJSs = Map.unionWith (<>) (siGHCJSs l) (siGHCJSs r)
         , siStack = Map.unionWith (<>) (siStack l) (siStack r) }
 
 instance Monoid SetupInfo where

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -333,7 +333,7 @@ data Config =
          ,configCabalConfigOpts     :: !(Map CabalConfigKey [Text])
          -- ^ Additional options to be passed to ./Setup.hs configure
          ,configSetupInfoLocations  :: ![String]
-         -- ^ URLs or paths to setup-info.yaml files, for finding tools.
+         -- ^ URLs or paths to stack-setup.yaml files, for finding tools.
          -- If none present, the default setup-info is used.
          ,configSetupInfoInline     :: !SetupInfo
          -- ^ Additional SetupInfo to use to find tools.
@@ -823,10 +823,9 @@ data ConfigMonoid =
     ,configMonoidExtraPath           :: ![Path Abs Dir]
     -- ^ Additional paths to search for executables in
     ,configMonoidSetupInfoLocations  :: ![String]
-    -- ^ URLs or paths to setup-info.yaml files, for finding tools.
-    -- If none present, the default setup-info is used.
+    -- ^ See 'configSetupInfoLocations'
     ,configMonoidSetupInfoInline     :: !SetupInfo
-    -- ^ Additional SetupInfo to use to find tools.
+    -- ^ See 'configSetupInfoInline'
     ,configMonoidLocalProgramsBase   :: !(First (Path Abs Dir))
     -- ^ Override the default local programs dir, where e.g. GHC is installed.
     ,configMonoidPvpBounds           :: !(First PvpBounds)

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -539,11 +539,11 @@ interpreterHandler currentDir args f = do
       return (a,(b,mempty))
 
 setupCmd :: SetupCmdOpts -> RIO Runner ()
-setupCmd sco@SetupCmdOpts{..} = withConfig YesReexec $ do
+setupCmd sco@SetupCmdOpts{..} = withConfig YesReexec $ withBuildConfig $ do
   (wantedCompiler, compilerCheck, mstack) <-
     case scoCompilerVersion of
       Just v -> return (v, MatchMinor, Nothing)
-      Nothing -> withBuildConfig $ (,,)
+      Nothing -> (,,)
         <$> view wantedCompilerVersionL
         <*> view (configL.to configCompilerCheck)
         <*> (Just <$> view stackYamlL)


### PR DESCRIPTION
This PR comes to fix various issues related to how `stack` decides where to resolves it's tooling locations, for the initial purpose of using `stack` offline or behind a firewall. 

* See the documentation changes and the changelog for details on the new behaviors.

Stack 2 broke the previous behavior of the `setup-info` field - which now does not overwrite the default location. [#2983](https://github.com/commercialhaskell/stack/issues/2983), [#2913](https://github.com/commercialhaskell/stack/issues/2913)

This existing breakage allowed for a backwards-compatible implementation of the wanted behavior - via the `setup-info-locations` yaml config for remote locations, and using `setup-info` for inline configuration only.

Also, as the `--stack-setup-yaml` CmdArg has been deprecated for 3 years, it is now removed, in favor of `--setup-info-yaml` [#2647](https://github.com/commercialhaskell/stack/issues/2647)

Design decisions:
1. Usability / Backwards compatability: The default `stack-setup-2.yaml` is added to the `setup-info-locations` only if no locations were specified (either in the cmd args or in the config yaml)
2. Extendability: Allow extending setup locations - inline configs extend the default, and locations allow extensions by the locations following them.

PR considerations:
* Documentation was updated
* Changelog was updated
* Manual tests performed:
  * Overriding precedence between `setup-info`, command line args, `setup-info-locations` and the default location, with missing / invalid locations to check that no unwanted accesses are made.

Relevant issues:
- Fixes [setup-info field in stack.yaml not consulted](https://github.com/commercialhaskell/stack/issues/2983)
- Fixes [Combine stack-info-yaml argument and config.yaml](https://github.com/commercialhaskell/stack/issues/2982)
- Fixes [`stack setup` should not fail if it couldn't download default stack-setup-yaml](https://github.com/commercialhaskell/stack/issues/2913)
- Fixes [Use setup-info in stack.yaml](https://github.com/ndmitchell/offline-stack/issues/2)
- Fixes [Feature Request: allow setup-info urls to be relative file paths](https://github.com/commercialhaskell/stack/issues/3394)
- Change Monoid ordering of `SetupInfo` [Consider if other order of combination is more appropriate for the monoids on config types](https://github.com/commercialhaskell/stack/issues/2078)
- [Improve UI for `stack setup --stack-setup-yaml` option](https://github.com/commercialhaskell/stack/issues/2647)
though.