### PR TITLE
Include setup-config modification time into reconfigure checks

### DIFF
--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -11,6 +11,7 @@ module Stack.Build.Cache
     ( tryGetBuildCache
     , tryGetConfigCache
     , tryGetCabalMod
+    , tryGetSetupConfigMod
     , getInstalledExes
     , tryGetFlagCache
     , deleteCaches
@@ -138,6 +139,17 @@ tryGetCabalMod :: HasEnvConfig env
                => Path Abs Dir -> RIO env (Maybe CTime)
 tryGetCabalMod dir = do
   fp <- toFilePath <$> configCabalMod dir
+  tryGetFileMod fp
+
+-- | Try to read the mod time of setup-config file from the last build
+tryGetSetupConfigMod :: HasEnvConfig env
+               => Path Abs Dir -> RIO env (Maybe CTime)
+tryGetSetupConfigMod dir = do
+  fp <- toFilePath <$> configSetupConfigMod dir
+  tryGetFileMod fp
+
+tryGetFileMod :: MonadIO m => FilePath -> m (Maybe CTime)
+tryGetFileMod fp =
   liftIO $ either (const Nothing) (Just . modificationTime) <$>
       tryIO (getFileStatus fp)
 

--- a/src/Stack/Constants/Config.hs
+++ b/src/Stack/Constants/Config.hs
@@ -4,11 +4,13 @@
 module Stack.Constants.Config
   ( distDirFromDir
   , rootDistDirFromDir
+  , setupConfigFromDir
   , workDirFromDir
   , distRelativeDir
   , imageStagingDir
   , projectDockerSandboxDir
   , configCabalMod
+  , configSetupConfigMod
   , buildCachesDir
   , testSuccessFile
   , testBuiltFile
@@ -74,6 +76,15 @@ configCabalMod dir =
         (</> $(mkRelFile "stack-cabal-mod"))
         (distDirFromDir dir)
 
+-- | The filename used for modification check of setup-config
+configSetupConfigMod :: (MonadThrow m, MonadReader env m, HasEnvConfig env)
+                     => Path Abs Dir      -- ^ Package directory.
+                     -> m (Path Abs File)
+configSetupConfigMod dir =
+    liftM
+        (</> $(mkRelFile "stack-setup-config-mod"))
+        (distDirFromDir dir)
+
 -- | Directory for HPC work.
 hpcDirFromDir
     :: (MonadThrow m, MonadReader env m, HasEnvConfig env)
@@ -87,6 +98,14 @@ hpcRelativeDir :: (MonadThrow m, MonadReader env m, HasEnvConfig env)
                => m (Path Rel Dir)
 hpcRelativeDir =
     liftM (</> $(mkRelDir "hpc")) distRelativeDir
+
+-- | Package's setup-config storing Cabal configuration
+setupConfigFromDir :: (MonadThrow m, MonadReader env m, HasEnvConfig env)
+                   => Path Abs Dir
+                   -> m (Path Abs File)
+setupConfigFromDir fp = do
+    dist <- distDirFromDir fp
+    return $ dist </> $(mkRelFile "setup-config")
 
 -- | Package's build artifacts directory.
 distDirFromDir :: (MonadThrow m, MonadReader env m, HasEnvConfig env)


### PR DESCRIPTION
This resolves issue #5147 appearing because a path for setup-config for a
package depend on OS and Cabal versions and is stored in .stack-work
inside package directory

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Tested locally using repro provided by @lehins in #5147
