### PR TITLE
Fix repl for test components

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,9 @@ Other enhancements:
 Bug fixes:
 
 * When using the `STACK_YAML` env var with Docker, make the path absolute.
+* Fix the problem of `stack repl foo:test:bar` failing without a project
+  build before that. See
+  [#5213](https://github.com/commercialhaskell/stack/issues/5213)
 
 * Fix `stack sdist` introducing unneded sublibrary syntax when using
   pvp-bounds. See

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -183,8 +183,13 @@ ghci opts@GhciOpts{..} = do
               -- need is the location of main modules, not the rest.
               pkgs0 <- getGhciPkgInfos installMap addPkgs (fmap fst mfileTargets) pkgDescs
               figureOutMainFile bopts mainIsTargets localTargets pkgs0
+    let pkgTargets pn targets =
+          case targets of
+            TargetAll _  -> [T.pack (packageNameString pn)]
+            TargetComps comps -> [renderPkgComponent (pn, c) | c <- toList comps]
     -- Build required dependencies and setup local packages.
-    buildDepsAndInitialSteps opts (map (T.pack . packageNameString . fst) localTargets)
+    buildDepsAndInitialSteps opts $
+      concatMap (\(pn, (_, t)) -> pkgTargets pn t) localTargets
     targetWarnings localTargets nonLocalTargets mfileTargets
     -- Load the list of modules _after_ building, to catch changes in
     -- unlisted dependencies (#1180)


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Tested using https://github.com/fduxiao/mal taken from https://github.com/haskell/haskell-ide-engine/issues/1564

It's not quite clear why `stack-head repl mal:exe:mal-exe` doesn't work. I have a suspicion that we could need component-based builds but I didn't investigate it deeper.