### PR TITLE
Revert bad merge on stable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## v2.3.x (unreleased changes)
+## Unreleased changes
 
 **Changes since v2.1.3.1**
 
@@ -13,21 +13,9 @@ Behavior changes:
 
 Other enhancements:
 
-* Show warning about `local-programs-path` with spaces on windows
-  when running scripts. See 
-  [#5013](https://github.com/commercialhaskell/stack/pull/5013)
-
-* Add `ls dependencies json` which will print dependencies as JSON.
-  `ls dependencies --tree`  is now `ls dependencies tree`. See
-  [#4424](https://github.com/commercialhaskell/stack/pull/4424)
-
 * Remove warning for using Stack with GHC 8.8 and Cabal 3.0.
 
 Bug fixes:
-
-* Upgrade `pantry`: module mapping insertions into the database are now atomic.
-  Previously, if you SIGTERMed at the wrong time while running a script, you
-  could end up with an inconsistent database state.
 
 * Fix using relative links in haddocks output.  See
   [#4971](https://github.com/commercialhaskell/stack/issues/4971).

--- a/etc/scripts/mirror-ghc-bindists-to-github.sh
+++ b/etc/scripts/mirror-ghc-bindists-to-github.sh
@@ -36,18 +36,16 @@ echo 'ghc:' >stack-setup-$GHCVER.yaml
 
 mirror_ () {
   base_url="$1"; shift
-  destsuffix="$1"; shift
   suffix="$1"; shift
   srcext="$1"; shift
   destext="$1"; shift
-  local srcurl="$base_url/ghc-$GHCVER-${suffix}.tar.${srcext}"
-  local srcfn=ghc-$GHCVER-${suffix}${destsuffix}.tar.${srcext}
+  local srcfn=ghc-$GHCVER-${suffix}.tar.${srcext}
   if [[ ! -s "$srcfn.downloaded" ]]; then
     rm -f "$srcfn"
-    curl -Lo "$srcfn" --fail "$srcurl"
+    curl -LO --fail "$base_url/$srcfn"
     date >"$srcfn.downloaded"
   fi
-  local destfn=ghc-$GHCVER-${suffix}${destsuffix}.tar.${destext}
+  local destfn=ghc-$GHCVER-${suffix}.tar.${destext}
   if [[ ! -s "$destfn.uploaded" ]]; then
     if [[ "${srcext}" == "xz" && "${destext}" == "bz2" ]]; then
       xzcat "$srcfn" | bzip2 -c > "$destfn"
@@ -64,7 +62,7 @@ mirror_ () {
     alias="$1"
     echo "    $alias:" >>stack-setup-$GHCVER.yaml
     echo "        $GHCVER:" >>stack-setup-$GHCVER.yaml
-    echo "            # Mirrored from $srcurl" >>stack-setup-$GHCVER.yaml
+    echo "            # Mirrored from $base_url/$srcfn" >>stack-setup-$GHCVER.yaml
     echo "            url: \"https://github.com/commercialhaskell/ghc/releases/download/ghc-$GHCVER-release/$destfn\"" >>stack-setup-$GHCVER.yaml
     echo "            content-length: $(stat --printf="%s" "$destfn" 2>/dev/null || stat -f%z "$destfn")" >>stack-setup-$GHCVER.yaml
     echo "            sha1: $(shasum -a 1 $destfn |cut -d' ' -f1)" >>stack-setup-$GHCVER.yaml
@@ -75,7 +73,7 @@ mirror_ () {
 }
 
 mirror () {
-  mirror_ http://downloads.haskell.org/~ghc/$GHCVER "" "$@"
+  mirror_ http://downloads.haskell.org/~ghc/$GHCVER "$@"
 }
 
 # NOTE: keep the 'mirror' commands in the same order as entries in
@@ -91,13 +89,8 @@ mirror x86_64-unknown-mingw32 xz xz windows64
 #mirror x86_64-portbld-freebsd11 xz xz freebsd64-11
 mirror aarch64-deb9-linux xz xz linux-aarch64
 
-mirror_ https://github.com/redneb/ghc-alt-libc/releases/download/ghc-$GHCVER-musl "" i386-unknown-linux-musl xz xz linux32-musl
-mirror_ https://github.com/redneb/ghc-alt-libc/releases/download/ghc-$GHCVER-musl "" x86_64-unknown-linux-musl xz xz linux64-musl
-
-mirror_ http://distcache.FreeBSD.org/local-distfiles/arrowd/stack-bindists/11 "" i386-portbld-freebsd xz xz freebsd32
-mirror_ http://distcache.FreeBSD.org/local-distfiles/arrowd/stack-bindists "-ino64" i386-portbld-freebsd xz xz freebsd32-ino64
-mirror_ http://distcache.FreeBSD.org/local-distfiles/arrowd/stack-bindists/11 "" x86_64-portbld-freebsd xz xz freebsd64
-mirror_ http://distcache.FreeBSD.org/local-distfiles/arrowd/stack-bindists "-ino64" x86_64-portbld-freebsd xz xz freebsd64-ino64
+mirror_ https://github.com/redneb/ghc-alt-libc/releases/download/ghc-$GHCVER-musl i386-unknown-linux-musl xz xz linux32-musl
+mirror_ https://github.com/redneb/ghc-alt-libc/releases/download/ghc-$GHCVER-musl x86_64-unknown-linux-musl xz xz linux64-musl
 
 set +x
 echo

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stack
-version: '2.2.0'
+version: '2.1.4'
 synopsis: The Haskell Tool Stack
 description: |
   Please see the documentation at <https://docs.haskellstack.org>
@@ -104,6 +104,8 @@ dependencies:
 - process
 - project-template
 - regex-applicative-text
+- resource-pool
+- resourcet
 - retry
 - rio
 - rio-prettyprint

--- a/snapshot-nightly.yaml
+++ b/snapshot-nightly.yaml
@@ -2,14 +2,14 @@ resolver: nightly-2019-07-15
 name: snapshot-for-building-stack-with-ghc-8.6.5
 
 packages:
+- github: snoyberg/filelock
+  commit: 97e83ecc133cd60a99df8e1fa5a3c2739ad007dc
 - rio-0.1.11.0@rev:0
 - persistent-template-2.7.1@rev:0
 - persistent-2.10.0@rev:0
 - persistent-sqlite-2.10.1@rev:0
 - pantry-0.2.0.0
-- github: snoyberg/filelock
-  commit: 97e83ecc133cd60a99df8e1fa5a3c2739ad007dc
-  
+
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712
 - cabal-install

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -281,12 +281,12 @@ configFromConfigMonoid
        shortLocalProgramsFilePath <-
          liftIO $ getShortPathName localProgramsFilePath
        when (' ' `elem` shortLocalProgramsFilePath) $ do
-         logError $ "Stack's 'programs' path contains a space character and " <>
+         logWarn $ "Stack's 'programs' path contains a space character and " <>
            "has no alternative short ('8 dot 3') name. This will cause " <>
            "problems with packages that use the GNU project's 'configure' " <>
-           "shell script. Use the 'local-programs-path' configuration option " <>
-           "to specify an alternative path. The current path is: " <>
-           display (T.pack localProgramsFilePath)
+           "shell script. Use the 'local-programs-path' configuation option " <>
+           "to specify an alternative path. The current 'shortest' path is: " <>
+           display (T.pack shortLocalProgramsFilePath)
      platformOnlyDir <- runReaderT platformOnlyRelDir (configPlatform, configPlatformVariant)
      let configLocalPrograms = configLocalProgramsBase </> platformOnlyDir
 

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -9,15 +9,11 @@ module Stack.Dot (dot
                  ,DotOpts(..)
                  ,DotPayload(..)
                  ,ListDepsOpts(..)
-                 ,ListDepsFormat(..)
-                 ,ListDepsFormatOpts(..)
                  ,resolveDependencies
                  ,printGraph
                  ,pruneGraph
                  ) where
 
-import           Data.Aeson
-import qualified Data.ByteString.Lazy.Char8 as LBC8
 import qualified Data.Foldable as F
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
@@ -30,7 +26,6 @@ import qualified Distribution.PackageDescription as PD
 import qualified Distribution.SPDX.License as SPDX
 import           Distribution.License (License(BSD3), licenseFromSPDX)
 import           Distribution.Types.PackageName (mkPackageName)
-import qualified Path
 import           RIO.PrettyPrint (HasTerm (..), HasStylesUpdate (..))
 import           RIO.Process (HasProcessContext (..))
 import           Stack.Build (loadPackage)
@@ -72,21 +67,15 @@ data DotOpts = DotOpts
     -- ^ Use global hints instead of relying on an actual GHC installation.
     }
 
-data ListDepsFormatOpts = ListDepsFormatOpts { listDepsSep :: !Text
-                                             -- ^ Separator between the package name and details.
-                                             , listDepsLicense :: !Bool
-                                             -- ^ Print dependency licenses instead of versions.
-                                             }
-
-data ListDepsFormat = ListDepsText ListDepsFormatOpts
-                    | ListDepsTree ListDepsFormatOpts
-                    | ListDepsJSON
-
 data ListDepsOpts = ListDepsOpts
-    { listDepsFormat :: !ListDepsFormat
-    -- ^ Format of printing dependencies
-    , listDepsDotOpts :: !DotOpts
+    { listDepsDotOpts :: !DotOpts
     -- ^ The normal dot options.
+    , listDepsSep :: !Text
+    -- ^ Separator between the package name and details.
+    , listDepsLicense :: !Bool
+    -- ^ Print dependency licenses instead of versions.
+    , listDepsTree :: !Bool
+    -- ^ Print dependency tree.
     }
 
 -- | Visualize the project's dependencies as a graphviz graph
@@ -101,8 +90,6 @@ data DotPayload = DotPayload
   -- ^ The package version.
   , payloadLicense :: Maybe (Either SPDX.License License)
   -- ^ The license the package was released under.
-  , payloadLocation :: Maybe PackageLocation
-  -- ^ The location of the package.
   } deriving (Eq, Show)
 
 -- | Create the dependency graph and also prune it as specified in the dot
@@ -144,11 +131,10 @@ createDependencyGraph dotOpts = do
           -- Skip packages that can't be loaded - see
           -- https://github.com/commercialhaskell/stack/issues/2967
           | name `elem` [mkPackageName "rts", mkPackageName "ghc"] =
-              return (Set.empty, DotPayload (Just version) (Just $ Right BSD3) Nothing)
-          | otherwise =
-              fmap (packageAllDeps &&& makePayload loc) (loadPackage loc flags ghcOptions cabalConfigOpts)
+              return (Set.empty, DotPayload (Just version) (Just $ Right BSD3))
+          | otherwise = fmap (packageAllDeps &&& makePayload) (loadPackage loc flags ghcOptions cabalConfigOpts)
   resolveDependencies (dotDependencyDepth dotOpts) graph depLoader
-  where makePayload loc pkg = DotPayload (Just $ packageVersion pkg) (Just $ packageLicense pkg) (Just $ PLImmutable loc)
+  where makePayload pkg = DotPayload (Just $ packageVersion pkg) (Just $ packageLicense pkg)
 
 listDependencies
   :: ListDepsOpts
@@ -156,52 +142,13 @@ listDependencies
 listDependencies opts = do
   let dotOpts = listDepsDotOpts opts
   (pkgs, resultGraph) <- createPrunedDependencyGraph dotOpts
-  liftIO $ case listDepsFormat opts of
-      ListDepsTree treeOpts -> Text.putStrLn "Packages" >> printTree treeOpts dotOpts 0 [] (treeRoots opts pkgs) resultGraph
-      ListDepsJSON -> printJSON pkgs resultGraph
-      ListDepsText textOpts -> void (Map.traverseWithKey go (snd <$> resultGraph))
-        where go name payload = Text.putStrLn $ listDepsLine textOpts name payload
-
-data DependencyTree = DependencyTree (Set PackageName) (Map PackageName (Set PackageName, DotPayload))
-
-instance ToJSON DependencyTree where
-  toJSON (DependencyTree _ dependencyMap) =
-    toJSON $ foldToList dependencyToJSON dependencyMap
-
-foldToList :: (k -> a -> b) -> Map k a -> [b]
-foldToList f = Map.foldrWithKey (\k a bs -> bs ++ [f k a]) []
-
-dependencyToJSON :: PackageName -> (Set PackageName, DotPayload) -> Value
-dependencyToJSON pkg (deps, payload) =  let fieldsAlwaysPresent = [ "name" .= packageNameString pkg
-                                                                  , "license" .= licenseText payload
-                                                                  , "version" .= versionText payload
-                                                                  , "dependencies" .= Set.map packageNameString deps
-                                                                  ]
-                                            loc = catMaybes [("location" .=) . pkgLocToJSON <$> payloadLocation payload]
-                                        in object $ fieldsAlwaysPresent ++ loc
-
-pkgLocToJSON :: PackageLocation -> Value
-pkgLocToJSON (PLMutable (ResolvedPath _ dir)) = object [ "type" .= ("project package" :: Text)
-                                              , "url" .= ("file://" ++ Path.toFilePath dir)]
-pkgLocToJSON (PLImmutable (PLIHackage pkgid _ _)) = object [ "type" .= ("hackage" :: Text)
-                                                  , "url" .= ("https://hackage.haskell.org/package/" ++ display pkgid)]
-pkgLocToJSON (PLImmutable (PLIArchive archive _)) = let url = case archiveLocation archive of
-                                                                ALUrl u -> u
-                                                                ALFilePath (ResolvedPath _ path) -> Text.pack $ "file://" ++ Path.toFilePath path
-                                                    in object [ "type" .= ("archive" :: Text)
-                                                              , "url" .= url ]
-pkgLocToJSON (PLImmutable (PLIRepo repo _)) = object [ "type" .= case repoType repo of
-                                                                   RepoGit -> "git" :: Text
-                                                                   RepoHg -> "hg" :: Text
-                                                     , "url" .= repoUrl repo
-                                                     , "commit" .= repoCommit repo
-                                                     , "subdir" .= repoSubdir repo
-                                                     ]
-
-printJSON :: Set PackageName
-          -> Map PackageName (Set PackageName, DotPayload)
-          -> IO ()
-printJSON pkgs dependencyMap = LBC8.putStrLn $ encode $ DependencyTree pkgs dependencyMap
+  if listDepsTree opts then
+    do
+      liftIO $ Text.putStrLn "Packages"
+      liftIO $ printTree opts 0 [] (treeRoots opts pkgs) resultGraph
+    else
+      void (Map.traverseWithKey go (snd <$> resultGraph))
+      where go name payload = liftIO $ Text.putStrLn $ listDepsLine opts name payload
 
 treeRoots :: ListDepsOpts -> Set PackageName -> Set PackageName
 treeRoots opts projectPackages' =
@@ -210,14 +157,13 @@ treeRoots opts projectPackages' =
         then projectPackages'
         else Set.fromList $ map (mkPackageName . Text.unpack) targets
 
-printTree :: ListDepsFormatOpts
-          -> DotOpts
+printTree :: ListDepsOpts
           -> Int
           -> [Int]
           -> Set PackageName
           -> Map PackageName (Set PackageName, DotPayload)
           -> IO ()
-printTree opts dotOpts depth remainingDepsCounts packages dependencyMap =
+printTree opts depth remainingDepsCounts packages dependencyMap =
   F.sequence_ $ Seq.mapWithIndex go (toSeq packages)
   where
     toSeq = Seq.fromList . Set.toList
@@ -225,23 +171,22 @@ printTree opts dotOpts depth remainingDepsCounts packages dependencyMap =
                      in
                       case Map.lookup name dependencyMap of
                         Just (deps, payload) -> do
-                          printTreeNode opts dotOpts depth newDepsCounts deps payload name
-                          if Just depth == dotDependencyDepth dotOpts
+                          printTreeNode opts depth newDepsCounts deps payload name
+                          if Just depth == dotDependencyDepth (listDepsDotOpts opts)
                              then return ()
-                             else printTree opts dotOpts (depth + 1) newDepsCounts deps dependencyMap
+                             else printTree opts (depth + 1) newDepsCounts deps dependencyMap
                         -- TODO: Define this behaviour, maybe return an error?
                         Nothing -> return ()
 
-printTreeNode :: ListDepsFormatOpts
-              -> DotOpts
+printTreeNode :: ListDepsOpts
               -> Int
               -> [Int]
               -> Set PackageName
               -> DotPayload
               -> PackageName
               -> IO ()
-printTreeNode opts dotOpts depth remainingDepsCounts deps payload name =
-  let remainingDepth = fromMaybe 999 (dotDependencyDepth dotOpts) - depth
+printTreeNode opts depth remainingDepsCounts deps payload name =
+  let remainingDepth = fromMaybe 999 (dotDependencyDepth (listDepsDotOpts opts)) - depth
       hasDeps = not $ null deps
    in Text.putStrLn $ treeNodePrefix "" remainingDepsCounts hasDeps  remainingDepth  <> " " <> listDepsLine opts name payload
 
@@ -256,20 +201,14 @@ treeNodePrefix t [_] False _ = t <> "├──"
 treeNodePrefix t (0:ns) d remainingDepth = treeNodePrefix (t <> "  ") ns d remainingDepth
 treeNodePrefix t (_:ns) d remainingDepth = treeNodePrefix (t <> "│ ") ns d remainingDepth
 
-listDepsLine :: ListDepsFormatOpts -> PackageName -> DotPayload -> Text
+listDepsLine :: ListDepsOpts -> PackageName -> DotPayload -> Text
 listDepsLine opts name payload = Text.pack (packageNameString name) <> listDepsSep opts <> payloadText opts payload
 
-payloadText :: ListDepsFormatOpts -> DotPayload -> Text
+payloadText :: ListDepsOpts -> DotPayload -> Text
 payloadText opts payload =
   if listDepsLicense opts
-    then licenseText payload
-    else versionText payload
-
-licenseText :: DotPayload -> Text
-licenseText payload = maybe "<unknown>" (Text.pack . display . either licenseFromSPDX id) (payloadLicense payload)
-
-versionText :: DotPayload -> Text
-versionText payload = maybe "<unknown>" (Text.pack . display) (payloadVersion payload)
+    then maybe "<unknown>" (Text.pack . display . either licenseFromSPDX id) (payloadLicense payload)
+    else maybe "<unknown>" (Text.pack . display) (payloadVersion payload)
 
 -- | @pruneGraph dontPrune toPrune graph@ prunes all packages in
 -- @graph@ with a name in @toPrune@ and removes resulting orphans
@@ -338,7 +277,7 @@ createDepLoader sourceMap globalDumpMap globalIdMap loadPackageDeps pkgName = do
       where
         loadDeps pp = do
           pkg <- loadCommonPackage (ppCommon pp)
-          pure (packageAllDeps pkg, payloadFromLocal pkg Nothing)
+          pure (packageAllDeps pkg, payloadFromLocal pkg)
 
     dependencyDeps =
       loadDeps <$> Map.lookup pkgName (smDeps sourceMap)
@@ -346,7 +285,7 @@ createDepLoader sourceMap globalDumpMap globalIdMap loadPackageDeps pkgName = do
         loadDeps DepPackage{dpLocation=PLMutable dir} = do
               pp <- mkProjectPackage YesPrintWarnings dir False
               pkg <- loadCommonPackage (ppCommon pp)
-              pure (packageAllDeps pkg, payloadFromLocal pkg (Just $ PLMutable dir))
+              pure (packageAllDeps pkg, payloadFromLocal pkg)
 
         loadDeps dp@DepPackage{dpLocation=PLImmutable loc} = do
           let common = dpCommon dp
@@ -374,23 +313,21 @@ createDepLoader sourceMap globalDumpMap globalIdMap loadPackageDeps pkgName = do
     noDepsErr = error ("Invariant violated: The '" ++ packageNameString pkgName
                 ++ "' package was not found in any of the dependency sources")
 
-    payloadFromLocal pkg loc = DotPayload (Just $ packageVersion pkg) (Just $ packageLicense pkg) loc
-    payloadFromDump dp = DotPayload (Just $ pkgVersion $ dpPackageIdent dp) (Right <$> dpLicense dp) Nothing
+    payloadFromLocal pkg = DotPayload (Just $ packageVersion pkg) (Just $ packageLicense pkg)
+    payloadFromDump dp = DotPayload (Just $ pkgVersion $ dpPackageIdent dp) (Right <$> dpLicense dp)
 
 -- | Resolve the direct (depth 0) external dependencies of the given local packages (assumed to come from project packages)
 projectPackageDependencies :: DotOpts -> [LocalPackage] -> [(PackageName, (Set PackageName, DotPayload))]
 projectPackageDependencies dotOpts locals =
     map (\lp -> let pkg = localPackageToPackage lp
-                    pkgDir = Path.parent $ lpCabalFile lp
-                    loc = PLMutable $ ResolvedPath (RelFilePath "N/A") pkgDir
-                 in (packageName pkg, (deps pkg, lpPayload pkg loc)))
+                 in (packageName pkg, (deps pkg, lpPayload pkg)))
         locals
   where deps pkg =
           if dotIncludeExternal dotOpts
             then Set.delete (packageName pkg) (packageAllDeps pkg)
             else Set.intersection localNames (packageAllDeps pkg)
         localNames = Set.fromList $ map (packageName . lpPackage) locals
-        lpPayload pkg loc = DotPayload (Just $ packageVersion pkg) (Just $ packageLicense pkg) (Just loc)
+        lpPayload pkg = DotPayload (Just $ packageVersion pkg) (Just $ packageLicense pkg)
 
 -- | Print a graphviz graph of the edges in the Map and highlight the given local packages
 printGraph :: (Applicative m, MonadIO m)

--- a/src/Stack/FileWatch.hs
+++ b/src/Stack/FileWatch.hs
@@ -13,18 +13,18 @@ import qualified Data.Set as Set
 import GHC.IO.Exception
 import Path
 import System.FSNotify
-import System.IO (getLine)
-import RIO.PrettyPrint hiding (line)
+import System.IO (hPutStrLn, getLine)
+import System.Terminal
 
 fileWatch
-  :: (HasLogFunc env, HasTerm env)
-  => ((Set (Path Abs File) -> IO ()) -> RIO env ())
+  :: Handle
+  -> ((Set (Path Abs File) -> IO ()) -> RIO env ())
   -> RIO env ()
 fileWatch = fileWatchConf defaultConfig
 
 fileWatchPoll
-  :: (HasLogFunc env, HasTerm env)
-  => ((Set (Path Abs File) -> IO ()) -> RIO env ())
+  :: Handle
+  -> ((Set (Path Abs File) -> IO ()) -> RIO env ())
   -> RIO env ()
 fileWatchPoll = fileWatchConf $ defaultConfig { confUsePolling = True }
 
@@ -33,11 +33,18 @@ fileWatchPoll = fileWatchConf $ defaultConfig { confUsePolling = True }
 -- The action provided takes a callback that is used to set the files to be
 -- watched. When any of those files are changed, we rerun the action again.
 fileWatchConf
-  :: (HasLogFunc env, HasTerm env)
-  => WatchConfig
+  :: WatchConfig
+  -> Handle
   -> ((Set (Path Abs File) -> IO ()) -> RIO env ())
   -> RIO env ()
-fileWatchConf cfg inner = withRunInIO $ \run -> withManagerConf cfg $ \manager -> do
+fileWatchConf cfg out inner = withRunInIO $ \run -> withManagerConf cfg $ \manager -> do
+    let putLn = hPutStrLn out -- FIXME
+    outputIsTerminal <- hIsTerminalDeviceOrMinTTY out
+    let withColor color str = putLn $ do
+            if outputIsTerminal
+            then concat [color, str, reset]
+            else str
+
     allFiles <- newTVarIO Set.empty
     dirtyVar <- newTVarIO True
     watchVar <- newTVarIO Map.empty
@@ -85,31 +92,32 @@ fileWatchConf cfg inner = withRunInIO $ \run -> withManagerConf cfg $ \manager -
     let watchInput = do
             line <- getLine
             unless (line == "quit") $ do
-                run $ case line of
+                case line of
                     "help" -> do
-                        logInfo ""
-                        logInfo "help: display this help"
-                        logInfo "quit: exit"
-                        logInfo "build: force a rebuild"
-                        logInfo "watched: display watched files"
+                        putLn ""
+                        putLn "help: display this help"
+                        putLn "quit: exit"
+                        putLn "build: force a rebuild"
+                        putLn "watched: display watched files"
                     "build" -> atomically $ writeTVar dirtyVar True
                     "watched" -> do
                         watch <- readTVarIO allFiles
-                        mapM_ (logInfo . fromString) (Set.toList watch)
+                        mapM_ putLn (Set.toList watch)
                     "" -> atomically $ writeTVar dirtyVar True
-                    _ -> logInfo $
-                        "Unknown command: " <>
-                        displayShow line <>
-                        ". Try 'help'"
+                    _ -> putLn $ concat
+                        [ "Unknown command: "
+                        , show line
+                        , ". Try 'help'"
+                        ]
 
                 watchInput
 
-    race_ watchInput $ run $ forever $ do
+    race_ watchInput $ forever $ do
         atomically $ do
             dirty <- readTVar dirtyVar
             check dirty
 
-        eres <- tryAny $ inner setWatched
+        eres <- tryAny $ run $ inner setWatched
 
         -- Clear dirtiness flag after the build to avoid an infinite
         -- loop caused by the build itself triggering dirtiness. This
@@ -119,13 +127,17 @@ fileWatchConf cfg inner = withRunInIO $ \run -> withManagerConf cfg $ \manager -
         -- https://github.com/commercialhaskell/stack/issues/822
         atomically $ writeTVar dirtyVar False
 
-        prettyInfo $
-          case eres of
-            Left e ->
-                let theStyle = case fromException e of
-                        Just ExitSuccess -> Good
-                        _ -> Error
-                 in style theStyle $ fromString $ show e
-            _ -> style Good "Success! Waiting for next file change."
+        case eres of
+            Left e -> do
+                let color = case fromException e of
+                        Just ExitSuccess -> green
+                        _ -> red
+                withColor color $ show e
+            _ -> withColor green "Success! Waiting for next file change."
 
-        logInfo "Type help for available commands. Press enter to force a rebuild."
+        putLn "Type help for available commands. Press enter to force a rebuild."
+
+green, red, reset :: String
+green = "\ESC[32m"
+red = "\ESC[31m"
+reset = "\ESC[0m"

--- a/src/Stack/Options/DotParser.hs
+++ b/src/Stack/Options/DotParser.hs
@@ -57,49 +57,23 @@ dotOptsParser externalDefault =
         globalHints = switch (long "global-hints" <>
                               help "Do not require an install GHC; instead, use a hints file for global packages")
 
-separatorParser :: Parser Text
-separatorParser =
-  fmap escapeSep
-  (textOption (long "separator" <>
-                metavar "SEP" <>
-                help ("Separator between package name " <>
-                      "and package version.") <>
-                value " " <>
-                showDefault))
-  where escapeSep sep = T.replace "\\t" "\t" (T.replace "\\n" "\n" sep)
-
-licenseParser :: Parser Bool
-licenseParser = boolFlags False
-                "license"
-                "printing of dependency licenses instead of versions"
-                idm
-
-listDepsFormatOptsParser :: Parser ListDepsFormatOpts
-listDepsFormatOptsParser = ListDepsFormatOpts <$> separatorParser <*> licenseParser
-
-listDepsTreeParser :: Parser ListDepsFormat
-listDepsTreeParser =  ListDepsTree <$> listDepsFormatOptsParser
-
-listDepsTextParser :: Parser ListDepsFormat
-listDepsTextParser = ListDepsText <$> listDepsFormatOptsParser
-
-listDepsJsonParser :: Parser ListDepsFormat
-listDepsJsonParser = pure ListDepsJSON
-
-toListDepsOptsParser :: Parser ListDepsFormat -> Parser ListDepsOpts
-toListDepsOptsParser formatParser = ListDepsOpts
-      <$> formatParser
-      <*> dotOptsParser True
-
-formatSubCommand :: String -> String -> Parser ListDepsFormat -> Mod CommandFields ListDepsOpts
-formatSubCommand cmd desc formatParser =
-  command cmd (info (toListDepsOptsParser formatParser)
-               (progDesc desc))
-
 -- | Parser for arguments to `stack ls dependencies`.
 listDepsOptsParser :: Parser ListDepsOpts
-listDepsOptsParser = subparser
-                     (  formatSubCommand "text" "Print dependencies as text (default)" listDepsTextParser
-                     <> formatSubCommand "tree" "Print dependencies as tree" listDepsTreeParser
-                     <> formatSubCommand "json" "Print dependencies as JSON" listDepsJsonParser
-                     ) <|> toListDepsOptsParser listDepsTextParser
+listDepsOptsParser = ListDepsOpts
+                 <$> dotOptsParser True -- Default for --external is True.
+                 <*> fmap escapeSep
+                     (textOption (long "separator" <>
+                                  metavar "SEP" <>
+                                  help ("Separator between package name " <>
+                                        "and package version.") <>
+                                  value " " <>
+                                  showDefault))
+                 <*> boolFlags False
+                                "license"
+                                "printing of dependency licenses instead of versions"
+                                idm
+                 <*> boolFlags False
+                                "tree"
+                                "printing of dependencies as a tree"
+                                idm
+  where escapeSep sep = T.replace "\\t" "\t" (T.replace "\\n" "\n" sep)

--- a/src/System/Process/Pager.hs
+++ b/src/System/Process/Pager.hs
@@ -3,63 +3,49 @@
 
 -- | Run external pagers (@$PAGER@, @less@, @more@).
 module System.Process.Pager
-  ( pageWriter
-  , pageText
-  , PagerException (..)
-  ) where
+  (pageWriter
+  ,pageText
+  ,PagerException(..))
+  where
 
 import Stack.Prelude
 import System.Directory (findExecutable)
 import System.Environment (lookupEnv)
-import System.Process ( createProcess, cmdspec, shell, proc, waitForProcess
-                      , CmdSpec (ShellCommand, RawCommand)
-                      , StdStream (CreatePipe)
-                      , CreateProcess (std_in, close_fds, delegate_ctlc)
-                      )
+import System.Process (createProcess,shell,waitForProcess,StdStream (CreatePipe)
+                      ,CreateProcess(std_in, close_fds, delegate_ctlc))
 import System.IO (stdout)
-import Control.Applicative ((<|>))
-import Control.Monad.Trans.Maybe (MaybeT (runMaybeT, MaybeT))
 import qualified Data.Text.IO as T
 
 -- | Run pager, providing a function that writes to the pager's input.
 pageWriter :: (Handle -> IO ()) -> IO ()
 pageWriter writer =
-  do mpager <- runMaybeT $ cmdspecFromEnvVar
-                       <|> cmdspecFromExeName "less"
-                       <|> cmdspecFromExeName "more"
+  do mpager <- lookupEnv "PAGER" `orElse`
+               findExecutable "less" `orElse`
+               findExecutable "more"
      case mpager of
        Just pager ->
-         do (Just h,_,_,procHandle) <- createProcess pager
-                                         { std_in = CreatePipe
-                                         , close_fds = True
-                                         , delegate_ctlc = True
-                                         }
-            (_ :: Either IOException ()) <- try (do writer h
-                                                    hClose h)
+         do (Just h,_,_,procHandle) <- createProcess (shell pager)
+                                                       {std_in = CreatePipe
+                                                       ,close_fds = True
+                                                       ,delegate_ctlc = True}
+            (_::Either IOException ()) <- try (do writer h
+                                                  hClose h)
             exit <- waitForProcess procHandle
             case exit of
               ExitSuccess -> return ()
-              ExitFailure n -> throwIO (PagerExitFailure (cmdspec pager) n)
+              ExitFailure n -> throwIO (PagerExitFailure pager n)
             return ()
        Nothing -> writer stdout
   where
-    cmdspecFromEnvVar = shell <$> MaybeT (lookupEnv "PAGER")
-    cmdspecFromExeName =
-      fmap (\path -> proc path []) . MaybeT . findExecutable
+    orElse a b = maybe b (return . Just) =<< a
 
 -- | Run pager to display a 'Text'
 pageText :: Text -> IO ()
 pageText = pageWriter . flip T.hPutStr
 
 -- | Exception running pager.
-data PagerException = PagerExitFailure CmdSpec Int
+data PagerException = PagerExitFailure FilePath Int
   deriving Typeable
 instance Show PagerException where
-  show (PagerExitFailure cmd n) =
-    let
-      getStr (ShellCommand c) = c
-      getStr (RawCommand exePath _) = exePath
-    in
-      "Pager (`" ++ getStr cmd ++ "') exited with non-zero status: " ++ show n
-
+  show (PagerExitFailure p n) = "Pager (`" ++ p ++ "') exited with non-zero status: " ++ show n
 instance Exception PagerException

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -562,8 +562,8 @@ buildCmd opts = do
     exitFailure
   local (over globalOptsL modifyGO) $
     case boptsCLIFileWatch opts of
-      FileWatchPoll -> fileWatchPoll (inner . Just)
-      FileWatch -> fileWatch (inner . Just)
+      FileWatchPoll -> fileWatchPoll stderr (inner . Just)
+      FileWatch -> fileWatch stderr (inner . Just)
       NoFileWatch -> inner Nothing
   where
     inner

--- a/src/test/Stack/DotSpec.hs
+++ b/src/test/Stack/DotSpec.hs
@@ -19,7 +19,7 @@ import           Test.QuickCheck (forAll,choose,Gen)
 import           Stack.Dot
 
 dummyPayload :: DotPayload
-dummyPayload = DotPayload (parseVersion "0.0.0.0") (Just (Right BSD3)) Nothing
+dummyPayload = DotPayload (parseVersion "0.0.0.0") (Just (Right BSD3))
 
 spec :: Spec
 spec = do

--- a/test/integration/tests/4101-dependency-tree/Main.hs
+++ b/test/integration/tests/4101-dependency-tree/Main.hs
@@ -3,7 +3,7 @@ import StackTest
 
 main :: IO ()
 main = do
-  stackCheckStdout ["ls", "dependencies", "tree"] $ \stdOut -> do
+  stackCheckStdout ["ls", "dependencies", "--tree"] $ \stdOut -> do
     let expected = unlines [ "Packages"
                            , "├─┬ files 0.1.0.0"
                            , "│ ├─┬ base 4.10.1.0"
@@ -13,75 +13,6 @@ main = do
                            , "│ │ │ └─┬ ghc-prim 0.5.1.1"
                            , "│ │ │   └── rts 1.0"
                            , "│ │ └── rts 1.0"
-                           , "│ ├─┬ filelock 0.1.1.2"
-                           , "│ │ ├─┬ base 4.10.1.0"
-                           , "│ │ │ ├─┬ ghc-prim 0.5.1.1"
-                           , "│ │ │ │ └── rts 1.0"
-                           , "│ │ │ ├─┬ integer-gmp 1.0.1.0"
-                           , "│ │ │ │ └─┬ ghc-prim 0.5.1.1"
-                           , "│ │ │ │   └── rts 1.0"
-                           , "│ │ │ └── rts 1.0"
-                           , "│ │ └─┬ unix 2.7.2.2"
-                           , "│ │   ├─┬ base 4.10.1.0"
-                           , "│ │   │ ├─┬ ghc-prim 0.5.1.1"
-                           , "│ │   │ │ └── rts 1.0"
-                           , "│ │   │ ├─┬ integer-gmp 1.0.1.0"
-                           , "│ │   │ │ └─┬ ghc-prim 0.5.1.1"
-                           , "│ │   │ │   └── rts 1.0"
-                           , "│ │   │ └── rts 1.0"
-                           , "│ │   ├─┬ bytestring 0.10.8.2"
-                           , "│ │   │ ├─┬ base 4.10.1.0"
-                           , "│ │   │ │ ├─┬ ghc-prim 0.5.1.1"
-                           , "│ │   │ │ │ └── rts 1.0"
-                           , "│ │   │ │ ├─┬ integer-gmp 1.0.1.0"
-                           , "│ │   │ │ │ └─┬ ghc-prim 0.5.1.1"
-                           , "│ │   │ │ │   └── rts 1.0"
-                           , "│ │   │ │ └── rts 1.0"
-                           , "│ │   │ ├─┬ deepseq 1.4.3.0"
-                           , "│ │   │ │ ├─┬ array 0.5.2.0"
-                           , "│ │   │ │ │ └─┬ base 4.10.1.0"
-                           , "│ │   │ │ │   ├─┬ ghc-prim 0.5.1.1"
-                           , "│ │   │ │ │   │ └── rts 1.0"
-                           , "│ │   │ │ │   ├─┬ integer-gmp 1.0.1.0"
-                           , "│ │   │ │ │   │ └─┬ ghc-prim 0.5.1.1"
-                           , "│ │   │ │ │   │   └── rts 1.0"
-                           , "│ │   │ │ │   └── rts 1.0"
-                           , "│ │   │ │ └─┬ base 4.10.1.0"
-                           , "│ │   │ │   ├─┬ ghc-prim 0.5.1.1"
-                           , "│ │   │ │   │ └── rts 1.0"
-                           , "│ │   │ │   ├─┬ integer-gmp 1.0.1.0"
-                           , "│ │   │ │   │ └─┬ ghc-prim 0.5.1.1"
-                           , "│ │   │ │   │   └── rts 1.0"
-                           , "│ │   │ │   └── rts 1.0"
-                           , "│ │   │ ├─┬ ghc-prim 0.5.1.1"
-                           , "│ │   │ │ └── rts 1.0"
-                           , "│ │   │ └─┬ integer-gmp 1.0.1.0"
-                           , "│ │   │   └─┬ ghc-prim 0.5.1.1"
-                           , "│ │   │     └── rts 1.0"
-                           , "│ │   └─┬ time 1.8.0.2"
-                           , "│ │     ├─┬ base 4.10.1.0"
-                           , "│ │     │ ├─┬ ghc-prim 0.5.1.1"
-                           , "│ │     │ │ └── rts 1.0"
-                           , "│ │     │ ├─┬ integer-gmp 1.0.1.0"
-                           , "│ │     │ │ └─┬ ghc-prim 0.5.1.1"
-                           , "│ │     │ │   └── rts 1.0"
-                           , "│ │     │ └── rts 1.0"
-                           , "│ │     └─┬ deepseq 1.4.3.0"
-                           , "│ │       ├─┬ array 0.5.2.0"
-                           , "│ │       │ └─┬ base 4.10.1.0"
-                           , "│ │       │   ├─┬ ghc-prim 0.5.1.1"
-                           , "│ │       │   │ └── rts 1.0"
-                           , "│ │       │   ├─┬ integer-gmp 1.0.1.0"
-                           , "│ │       │   │ └─┬ ghc-prim 0.5.1.1"
-                           , "│ │       │   │   └── rts 1.0"
-                           , "│ │       │   └── rts 1.0"
-                           , "│ │       └─┬ base 4.10.1.0"
-                           , "│ │         ├─┬ ghc-prim 0.5.1.1"
-                           , "│ │         │ └── rts 1.0"
-                           , "│ │         ├─┬ integer-gmp 1.0.1.0"
-                           , "│ │         │ └─┬ ghc-prim 0.5.1.1"
-                           , "│ │         │   └── rts 1.0"
-                           , "│ │         └── rts 1.0"
                            , "│ ├─┬ mtl 2.2.2"
                            , "│ │ ├─┬ base 4.10.1.0"
                            , "│ │ │ ├─┬ ghc-prim 0.5.1.1"
@@ -118,11 +49,10 @@ main = do
     when (stdOut /= expected) $
       error $ unlines [ "Expected:", expected, "Actual:", stdOut ]
 
-  stackCheckStdout ["ls", "dependencies", "tree", "--depth=1"] $ \stdOut -> do
+  stackCheckStdout ["ls", "dependencies", "--tree", "--depth=1"] $ \stdOut -> do
     let expected = unlines [ "Packages"
                            , "├─┬ files 0.1.0.0"
                            , "│ ├── base 4.10.1.0"
-                           , "│ ├── filelock 0.1.1.2"
                            , "│ ├── mtl 2.2.2"
                            , "│ └── subproject 0.1.0.0"
                            , "└─┬ subproject 0.1.0.0"
@@ -131,7 +61,7 @@ main = do
     when (stdOut /= expected) $
       error $ unlines [ "Expected:", expected, "Actual:", stdOut ]
 
-  stackCheckStdout ["ls", "dependencies", "tree", "subproject"] $ \stdOut -> do
+  stackCheckStdout ["ls", "dependencies", "--tree", "subproject"] $ \stdOut -> do
     let expected = unlines [ "Packages"
                            , "└─┬ subproject 0.1.0.0"
                            , "  └─┬ base 4.10.1.0"
@@ -142,11 +72,5 @@ main = do
                            , "    │   └── rts 1.0"
                            , "    └── rts 1.0"
                            ]
-    when (stdOut /= expected) $
-      error $ unlines [ "Expected:", expected, "Actual:", stdOut ]
-
-  stackCheckStdout ["ls", "dependencies", "json"] $ \stdOut -> do
-    dir <- testDir
-    let expected = "[{\"dependencies\":[\"base\",\"bytestring\",\"time\"],\"name\":\"unix\",\"version\":\"2.7.2.2\",\"license\":\"BSD3\"},{\"dependencies\":[\"base\"],\"name\":\"transformers\",\"version\":\"0.5.2.0\",\"license\":\"BSD3\"},{\"dependencies\":[\"base\",\"deepseq\"],\"name\":\"time\",\"version\":\"1.8.0.2\",\"license\":\"BSD3\"},{\"location\":{\"url\":\"file://" ++ dir ++ "/files/subproject/\",\"type\":\"project package\"},\"dependencies\":[\"base\"],\"name\":\"subproject\",\"version\":\"0.1.0.0\",\"license\":\"AllRightsReserved\"},{\"dependencies\":[],\"name\":\"rts\",\"version\":\"1.0\",\"license\":\"BSD3\"},{\"location\":{\"url\":\"https://hackage.haskell.org/package/mtl-2.2.2\",\"type\":\"hackage\"},\"dependencies\":[\"base\",\"transformers\"],\"name\":\"mtl\",\"version\":\"2.2.2\",\"license\":\"BSD3\"},{\"dependencies\":[\"ghc-prim\"],\"name\":\"integer-gmp\",\"version\":\"1.0.1.0\",\"license\":\"BSD3\"},{\"dependencies\":[\"rts\"],\"name\":\"ghc-prim\",\"version\":\"0.5.1.1\",\"license\":\"BSD3\"},{\"location\":{\"url\":\"file://" ++ dir ++ "/files/\",\"type\":\"project package\"},\"dependencies\":[\"base\",\"filelock\",\"mtl\",\"subproject\"],\"name\":\"files\",\"version\":\"0.1.0.0\",\"license\":\"AllRightsReserved\"},{\"location\":{\"subdir\":\"\",\"url\":\"git@github.com:snoyberg/filelock\",\"type\":\"git\",\"commit\":\"4f080496d8bf153fbe26e64d1f52cf73c7db25f6\"},\"dependencies\":[\"base\",\"unix\"],\"name\":\"filelock\",\"version\":\"0.1.1.2\",\"license\":\"PublicDomain\"},{\"dependencies\":[\"array\",\"base\"],\"name\":\"deepseq\",\"version\":\"1.4.3.0\",\"license\":\"BSD3\"},{\"dependencies\":[\"base\",\"deepseq\",\"ghc-prim\",\"integer-gmp\"],\"name\":\"bytestring\",\"version\":\"0.10.8.2\",\"license\":\"BSD3\"},{\"dependencies\":[\"ghc-prim\",\"integer-gmp\",\"rts\"],\"name\":\"base\",\"version\":\"4.10.1.0\",\"license\":\"BSD3\"},{\"dependencies\":[\"base\"],\"name\":\"array\",\"version\":\"0.5.2.0\",\"license\":\"BSD3\"}]\n"
     when (stdOut /= expected) $
       error $ unlines [ "Expected:", expected, "Actual:", stdOut ]

--- a/test/integration/tests/4101-dependency-tree/files/files.cabal
+++ b/test/integration/tests/4101-dependency-tree/files/files.cabal
@@ -6,5 +6,5 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Lib
-  build-depends:       base >= 4.7 && < 5, mtl, subproject, filelock
+  build-depends:       base >= 4.7 && < 5, mtl, subproject
   default-language:    Haskell2010

--- a/test/integration/tests/4101-dependency-tree/files/stack.yaml
+++ b/test/integration/tests/4101-dependency-tree/files/stack.yaml
@@ -3,5 +3,5 @@ packages:
 - .
 - subproject
 extra-deps:
-- github: snoyberg/filelock
+- git: git@github.com:snoyberg/filelock
   commit: 4f080496d8bf153fbe26e64d1f52cf73c7db25f6

--- a/test/integration/tests/4101-dependency-tree/files/stack.yaml
+++ b/test/integration/tests/4101-dependency-tree/files/stack.yaml
@@ -2,6 +2,3 @@ resolver: lts-11.22
 packages:
 - .
 - subproject
-extra-deps:
-- git: git@github.com:snoyberg/filelock
-  commit: 4f080496d8bf153fbe26e64d1f52cf73c7db25f6


### PR DESCRIPTION
The merge that @chrisdone did was correct, but shouldn't have been merged to stable (it should have remained on master). We _could_ do a force-push to stable to undo that and restore the previous commit (eb9f921e86e31d5df97d1b4041ae5c5e737b8ec2). This PR instead reverts both Chris's merge and a small commit I added on top to fix integration tests.

Once this is merged in, we would need to also revert this revert on master to avoid losing Chris's changes on master later. I have a branch for that ready to go: https://github.com/commercialhaskell/stack/pull/new/undo-revert-on-master.

@borsboom would you prefer the force-push approach or the revert+double revert approach?