### PR TITLE
travis-complex.yml: Address validator warnings and hints

### DIFF
--- a/doc/travis-complex.yml
+++ b/doc/travis-complex.yml
@@ -8,8 +8,8 @@
 # Copy these contents into the root directory of your Github project in a file
 # named .travis.yml
 
-# Use new container infrastructure to enable caching
-sudo: false
+# Run jobs on Linux unless "os" is specified explicitly.
+os: linux
 
 # Do not choose a language; we provide our own build tools.
 language: generic
@@ -30,9 +30,9 @@ cache:
 # cache file per set of arguments.
 #
 # If you need to have different apt packages for each combination in the
-# matrix, you can use a line such as:
+# job matrix, you can use a line such as:
 #     addons: {apt: {packages: [libfcgi-dev,libgmp-dev]}}
-matrix:
+jobs:
   include:
   # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
   # https://github.com/hvr/multi-ghc-travis


### PR DESCRIPTION
Based on this Travis configuration validation report:

![Screenshot from 2020-01-28 14-48-05](https://user-images.githubusercontent.com/697092/73283794-ebf85400-41f3-11ea-9057-d48c24ea4a88.png)

- `root`: deprecated key `sudo` (The key `sudo` has no effect anymore.)
   => `sudo: false` removed
- `root`: missing `os`, using the default `linux`
   => `os: linux` added at top-level
- `root`: key `matrix` is an alias for `jobs`, using `jobs`
   => `matrix` renamed to `jobs` at top-level

With the changes in this PR, the warnings go away.