### PR TITLE
Fix #5356 Allow all colours to be customised

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,9 @@ Other enhancements:
 * Build failures now show a hint to scroll up to the corresponding section
   [#5279](https://github.com/commercialhaskell/stack/issues/5279)
 * Add the `stack-developer-mode` flag
+* Customisable output styles (see `stack --help` and the `--stack-colors`
+  option, and `stack ls stack-colors --help`) now include `info`, `debug`,
+  `other-level`, `secondary` and `highlight`, used with verbose output.
 
 Bug fixes:
 
@@ -118,7 +121,7 @@ Other enhancements:
   prefixes each build log output line with a timestamp.
 
 * Show warning about `local-programs-path` with spaces on windows
-  when running scripts. See 
+  when running scripts. See
   [#5013](https://github.com/commercialhaskell/stack/pull/5013)
 
 * Add `ls dependencies json` which will print dependencies as JSON.

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -614,7 +614,7 @@ Specify a variant binary distribution of GHC to use.  Known values:
 * `integersimple`: Use a GHC bindist that uses
   [integer-simple instead of GMP](https://ghc.haskell.org/trac/ghc/wiki/ReplacingGMPNotes)
 * any other value: Use a custom GHC bindist. You should specify
-  [setup-info](#setup-info) or [setup-info-locations](#setup-info-locations) 
+  [setup-info](#setup-info) or [setup-info-locations](#setup-info-locations)
   so `stack setup` knows where to download it,
   or pass the `stack setup --ghc-bindist` argument on the command-line
 
@@ -1143,11 +1143,12 @@ For example, users of the popular
 terminal theme might wish to set the styles as follows:
 
 ```yaml
-stack-colors: error=31:good=32:shell=35:dir=34:recommendation=32:target=95:module=35:package-component=95
+stack-colors: error=31:good=32:shell=35:dir=34:recommendation=32:target=95:module=35:package-component=95:secondary=92:highlight=32
 ```
 The styles can also be set at the command line using the equivalent `--stack-colors=<STYLES>`
 global option. Styles set at the command line take precedence over those set in
-a yaml configuration file.
+a yaml configuration file. (In respect of styles used in verbose output, some of
+that output occurs before the configuration file is processed.)
 
 (The British English spelling (colour) is also accepted. In yaml configuration
 files, the American spelling is the alternative that has priority.)

--- a/package.yaml
+++ b/package.yaml
@@ -106,8 +106,8 @@ dependencies:
 - project-template
 - regex-applicative-text
 - retry
-- rio
-- rio-prettyprint
+- rio >= 0.1.18.0
+- rio-prettyprint >= 0.1.1.0
 - semigroups
 - split
 - stm

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -148,15 +148,8 @@ withRunnerGlobal go inner = do
                                     <$> getTerminalWidth)
                                    pure (globalTermWidth go)
   menv <- mkDefaultProcessContext
-  logOptions0 <- logOptionsHandle stderr False
-  let logOptions
-        = setLogUseColor useColor
-        $ setLogUseTime (globalTimeInLog go)
-        $ setLogMinLevel (globalLogLevel go)
-        $ setLogVerboseFormat (globalLogLevel go <= LevelDebug)
-        $ setLogTerminal (globalTerminal go)
-          logOptions0
-  withLogFunc logOptions $ \logFunc -> runRIO Runner
+  let update = globalStylesUpdate go
+  withNewLogFunc go useColor update $ \logFunc -> runRIO Runner
     { runnerGlobalOpts = go
     , runnerUseColor = useColor
     , runnerLogFunc = logFunc

--- a/stack.cabal
+++ b/stack.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2a288b315557ca9df67fb60c003674a0dd6618aa5f8bc2b04527fb8feae4b16d
+-- hash: 40180d8b137f1935be8e5493b14ff579fc5174c0bd488f713b1020be585169e1
 
 name:           stack
 version:        2.4.0
@@ -284,8 +284,8 @@ library
     , project-template
     , regex-applicative-text
     , retry
-    , rio
-    , rio-prettyprint
+    , rio >=0.1.18.0
+    , rio-prettyprint >=0.1.1.0
     , semigroups
     , split
     , stm
@@ -408,8 +408,8 @@ executable stack
     , project-template
     , regex-applicative-text
     , retry
-    , rio
-    , rio-prettyprint
+    , rio >=0.1.18.0
+    , rio-prettyprint >=0.1.1.0
     , semigroups
     , split
     , stack
@@ -531,8 +531,8 @@ executable stack-integration-test
     , project-template
     , regex-applicative-text
     , retry
-    , rio
-    , rio-prettyprint
+    , rio >=0.1.18.0
+    , rio-prettyprint >=0.1.1.0
     , semigroups
     , split
     , stm
@@ -660,8 +660,8 @@ test-suite stack-test
     , raw-strings-qq
     , regex-applicative-text
     , retry
-    , rio
-    , rio-prettyprint
+    , rio >=0.1.18.0
+    , rio-prettyprint >=0.1.1.0
     , semigroups
     , smallcheck
     , split

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,6 +29,8 @@ extra-deps:
 - http-download-0.2.0.0@rev:0
 - filelock-0.1.1.5@rev:0
 - pantry-0.5.1.1@rev:0
+- rio-0.1.18.0@rev:0
+- rio-prettyprint-0.1.1.0@rev:0
 - casa-client-0.0.1@rev:0
 - casa-types-0.0.1@rev:0
 


### PR DESCRIPTION
Adds a new helper function `Stack.Config.withNewLogFunc`, used in `Stack.Config.configFromConfigMonoid` and in `Stack.Runners.withRunnerGlobal`. As indicated in the code comments, the function runs the provided action with a new `LogFunc`, given a `StylesUpdate`.

Depends on `rio-0.1.18.0`, which now includes colours in `LogOptions`, and `rio-prettyprint-0.1.1.0`.

However, I have not been able to identify why the 'SQL'-type debug log messages pick up the `LogFunc` from `withRunnerGlobal` and not the `LogFunc` fron `configFromConfigMonoid` - or by what mechanism the `LogFunc` is picked up in lines such as the one below (taken from `Stack.Storage.User.loadCompilerPaths` - the line generates a 'SQL'-type debug log message):

```haskell
mres <- withUserStorage $ getBy $ UniqueCompilerInfo $ toFilePath compiler
```

In that sense, the 'fix' works but is not quite complete. I will need assistance to be able to complete the fix myself. 

Tested by building and using `stack` on Windows 10 version 2004.

EDIT: I have also updated the following:
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.