### PR TITLE
CI: Build Windows 64-bit only

### DIFF
--- a/.azure/azure-nightly-template-windows.yml
+++ b/.azure/azure-nightly-template-windows.yml
@@ -44,8 +44,6 @@ jobs:
       $env:STACK_ROOT = "$(Build.SourcesDirectory)\.stack-root"
       $env:PATH += ";$env:HOME\.local\bin"
       stack etc/scripts/release.hs --arch=x86_64 build
-      git clean -f
-      stack etc/scripts/release.hs --arch=x86_64 build
       copy _release/stack-* $(Build.ArtifactStagingDirectory)
     displayName: Build bindist
     condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')

--- a/.azure/azure-nightly-template-windows.yml
+++ b/.azure/azure-nightly-template-windows.yml
@@ -28,7 +28,7 @@ jobs:
       export PATH=$PATH:"/C/Program Files/Mercurial/"
       /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack --base-branch="${BASE_BRANCH}"
       /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack work --base-branch="${BASE_BRANCH}"
-      curl -sSkL http://www.stackage.org/stack/windows-i386 -o /usr/bin/stack.zip
+      curl -sSkL http://www.stackage.org/stack/windows-x86_64 -o /usr/bin/stack.zip
       unzip -o /usr/bin/stack.zip -d /usr/bin/
       stack setup
       stack --version
@@ -43,7 +43,7 @@ jobs:
   - powershell: |
       $env:STACK_ROOT = "$(Build.SourcesDirectory)\.stack-root"
       $env:PATH += ";$env:HOME\.local\bin"
-      stack etc/scripts/release.hs --arch=i386 build
+      stack etc/scripts/release.hs --arch=x86_64 build
       git clean -f
       stack etc/scripts/release.hs --arch=x86_64 build
       copy _release/stack-* $(Build.ArtifactStagingDirectory)

--- a/.azure/azure-windows-template.yml
+++ b/.azure/azure-windows-template.yml
@@ -29,7 +29,7 @@ jobs:
       # unzip -o /tmp/cache-s3.zip -d /usr/bin
       /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack --base-branch="${BASE_BRANCH}"
       /tmp/cache-s3 --prefix="${CACHE_S3_PREFIX}" --git-branch="$(Build.SourceBranchName)" --suffix="${OS_NAME}" restore stack work --base-branch="${BASE_BRANCH}"
-      curl -sSkL http://www.stackage.org/stack/windows-i386 -o /usr/bin/stack.zip
+      curl -sSkL http://www.stackage.org/stack/windows-x86_64 -o /usr/bin/stack.zip
       unzip -o /usr/bin/stack.zip -d /usr/bin/
       stack setup
       stack test --jobs 1


### PR DESCRIPTION
Separate from #5188, this applies the change directly to master. If this is merged, then #5188 should be closed and #5162 should be rebased.