### PR TITLE
Do not prompt user when overwriting stack binary on Windows

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -278,7 +278,7 @@ do_windows_install() {
     # should never happen, the -d flag appends stack itself
     die "Currently the destination must always end with 'stack' on Windows, got: $DEST"
   fi
-  if ! 7z x $STACK_TEMP_DIR/stack.zip stack.exe "-o$(dirname $DEST)"; then
+  if ! 7z x $STACK_TEMP_DIR/stack.zip stack.exe "-o$(dirname $DEST)" -y; then
     die "Extract zip file failed, you probably don't have 7z installed"
   fi
   post_install_separator


### PR DESCRIPTION

Using current `get-stack.sh` script on windows results in this prompt when `stack` is already present which naturally causes the script to fail on CI if stack was restored with cache or was already installed (eg. Github Actions already has stack installed):
```
7-Zip 19.00 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2019-02-21

Scanning the drive for archives:
1 file, 16509987 bytes (16 MiB)

Extracting archive: C:\Users\RUNNER~1\AppData\Local\Temp\tmp.LHN5OanPDA\stack.zip
--
Path = C:\Users\RUNNER~1\AppData\Local\Temp\tmp.LHN5OanPDA\stack.zip
Type = zip
Physical Size = 16509987


Would you like to replace the existing file:
  Path:     C:/hostedtoolcache/windows/stack/2.5.1/x64\stack.exe
  Size:     72569344 bytes (70 MiB)
  Modified: 2020-10-15 15:26:04
with the file from archive:
  Path:     stack.exe
  Size:     72569344 bytes (70 MiB)
  Modified: 2020-10-15 15:26:04

? (Y)es / (N)o / (A)lways / (S)kip all / A(u)to rename all / (Q)uit? (Y)es / (N)o / (A)lways / (S)kip all / A(u)to rename all / (Q)uit? 

Archives with Errors: 1
Break signaled

Extract zip file failed, you probably don't have 7z installed
Error: Process completed with exit code 1.
```

In order to fix this we need to mimic behavior on  other OSes and overwrite the binary without prompting user for confirmation, which is exactly the fix in this script.

-----

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
