### PR TITLE
Use released filelock

### DIFF
--- a/stack-ghc-84.yaml
+++ b/stack-ghc-84.yaml
@@ -43,8 +43,7 @@ extra-deps:
 - pantry-0.4.0.1@rev:0
 - casa-client-0.0.1@rev:0
 - casa-types-0.0.1@rev:0
-- github: snoyberg/filelock
-  commit: 97e83ecc133cd60a99df8e1fa5a3c2739ad007dc
+- filelock-0.1.1.4@rev:0
 
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712

--- a/stack-ghc-88.yaml
+++ b/stack-ghc-88.yaml
@@ -26,8 +26,7 @@ extra-deps:
 - lukko-0.1.1.1@sha256:5c674bdd8a06b926ba55d872abe254155ed49a58df202b4d842b643e5ed6bcc9,4289
 - hpack-0.33.0@rev:0
 - http-download-0.2.0.0@rev:0
-- github: snoyberg/filelock
-  commit: 97e83ecc133cd60a99df8e1fa5a3c2739ad007dc
+- filelock-0.1.1.4@rev:0
 - pantry-0.4.0.1@rev:0
 - casa-client-0.0.1@rev:0
 - casa-types-0.0.1@rev:0

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,8 +24,7 @@ extra-deps:
 - Cabal-3.0.0.0@rev:0
 - hpack-0.33.0@rev:0
 - http-download-0.2.0.0@rev:0
-- git: https://github.com/snoyberg/filelock.git
-  commit: 97e83ecc133cd60a99df8e1fa5a3c2739ad007dc
+- filelock-0.1.1.4@rev:0
 - pantry-0.4.0.1@rev:0
 - casa-client-0.0.1@rev:0
 - casa-types-0.0.1@rev:0


### PR DESCRIPTION
We've been hoping for https://github.com/takano-akio/filelock/pull/7 to
get merged and released. However, this is dragging on, and we'd rather
use the released version of all packages in releases. Ultimately the
interruptible FFI issue isn't serious enough to warrant continuing to
use the non-released version of filelock.