### PR TITLE
Fix compatibility with Cabal 3.2

### DIFF
--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -232,7 +232,7 @@ getCabalLbs pvpBounds mrev cabalfp sourceMap = do
             [ style Url "https://github.com/commercialhaskell/stack/issues/new"
             , style Url "https://github.com/haskell/cabal/issues/new"
             ]
-          , flow $ "The parse error is: " ++ unlines (map show errs)
+          , flow $ "The parse error is: " ++ unlines (map show (toList errs))
           , ""
           ]
     return


### PR DESCRIPTION
Follows the change in https://github.com/commercialhaskell/pantry/pull/22

Fixes the only build failure with Cabal 3.2

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
