### PR TITLE
Documentation fix: change the exec subcommand for pacman on Windows

### DIFF
--- a/doc/developing_on_windows.md
+++ b/doc/developing_on_windows.md
@@ -49,9 +49,11 @@ pacman, so have a look to see what works for you. Both tools can be
 installed with the commands:
 
 ```
-stack exec -- pacman -S mingw-w64-x86_64-make
-stack exec -- pacman -S mingw-w64-x86_64-cmake
+stack exec -- pacman -- -S mingw-w64-x86_64-make
+stack exec -- pacman -- -S mingw-w64-x86_64-cmake
 ```
+Note that in the command example above, arguments starting with `-`
+are also prepended with `--`.
 
 Even though make and cmake are then both installed into the same
 environment. Cmake still seems to have trouble to find make. To help


### PR DESCRIPTION
When invoking pacman subcommands on windows, the argument flags
should also be escaped. Otherwise stack will take them are arguments to
it self.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ x ] The documentation has been updated, if necessary.
