### PR TITLE
fix "--resolver global " needs network 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,9 @@ Other enhancements:
 
 Bug fixes:
 
+* `--resolver global` doesn't retrieve snapshots list from the internet
+   beause doesn't need it. See [#5103](https://github.com/commercialhaskell/stack/issues/5103)
+
 * Fix using relative links in haddocks output.  See
   [#4971](https://github.com/commercialhaskell/stack/issues/4971).
 * Do not include generated cabal file information in lock files. See


### PR DESCRIPTION
issue: https://github.com/commercialhaskell/stack/issues/5103


* [ x ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ x ] The documentation has been updated, if necessary.

Test case:
```
stack test   673 examples, 0 failures
stack --resolver global   is ok
stack --resolver nightly is ok
stack --resolver lts-14   is ok
stack --resolver lts-14.13 is ok
```
