### PR TITLE
doc/installation: Fedora now has a stack package

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -139,12 +139,8 @@ so we recommend running `stack upgrade` after installing it.
 
 Use the [generic Linux option](#linux).
 
-There is also an
-unofficial
-[Fedora Copr repo](https://copr.fedoraproject.org/coprs/petersen/stack2/) which
-can be enabled with: `sudo dnf copr enable petersen/stack2`. Note that this Stack
-version may lag behind, so we recommend running `stack upgrade` after installing
-it.
+Fedora includes builds of stack, but the version may lag behind,
+so we recommend running `stack upgrade` after installing it.
 
 ## <a name="suse"></a>openSUSE / SUSE Linux Enterprise
 


### PR DESCRIPTION
update Fedora installation instructions to mention the Fedora package rather than the obsolete copr.