### PR TITLE
Fix #5364 Add the new LogFunc to the environment too

### DIFF
--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -403,7 +403,7 @@ configFromConfigMonoid
 
      withNewLogFunc go useColor'' stylesUpdate' $ \logFunc -> do
        let configRunner = configRunner'' & logFuncL .~ logFunc
-       withPantryConfig
+       withLocalLogFunc logFunc $ withPantryConfig
          pantryRoot
          hsc
          (maybe HpackBundled HpackCommand $ getFirst configMonoidOverrideHpack)
@@ -414,6 +414,10 @@ configFromConfigMonoid
          (\configPantryConfig -> initUserStorage
            (configStackRoot </> relFileStorage)
            (\configUserStorage -> inner Config {..}))
+
+-- | Runs the provided action with the given 'LogFunc' in the environment
+withLocalLogFunc :: HasLogFunc env => LogFunc -> RIO env a -> RIO env a
+withLocalLogFunc logFunc = local (set logFuncL logFunc)
 
 -- | Runs the provided action with a new 'LogFunc', given a 'StylesUpdate'.
 withNewLogFunc :: MonadUnliftIO m


### PR DESCRIPTION
The 'SQL' debug log messages take their logging function from the environment, not from the `configRunner` of the `Config`. This proposed change uses a new helper function, `withLocalLogFunc`, to modify that part of the environment.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Tested by building, installing and using `stack` with the change on Windows 10 version 2004.