### PR TITLE
Do not remove sublibrary information when adding pvp-bounds

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,10 @@ Bug fixes:
 
 * When using the `STACK_YAML` env var with Docker, make the path absolute.
 
+* Fix `stack sdist` introducing unneded sublibrary syntax when using
+  pvp-bounds. See
+  [#5289](https://github.com/commercialhaskell/stack/issues/5289)
+
 ## v2.3.1
 
 Release notes:

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -241,8 +241,7 @@ getCabalLbs pvpBounds mrev cabalfp sourceMap = do
       )
   where
     addBounds :: Set PackageName -> InstallMap -> InstalledMap -> Dependency -> Dependency
-    -- FIXME
-    addBounds internalPackages installMap installedMap dep@(Dependency name range _) =
+    addBounds internalPackages installMap installedMap dep@(Dependency name range s) =
       if name `Set.member` internalPackages
         then dep
         else case foundVersion of
@@ -250,7 +249,7 @@ getCabalLbs pvpBounds mrev cabalfp sourceMap = do
           Just version -> Dependency name (simplifyVersionRange
             $ (if toAddUpper && not (hasUpperBound range) then addUpper version else id)
             $ (if toAddLower && not (hasLowerBound range) then addLower version else id)
-              range) Set.empty
+              range) s
       where
         foundVersion =
           case Map.lookup name installMap of


### PR DESCRIPTION
This fixes `stack sdist` broken when using pvp-bounds, see
https://github.com/commercialhaskell/stack/issues/5289. This is a
regression after https://github.com/commercialhaskell/stack/pull/5156.

When using pvp-bounds we pretty-print an updated package description
back to .cabal file. If a set of sublibraries used in a dependency is
empty (from cabal-the-library perspective) then `instance Pretty
Dependency` from
https://hackage.haskell.org/package/Cabal-3.0.0.0/docs/src/Distribution.Types.Dependency.html#line-58
will just print an empty set there:

    build-depends: vector : {} <0.13

This leads to the following error when using `stack sdist`:

    - 46:16:
    unexpected Sublibrary dependency syntax used. To use this syntax the package needs to specify at least 'cabal-version: 3.0'. Alternatively, if you are depending on an internal library, you can write directly the library name as it were a package.
    expecting space

What we want instead is to use the same sublibrary set as the original
dep. I suspect most of the time it's just `[LMainLibName]`, which
thanks to `instance Pretty Dependency` omits the `{}` in the
dependency line and is hence (hopefully) compatible with whatever
`cabal-version` the original .cabal file used.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I tested this manually doing a `stack sdist` in a package which has `pvp-bounds` enabled.