### PR TITLE
Support Linux Sparc

### DIFF
--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -1245,6 +1245,7 @@ getOSKey platform =
         Platform X86_64                Cabal.Windows -> return "windows64"
         Platform Arm                   Cabal.Linux   -> return "linux-armv7"
         Platform AArch64               Cabal.Linux   -> return "linux-aarch64"
+        Platform Sparc                 Cabal.Linux   -> return "linux-sparc"
         Platform arch os -> throwM $ UnsupportedSetupCombo os arch
 
 downloadOrUseLocal


### PR DESCRIPTION
Due to monadic nature of the platform detection (`getOSKey`), each platform we want to runs `stack` from needs to be explicitly spelled out.
This change only affects the specified platform by allowing to install additional tools and `ghc`s.
