### PR TITLE
Add tip to scroll up on package build failure.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,9 @@ Behavior changes:
 
 Other enhancements:
 
+* Build failures now show a hint to scroll up to the corresponding section
+  [#5279](https://github.com/commercialhaskell/stack/issues/5279)
+
 Bug fixes:
 
 

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -348,7 +348,7 @@ showBuildError isBuildingSetup exitCode mtaskProvides execName fullArgs logFiles
        (True, Nothing) -> "simple Setup.hs"
        (True, Just taskProvides') -> "custom Setup.hs for package " ++ dropQuotes (packageIdentifierString taskProvides')
      ) ++
-     " using:\n      " ++ fullCmd ++ "\n" ++
+     " (scroll up to its section to see the error) using:\n      " ++ fullCmd ++ "\n" ++
      "    Process exited with code: " ++ show exitCode ++
      (if exitCode == ExitFailure (-9)
           then " (THIS MAY INDICATE OUT OF MEMORY)"


### PR DESCRIPTION
Many users don't get that when they see an error like

    [tons of output]
    --  While building package hopenssl-2.2.4 using:
    [one bit line more output]

they have to scroll up (potentially multiple terminal pages!) to the last output starting with e.g. `hopenssl >`.

This adds an explicit call to scroll up to that section, so that this user confusion can be reduced.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

###### Please also shortly describe how you tested your change. Bonus points for added tests!

I haven't tested this at all because it's just a simple string change I made on a whim and hopw CI will do it for me :)