### PR TITLE
Update GUIDE.md about debugging symbols

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1819,13 +1819,11 @@ To generate a backtrace in case of exceptions during a test or benchmarks run,
 use the `--trace` flag. Like `--profile` this compiles with profiling options,
 but adds the `+RTS -xc` runtime option.
 
-### DWARF
+### Debugging symbols
 
-`stack` now supports debugging and profiling with
-[DWARF information](https://ghc.haskell.org/trac/ghc/wiki/DWARF),
-using the `--no-strip`, `--no-library-stripping`, and `--no-executable-stripping`
-flags to disable the default behavior of removing such information from compiled
-libraries and executables.
+Building with debugging symbols in the [DWARF information](https://ghc.haskell.org/trac/ghc/wiki/DWARF) is supported by `stack`. This can be done by passing the flag `--ghc-options="-g"` and also to override the default behaviour of stripping executables of debugging symbols by passing either one of the following flags: `--no-strip`, `--no-library-stripping` or `--no-executable-stripping`.
+
+In Windows GDB can be isntalled to debug an executable with `stack exec -- pacman -S gdb`. Windows visual studio compiler's debugging format PDB is not supported at the moment. This might be possible by [separating](https://stackoverflow.com/questions/866721/how-to-generate-gcc-debug-symbol-outside-the-build-target) debugging symbols and [converting](https://github.com/rainers/cv2pdb) their format. Or as an option when [using the LLVM backend](http://blog.llvm.org/2017/08/llvm-on-windows-now-supports-pdb-debug.html).
 
 ## More resources
 


### PR DESCRIPTION
I found minor points in this section of the guide that made me want to rewrite it:

* people recognize debugging symbols as a broader subject than DWARF as title
* `now` is not informative to the reader
* No mention of having to pass `--ghc-options="-g"` flag
* No help on how to do things in windows was present, taking into consideration windows "native" debugging tools such as `WinDbg` which need PDB and thus is not supported, but might be feasible.

I hope that it will be more clear for windows users especially but also for linux and macOS users about which flags to pass. I also hope that someone by reading this will look into getting the windows native platform tools working if a PDB file can be produced. Though i am a bit hesitant about leaving this last part in actually.