### PR TITLE
Fix typo in Stack/Coverage.hs

### DIFF
--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -379,7 +379,7 @@ generateHpcMarkupIndex = do
                 encodeUtf8Builder (pathToHtml outputDir) <>
                 "\".</b>"
             else
-                "<table class=\"dashboard\" width=\"100%\" boder=\"1\"><tbody>" <>
+                "<table class=\"dashboard\" width=\"100%\" border=\"1\"><tbody>" <>
                 "<p><b>NOTE: This is merely a listing of the html files found in the coverage reports directory.  Some of these reports may be old.</b></p>" <>
                 "<tr><th>Package</th><th>TestSuite</th><th>Modification Time</th></tr>" <>
                 foldMap encodeUtf8Builder rows <>


### PR DESCRIPTION
Fixed typo in table's "border" attribute. It didn't affect table style before because its every child draws own border.
