### PR TITLE
Fix small typo in coverage.md

### DIFF
--- a/doc/coverage.md
+++ b/doc/coverage.md
@@ -81,7 +81,7 @@ However, advanced users may want to understand exactly how `--coverage` works:
    the executable.
 
    When switching on this flag, it will usually cause all local packages to be
-   rebuilt (see [#1940](https://github.com/commercialhaskell/stack/issues/1940).
+   rebuilt (see [#1940](https://github.com/commercialhaskell/stack/issues/1940)).
 
 2. Before the build runs with `--coverage`, the contents of `stack path --local-hpc-root`
    gets deleted. This prevents old reports from getting mixed


### PR DESCRIPTION
A missing closing brace left the text being show as:  "… to be rebuilt (see #1940."

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
