### PR TITLE
Remove warning for using Stack with GHC 8.8 and Cabal 3.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@ Behavior changes:
 
 Other enhancements:
 
+* Remove warning for using Stack with GHC 8.8 and Cabal 3.0.
+
 Bug fixes:
 
 * Fix using relative links in haddocks output.  See

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -482,9 +482,9 @@ warnUnsupportedCompiler ghcVersion = do
         logWarn "For more information, see: https://github.com/commercialhaskell/stack/issues/648"
         logWarn ""
         pure True
-    | ghcVersion >= mkVersion [8, 7] -> do
+    | ghcVersion >= mkVersion [8, 9] -> do
         logWarn $
-          "Stack has not been tested with GHC versions above 8.6, and using " <>
+          "Stack has not been tested with GHC versions above 8.8, and using " <>
           fromString (versionString ghcVersion) <>
           ", this may fail"
         pure True
@@ -509,9 +509,9 @@ warnUnsupportedCompilerCabal cp didWarn = do
         logWarn "This invocation will most likely fail."
         logWarn "To fix this, either use an older version of Stack or a newer resolver"
         logWarn "Acceptable resolvers: lts-3.0/nightly-2015-05-05 or later"
-    | cabalVersion >= mkVersion [2, 5] ->
+    | cabalVersion >= mkVersion [3, 1] ->
         logWarn $
-          "Stack has not been tested with Cabal versions above 2.4, but version " <>
+          "Stack has not been tested with Cabal versions above 3.0, but version " <>
           fromString (versionString cabalVersion) <>
           " was found, this may fail"
     | otherwise -> pure ()


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

Confirmed by @DanBurton by running a Stackage Nightly build with GHC 8.8.