### PR TITLE
Fix 'cabal file warnings', when building stack

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -137,8 +137,9 @@ when:
     dependencies:
     - Win32
   else:
-    build-tools:
-    - hsc2hs
+    verbatim: |
+      build-tool-depends:
+          hsc2hs:hsc2hs
     dependencies:
     - unix
 - condition: flag(developer-mode)

--- a/stack.cabal
+++ b/stack.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 40180d8b137f1935be8e5493b14ff579fc5174c0bd488f713b1020be585169e1
+-- hash: 2991e5ffcda3a90f2be71a0df883bf7706afef078dd3cc0abfc98868a3e8028f
 
 name:           stack
 version:        2.4.0
@@ -313,10 +313,10 @@ library
     build-depends:
         Win32
   else
-    build-tools:
-        hsc2hs
     build-depends:
         unix
+    build-tool-depends:
+        hsc2hs:hsc2hs
   if flag(developer-mode)
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=True
   else
@@ -438,10 +438,10 @@ executable stack
     build-depends:
         Win32
   else
-    build-tools:
-        hsc2hs
     build-depends:
         unix
+    build-tool-depends:
+        hsc2hs:hsc2hs
   if flag(developer-mode)
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=True
   else
@@ -560,10 +560,10 @@ executable stack-integration-test
     build-depends:
         Win32
   else
-    build-tools:
-        hsc2hs
     build-depends:
         unix
+    build-tool-depends:
+        hsc2hs:hsc2hs
   if flag(developer-mode)
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=True
   else
@@ -691,10 +691,10 @@ test-suite stack-test
     build-depends:
         Win32
   else
-    build-tools:
-        hsc2hs
     build-depends:
         unix
+    build-tool-depends:
+        hsc2hs:hsc2hs
   if flag(developer-mode)
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=True
   else


### PR DESCRIPTION
When building `stack` with `stack build` on Windows 10 version 2004 (the version currently in the respository), I get the following warnings:

```
Cabal file warning inC:\Users\mikep\Documents\Code\GitHub\stack\stack.cabal@694:5: The field "build-tools" is deprecated in the Cabal specification version 2.0. Please use 'build-tool-depends' field
Cabal file warning inC:\Users\mikep\Documents\Code\GitHub\stack\stack.cabal@563:5: The field "build-tools" is deprecated in the Cabal specification version 2.0. Please use 'build-tool-depends' field
Cabal file warning inC:\Users\mikep\Documents\Code\GitHub\stack\stack.cabal@441:5: The field "build-tools" is deprecated in the Cabal specification version 2.0. Please use 'build-tool-depends' field
Cabal file warning inC:\Users\mikep\Documents\Code\GitHub\stack\stack.cabal@316:5: The field "build-tools" is deprecated in the Cabal specification version 2.0. Please use 'build-tool-depends' field
```

In case it is relevant (after applying the fix):

```
stack exec -- cabal --version
cabal-install version 3.2.0.0
compiled using version 3.2.0.0 of the Cabal library
```

I understand that `hpack` does not generate `build-tool-depends` fields for `hsc2hs`. This proposed pull request fixes the warnings, by using `hpack`'s `verbatim` feature.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Tested by building, and using, `stack` on Windows 10 version 2004.