### PR TITLE
Find nix versions of GHC with "Binary" suffix.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,9 @@ Behavior changes:
   [#2647](https://github.com/commercialhaskell/stack/issues/2647)
 
 Other enhancements:
+* Find GHC versions in nixpkgs with "Binary" suffix. See
+  [#5094](https://github.com/commercialhaskell/stack/pull/5094)
+
 * Add `build-output-timestamps` flag in yaml. Setting it to true
   prefixes each build log output line with a timestamp.
 

--- a/src/Stack/Config/Nix.hs
+++ b/src/Stack/Config/Nix.hs
@@ -58,21 +58,17 @@ nixCompiler compilerVersion =
       case T.split (== '.') (fromString $ versionString version) of
         x : y : minor ->
           Right $
-          case minor of
-            [] ->
-              -- The minor version is not specified. Select the latest minor
-              -- version in Nixpkgs corresponding to the requested major
-              -- version.
-              let major = T.concat [x, y] in
-              "(let compilers = builtins.filter \
-              \(name: builtins.match \
-              \\"ghc" <> major <> "[[:digit:]]*\" name != null) \
-              \(lib.attrNames haskell.compiler); in \
-              \if compilers == [] \
-              \then abort \"No compiler found for GHC "
-              <> T.pack (versionString version) <> "\"\
-              \else haskell.compiler.${builtins.head compilers})"
-            _ -> "haskell.compiler.ghc" <> T.concat (x : y : minor)
+          -- Select the latest version in Nixpkgs corresponding to the requested
+          -- version.
+          let major = T.concat (x : y : minor) in
+          "(let compilers = builtins.filter \
+          \(name: builtins.match \
+          \\"ghc" <> major <> "[[:digit:]]*(Binary)?\" name != null) \
+          \(lib.attrNames haskell.compiler); in \
+          \if compilers == [] \
+          \then abort \"No compiler found for GHC "
+          <> T.pack (versionString version) <> "\"\
+          \else haskell.compiler.${builtins.head compilers})"
         _ -> Left $ stringException "GHC major version not specified"
     WCGhcjs{} -> Left $ stringException "Only GHC is supported by stack --nix"
     WCGhcGit{} -> Left $ stringException "Only GHC is supported by stack --nix"

--- a/src/test/Stack/NixSpec.hs
+++ b/src/test/Stack/NixSpec.hs
@@ -102,4 +102,4 @@ spec = beforeAll setup $ do
         nixPackages (configNix config) `shouldBe` ["glpk"]
         v <- parseVersionThrowing "7.10.3"
         ghc <- either throwIO return $ nixCompiler (WCGhc v)
-        ghc `shouldBe` "haskell.compiler.ghc7103"
+        ghc `shouldBe` "(let compilers = builtins.filter (name: builtins.match \"ghc7103[[:digit:]]*(Binary)?\" name != null) (lib.attrNames haskell.compiler); in if compilers == [] then abort \"No compiler found for GHC 7.10.3\"else haskell.compiler.${builtins.head compilers})"


### PR DESCRIPTION
This broadens the regex for GHC versions (by adding an optional "Binary"
suffix), then uses this regex regardless of whether a minor version was
specifed (since we still need to discover whether, say, ghc7103 or ghc7103Binary
exists).

Fixes #5094.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

I updated one test that previously expected a fixed version. Also tested locally with nix, retrieving different GHC versions, with and without minor versions, and with and without the "Binary" suffix.