### PR TITLE
WIP: Make sure CI cache is namespaced by the resolver

### DIFF
--- a/.azure/azure-linux-template.yml
+++ b/.azure/azure-linux-template.yml
@@ -29,8 +29,8 @@ jobs:
       curl -f -L "https://github.com/fpco/cache-s3/releases/download/${CACHE_S3_VERSION}/cache-s3-${CACHE_S3_VERSION}-${OS_NAME}-x86_64.tar.gz" -o ~/.local/bin/cache-s3.tar.gz
       tar xzf ~/.local/bin/cache-s3.tar.gz -C ~/.local/bin
       export PATH=$HOME/.local/bin:$PATH;
-      cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack --base-branch="${BASE_BRANCH}"
-      cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack work --base-branch="${BASE_BRANCH}"
+      cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" restore stack --base-branch="${BASE_BRANCH}"
+      cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" restore stack work --base-branch="${BASE_BRANCH}"
       etc/scripts/ci-setup.sh
       case "$BUILD" in
         style)
@@ -112,9 +112,9 @@ jobs:
       export AWS_SECRET_ACCESS_KEY="$(AWS_SECRET_ACCESS_KEY)";
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root;
       if [ "$(Build.SourceBranchName)" = "${BASE_BRANCH}" ]; then
-        cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" save stack;
+        cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" save stack;
       fi;
-      cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" save stack work
+      cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" save stack work
     condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
     env:
       OS_NAME: ${{ parameters.os }}

--- a/.azure/azure-nightly-template-linux.yml
+++ b/.azure/azure-nightly-template-linux.yml
@@ -18,8 +18,8 @@ jobs:
       curl -f -L "https://github.com/fpco/cache-s3/releases/download/${CACHE_S3_VERSION}/cache-s3-${CACHE_S3_VERSION}-${OS_NAME}-x86_64.tar.gz" -o ~/.local/bin/cache-s3.tar.gz
       tar xzf ~/.local/bin/cache-s3.tar.gz -C ~/.local/bin
       export PATH=$HOME/.local/bin:$PATH;
-      cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack --base-branch="${BASE_BRANCH}"
-      cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack work --base-branch="${BASE_BRANCH}"
+      cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" restore stack --base-branch="${BASE_BRANCH}"
+      cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" restore stack work --base-branch="${BASE_BRANCH}"
       etc/scripts/ci-setup.sh
       export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.7/bin:$PATH
     env:
@@ -61,9 +61,9 @@ jobs:
       export AWS_SECRET_ACCESS_KEY="$(AWS_SECRET_ACCESS_KEY)";
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root;
       if [ "$(Build.SourceBranchName)" = "${BASE_BRANCH}" ]; then
-        cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" save stack;
+        cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" save stack;
       fi;
-      cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" save stack work
+      cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" save stack work
     env:
       OS_NAME: ${{ parameters.os }}
     displayName: 'Cache data'

--- a/.azure/azure-nightly-template-osx.yml
+++ b/.azure/azure-nightly-template-osx.yml
@@ -20,8 +20,8 @@ jobs:
       curl -f -L "https://github.com/fpco/cache-s3/releases/download/${CACHE_S3_VERSION}/cache-s3-${CACHE_S3_VERSION}-${OS_NAME}-x86_64.tar.gz" -o ~/.local/bin/cache-s3.tar.gz
       tar xzf ~/.local/bin/cache-s3.tar.gz -C ~/.local/bin
       export PATH=$HOME/.local/bin:$PATH;
-      cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack --base-branch="${BASE_BRANCH}"
-      cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack work --base-branch="${BASE_BRANCH}"
+      cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" restore stack --base-branch="${BASE_BRANCH}"
+      cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" restore stack work --base-branch="${BASE_BRANCH}"
       etc/scripts/ci-setup.sh
       brew install mercurial
       export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.7/bin:$PATH
@@ -53,9 +53,9 @@ jobs:
       export AWS_SECRET_ACCESS_KEY="$(AWS_SECRET_ACCESS_KEY)";
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root;
       if [ "$(Build.SourceBranchName)" = "${BASE_BRANCH}" ]; then
-        cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" save stack;
+        cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" save stack;
       fi;
-      cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" save stack work
+      cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" save stack work
     env:
       OS_NAME: ${{ parameters.os }}
     displayName: 'Cache data'

--- a/.azure/azure-nightly-template-windows.yml
+++ b/.azure/azure-nightly-template-windows.yml
@@ -26,8 +26,8 @@ jobs:
       export AWS_SECRET_ACCESS_KEY="$(AWS_SECRET_ACCESS_KEY)";
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root;
       export PATH=$PATH:"/C/Program Files/Mercurial/"
-      /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack --base-branch="${BASE_BRANCH}"
-      /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack work --base-branch="${BASE_BRANCH}"
+      /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" restore stack --base-branch="${BASE_BRANCH}"
+      /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" restore stack work --base-branch="${BASE_BRANCH}"
       curl -sSkL http://www.stackage.org/stack/windows-i386 -o /usr/bin/stack.zip
       unzip -o /usr/bin/stack.zip -d /usr/bin/
       stack setup
@@ -60,9 +60,9 @@ jobs:
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root;
       export PATH=$HOME/.local/bin:$PATH;
       if [ "$(Build.SourceBranchName)" = "${BASE_BRANCH}" ]; then
-        /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" save stack;
+        /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" save stack;
       fi;
-      /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" save stack work
+      /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" save stack work
     env:
       OS_NAME: ${{ parameters.os }}
     displayName: 'Cache data'

--- a/.azure/azure-osx-template.yml
+++ b/.azure/azure-osx-template.yml
@@ -19,8 +19,8 @@ jobs:
       curl -f -L "https://github.com/fpco/cache-s3/releases/download/${CACHE_S3_VERSION}/cache-s3-${CACHE_S3_VERSION}-${OS_NAME}-x86_64.tar.gz" -o ~/.local/bin/cache-s3.tar.gz
       tar xzf ~/.local/bin/cache-s3.tar.gz -C ~/.local/bin
       export PATH=$HOME/.local/bin:$PATH;
-      cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack --base-branch="${BASE_BRANCH}"
-      cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack work --base-branch="${BASE_BRANCH}"
+      cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" restore stack --base-branch="${BASE_BRANCH}"
+      cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" restore stack work --base-branch="${BASE_BRANCH}"
       etc/scripts/ci-setup.sh
       brew install mercurial
       export PATH=$HOME/.local/bin:$PATH
@@ -38,9 +38,9 @@ jobs:
       export AWS_SECRET_ACCESS_KEY="$(AWS_SECRET_ACCESS_KEY)";
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root;
       if [ "$(Build.SourceBranchName)" = "${BASE_BRANCH}" ]; then
-        cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" save stack;
+        cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" save stack;
       fi;
-      cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" save stack work
+      cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" save stack work
     condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
     env:
       OS_NAME: ${{ parameters.os }}

--- a/.azure/azure-windows-template.yml
+++ b/.azure/azure-windows-template.yml
@@ -27,8 +27,8 @@ jobs:
       choco install hg -y
       # curl -f -L "https://github.com/fpco/cache-s3/releases/download/${CACHE_S3_VERSION}/cache-s3-${CACHE_S3_VERSION}-${OS_NAME}-x86_64.zip" -o /usr/bin/cache-s3.zip
       # unzip -o /tmp/cache-s3.zip -d /usr/bin
-      /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack --base-branch="${BASE_BRANCH}"
-      /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack work --base-branch="${BASE_BRANCH}"
+      /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" restore stack --base-branch="${BASE_BRANCH}"
+      /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" restore stack work --base-branch="${BASE_BRANCH}"
       curl -sSkL http://www.stackage.org/stack/windows-i386 -o /usr/bin/stack.zip
       unzip -o /usr/bin/stack.zip -d /usr/bin/
       stack setup
@@ -42,9 +42,9 @@ jobs:
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root;
       export PATH=$HOME/.local/bin:$PATH;
       if [ "$(Build.SourceBranchName)" = "${BASE_BRANCH}" ]; then
-        /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" save stack;
+        /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" save stack;
       fi;
-      /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" save stack work
+      /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}/${OS_NAME}" --git-branch="$(Build.SourceBranchName)" save stack work
     condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
     env:
       OS_NAME: ${{ parameters.os }}


### PR DESCRIPTION
`cache-s3` uses suffix for the resolver, so it is automatically namespaced for all `cache-s3 save/restore stack` commands.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
