### PR TITLE
Support docker integration on Windows

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,7 @@ Behavior changes:
 Other enhancements:
 
 Bug fixes:
-
+* Fix Docker integration on Windows. See [#2421](https://github.com/commercialhaskell/stack/issues/2421)
 
 ## v2.5.1
 

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -263,7 +263,7 @@ runContainerAndExit = do
           ,"-v",toFilePathNoTrailingSep stackRoot ++ ":" ++ toLinuxStylePath (toFilePathNoTrailingSep stackRoot ++ mountSuffix)
           ,"-v",toFilePathNoTrailingSep projectRoot ++ ":" ++ toLinuxStylePath (toFilePathNoTrailingSep projectRoot ++ mountSuffix)
           ,"-v",toFilePathNoTrailingSep sandboxHomeDir ++ ":" ++ toLinuxStylePath (toFilePathNoTrailingSep sandboxHomeDir ++ mountSuffix)
-          ,"-w", toLinuxStylePath (toFilePathNoTrailingSep pwd)]
+          ,"-w",toLinuxStylePath (toFilePathNoTrailingSep pwd)]
          ,case dockerNetwork docker of
             Nothing -> ["--net=host"]
             Just name -> ["--net=" ++ name]
@@ -278,8 +278,8 @@ runContainerAndExit = do
          ,case mstackYaml of
             Nothing -> []
             Just stackYaml ->
-              ["-e","STACK_YAML=" ++ stackYaml
-              ,"-v",stackYaml++ ":" ++ stackYaml ++ ":ro"]
+              ["-e","STACK_YAML=" ++ toLinuxStylePath stackYaml
+              ,"-v",stackYaml ++ ":" ++ toLinuxStylePath stackYaml ++ ":ro"]
            -- Disable the deprecated entrypoint in FP Complete-generated images
          ,["--entrypoint=/usr/bin/env"
              | isJust (lookupImageEnv oldSandboxIdEnvVar imageEnvVars) &&

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -352,8 +352,8 @@ runContainerAndExit = do
       & addStartingSlashIfMissing
                        | otherwise   = s
       where
-        addStartingSlashIfMissing s@('/':_) = s
-        addStartingSlashIfMissing s         = '/':s
+        addStartingSlashIfMissing path@('/':_) = path
+        addStartingSlashIfMissing path         = '/':path
 
 -- | Inspect Docker image or container.
 inspect :: (HasProcessContext env, HasLogFunc env)

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -229,10 +229,12 @@ runContainerAndExit = do
      when (isNothing mpath) $ do
        logWarn "The Docker image does not set the PATH env var"
        logWarn "This will likely fail, see https://github.com/commercialhaskell/stack/issues/2742"
-     newPathEnv <- either throwM return $ augmentPath
-                      [ hostBinDir
-                      , toFilePath (sandboxHomeDir </> relDirDotLocal </> relDirBin)]
-                      mpath
+     newPathEnv <- either throwM return $
+                   bool id (T.replace ";" ":") osIsWindows <$>
+                   augmentPath
+                     [ hostBinDir
+                       , toLinuxStylePath $ toFilePath (sandboxHomeDir </> relDirDotLocal </> relDirBin)]
+                     mpath
      (cmnd,args,envVars,extraMount) <- getCmdArgs docker imageInfo isRemoteDocker
      pwd <- getCurrentDir
      liftIO $ mapM_ ensureDir [sandboxHomeDir, stackRoot]


### PR DESCRIPTION
Fixes #2421 

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

### What did I do?
I added function transforming Windows paths to Linux paths and applied it places in which the path needs to be in Linux style (because it's a path inside the container).

### How did I test it?
I ran ``stack --docker ghci``, ``stack --docker build``, ``stack --docker test`` for https://github.com/BNFC/bnfc with and without STACK_YAML on my Windows 10 + Docker for Windows (wsl2 engine) machine.