### PR TITLE
Update Fedora repo in the install guide

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -141,7 +141,7 @@ Use the [generic Linux option](#linux).
 
 There is also an
 unofficial
-[Fedora Copr repo](https://copr.fedoraproject.org/coprs/petersen/stack/) which
+[Fedora Copr repo](https://copr.fedoraproject.org/coprs/petersen/stack2/) which
 can be enabled with: `sudo dnf copr enable petersen/stack`. Note that this Stack
 version may lag behind, so we recommend running `stack upgrade` after installing
 it.

--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -142,7 +142,7 @@ Use the [generic Linux option](#linux).
 There is also an
 unofficial
 [Fedora Copr repo](https://copr.fedoraproject.org/coprs/petersen/stack2/) which
-can be enabled with: `sudo dnf copr enable petersen/stack`. Note that this Stack
+can be enabled with: `sudo dnf copr enable petersen/stack2`. Note that this Stack
 version may lag behind, so we recommend running `stack upgrade` after installing
 it.
 


### PR DESCRIPTION
The Fedora Copr repo link was pointing to an obsolete repository, containing stack 1.9.3, so I've updated the link to point to the newer repo.