### PR TITLE
Enable nightly build for stable branch

### DIFF
--- a/azure-nightly-pipeline.yml
+++ b/azure-nightly-pipeline.yml
@@ -1,6 +1,14 @@
 trigger: none
 pr: none
 
+schedules:
+- cron: "0 0 * * *"
+  displayName: Nightly build
+  branches:
+    include:
+    - master
+    - stable
+
 variables:
   BASE_BRANCH: "master"
   CACHE_S3_PREFIX: "stack-nightly"


### PR DESCRIPTION
@borsboom pinged me that nightly pipeline seems to be missing in the
UI. Analyzing it further, I found that the nightly pipeline in the
dashboard has zero scheduled builds. The likely reason for this seems
to be because of new deployment of azure pipelines.

The good news is now we can control the nightly builds using the yaml
file itself (this wasn't possible before when we added azure builds to
stack initially). This PR does that and make sure we don't rely on UI
for the CI configuration anymore.