### PR TITLE
Support build with persistent-2.11 and optparse-applicative-0.16

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## v2.5.1.1
+
+Hackage-only release:
+
+* Support build with persistent-2.11.x and optparse-applicative-0.16.x
+
+
 ## v2.5.1
 
 **Changes since v2.3.3**

--- a/etc/scripts/mirror-ghc-bindists-to-github.sh
+++ b/etc/scripts/mirror-ghc-bindists-to-github.sh
@@ -93,7 +93,7 @@ mirror x86_64-unknown-mingw32 "" xz xz windows64
 mirror x86_64-unknown-freebsd "" xz xz freebsd64-11
 mirror aarch64-deb10-linux "" xz xz linux-aarch64
 mirror armv7-deb10-linux "" xz xz linux-armv7
-#mirror x86_64-alpine3.10-linux-integer-simple "" xz xz @@@
+#mirror x86_64-alpine3.10-linux-integer-simple "" xz xz
 
 mirror_ https://github.com/redneb/ghc-alt-libc/releases/download/ghc-$GHCVER-musl i386-unknown-linux-musl "" xz xz linux32-musl
 mirror_ https://github.com/redneb/ghc-alt-libc/releases/download/ghc-$GHCVER-musl x86_64-unknown-linux-musl "" xz xz linux64-musl

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stack
-version: '2.5.1'
+version: '2.5.1.1'
 synopsis: The Haskell Tool Stack
 description: |
   Please see the documentation at <https://docs.haskellstack.org>

--- a/src/Options/Applicative/Builder/Extra.hs
+++ b/src/Options/Applicative/Builder/Extra.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -31,6 +32,7 @@ module Options.Applicative.Builder.Extra
   ,defaultPathCompleterOpts
   ,pathCompleterWith
   ,unescapeBashArg
+  ,showHelpText
   ) where
 
 import Data.List (isPrefixOf)
@@ -164,7 +166,7 @@ execExtraHelp args helpOpt parser pd =
                                 some (strArgument (metavar "OTHER ARGUMENTS") :: Parser String)))
                         (fullDesc <> progDesc pd))
         return ()
-  where hiddenHelper = abortOption ShowHelpText (long "help" <> hidden <> internal)
+  where hiddenHelper = abortOption showHelpText (long "help" <> hidden <> internal)
 
 -- | 'option', specialized to 'Text'.
 textOption :: Mod OptionFields Text -> Parser Text
@@ -283,3 +285,10 @@ unescapeBashArg input = go input
     go [] = []
     go ('\\' : x : xs) = x : go xs
     go (x : xs) = x : go xs
+
+showHelpText :: ParseError
+#if MIN_VERSION_optparse_applicative(0,16,0)
+showHelpText = ShowHelpText Nothing
+#else
+showHelpText = ShowHelpText
+#endif

--- a/src/Options/Applicative/Complicated.hs
+++ b/src/Options/Applicative/Complicated.hs
@@ -17,6 +17,7 @@ import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Writer
 import           Options.Applicative
 import           Options.Applicative.Types
+import           Options.Applicative.Builder.Extra
 import           Options.Applicative.Builder.Internal
 import           Stack.Prelude
 import           System.Environment
@@ -152,6 +153,6 @@ hsubparser' commandMetavar m = mkParser d g rdr
 -- | Non-hidden help option.
 helpOption :: Parser (a -> a)
 helpOption =
-    abortOption ShowHelpText $
+    abortOption showHelpText $
     long "help" <>
     help "Show this help text"

--- a/src/Stack/Storage/Project.hs
+++ b/src/Stack/Storage/Project.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}

--- a/src/Stack/Storage/User.hs
+++ b/src/Stack/Storage/User.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}

--- a/stack-ghc-810.yaml
+++ b/stack-ghc-810.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-10-14
+resolver: nightly-2020-12-07
 
 packages:
 - .
@@ -20,7 +20,10 @@ ghc-options:
    "$locals": -fhide-source-paths
 
 extra-deps:
-- pantry-0.5.1.3@rev:0
+- persistent-2.11.0.1@rev:0
+- persistent-sqlite-2.11.0.0@rev:0
+- persistent-template-2.9.1.0@rev:0
+- optparse-applicative-0.16.1.0@rev:0
 
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712

--- a/stack.cabal
+++ b/stack.cabal
@@ -4,10 +4,10 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 265e6df5e6ccdf8dbeba4610b98ea6a3d437577cf7be6745d7dc94e4205de09a
+-- hash: 9b3289398fca2c9059ee52c9b32914501b027dc6fdf5e9b5b739755887cb6b0c
 
 name:           stack
-version:        2.5.1
+version:        2.5.1.1
 synopsis:       The Haskell Tool Stack
 description:    Please see the documentation at <https://docs.haskellstack.org>
                 for usage information.


### PR DESCRIPTION
This is intended to be a hackage-only patch release so that `stack` builds with the latest persistent and optparse-applicative versions.