### PR TITLE
Fix building coverage report with Cabal 3

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -40,6 +40,8 @@ Bug fixes:
   pvp-bounds. See
   [#5289](https://github.com/commercialhaskell/stack/issues/5289)
 
+* Fix `stack test --coverage` when using Cabal 3
+
 ## v2.3.1
 
 Release notes:

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -434,7 +434,7 @@ findPackageFieldForBuiltPackage pkgDir pkgId internalLibs field = do
         extractField path = do
             contents <- readFileUtf8 (toFilePath path)
             case asum (map (T.stripPrefix (field <> ": ")) (T.lines contents)) of
-                Just result -> return $ Right result
+                Just result -> return $ Right $ T.strip result
                 Nothing -> notFoundErr
     cabalVer <- view cabalVersionL
     if cabalVer < mkVersion [1, 24]

--- a/test/integration/tests/3997-coverage-with-cabal-3/Main.hs
+++ b/test/integration/tests/3997-coverage-with-cabal-3/Main.hs
@@ -1,0 +1,10 @@
+import Control.Monad (unless)
+import Data.List (isInfixOf)
+import StackTest
+
+main :: IO ()
+main = do
+    stack ["setup"]
+    stackCheckStderr ["test", "--coverage"] $ \out -> do
+        unless ("The coverage report for foo's test-suite \"foo-test\" is available at" `isInfixOf` out) $
+            fail "Coverage report didn't build"

--- a/test/integration/tests/3997-coverage-with-cabal-3/files/package.yaml
+++ b/test/integration/tests/3997-coverage-with-cabal-3/files/package.yaml
@@ -1,0 +1,14 @@
+name: foo
+
+dependencies:
+  - base
+
+library:
+  source-dirs: src
+
+tests:
+  foo-test:
+    source-dirs: test
+    main: Main.hs
+    dependencies:
+      - foo

--- a/test/integration/tests/3997-coverage-with-cabal-3/files/src/Lib.hs
+++ b/test/integration/tests/3997-coverage-with-cabal-3/files/src/Lib.hs
@@ -1,0 +1,4 @@
+module Lib (foo) where
+
+foo :: Int
+foo = 1

--- a/test/integration/tests/3997-coverage-with-cabal-3/files/stack.yaml
+++ b/test/integration/tests/3997-coverage-with-cabal-3/files/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-15.0

--- a/test/integration/tests/3997-coverage-with-cabal-3/files/test/Main.hs
+++ b/test/integration/tests/3997-coverage-with-cabal-3/files/test/Main.hs
@@ -1,0 +1,4 @@
+import Lib
+
+main :: IO ()
+main = print foo


### PR DESCRIPTION
Fixes #3997 

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Added a test making sure that `stack test --coverage` for a minimal library + test suite builds a coverage report. Maybe it should be generalized to run on the latest / matrix of LTS versions?
