### PR TITLE
Make on_path() more robust

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -728,19 +728,11 @@ has_cmd() {
 
 # Check whether the given (query) path is listed in the PATH environment variable.
 on_path() {
-    # Below we normalize PATH and query regarding ~ by ensuring ~ is expanded to $HOME, avoiding
+    # Below we normalize PATH and query by ensuring ~ is expanded to $HOME, avoiding
     # false negatives in case where ~ is expanded in query but not in PATH and vice versa.
-
     # NOTE: If PATH or query have '|' somewhere in it, sed commands bellow will fail due to using | as their delimiter.
-
-    # If ~ is after : or if it is the first character in the path, replace it with expanded $HOME.
-    # For example, if $PATH is ~/martin/bin:~/martin/~tmp/bin,
-    # result will be /home/martin/bin:/home/martin/~tmp/bin .
     local PATH_NORMALIZED=$(printf '%s' "$PATH" | sed -e "s|:~|:$HOME|g" | sed -e "s|^~|$HOME|")
-
-    # Replace ~ with expanded $HOME if it is the first character in the query path.
     local QUERY_NORMALIZED=$(printf '%s' "$1" | sed -e "s|^~|$HOME|")
-
     echo ":$PATH_NORMALIZED:" | grep -q ":$QUERY_NORMALIZED:"
 }
 

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -728,12 +728,20 @@ has_cmd() {
 
 # Check whether the given (query) path is listed in the PATH environment variable.
 on_path() {
-    # We normalize PATH and query regarding ~ by ensuring ~ is expanded to $HOME, avoiding
+    # Below we normalize PATH and query regarding ~ by ensuring ~ is expanded to $HOME, avoiding
     # false negatives in case where ~ is expanded in query but not in PATH and vice versa.
-    local PATH_BOUNDED=":$PATH:"
-    local PATH_NORMALIZED="${PATH_BOUNDED//:\~/:$HOME}" # Expand all ~ that are after :
-    local QUERY_NORMALIZED=":${1/#\~/$HOME}:" # Expand ~ if it is first character.
-    echo "$PATH_NORMALIZED" | grep -q "$QUERY_NORMALIZED"
+
+    # NOTE: If PATH or query have '|' somewhere in it, sed commands bellow will fail due to using | as their delimiter.
+
+    # If ~ is after : or if it is the first character in the path, replace it with expanded $HOME.
+    # For example, if $PATH is ~/martin/bin:~/martin/~tmp/bin,
+    # result will be /home/martin/bin:/home/martin/~tmp/bin .
+    local PATH_NORMALIZED=$(printf '%s' "$PATH" | sed -e "s|:~|:$HOME|g" | sed -e "s|^~|$HOME|")
+
+    # Replace ~ with expanded $HOME if it is the first character in the query path.
+    local QUERY_NORMALIZED=$(printf '%s' "$1" | sed -e "s|^~|$HOME|")
+
+    echo ":$PATH_NORMALIZED:" | grep -q ":$QUERY_NORMALIZED:"
 }
 
 # Check whether ~/.local/bin is on the PATH, and print a warning if not.

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -726,9 +726,14 @@ has_cmd() {
   command -v "$1" > /dev/null 2>&1
 }
 
-# Check whether the given path is listed in the PATH environment variable
+# Check whether the given (query) path is listed in the PATH environment variable.
 on_path() {
-  echo ":$PATH:" | grep -q :"$1":
+    # We normalize PATH and query regarding ~ by ensuring ~ is expanded to $HOME, avoiding
+    # false negatives in case where ~ is expanded in query but not in PATH and vice versa.
+    local PATH_BOUNDED=":$PATH:"
+    local PATH_NORMALIZED="${PATH_BOUNDED//:\~/:$HOME}" # Expand all ~ that are after :
+    local QUERY_NORMALIZED=":${1/#\~/$HOME}:" # Expand ~ if it is first character.
+    echo "$PATH_NORMALIZED" | grep -q "$QUERY_NORMALIZED"
 }
 
 # Check whether ~/.local/bin is on the PATH, and print a warning if not.


### PR DESCRIPTION
I was getting false negatives from the get_stack script in the case where my PATH contained `~/.local/bin`, script saying that `/home/martin/.local/bin` is not on PATH.

With this change, paths are normalized by expanding ~ so false negatives like this one should not be happening any more.

This however does make the function significantly more complicated, and it could be questionable if it is worth it. There is also problem with sed commands - they will fails if paths contain `|`. I couldn't figure out a way to go around this, since from what I read, any character can be in theory used in the filepath. Happy to hear your opinion on it!

----------

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md -> In this case none.
* [x] The documentation has been updated, if necessary. -> In this case, no.

I tested manually in interactive shell with different scenarios, and I also tested by running my install script which has the same function.
