### PR TITLE
breaking change with optparse-applicative 0.16.0.0

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -91,7 +91,7 @@ dependencies:
 - neat-interpolation
 - network-uri
 - open-browser
-- optparse-applicative
+- optparse-applicative >= 0.15.0.0 && < 0.16.0.0
 - pantry
 - casa-client
 - casa-types

--- a/package.yaml
+++ b/package.yaml
@@ -91,7 +91,7 @@ dependencies:
 - neat-interpolation
 - network-uri
 - open-browser
-- optparse-applicative >= 0.15.0.0 && < 0.16.0.0
+- optparse-applicative >=0.14.0.0 && < 0.16.0.0
 - pantry
 - casa-client
 - casa-types

--- a/stack.cabal
+++ b/stack.cabal
@@ -271,7 +271,7 @@ library
     , neat-interpolation
     , network-uri
     , open-browser
-    , optparse-applicative
+    , optparse-applicative >=0.14.0.0 && < 0.16.0.0
     , pantry
     , path
     , path-io


### PR DESCRIPTION
cannot compile with cabal since there is a breaking change with optparse-applicative 0.16.0.0 release
