### PR TITLE
Adds Flag to Upload Package Candidate

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -35,6 +35,9 @@ Other enhancements:
   stack to be aware of any custom preprocessors you have added to `Setup.hs`.
   See [#3491](https://github.com/commercialhaskell/stack/issues/3491)
 
+* Added `--candidate` flag to `upload` command to upload a package candidate
+  rather than publishing the package.
+
 Bug fixes:
 
 * `stack new` now suppports branches other than `master` as default for

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1663,6 +1663,7 @@ users. Here's a quick rundown:
   per
   [our blog post](https://www.fpcomplete.com/blog/2016/05/stack-security-gnupg-keys).
     * `--no-signature` disables signing of packages
+    * `--candidate` upload a [package candidate](http://hackage.haskell.org/upload#candidates)
     * `username` and `password` can be read by environment
 
     ```bash

--- a/package.yaml
+++ b/package.yaml
@@ -222,6 +222,7 @@ library:
   - Stack.Options.ScriptParser
   - Stack.Options.SDistParser
   - Stack.Options.TestParser
+  - Stack.Options.UploadParser
   - Stack.Options.Utils
   - Stack.Package
   - Stack.PackageDump

--- a/src/Stack/Options/SDistParser.hs
+++ b/src/Stack/Options/SDistParser.hs
@@ -7,7 +7,7 @@ import           Stack.Prelude
 import           Stack.SDist
 import           Stack.Options.HpcReportParser (pvpBoundsOption)
 
--- | Parser for arguments to `stack sdist` and `stack upload`
+-- | Parser for arguments to `stack sdist`
 sdistOptsParser :: Parser SDistOpts
 sdistOptsParser = SDistOpts <$>
   many (strArgument $ metavar "DIR" <> completer dirCompleter) <*>

--- a/src/Stack/Options/UploadParser.hs
+++ b/src/Stack/Options/UploadParser.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Stack.Options.UploadParser
+  ( UploadOpts(..)
+  , UploadVariant(..)
+  , uploadOptsParser
+  ) where
+
+import           Options.Applicative
+import           Stack.Options.SDistParser (sdistOptsParser)
+import           Stack.Prelude
+import           Stack.SDist (SDistOpts(..))
+
+data UploadOpts = UploadOpts
+  { uoptsSDistOpts :: SDistOpts
+  , uoptsUploadVariant :: UploadVariant
+  -- ^ Says whether to publish the package or upload as a release candidate
+  }
+
+data UploadVariant
+  = Publishing
+  -- ^ Publish the package
+  | Candidate
+  -- ^ Create a package candidate
+
+-- | Parser for arguments to `stack upload`
+uploadOptsParser :: Parser UploadOpts
+uploadOptsParser =
+  UploadOpts
+    <$> sdistOptsParser
+    <*> uploadVariant
+  where
+    uploadVariant =
+      flag Publishing Candidate
+        (long "candidate" <>
+         help "Upload as a package candidate")

--- a/stack.cabal
+++ b/stack.cabal
@@ -177,6 +177,7 @@ library
       Stack.Options.ScriptParser
       Stack.Options.SDistParser
       Stack.Options.TestParser
+      Stack.Options.UploadParser
       Stack.Options.Utils
       Stack.Package
       Stack.PackageDump


### PR DESCRIPTION
This adds a `--candidate` flag to the `upload` command to upload
a package candidate rather than publishing the package.
This is useful for checking that everything looks right before
publishing. (see https://hackage.haskell.org/upload#candidates)

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I have tested that passing the `--candidate` flag creates a package candidate on hackage.
