### PR TITLE
Remove ModTime check during build (#5125)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,9 @@ Bug fixes:
 * Fix `stack sdist` introducing unneded sublibrary syntax when using
   pvp-bounds. See
   [#5289](https://github.com/commercialhaskell/stack/issues/5289)
+* Fix modified time busting caches by always calculating sha256 digest
+  during the build process.
+  [#5125](https://github.com/commercialhaskell/stack/issues/5125)
 
 ## v2.3.1
 
@@ -116,7 +119,7 @@ Other enhancements:
   prefixes each build log output line with a timestamp.
 
 * Show warning about `local-programs-path` with spaces on windows
-  when running scripts. See 
+  when running scripts. See
   [#5013](https://github.com/commercialhaskell/stack/pull/5013)
 
 * Add `ls dependencies json` which will print dependencies as JSON.

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -496,7 +496,7 @@ getFileDigestMaybe fp =
 -- | Create FileCacheInfo for a file.
 calcFci :: MonadIO m => (FileSize,SHA256) -> FilePath -> m FileCacheInfo
 calcFci (size, digest) fp = liftIO $ do
-    modTime' <- fmap modificationTime $ getFileStatus fp
+    modTime' <- modificationTime <$> getFileStatus fp
     return FileCacheInfo
         { fciModTime = modTime'
         , fciSize = size

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -11,7 +11,6 @@
 module Stack.Types.Package where
 
 import           Stack.Prelude
-import           Foreign.C.Types (CTime)
 import qualified RIO.Text as T
 import           Data.Aeson (ToJSON (..), FromJSON (..), (.=), (.:), object, withObject)
 import qualified Data.Map as M
@@ -342,10 +341,8 @@ instance Monoid InstallLocation where
 data InstalledPackageLocation = InstalledTo InstallLocation | ExtraGlobal
     deriving (Show, Eq)
 
-data FileCacheInfo = FileCacheInfo
-    { fciModTime :: !CTime
-    , fciSize :: !FileSize
-    , fciHash :: !SHA256
+newtype FileCacheInfo = FileCacheInfo
+    { fciHash :: SHA256
     }
     deriving (Generic, Show, Eq, Typeable)
 instance NFData FileCacheInfo
@@ -353,16 +350,12 @@ instance NFData FileCacheInfo
 -- Provided for storing the BuildCache values in a file. But maybe
 -- JSON/YAML isn't the right choice here, worth considering.
 instance ToJSON FileCacheInfo where
-  toJSON (FileCacheInfo time size hash') = object
-    [ "modtime" .= time
-    , "size" .= size
-    , "hash" .= hash'
+  toJSON (FileCacheInfo hash') = object
+    [ "hash" .= hash'
     ]
 instance FromJSON FileCacheInfo where
   parseJSON = withObject "FileCacheInfo" $ \o -> FileCacheInfo
-    <$> o .: "modtime"
-    <*> o .: "size"
-    <*> o .: "hash"
+    <$> o .: "hash"
 
 -- | A descriptor from a .cabal file indicating one of the following:
 --


### PR DESCRIPTION
As the issue (#5125) suggests, modified time makes using a stack cache in CI very difficult (if at all possible). This PR suggests making a change in how the build process marks a file as dirty.

Summary of changes:
- When checking the build cache, always create a digest and use that to check against the cache if it exists.
  - Note: let's discuss here about also checking for size.
- When adding unlisted files to the build cache don't check for pre build time. 
  - This was a strange call to make to begin with and looking into the commit history it looks like it was a patch for an issue about Template Haskell (#838). Removing this check does not break the fix. I ran the two test cases mentioned in the issue with latest stack version and with the modified one from this PR and it did not cause a regression.

Questions and comments:
- I wasn't able to figure out the styling, hindent seems to change too many lines. I tried to keep it as stable as possible.
- After this change mod time becomes obsolete (no uses), should we remove it? I wasn't sure how it would affect the json instance supplied to `FileCacheInfo`.
- If checking against size is not required removing size would also cleanup the process a lot more (no necessary composed tuples).
- In terms of performance I built our team's current library with about 1500 modules and there is negligible time difference between the runs. Creating the digest is pretty fast! I do however realize that I run this on a beasty machine so it would be nice to get some insight here. 