### PR TITLE
Warn, not error, on duplicate modules (fixes #5407)

### DIFF
--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -823,7 +823,7 @@ checkForDuplicateModules :: HasTerm env => [GhciPkgInfo] -> RIO env ()
 checkForDuplicateModules pkgs = do
     unless (null duplicates) $ do
         borderedWarning $ do
-            prettyError $ "Multiple files use the same module name:" <>
+            prettyWarn $ "Multiple files use the same module name:" <>
               line <> bulletedList (map prettyDuplicate duplicates)
         -- MSS 2020-10-13 Disabling, may remove entirely in the future
         -- See: https://github.com/commercialhaskell/stack/issues/5407#issuecomment-707339928

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -825,7 +825,9 @@ checkForDuplicateModules pkgs = do
         borderedWarning $ do
             prettyError $ "Multiple files use the same module name:" <>
               line <> bulletedList (map prettyDuplicate duplicates)
-        throwM LoadingDuplicateModules
+        -- MSS 2020-10-13 Disabling, may remove entirely in the future
+        -- See: https://github.com/commercialhaskell/stack/issues/5407#issuecomment-707339928
+        -- throwM LoadingDuplicateModules
   where
     duplicates :: [(ModuleName, Map (Path Abs File) (Set (PackageName, NamedComponent)))]
     duplicates =


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

I tested by trying out the repro from #5407