### PR TITLE
On newer-lts branch: switch Windows to 64-bit builds

### DIFF
--- a/.azure/azure-nightly-template-windows.yml
+++ b/.azure/azure-nightly-template-windows.yml
@@ -28,7 +28,7 @@ jobs:
       export PATH=$PATH:"/C/Program Files/Mercurial/"
       /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack --base-branch="${BASE_BRANCH}"
       /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack work --base-branch="${BASE_BRANCH}"
-      curl -sSkL http://www.stackage.org/stack/windows-i386 -o /usr/bin/stack.zip
+      curl -sSkL http://www.stackage.org/stack/windows-x86_64 -o /usr/bin/stack.zip
       unzip -o /usr/bin/stack.zip -d /usr/bin/
       stack setup
       stack --version
@@ -43,7 +43,7 @@ jobs:
   - powershell: |
       $env:STACK_ROOT = "$(Build.SourcesDirectory)\.stack-root"
       $env:PATH += ";$env:HOME\.local\bin"
-      stack etc/scripts/release.hs --arch=i386 build
+      stack etc/scripts/release.hs --arch=x86_64 build
       git clean -f
       stack etc/scripts/release.hs --arch=x86_64 build
       copy _release/stack-* $(Build.ArtifactStagingDirectory)

--- a/.azure/azure-windows-template.yml
+++ b/.azure/azure-windows-template.yml
@@ -29,7 +29,7 @@ jobs:
       # unzip -o /tmp/cache-s3.zip -d /usr/bin
       /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack --base-branch="${BASE_BRANCH}"
       /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack work --base-branch="${BASE_BRANCH}"
-      curl -sSkL http://www.stackage.org/stack/windows-i386 -o /usr/bin/stack.zip
+      curl -sSkL http://www.stackage.org/stack/windows-x86_64 -o /usr/bin/stack.zip
       unzip -o /usr/bin/stack.zip -d /usr/bin/
       stack setup
       stack test --jobs 1


### PR DESCRIPTION
It looks to me like there may be a bug in 32-bit GHC 8.6.5 on Windows. I've been seeing:

```
pantry                > ghc.exe:  | D:\a\1\s\.stack-root\snapshots\d08f6e4c\lib\i386-windows-ghc-8.6.5\persistent-sqlite-2.9.3-HO1GqQrWtVL3PHyDCYo1QZ\HSpersistent-sqlite-2.9.3-HO1GqQrWtVL3PHyDCYo1QZ.o: unknown symbol `___udivmoddi4'
```