### PR TITLE
Fix stack installation in alpine

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -313,20 +313,20 @@ do_osx_install() {
 #     die "Sorry, there is currently no 32-bit FreeBSD binary available."
 #   fi
 # }
-#
-# # Alpine distro install
-# do_alpine_install() {
-#   install_dependencies() {
-#     apk_install_pkgs gmp libgcc xz make
-#   }
-#   install_dependencies
-#   if is_64_bit ; then
-#     print_bindist_notice
-#     install_64bit_standard_binary
-#   else
-#     die "Sorry, there is currently no 32-bit Alpine Linux binary available."
-#   fi
-# }
+
+# Alpine distro install
+do_alpine_install() {
+  install_dependencies() {
+    apk_install_pkgs gmp libgcc xz make
+  }
+  install_dependencies
+  if is_x86_64 ; then
+    print_bindist_notice
+    install_x86_64_linux_binary
+  else
+    die "Sorry, currently only 64-bit (x86_64) Alpine Linux binary is available."
+  fi
+}
 
 # Attempts to install on unsupported Linux distribution by downloading
 # the bindist.


### PR DESCRIPTION
Small PR to fix installation using installation script in alpine linux. `do_alpine_install` is commented out in 87ff1220c579ec03cff8874d6ee59e87b1b0aec0 but it still occurred in the installation. That caused an error as shown below.

```
/workdir # ./etc/scripts/get-stack.sh
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
(1/2) Installing libbz2 (1.0.6-r7)
(2/2) Installing perl (5.28.2-r1)
Executing busybox-1.30.1-r2.trigger
OK: 44 MiB in 16 packages
Detected Linux distribution: alpine
./etc/scripts/get-stack.sh: line 465: do_alpine_install: not found
```

This PR fixes this by simply skipping the branch for alpine in `do_distro` and make the script try "generic" installation. I tested this change by running `./etc/scripts/get-stack.sh` in a docker container of `alpine:3.11` image and confirmed that the installation finishes successfully with a warning "there is no guarantee that 'stack' will work at all!..." as expected.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
  * I'm not sure whether this should be recorded in changelog
* [x] The documentation has been updated, if necessary.
  * I this there is no need for this