### PR TITLE
fix(#5008): "Invalid option --internal-re-exec-version" error when using "nix" with options "enable: true", "pure: true", "shell-file: .." -> prevent entering "nix-shell --pure" recursively by exporting STACK_IN_NIX_SHELL properly

### DIFF
--- a/src/Stack/Nix.hs
+++ b/src/Stack/Nix.hs
@@ -95,7 +95,7 @@ runShellAndExit = do
                                                 F.</> "nix-gc-symlinks" F.</> "gc-root"] else []
                            ,map T.unpack (nixShellOptions (configNix config))
                            ,nixopts
-                           ,["--run", unwords (cmnd:"$STACK_IN_NIX_EXTRA_ARGS":args')]
+                           ,["--run", unwords ("export " <> inNixShellEnvVar <> "=1; ":cmnd:"$STACK_IN_NIX_EXTRA_ARGS":args')]
                            ]
                            -- Using --run instead of --command so we cannot
                            -- end up in the nix-shell if stack build is Ctrl-C'd

--- a/src/Stack/Nix.hs
+++ b/src/Stack/Nix.hs
@@ -76,7 +76,6 @@ runShellAndExit = do
                               ,"runCommand ''myEnv'' { "
                               ,"buildInputs = lib.optional stdenv.isLinux glibcLocales ++ inputs; "
                               ,T.pack platformVariantEnvVar <> "=''nix''; "
-                              ,T.pack inNixShellEnvVar <> "=1; "
                               ,if inContainer
                                   -- If shell is pure, this env var would not
                                   -- be seen by stack inside nix


### PR DESCRIPTION
fixes ##5008


I've run this on https://github.com/srghma/generate-all-tests/commit/50630d2546b353b386e72f15e337a18be4dd4f99

here is the output


```
$ ~/projects/stack/.stack-work/dist/x86_64-linux-nix/Cabal-2.0.1.0/build/stack/stack build --verbose
Version 2.2.0, Git revision 602253507622b55ca627bf22a66e5874182e7345 (dirty) (7902 commits) PRE-RELEASE x86_64 hpack-0.31.2
2019-12-26 11:29:33.749556: [debug] Checking for project config at: /home/srghma/projects/generate-all-tests/stack.yaml
2019-12-26 11:29:33.749814: [debug] Loading project config file stack.yaml
2019-12-26 11:29:33.757926: [debug] SELECT COUNT(*) FROM "last_performed" WHERE ("action"=?) AND ("timestamp">=?); [PersistInt64 1,PersistUTCTime 2019-12-25 09:29:33.757888904 UTC]
2019-12-26 11:29:33.758500: [debug] Using package location completions from a lock file
2019-12-26 11:29:33.766725: [debug] Loaded snapshot from Pantry database.
2019-12-26 11:29:33.877276: [debug] Running hpack on /home/srghma/projects/generate-all-tests/package.yaml
2019-12-26 11:29:33.880535: [debug] hpack output unchanged in /home/srghma/projects/generate-all-tests/generate-all-tests.cabal
2019-12-26 11:29:33.896857: [debug] Migration executed: CREATE TABLE "config_cache"("id" INTEGER PRIMARY KEY,"directory" VARCHAR NOT NULL DEFAULT (hex(randomblob(16))),"type" VARCHAR NOT NULL,"pkg_src" VARCHAR NOT NULL,"active" BOOLEAN NOT NULL,"path_env_var" VARCHAR NOT NULL,"haddock" BOOLEAN NOT NULL DEFAULT 0,CONSTRAINT "unique_config_cache" UNIQUE ("directory","type"))
2019-12-26 11:29:33.897105: [debug] Migration executed: CREATE TABLE "config_cache_dir_option"("id" INTEGER PRIMARY KEY,"config_cache_id" INTEGER NOT NULL REFERENCES "config_cache","index" INTEGER NOT NULL,"option" VARCHAR NOT NULL,CONSTRAINT "unique_config_cache_dir_option" UNIQUE ("config_cache_id","index"))
2019-12-26 11:29:33.897234: [debug] Migration executed: CREATE TABLE "config_cache_no_dir_option"("id" INTEGER PRIMARY KEY,"config_cache_id" INTEGER NOT NULL REFERENCES "config_cache","index" INTEGER NOT NULL,"option" VARCHAR NOT NULL,CONSTRAINT "unique_config_cache_no_dir_option" UNIQUE ("config_cache_id","index"))
2019-12-26 11:29:33.897339: [debug] Migration executed: CREATE TABLE "config_cache_dep"("id" INTEGER PRIMARY KEY,"config_cache_id" INTEGER NOT NULL REFERENCES "config_cache","ghc_pkg_id" VARCHAR NOT NULL,CONSTRAINT "unique_config_cache_dep" UNIQUE ("config_cache_id","ghc_pkg_id"))
2019-12-26 11:29:33.897435: [debug] Migration executed: CREATE TABLE "config_cache_component"("id" INTEGER PRIMARY KEY,"config_cache_id" INTEGER NOT NULL REFERENCES "config_cache","component" BLOB NOT NULL,CONSTRAINT "unique_config_cache_component" UNIQUE ("config_cache_id","component"))
2019-12-26 11:29:33.897980: [debug] PATH is: Just "/home/srghma/.gem/ruby/2.4.0/bin:/home/srghma/.node_modules/bin:/home/srghma/bin:/run/wrappers/bin:/home/srghma/.nix-profile/bin:/etc/profiles/per-user/srghma/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:./node_modules/.bin"
2019-12-26 11:29:33.898159: [debug] Using a nix-shell environment from file: /home/srghma/projects/generate-all-tests/stack-shell.nix
2019-12-26 11:29:33.898535: [debug] Run process: /run/current-system/sw/bin/nix-shell /home/srghma/projects/generate-all-tests/stack-shell.nix --arg ghc "with (import <nixpkgs> {}); haskell.compiler.ghc865" --run "export STACK_IN_NIX_SHELL=1;  '/home/srghma/projects/stack/.stack-work/dist/x86_64-linux-nix/Cabal-2.0.1.0/build/stack/stack' $STACK_IN_NIX_EXTRA_ARGS '--internal-re-exec-version=2.2.0' 'build' '--verbose'"
```