### PR TITLE
Documenting --profile usage with stack exec

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1788,7 +1788,7 @@ The `my-tests.prof` file now contains time and allocation info for the test run.
 To create a profiling report for an executable, e.g. `my-exe`, you can
 run
 
-     stack exec -- my-exe +RTS -p
+     stack exec --profile -- my-exe +RTS -p
 
 For more fine-grained control of compilation options there are the
 `--library-profiling` and `--executable-profiling` flags which will turn on the


### PR DESCRIPTION
Documents mandatory for profiling `--profile` key for `stack exec`.

I'm building project with `stack clean --full && stack build --profile`.
With the code from the current wiki: ` stack exec -- vector-try-exe +RTS -p` it will not find `vector-try-exe`.
With the updated code from this commit: ` stack exec --profile -- vector-try-exe +RTS -p` it will run fine.