### PR TITLE
Update documentation for cabal flags

### DIFF
--- a/doc/nonstandard_project_init.md
+++ b/doc/nonstandard_project_init.md
@@ -41,13 +41,7 @@ flags:
 ```
 
 It is also possible to pass the same flag to multiple packages, i.e.
-`stack build --flag *:necessary`
-
-Currently one needs to list all of your modules that interpret flags in the
-`other-modules` section of a cabal file. `cabal-install` has a different
-behavior currently and doesn't require that the modules be listed. This may
-change in a future release.
-
+`stack build --flag '*:necessary'`
 
 ### Issues Referenced
   - https://github.com/commercialhaskell/stack/issues/191


### PR DESCRIPTION
Listing the modules in `other-modules` doesn't seem to be necessary anymore. Also passing flags with wildcards require escaping the asterisk with `\*` or wrap it in quotes.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
