### PR TITLE
Remove the TMP env var on Windows integration tests

### DIFF
--- a/.azure/azure-nightly-template-windows.yml
+++ b/.azure/azure-nightly-template-windows.yml
@@ -23,7 +23,6 @@ jobs:
       export AWS_SECRET_ACCESS_KEY="$(AWS_SECRET_ACCESS_KEY)";
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root;
       export PATH=$PATH:"/C/Program Files/Mercurial/"
-      export TMP=/D/tmp
       choco install hg -y
       /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack --base-branch="${BASE_BRANCH}"
       /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack work --base-branch="${BASE_BRANCH}"
@@ -37,7 +36,6 @@ jobs:
   - bash: |
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root;
       export PATH=$PATH:"/C/Program Files/Mercurial/"
-      export TMP=/D/tmp
       stack etc/scripts/release.hs check
     displayName: Integration Test
   - powershell: |


### PR DESCRIPTION
@jeffhappily and I were debugging some integration test failures on CI, and believe this fix should do the trick for failing Windows builds. Sibi: is there a reason why this may cause problems?