### PR TITLE
GitHub API URL to support arbitrary default branches for templates

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ Other enhancements:
 
 Bug fixes:
 
+* `stack new` now suppports branches other than `master` as default for
+  GitHub repositories. See
+  [#5422](https://github.com/commercialhaskell/stack/issues/5422)
 
 ## v2.5.1
 

--- a/src/Network/HTTP/StackClient.hs
+++ b/src/Network/HTTP/StackClient.hs
@@ -11,6 +11,7 @@ module Network.HTTP.StackClient
   , httpNoBody
   , httpSink
   , withResponse
+  , setRequestCheckStatus
   , setRequestMethod
   , setRequestHeader
   , addRequestHeader
@@ -66,7 +67,7 @@ import           Data.Monoid (Sum (..))
 import qualified Data.Text as T
 import           Data.Time.Clock (NominalDiffTime, diffUTCTime, getCurrentTime)
 import           Network.HTTP.Client (Request, RequestBody(..), Response, parseRequest, getUri, path, checkResponse, parseUrlThrow)
-import           Network.HTTP.Simple (setRequestMethod, setRequestBody, setRequestHeader, addRequestHeader, HttpException(..), getResponseBody, getResponseStatusCode, getResponseHeaders)
+import           Network.HTTP.Simple (setRequestCheckStatus, setRequestMethod, setRequestBody, setRequestHeader, addRequestHeader, HttpException(..), getResponseBody, getResponseStatusCode, getResponseHeaders)
 import           Network.HTTP.Types (hAccept, hContentLength, hContentMD5, methodPut)
 import           Network.HTTP.Conduit (requestHeaders)
 import           Network.HTTP.Client.TLS (getGlobalManager, applyDigestAuth, displayDigestAuthException)


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Resolves #5422 
Tested manually
