### PR TITLE
Make snapshot locations configurable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,9 @@ Release notes:
 **Changes since v2.3.1**
 
 Major changes:
+* Add the `snapshot-location-base` yaml configuration option, which allows to override the default location of
+   snapshot configuration files. This option affects how snapshot synonyms (LTS/Nightly) are expanded to URLs
+   by the `pantry` library.
 
 * `docker-network` configuration key added to overwrite docker `--net` arg
 

--- a/doc/pantry.md
+++ b/doc/pantry.md
@@ -25,8 +25,10 @@ location:
 * Via a _convenience synonym_, which provides a short form for some
   common URLs. These are:
     * Github: `github:user/repo:path` is treated as `https://raw.githubusercontent.com/user/repo/master/path`
-    * LTS Haskell: `lts-X.Y` is treated as `github:commercialhaskell/stackage-snapshots:lts/X/Y.yaml`
-    * Stackage Nightly: `nightly-YYYY-MM-DD` is treated as `github:commercialhaskell/stackage-snapshots:nightly/YYYY/M/D.yaml`
+    * LTS Haskell: `lts-X.Y` is treated by default as `github:commercialhaskell/stackage-snapshots:lts/X/Y.yaml`
+    * Stackage Nightly: `nightly-YYYY-MM-DD` is treated by default as `github:commercialhaskell/stackage-snapshots:nightly/YYYY/M/D.yaml`
+
+By default, LTS Haskell/Stackage Nightly snapshot configurations are retrieved from `commercialhaskell`'s GitHub repository. You can set a custom location in the [snapshot-location-base](yaml_configuration.md#snapshot-location-base) yaml configuration field.
 
 For safer, more reproducible builds, you can optionally specify a URL
 together with a cryptographic hash of its content, e.g.:

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -1187,3 +1187,19 @@ recommend-stack-upgrade: true
 ```
 
 Since 2.0
+
+### snapshot-location-base
+Sets the base location of LTS Haskell/Stackage Nightly snapshots. Default is https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/ (as set in the `pantry` library).
+
+For example:
+```yaml
+snapshot-location-base: https://example.com/snapshots/location/
+```
+has the following effect:
+* `lts-X.Y` expands to `https://example.com/snapshots/location/lts/X/Y.yaml`
+* `nightly-YYYY-MM-DD` expands to `https://example.com/snapshots/location/nightly/YYYY/M/D.yaml`
+
+This field is convenient in setups that restrict access to GitHub, for instance closed corporate setups. In this setting, it is common for the development environment to have general access to the internet, but not for testing/building environments. To avoid the firewall, one can run a local snapshots mirror and then use a custom `snapshot-location-base` in the closed environments only.
+
+
+Since FIXME:

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -45,7 +45,6 @@ import           Stack.Types.SourceMap
 import           Stack.Types.Version
 import           Stack.Types.Config
 import           Stack.Types.Compiler
-import           Stack.Types.Resolver
 
 data BuildPlanException
     = UnknownPackages
@@ -62,7 +61,7 @@ instance Show BuildPlanException where
         , "Non existing resolver: " ++ snapName' ++ "."
         , "For a complete list of available snapshots see https://www.stackage.org/snapshots"
         ]
-        where snapName' = show $ renderSnapName snapName
+        where snapName' = show snapName
     show (UnknownPackages stackYaml unknown shadowed) =
         unlines $ unknown' ++ shadowed'
       where
@@ -387,9 +386,7 @@ selectBestSnapshot pkgDirs snaps = do
     logInfo $ "Selecting the best among "
                <> displayShow (NonEmpty.length snaps)
                <> " snapshots...\n"
-    let resolverStackage (LTS x y) = ltsSnapshotLocation x y
-        resolverStackage (Nightly d) = nightlySnapshotLocation d
-    F.foldr1 go (NonEmpty.map (getResult . resolverStackage) snaps)
+    F.foldr1 go (NonEmpty.map (getResult <=< snapshotLocation) snaps)
     where
         go mold mnew = do
             old@(_snap, _loc, bpc) <- mold

--- a/src/Stack/Ls.hs
+++ b/src/Stack/Ls.hs
@@ -12,7 +12,7 @@ module Stack.Ls
 import Control.Exception (throw)
 import Data.Aeson
 import Data.Array.IArray ((//), elems)
-import Stack.Prelude hiding (Snapshot (..))
+import Stack.Prelude hiding (Snapshot (..), SnapName (..))
 import qualified Data.Aeson.Types as A
 import qualified Data.List as L
 import Data.Text hiding (pack, intercalate)

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -22,7 +22,7 @@ configOptsParser currentDir hide0 =
     (\stackRoot workDir buildOpts dockerOpts nixOpts systemGHC installGHC arch
         ghcVariant ghcBuild jobs includes libs overrideGccPath overrideHpack
         skipGHCCheck skipMsys localBin setupInfoLocations modifyCodePage
-        allowDifferentUser dumpLogs colorWhen -> mempty
+        allowDifferentUser dumpLogs colorWhen snapLoc -> mempty
             { configMonoidStackRoot = stackRoot
             , configMonoidWorkDir = workDir
             , configMonoidBuildOpts = buildOpts
@@ -46,6 +46,7 @@ configOptsParser currentDir hide0 =
             , configMonoidAllowDifferentUser = allowDifferentUser
             , configMonoidDumpLogs = dumpLogs
             , configMonoidColorWhen = colorWhen
+            , configMonoidSnapshotLocation = snapLoc
             })
     <$> optionalFirst (absDirOption
             ( long stackRootOptionName
@@ -161,6 +162,11 @@ configOptsParser currentDir hide0 =
                     \support color codes"
             <> hide
              ))
+    <*> optionalFirst (strOption
+            ( long "snapshot-location-base"
+           <> help "The base location of LTS/Nightly snapshots"
+           <> metavar "URL"
+            ))
   where
     hide = hideMods (hide0 /= OuterGlobalOpts)
     toDumpLogs (First (Just True)) = First (Just DumpAllLogs)

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -859,6 +859,8 @@ data ConfigMonoid =
     , configMonoidRecommendUpgrade   :: !FirstTrue
     -- ^ See 'configRecommendUpgrade'
     , configMonoidCasaRepoPrefix     :: !(First CasaRepoPrefix)
+    , configMonoidSnapshotLocation :: !(First Text)
+    -- ^ Custom location of LTS/Nightly snapshots
     }
   deriving (Show, Generic)
 
@@ -982,6 +984,7 @@ parseConfigMonoidObject rootDir obj = do
     configMonoidRecommendUpgrade <- FirstTrue <$> obj ..:? configMonoidRecommendUpgradeName
 
     configMonoidCasaRepoPrefix <- First <$> obj ..:? configMonoidCasaRepoPrefixName
+    configMonoidSnapshotLocation <- First <$> obj ..:? configMonoidSnapshotLocationName
 
     return ConfigMonoid {..}
   where
@@ -1148,6 +1151,9 @@ configMonoidRecommendUpgradeName = "recommend-stack-upgrade"
 configMonoidCasaRepoPrefixName :: Text
 configMonoidCasaRepoPrefixName = "casa-repo-prefix"
 
+configMonoidSnapshotLocationName :: Text
+configMonoidSnapshotLocationName = "snapshot-location-base"
+
 data ConfigException
   = ParseConfigFileException (Path Abs File) ParseException
   | ParseCustomSnapshotException Text ParseException
@@ -1212,7 +1218,7 @@ instance Show ConfigException where
     show (NoMatchingSnapshot names) = concat
         [ "None of the following snapshots provides a compiler matching "
         , "your package(s):\n"
-        , unlines $ map (\name -> "    - " <> T.unpack (renderSnapName name))
+        , unlines $ map (\name -> "    - " <> show name)
                         (NonEmpty.toList names)
         , resolveOptions
         ]

--- a/src/test/Stack/Config/DockerSpec.hs
+++ b/src/test/Stack/Config/DockerSpec.hs
@@ -1,37 +1,26 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns #-}
 module Stack.Config.DockerSpec (spec) where
 
 import Test.Hspec
-import Test.Hspec.QuickCheck
 import Stack.Prelude
 import Stack.Types.Resolver
 import RIO.Time (fromGregorian)
-import Stack.Config.Docker (parseLtsName, addDefaultTag)
+import Stack.Config.Docker (addDefaultTag)
 
 spec :: Spec
 spec = do
-  prop "parseLtsName" $ \(abs -> x) (abs -> y) -> do
-    case ltsSnapshotLocation x y of
-      RSLUrl url _ ->
-        case parseLtsName url of
-          Just (x', y') -> do
-            x `shouldBe` x'
-            y `shouldBe` y'
-          Nothing -> error "parseLtsName failed"
-      loc -> error $ show loc
   describe "addDefaultTag" $ do
     it "succeeds fails no resolver" $ addDefaultTag "foo/bar" Nothing Nothing `shouldBe` Nothing
     it "succeeds on LTS" $
       addDefaultTag
         "foo/bar"
         Nothing
-        (Just $ ARResolver $ ltsSnapshotLocation 1 2)
+        (Just $ ARResolver $ RSLSynonym $ LTS 1 2)
       `shouldBe` Just "foo/bar:lts-1.2"
     it "fails on nightly" $
       addDefaultTag
         "foo/bar"
         Nothing
-        (Just $ ARResolver $ nightlySnapshotLocation $ fromGregorian 2018 1 1)
+        (Just $ ARResolver $ RSLSynonym $ Nightly $ fromGregorian 2018 1 1)
       `shouldBe` Nothing

--- a/src/test/Stack/ConfigSpec.hs
+++ b/src/test/Stack/ConfigSpec.hs
@@ -121,11 +121,11 @@ spec = beforeAll setup $ do
 
     it "parses snapshot using 'resolver'" $ inTempDir $ do
       loadProject resolverConfig $ \Project{..} ->
-        projectResolver `shouldBe` ltsSnapshotLocation 2 10
+        projectResolver `shouldBe` RSLSynonym (LTS 2 10)
 
     it "parses snapshot using 'snapshot'" $ inTempDir $ do
       loadProject snapshotConfig $ \Project{..} ->
-        projectResolver `shouldBe` ltsSnapshotLocation 2 10
+        projectResolver `shouldBe` RSLSynonym (LTS 2 10)
 
     it "throws if both 'resolver' and 'snapshot' are present" $ inTempDir $ do
       loadProject resolverSnapshotConfig (const (return ()))

--- a/stack-ghc-84.yaml
+++ b/stack-ghc-84.yaml
@@ -40,7 +40,7 @@ extra-deps:
 - rio-prettyprint-0.1.0.0@rev:0
 - hi-file-parser-0.1.0.0@rev:0
 - http-download-0.2.0.0@rev:0
-- pantry-0.4.0.1@rev:0
+- pantry-0.5.0.0
 - casa-client-0.0.1@rev:0
 - casa-types-0.0.1@rev:0
 - filelock-0.1.1.4@rev:0

--- a/stack-ghc-88.yaml
+++ b/stack-ghc-88.yaml
@@ -27,7 +27,7 @@ extra-deps:
 - hpack-0.33.0@rev:0
 - http-download-0.2.0.0@rev:0
 - filelock-0.1.1.4@rev:0
-- pantry-0.4.0.1@rev:0
+- pantry-0.5.0.0
 - casa-client-0.0.1@rev:0
 - casa-types-0.0.1@rev:0
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -27,7 +27,7 @@ extra-deps:
 - hpack-0.33.0@rev:0
 - http-download-0.2.0.0@rev:0
 - filelock-0.1.1.4@rev:0
-- pantry-0.4.0.1@rev:0
+- pantry-0.5.0.0
 - casa-client-0.0.1@rev:0
 - casa-types-0.0.1@rev:0
 


### PR DESCRIPTION
This PR adds the new yaml option `snapshot-location-base`, which overrides the default location of snapshot synonyms (LTS/Nightly). It requires [this (commercialhaskell/pantry#20)](https://github.com/commercialhaskell/pantry/pull/20) corresponding PR for `pantry`.

#### Behaviour
https://github.com/commercialhaskell/pantry/pull/20 adds to `PantryConfig` a new field `pcSnapshotLocation :: SnapName -> RawSnapshotLocation` which allows to configure how a snapshot name expands to its location. 

When `snapshot-location-base` is not supplied, `stack` just uses the `defaultSnapshotLocation` provided by pantry. When the user supplies a URL in the `snapshot-location-base` field, say:
```yaml
snapshot-location-base: https://example.com/snapshots/location/
```
then the custom snapshot location is defined as follows:
* `lts-X.Y` expands to `https://example.com/snapshots/location/lts/X/Y.yaml`
* `nightly-YYYY-MM-DD` expands to `https://example.com/snapshots/location/nightly/YYYY/M/D.yaml`

#### Changes
- Add to `ConfigMonoid` the new entry `configMonoidSnapshotLocation`
- Move the datatype `SnapName` to `pantry` (see https://github.com/commercialhaskell/pantry/pull/20) together with `parseSnapName` and `ParseSnapNameException`
- remove obsolete code, like `parseLtsName`.

#### Requested info
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
* [ ] I have only tested the change locally&manually. I could add some tests later, when the maintainers are happy with the changes
