### PR TITLE
doc/nix_integration.md: nix-repl -> nix repl

### DIFF
--- a/doc/nix_integration.md
+++ b/doc/nix_integration.md
@@ -86,12 +86,11 @@ You can list all known Haskell compilers in Nix with the following:
 $ nix-instantiate --eval -E "with import <nixpkgs> {}; lib.attrNames haskell.compiler"
 ```
 
-Alternatively, install `nix-repl`, a convenient tool to explore
+Alternatively, use `nix repl`, a convenient tool to explore
 nixpkgs:
 
 ```sh
-$ nix-env -i nix-repl
-$ nix-repl
+$ nix repl
 ```
 
 In the REPL, load nixpkgs and get the same information through
@@ -102,7 +101,7 @@ nix-repl> :l <nixpkgs>
 nix-repl> haskell.compiler.ghc<Tab>
 ```
 
-You can type and evaluate any nix expression in the nix-repl, such as
+You can type and evaluate any nix expression in the nix repl, such as
 the one we gave to `nix-instantiate` earlier.
 
 **Note:** currently, stack only discovers dynamic and static libraries

--- a/test/integration/tests/4101-dependency-tree/files/stack.yaml
+++ b/test/integration/tests/4101-dependency-tree/files/stack.yaml
@@ -3,5 +3,5 @@ packages:
 - .
 - subproject
 extra-deps:
-- git: git@github.com:snoyberg/filelock
+- github: snoyberg/filelock
   commit: 4f080496d8bf153fbe26e64d1f52cf73c7db25f6


### PR DESCRIPTION
nix repl has been integrated into the nix command and
the nix-repl package has been removed.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
