### PR TITLE
get-stack.sh: get_isa to detect armv7l/armv8l

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -72,7 +72,7 @@ post_install_separator() {
 
 # determines the the CPU's instruction set
 get_isa() {
-  if arch | grep -q armv7 ; then
+  if arch | grep -Eq 'armv[78]l?' ; then
     echo arm
   elif arch | grep -q aarch64 ; then
     echo aarch64


### PR DESCRIPTION
Tested on [a1.xlarge](https://aws.amazon.com/ec2/instance-types/a1/) instance running a Raspbian Buster armhf chroot inside aarch64 Ubuntu. LTS version is 13.11. LLVM version is 7.0.1.

Still needs this notorious hack for compilation to work: https://gist.github.com/proger/28b1bf9222828a9cd77a74a480aee5f3

I also needed to re-run `stack setup` with 
```
export LD_LIBRARY_PATH=$(echo /home/ubuntu/.stack/programs/arm-linux/ghc-8.6.3/lib/ghc-8.6.3/*  | tr ' ' :)
```
because of some weird ld.so behaviour when loading ghc-pkg:

```
# ldd /home/ubuntu/.stack/programs/arm-linux/ghc-8.6.3/lib/ghc-8.6.3/bin/ghc-pkg
	/usr/lib/arm-linux-gnueabihf/libarmmem-${PLATFORM}.so => /usr/lib/arm-linux-gnueabihf/libarmmem-v8l.so (0xf7ad1000)
	libm.so.6 => /lib/arm-linux-gnueabihf/libm.so.6 (0xf7a4f000)
	libHSterminfo-0.4.1.2-ghc8.6.3.so => /home/ubuntu/.stack/programs/arm-linux/ghc-8.6.3/lib/ghc-8.6.3/terminfo-0.4.1.2/libHSterminfo-0.4.1.2-ghc8.6.3.so (0xf7a0b000)
	libHSghc-boot-8.6.3-ghc8.6.3.so => /home/ubuntu/.stack/programs/arm-linux/ghc-8.6.3/lib/ghc-8.6.3/bin/../ghc-boot-8.6.3/libHSghc-boot-8.6.3-ghc8.6.3.so (0xf7970000)
	libHSghc-boot-th-8.6.3-ghc8.6.3.so => /home/ubuntu/.stack/programs/arm-linux/ghc-8.6.3/lib/ghc-8.6.3/bin/../ghc-boot-th-8.6.3/libHSghc-boot-th-8.6.3-ghc8.6.3.so (0xf7939000)
...

# strace /home/ubuntu/.stack/programs/arm-linux/ghc-8.6.3/lib/ghc-8.6.3/bin/ghc-pkg 2>&1 | grep libHSghc-boot
... it goes on to search in the wrong place

```
