### PR TITLE
[WIP] chore(docs): update lts version and fix nightly link

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -450,7 +450,7 @@ With that out of the way, let's dig a little bit more into these package sets,
 also known as *snapshots*. We mentioned the LTS resolvers, and you can get quite a bit of
 information about it at [https://www.stackage.org/lts](https://www.stackage.org/lts), including:
 
-* The appropriate resolver value (`resolver: lts-11.22`, as is currently the latest LTS)
+* The appropriate resolver value (`resolver: lts-15.3`, as is currently the latest LTS)
 * The GHC version used
 * A full list of all packages available in this snapshot
 * The ability to perform a Hoogle search on the packages in this snapshot
@@ -467,15 +467,14 @@ default as well).
 
 ## Resolvers and changing your compiler version
 
-Let's explore package sets a bit further. Instead of lts-11.22, let's change our
-`stack.yaml` file to use [the latest nightly](https://www.stackage.org/nightly). Right now,
-this is currently 2018-07-25 - please see the resolve from the link above to get the latest.
+Let's explore package sets a bit further. Instead of lts-15.3, let's use [the latest nightly](https://www.stackage.org/snapshots) by replacing the value of the `resolver` field in our `stack.yaml` file. Right now,
+this is currently [`nightly-2020-03-14`](https://www.stackage.org/nightly-2020-03-14) - please see the resolve from the link above to get the latest.
 
 Then, Rerunning `stack build` will produce:
 
 ```
 michael@d30748af6d3d:~/helloworld$ stack build
-Downloaded nightly-2018-07-31 build plan.
+Downloaded nightly-2020-03-14 build plan.
 # build output ...
 ```
 
@@ -483,8 +482,8 @@ We can also change resolvers on the command line, which can be useful in a
 Continuous Integration (CI) setting, like on Travis. For example:
 
 ```
-michael@d30748af6d3d:~/helloworld$ stack --resolver lts-11.22 build
-Downloaded lts-11.22 build plan.
+michael@d30748af6d3d:~/helloworld$ stack --resolver lts-15.3 build
+Downloaded lts-15.3 build plan.
 # build output ...
 ```
 
@@ -559,7 +558,7 @@ cueball:~/yackage-0.8.0$ stack init
 # init output ...
 ```
 
-stack init does quite a few things for you behind the scenes:
+`stack init` does quite a few things for you behind the scenes:
 
 * Finds all of the `.cabal` files in your current directory and subdirectories
   (unless you use `--ignore-subdirs`) and determines the packages and versions
@@ -590,7 +589,7 @@ cueball:~/yackage-0.8.0$ stack init --force
 # init failure output
 ```
 
-stack has tested six different snapshots, and in every case discovered that
+stack has tested 18 different snapshots, and in every case discovered that
 acme-missiles is not available. In the end it suggested that you use the
 `--solver` command line switch if you want to use packages outside Stackage. So
 let's give it a try:


### PR DESCRIPTION
Few things I noticed and partially addressed while getting started with the Guide:

- [x] updated resolver version to latest lts.
- [x] fixed nightly link (`/nightly` doesn't resolve)

Under heading `Stack's functions`, I'd would be nice to have a short paragraph on:
- how Stack relates to Cabal and other relevant tooling
- what Stack does not attempt to solve

Also, two issues I would need your input on:

1. The guide mentions `--solver` under section [External Dependencies](https://github.com/commercialhaskell/stack/blob/6907ca032fb3e1cc2759873baf4de88d416c434f/doc/GUIDE.md#external-dependencies). This flag doesn't exist anymore and seems to be replaced by `--resolver <arg>` which needs an argument. How to update this part?

2. Following (1), I tried to run `stack install caball-install` anyway. It errors with a version conflict:
    ```
    In the dependencies for cabal-install-3.0.0.0:
    base-4.13.0.0 from stack configuration does not
                  match >=4.8 && <4.13  (latest matching version
                  is 4.12.0.0)
    hackage-security must match >=0.5.2.2 && <0.6, but the stack
                     configuration has no specified version  (latest
                     matching version is 0.5.3.0)
    needed since cabal-install is a build target.
    ```

    How to handle this in the Guide?
