### PR TITLE
Fix `stack build` & improve `stack path` help text

### DIFF
--- a/src/Stack/Options/BuildMonoidParser.hs
+++ b/src/Stack/Options/BuildMonoidParser.hs
@@ -112,7 +112,7 @@ buildOptsMonoidParser hide0 =
     copyBins =
         firstBoolFlagsFalse
             "copy-bins"
-            "copying binaries to the local-bin-path (see 'stack path')"
+            "copying binaries to local-bin (see 'stack path')"
             hide
     copyCompilerTool =
         firstBoolFlagsFalse

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -167,7 +167,7 @@ paths =
     , ( "Directory containing binaries specific to a particular compiler (e.g. intero)"
       , "compiler-tools-bin"
       , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . piToolsDir )
-    , ( "Local bin dir where stack installs executables (e.g. ~/.local/bin)"
+    , ( "Local bin dir where stack installs executables (e.g. ~/.local/bin (Unix-like OSs) or %APPDATA%\\local\\bin (Windows))"
       , "local-bin"
       , WithoutHaddocks $ view $ configL.to configLocalBin.to toFilePathNoTrailingSep.to T.pack)
     , ( "Extra include directories"


### PR DESCRIPTION
Updates `stack build` help text to reflect that, under `stack path`, `local-bin-path` is deprecated and replaced by `local-bin`.

Updates `stack path` help text to reflect Windows default in addition to default for Unix-like OSs.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md N/A
* [x] The documentation has been updated, if necessary. N/A

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested by building and using on Windows 10 version 2004.