### PR TITLE
add 'list' command to query package-version in snapshot

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,9 @@ Behavior changes:
 
 Other enhancements:
 
+* `stack list` is a new command to list package versions in a snapshot.
+  See [#5431](https://github.com/commercialhaskell/stack/pull/5431)
+
 Bug fixes:
 
 * `stack new` now suppports branches other than `master` as default for

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1666,6 +1666,9 @@ users. Here's a quick rundown:
   (`-l`) and nightly (`-n`) snapshots.
 * `stack ls dependencies` lists all of the packages and versions used for a
   project
+* `stack list [PACKAGE]...` list the version of the specified package(s) in a
+  snapshot, or without an argument list all the snapshot's package versions.
+  If no resolver is specified the latest package version from Hackage is given.
 * `stack sig` subcommand can help you with GPG signing & verification
     * `sign` will sign an sdist tarball and submit the signature to
       sig.commercialhaskell.org for storage in the sig-archive git repo.

--- a/package.yaml
+++ b/package.yaml
@@ -194,6 +194,7 @@ library:
   - Stack.Hoogle
   - Stack.IDE
   - Stack.Init
+  - Stack.List
   - Stack.Ls
   - Stack.Lock
   - Stack.New

--- a/src/Stack/List.hs
+++ b/src/Stack/List.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Stack.List
+  ( listPackages
+  ) where
+
+import Stack.Prelude
+import qualified RIO.Map as Map
+import RIO.List (intercalate)
+import RIO.Process (HasProcessContext)
+
+newtype ListException
+  = CouldNotParsePackageSelectors [String]
+    deriving Typeable
+instance Exception ListException
+instance Show ListException where
+    show (CouldNotParsePackageSelectors strs) = unlines $ map ("- " ++) strs
+
+-- | Intended to work for the command line command.
+listPackages
+  :: forall env. (HasPantryConfig env, HasLogFunc env, HasProcessContext env)
+  => Maybe RawSnapshot -- ^ when looking up by name, take from this build plan
+  -> [String] -- ^ names or identifiers
+  -> RIO env ()
+listPackages mSnapshot input = do
+    let (errs1, names) = case mSnapshot of
+                   Just snapshot | null input ->
+                                     ([], Map.keys (rsPackages snapshot))
+                   _ -> partitionEithers $ map parse input
+    (errs2, locs) <- partitionEithers <$> traverse toLoc names
+    case errs1 ++ errs2 of
+      [] -> pure ()
+      errs -> throwM $ CouldNotParsePackageSelectors errs
+    mapM_ (logInfo . fromString . packageIdentifierString) locs
+  where
+    toLoc | Just snapshot <- mSnapshot = toLocSnapshot snapshot
+          | otherwise = toLocNoSnapshot
+
+    toLocNoSnapshot :: PackageName -> RIO env (Either String PackageIdentifier)
+    toLocNoSnapshot name = do
+      mloc1 <- getLatestHackageLocation YesRequireHackageIndex name UsePreferredVersions
+      mloc <-
+        case mloc1 of
+          Just _ -> pure mloc1
+          Nothing -> do
+            updated <- updateHackageIndex $ Just $ "Could not find package " <> fromString (packageNameString name) <> ", updating"
+            case updated of
+              UpdateOccurred -> getLatestHackageLocation YesRequireHackageIndex name UsePreferredVersions
+              NoUpdateOccurred -> pure Nothing
+      case mloc of
+        Nothing -> do
+          candidates <- getHackageTypoCorrections name
+          pure $ Left $ concat
+            [ "Could not find package "
+            , packageNameString name
+            , " on Hackage"
+            , if null candidates
+                then ""
+                else ". Perhaps you meant: " ++ intercalate ", " (map packageNameString candidates)
+            ]
+        Just loc -> pure $ Right (packageLocationIdent loc)
+
+    toLocSnapshot :: RawSnapshot -> PackageName -> RIO env (Either String PackageIdentifier)
+    toLocSnapshot snapshot name =
+        case Map.lookup name (rsPackages snapshot) of
+          Nothing ->
+            pure $ Left $ "Package does not appear in snapshot: " ++ packageNameString name
+          Just sp -> do
+            loc <- cplComplete <$> completePackageLocation (rspLocation sp)
+            pure $ Right (packageLocationIdent loc)
+
+    parse s =
+        case parsePackageName s of
+            Just x -> Right x
+            Nothing -> Left $ "Could not parse as package name or identifier: " ++ s

--- a/stack.cabal
+++ b/stack.cabal
@@ -149,6 +149,7 @@ library
       Stack.Hoogle
       Stack.IDE
       Stack.Init
+      Stack.List
       Stack.Ls
       Stack.Lock
       Stack.New


### PR DESCRIPTION
currently not working for core ghc libs with resolver

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

```
$ stack list zlib
zlib-0.6.2.2
$ stack --resolver lts-13 list zlib
Selected resolver: lts-13.30
zlib-0.6.2
```