### PR TITLE
add docker network option (fixes #5121)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,8 @@ Release notes:
 
 Major changes:
 
+* `docker-network` configuration key added to overwrite docker `--net` arg
+
 Behavior changes:
 
 Other enhancements:

--- a/doc/docker_integration.md
+++ b/doc/docker_integration.md
@@ -199,6 +199,10 @@ otherwise noted.
       # What to name the Docker container.  Only useful with `detach` or
       # `persist` true.  (default none)
       container-name: "example-name"
+      
+      # Sets the network used by docker. Gets directly passed to dockers `net`
+      # argument (default: host)
+      network: host
 
       # Additional arguments to pass to `docker run`.  (default none)
       run-args: ["--net=bridge"]

--- a/src/Stack/Config/Docker.hs
+++ b/src/Stack/Config/Docker.hs
@@ -70,6 +70,7 @@ dockerOptsFromMonoid mproject maresolver DockerOptsMonoid{..} = do
         dockerDetach = fromFirstFalse dockerMonoidDetach
         dockerPersist = fromFirstFalse dockerMonoidPersist
         dockerContainerName = emptyToNothing (getFirst dockerMonoidContainerName)
+        dockerNetwork = emptyToNothing (getFirst dockerMonoidNetwork)
         dockerRunArgs = dockerMonoidRunArgs
         dockerMount = dockerMonoidMount
         dockerMountMode = emptyToNothing (getFirst dockerMonoidMountMode)

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -253,7 +253,6 @@ runContainerAndExit = do
      containerID <- withWorkingDir (toFilePath projectRoot) $ trim . decodeUtf8 <$> readDockerProcess
        (concat
          [["create"
-          ,"--net=host"
           ,"-e",inContainerEnvVar ++ "=1"
           ,"-e",stackRootEnvVar ++ "=" ++ toFilePathNoTrailingSep stackRoot
           ,"-e",platformVariantEnvVar ++ "=dk" ++ platformVariant
@@ -265,6 +264,9 @@ runContainerAndExit = do
           ,"-v",toFilePathNoTrailingSep projectRoot ++ ":" ++ toFilePathNoTrailingSep projectRoot ++ mountSuffix
           ,"-v",toFilePathNoTrailingSep sandboxHomeDir ++ ":" ++ toFilePathNoTrailingSep sandboxHomeDir ++ mountSuffix
           ,"-w",toFilePathNoTrailingSep pwd]
+         ,case dockerNetwork docker of
+            Nothing -> ["--net=host"]
+            Just name -> ["--net=" ++ name]
          ,case muserEnv of
             Nothing -> []
             Just userEnv -> ["-e","USER=" ++ userEnv]

--- a/src/Stack/Options/DockerParser.hs
+++ b/src/Stack/Options/DockerParser.hs
@@ -59,6 +59,10 @@ dockerOptsParser hide0 =
                         hide <>
                         metavar "NAME" <>
                         help "Docker container name")
+    <*> firstStrOption (long (dockerOptName dockerNetworkArgName) <>
+                        hide <>
+                        metavar "NETWORK" <>
+                        help "Docker network")
     <*> argsOption (long (dockerOptName dockerRunArgsArgName) <>
                     hide <>
                     value [] <>

--- a/src/Stack/Types/Docker.hs
+++ b/src/Stack/Types/Docker.hs
@@ -43,6 +43,8 @@ data DockerOpts = DockerOpts
   ,dockerContainerName :: !(Maybe String)
     -- ^ Container name to use, only makes sense from command-line with `dockerPersist`
     -- or `dockerDetach`.
+  ,dockerNetwork :: !(Maybe String)
+   -- ^ The network docker uses.
   ,dockerRunArgs :: ![String]
     -- ^ Arguments to pass directly to @docker run@.
   ,dockerMount :: ![Mount]
@@ -85,6 +87,8 @@ data DockerOptsMonoid = DockerOptsMonoid
   ,dockerMonoidContainerName :: !(First String)
     -- ^ Container name to use, only makes sense from command-line with `dockerPersist`
     -- or `dockerDetach`.
+  ,dockerMonoidNetwork :: !(First String)
+    -- ^ See: 'dockerNetwork'
   ,dockerMonoidRunArgs :: ![String]
     -- ^ Arguments to pass directly to @docker run@
   ,dockerMonoidMount :: ![Mount]
@@ -118,6 +122,7 @@ instance FromJSON (WithJSONWarnings DockerOptsMonoid) where
               dockerMonoidDetach           <- FirstFalse <$> o ..:? dockerDetachArgName
               dockerMonoidPersist          <- FirstFalse <$> o ..:? dockerPersistArgName
               dockerMonoidContainerName    <- First <$> o ..:? dockerContainerNameArgName
+              dockerMonoidNetwork          <- First <$> o ..:? dockerNetworkArgName
               dockerMonoidRunArgs          <- o ..:? dockerRunArgsArgName ..!= []
               dockerMonoidMount            <- o ..:? dockerMountArgName ..!= []
               dockerMonoidMountMode        <- First <$> o ..:? dockerMountModeArgName
@@ -391,6 +396,10 @@ dockerEnvArgName = "env"
 -- | Docker container name argument name.
 dockerContainerNameArgName :: Text
 dockerContainerNameArgName = "container-name"
+--
+-- | Docker container name argument name.
+dockerNetworkArgName :: Text
+dockerNetworkArgName = "network"
 
 -- | Docker persist argument name.
 dockerPersistArgName :: Text


### PR DESCRIPTION
Adds a new configuration key `docker-network` to allow overwriting the `--net` argument passed to docker. This is not possible via `--docker-run-args='--net=…'` because the latter adds an additional conflicting `--net` arg passed to docker rather than overwriting the existing one.

If `docker-network` is not set `--net=host` is passed to docker to retain the current behaviour.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

For testing I found it necessary to use this commit on the release branch. Otherwise stack wouldn't find a Docker-compatible stack executable for the current version. I used a test project that spawns a web server with the following docker configuration in the stack.yaml file:
```
docker:
  enable: true
  network: bridge
  run-args:
    - --publish=8080:8080
```