### PR TITLE
Remove warning about GHC 8.10/Cabal 3.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -59,7 +59,7 @@ Other enhancements:
   `ls dependencies --tree`  is now `ls dependencies tree`. See
   [#4424](https://github.com/commercialhaskell/stack/pull/4424)
 
-* Remove warning for using Stack with GHC 8.8 and Cabal 3.0.
+* Remove warning for using Stack with GHC 8.8-8.10, and Cabal 3.0-3.2.
 
 * Allow relative paths in `--setup-info-yaml` and tool paths
   [#3394](https://github.com/commercialhaskell/stack/issues/3394)

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -465,9 +465,9 @@ warnUnsupportedCompiler ghcVersion = do
         logWarn "For more information, see: https://github.com/commercialhaskell/stack/issues/648"
         logWarn ""
         pure True
-    | ghcVersion >= mkVersion [8, 9] -> do
+    | ghcVersion >= mkVersion [8, 11] -> do
         logWarn $
-          "Stack has not been tested with GHC versions above 8.8, and using " <>
+          "Stack has not been tested with GHC versions above 8.10, and using " <>
           fromString (versionString ghcVersion) <>
           ", this may fail"
         pure True
@@ -492,9 +492,9 @@ warnUnsupportedCompilerCabal cp didWarn = do
         logWarn "This invocation will most likely fail."
         logWarn "To fix this, either use an older version of Stack or a newer resolver"
         logWarn "Acceptable resolvers: lts-3.0/nightly-2015-05-05 or later"
-    | cabalVersion >= mkVersion [3, 1] ->
+    | cabalVersion >= mkVersion [3, 3] ->
         logWarn $
-          "Stack has not been tested with Cabal versions above 3.0, but version " <>
+          "Stack has not been tested with Cabal versions above 3.2, but version " <>
           fromString (versionString cabalVersion) <>
           " was found, this may fail"
     | otherwise -> pure ()


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
