### PR TITLE
Comp/doc and refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ tags
 .hspec-failures
 better-cache/
 stack*.yaml.lock
+stack.code-workspace

--- a/src/Control/Concurrent/Execute.hs
+++ b/src/Control/Concurrent/Execute.hs
@@ -33,6 +33,8 @@ data ActionType
     deriving (Show, Eq, Ord)
 data ActionId = ActionId !PackageIdentifier !ActionType
     deriving (Show, Eq, Ord)
+-- | This is mainly the result of one or more 'Task' in "Stack.Types.Build".
+-- Its actual content is completely contained in actionDo.
 data Action = Action
     { actionId :: !ActionId
     , actionDeps :: !(Set ActionId)

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -29,6 +29,8 @@ import           Stack.Types.GhcPkgId
 import           Stack.Types.Package
 import           Stack.Types.SourceMap
 
+-- | Returns all the stack.yaml-specified project and dependencies
+-- as a map of package names and package/file locations.
 toInstallMap :: MonadIO m => SourceMap -> m InstallMap
 toInstallMap sourceMap = do
     projectInstalls <-

--- a/src/Stack/Build/Precompiled.hs
+++ b/src/Stack/Build/Precompiled.hs
@@ -1,0 +1,198 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Cache management during a build.
+-- Handle all the pre-installed, precompiled & prebuilt stuff.
+module Stack.Build.Precompiled
+(
+    copyPreCompiled
+    , getPrecompiled
+    , loadInstalledPkg
+    , getExecutableBuildStatuses
+) where
+
+import           Stack.Prelude
+import           Stack.GhcPkg
+import           Stack.Types.Build
+import           Stack.Types.Package
+import           Stack.Types.Config
+import           Stack.Types.Execute
+import           Stack.Types.GhcPkgId
+import           Stack.Build.Cache
+import           Stack.PackageDump (conduitDumpPackage, ghcPkgDescribe)
+import qualified Data.Text as T
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Path.Extra (toFilePathNoTrailingSep)
+import Path (
+    filename, (</>), toFilePath, isProperPrefixOf, parseRelFile,
+    parseRelDir
+    )
+import qualified Data.Conduit.List as CL
+import RIO.Process (HasProcessContext, withModifyEnvVars, proc, readProcess_)
+import Path.IO (ensureDir, copyFile, doesFileExist)
+import System.PosixCompat.Files (createLink)
+import Distribution.System (OS (..), Platform (..))
+import Stack.Constants (relDirBuild)
+import Stack.Constants.Config (distDirFromDir)
+
+getPrecompiled :: HasEnvConfig env =>
+    TaskType
+    -> BaseConfigOpts
+    -> ConfigCache
+    -> RIO env (Maybe (PrecompiledCache Abs))
+getPrecompiled taskTypeVal envConfigOpts cache =
+    case taskTypeVal of
+        TTRemotePackage Immutable _ loc -> do
+            mpc <- readPrecompiledCache
+                   loc
+                   (configCacheOpts cache)
+                   (configCacheHaddock cache)
+                   (configCacheDeps cache)
+            case mpc of
+                Nothing -> return Nothing
+                -- Only pay attention to precompiled caches that refer to packages within
+                -- the snapshot.
+                Just pc | maybe False
+                                (bcoSnapInstallRoot envConfigOpts `isProperPrefixOf`)
+                                (pcLibrary pc) ->
+                    return Nothing
+                -- If old precompiled cache files are left around but snapshots are deleted,
+                -- it is possible for the precompiled file to refer to the very library
+                -- we're building, and if flags are changed it may try to copy the library
+                -- to itself. This check prevents that from happening.
+                Just pc -> do
+                    let allM _ [] = return True
+                        allM f (x:xs) = do
+                            b <- f x
+                            if b then allM f xs else return False
+                    b <- liftIO $ allM doesFileExist $ maybe id (:) (pcLibrary pc) $ pcExes pc
+                    return $ if b then Just pc else Nothing
+        _ -> return Nothing
+
+copyPreCompiled :: HasEnvConfig env =>
+    PackageName
+    -> ExecuteEnv
+    -> Task
+    -> PrecompiledCache b0
+    -> RIO env (Maybe Installed)
+copyPreCompiled pname execEnv task (PrecompiledCache mlib sublibs exes) = do
+    wc <- view $ actualCompilerVersionL.whichCompilerL
+    announceTask execEnv task "using precompiled package"
+    -- We need to copy .conf files for the main library and all sublibraries which exist in the cache,
+    -- from their old snapshot to the new one. However, we must unregister any such library in the new
+    -- snapshot, in case it was built with different flags.
+    let
+      subLibNames = map T.unpack . Set.toList $ case taskType task of
+        TTLocalMutable lp -> packageInternalLibraries $ lpPackage lp
+        TTRemotePackage _ p _ -> packageInternalLibraries p
+      PackageIdentifier name version = taskProvides task
+      mainLibName = packageNameString name
+      mainLibVersion = versionString version
+      ghcPkgName = mainLibName ++ "-" ++ mainLibVersion
+      -- z-package-z-internal for internal lib internal of package package
+      toCabalInternalLibName n = concat ["z-", mainLibName, "-z-", n, "-", mainLibVersion]
+      allToUnregister = map (const ghcPkgName) (maybeToList mlib) ++ map toCabalInternalLibName subLibNames
+      allToRegister = maybeToList mlib ++ sublibs
+    unless (null allToRegister) $ do
+        withMVar installLock $ \() -> do
+            -- We want to ignore the global and user databases.
+            -- Unfortunately, ghc-pkg doesn't take such arguments on the
+            -- command line. Instead, we'll set GHC_PACKAGE_PATH. See:
+            -- https://github.com/commercialhaskell/stack/issues/1146
+            let modifyEnv = Map.insert
+                  (ghcPkgPathEnvVar wc)
+                  (T.pack $ toFilePathNoTrailingSep $ bcoSnapDB configOpts)
+            withModifyEnvVars modifyEnv $ do
+              GhcPkgExe ghcPkgExe <- getGhcPkgExe
+              -- first unregister everything that needs to be unregistered
+              forM_ allToUnregister $ \pName -> catchAny
+                  (readProcessNull (toFilePath ghcPkgExe) [ "unregister", "--force", pName])
+                  (const (return ()))
+              -- now, register the cached conf files
+              forM_ allToRegister $ \libpath ->
+                proc (toFilePath ghcPkgExe) [ "register", "--force", toFilePath libpath] readProcess_
+    liftIO $ forM_ exes $ \exe -> do
+        ensureDir bindir
+        let dst = bindir </> filename exe
+        createLink (toFilePath exe) (toFilePath dst) `catchIO` \_ -> copyFile exe dst
+    case (mlib, exes) of
+        (Nothing, _:_) -> markExeInstalled (taskLocation task) taskProvidesVal
+        _ -> return ()
+    -- Find the package in the database
+    let pkgDbs = [bcoSnapDB configOpts]
+    case mlib of
+        Nothing -> return $ Just $ Executable taskProvidesVal
+        Just _ -> do
+            mpkgid <- loadInstalledPkg pkgDbs snapshotDumpPkg pname
+            return $ Just $
+                case mpkgid of
+                    Nothing -> assert False $ Executable taskProvidesVal
+                    Just pkgid -> Library taskProvidesVal pkgid Nothing
+  where
+    installLock = eeInstallLock execEnv
+    snapshotDumpPkg = eeSnapshotDumpPkgs execEnv
+    configOpts = eeBaseConfigOpts execEnv
+    taskProvidesVal = taskProvides task
+    bindir = bcoSnapInstallRoot configOpts </> bindirSuffix
+
+loadInstalledPkg :: (HasCompiler env,
+    HasProcessContext env, HasLogFunc env) =>
+    [Path Abs Dir]
+    -> TVar (Map GhcPkgId DumpPackage)
+    -> PackageName
+    -> RIO env (Maybe GhcPkgId)
+loadInstalledPkg pkgDbs tvar name = do
+    pkgexe <- getGhcPkgExe
+    dps <- ghcPkgDescribe pkgexe name pkgDbs $ conduitDumpPackage .| CL.consume
+    case dps of
+        [] -> return Nothing
+        [dp] -> do
+            liftIO $ atomically $ modifyTVar' tvar (Map.insert (dpGhcPkgId dp) dp)
+            return $ Just (dpGhcPkgId dp)
+        _ -> error $ "singleBuild: invariant violated: multiple results when describing installed package " ++ show (name, dps)
+
+-- | Get the build status of all the package executables.
+-- As opposed to libraries, we do not have a way to get installed packages through
+-- ghc-pkg for executables, so we test whether their expected output file exists
+-- e.g.
+--
+-- .stack-work/dist/x86_64-osx/Cabal-1.22.4.0/build/alpha/alpha
+-- .stack-work/dist/x86_64-osx/Cabal-1.22.4.0/build/alpha/alpha.exe
+-- .stack-work/dist/x86_64-osx/Cabal-1.22.4.0/build/alpha/alpha.jsexe/ (NOTE: a dir)
+getExecutableBuildStatuses
+    :: HasEnvConfig env
+    => Package -> Path Abs Dir -> RIO env (Map Text ExecutableBuildStatus)
+getExecutableBuildStatuses package pkgDir = do
+    distDir <- distDirFromDir pkgDir
+    platform <- view platformL
+    fmap
+        Map.fromList
+        (mapM (checkExeStatus platform distDir) (Set.toList (packageExes package)))
+
+-- | Check whether the given executable is defined in the given dist directory.
+checkExeStatus
+    :: HasLogFunc env
+    => Platform
+    -> Path b Dir
+    -> Text
+    -> RIO env (Text, ExecutableBuildStatus)
+checkExeStatus platform distDir name = do
+    exename <- parseRelDir (T.unpack name)
+    exists <- checkPath (distDir </> relDirBuild </> exename)
+    pure
+        ( name
+        , if exists
+              then ExecutableBuilt
+              else ExecutableNotBuilt)
+  where
+    checkPath base =
+        case platform of
+            Platform _ Windows -> do
+                fileandext <- parseRelFile (file ++ ".exe")
+                doesFileExist (base </> fileandext)
+            _ -> do
+                fileandext <- parseRelFile file
+                doesFileExist (base </> fileandext)
+      where
+        file = T.unpack name

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -380,7 +380,7 @@ loadLocalPackage pp = do
         , lpDirtyFiles = dirtyFiles
         , lpNewBuildCaches = newBuildCaches
         , lpCabalFile = ppCabalFP pp
-        , lpWanted = isWanted
+        , lpShouldBeBuilt = isWanted
         , lpComponents = nonLibComponents
         -- TODO: refactor this so that it's easier to be sure that these
         -- components are indeed unbuildable.

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -132,7 +132,7 @@ createDependencyGraph
 createDependencyGraph dotOpts = do
   sourceMap <- view sourceMapL
   locals <- for (toList $ smProject sourceMap) loadLocalPackage
-  let graph = Map.fromList $ projectPackageDependencies dotOpts (filter lpWanted locals)
+  let graph = Map.fromList $ projectPackageDependencies dotOpts (filter lpShouldBeBuilt locals)
   globalDump <- view $ to dcGlobalDump
   -- TODO: Can there be multiple entries for wired-in-packages? If so,
   -- this will choose one arbitrarily..

--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -151,7 +151,8 @@ instance Show PackageDumpException where
     show (Couldn'tParseField name ls) =
         "Couldn't parse the field " ++ show name ++ " from lines: " ++ show ls
 
--- | Convert a stream of bytes into a stream of @DumpPackage@s
+-- | Convert a stream of bytes into a stream of @DumpPackage@s.
+-- Essentially parses the output of @ghc-pkg dump@.
 conduitDumpPackage :: MonadThrow m
                    => ConduitM Text DumpPackage m ()
 conduitDumpPackage = (.| CL.catMaybes) $ eachSection $ do

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -307,7 +307,7 @@ readLocalPackage pkgDir = do
     let package = resolvePackage config gpd
     return LocalPackage
         { lpPackage = package
-        , lpWanted = False -- HACK: makes it so that sdist output goes to a log instead of a file.
+        , lpShouldBeBuilt = False -- HACK: makes it so that sdist output goes to a log instead of a file.
         , lpCabalFile = cabalfp
         -- NOTE: these aren't the 'correct values, but aren't used in
         -- the usage of this function in this module.

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1960,7 +1960,14 @@ newtype GhcPkgExe = GhcPkgExe (Path Abs File)
 getGhcPkgExe :: HasCompiler env => RIO env GhcPkgExe
 getGhcPkgExe = view $ compilerPathsL.to cpPkg
 
--- | Dump information for a single package
+-- | Dump information for a single package.
+-- This is essentially a replicate of
+-- <https://downloads.haskell.org/ghc/latest/docs/html/libraries/Cabal-3.2.0.0/Distribution-InstalledPackageInfo.html#t:InstalledPackageInfo the cabal ghc-pkg dump type>.
+-- The real format from which it is aprsed is the GHC package database (@ghc-pkg describe x@)
+-- <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/packages.html#installedpackageinfo-a-package-specification see this>.
+-- Why is this not the full cabal datatype ?
+-- There seems to be no trace of components in this (at the ghc-pkg level at least, the 
+-- cabal type has it).
 data DumpPackage = DumpPackage
     { dpGhcPkgId :: !GhcPkgId
     , dpPackageIdent :: !PackageIdentifier

--- a/src/Stack/Types/Execute.hs
+++ b/src/Stack/Types/Execute.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | These are the types for the Execute module. It's separated from the Control.Concurrent.Execute
+-- because it's entirely stack specific and could never be generalized.
+module Stack.Types.Execute
+(
+    ExecuteEnv(..)
+    , ExecutableBuildStatus(..)
+    , packageNamePrefix
+    , announceTask
+    , OutputType(..)
+)
+where
+
+import           Stack.Prelude
+import           Stack.Types.Build
+import           Stack.Types.Config
+import           Stack.Types.GhcPkgId
+import Data.List ( repeat )
+import qualified RIO
+
+data ExecuteEnv = ExecuteEnv
+    { eeConfigureLock  :: !(MVar ())
+    , eeInstallLock    :: !(MVar ())
+    , eeBuildOpts      :: !BuildOpts
+    , eeBuildOptsCLI   :: !BuildOptsCLI
+    , eeBaseConfigOpts :: !BaseConfigOpts
+    , eeGhcPkgIds      :: !(TVar (Map PackageIdentifier Installed))
+    -- ^ The map of installed packages, pinned by their 'PackageIdentifier'.
+    -- This is a TVar to prevent errors while concurrently executing installs
+    -- and trying to update the value.
+    , eeTempDir        :: !(Path Abs Dir)
+    , eeSetupHs        :: !(Path Abs File)
+    -- ^ Temporary Setup.hs for simple builds
+    , eeSetupShimHs    :: !(Path Abs File)
+    -- ^ Temporary SetupShim.hs, to provide access to initial-build-steps
+    , eeSetupExe       :: !(Maybe (Path Abs File))
+    -- ^ Compiled version of eeSetupHs
+    , eeCabalPkgVer    :: !Version
+    , eeTotalWanted    :: !Int
+    , eeLocals         :: ![LocalPackage]
+    , eeGlobalDB       :: !(Path Abs Dir)
+    , eeGlobalDumpPkgs :: !(Map GhcPkgId DumpPackage)
+    , eeSnapshotDumpPkgs :: !(TVar (Map GhcPkgId DumpPackage))
+    , eeLocalDumpPkgs  :: !(TVar (Map GhcPkgId DumpPackage))
+    , eeLogFiles       :: !(TChan (Path Abs Dir, Path Abs File))
+    , eeCustomBuilt    :: !(IORef (Set PackageName))
+    -- ^ Stores which packages with custom-setup have already had their
+    -- Setup.hs built.
+    , eeLargestPackageName :: !(Maybe Int)
+    -- ^ For nicer interleaved output: track the largest package name size
+    , eePathEnvVar :: !Text
+    -- ^ Value of the PATH environment variable
+    }
+
+-- | Has an executable been built or not?
+data ExecutableBuildStatus
+    = ExecutableBuilt
+    | ExecutableNotBuilt
+  deriving (Show, Eq, Ord)
+
+-- | Make a padded prefix for log messages
+packageNamePrefix :: ExecuteEnv -> PackageName -> Utf8Builder
+packageNamePrefix ee name' =
+  let name = packageNameString name'
+      paddedName =
+        case eeLargestPackageName ee of
+          Nothing -> name
+          Just len -> assert (len >= length name) $ RIO.take len $ name ++ repeat ' '
+   in fromString paddedName <> "> "
+
+announceTask :: HasLogFunc env => ExecuteEnv -> Task -> Utf8Builder -> RIO env ()
+announceTask ee task action = logInfo $
+    packageNamePrefix ee (pkgName (taskProvides task)) <>
+    action
+
+-- | How we deal with output from GHC, either dumping to a log file or the
+-- console (with some prefix).
+data OutputType
+  = OTLogFile !(Path Abs File) !Handle
+  | OTConsole !(Maybe Utf8Builder)

--- a/stack.cabal
+++ b/stack.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e0fafccff758c3515731220888162806b25dd39ae06a130f30cba3f9955f20dc
+-- hash: 921d1d75f45e1413bf27bb605231ab84c688fd4a5e8c3c02486759fd6ccba8eb
 
 name:           stack
 version:        2.6.0
@@ -218,7 +218,9 @@ library
       Paths_stack
   other-modules:
       Path.Extended
+      Stack.Build.Precompiled
       Stack.Types.Cache
+      Stack.Types.Execute
   autogen-modules:
       Paths_stack
   hs-source-dirs:


### PR DESCRIPTION
This is mostly a doc PR, but it also contains the following refactorings (no actual behavior has been touched, these are "pure" refactorings):

- Rename lpWanted to lpShouldBeBuilt
- move printPlan and displayTask in thee Build.hs file (where Plan and Task are defined)
- isolate the merging of planTasks and planFinals into their own function (and remove mergeWithKeys as it's recommended to not use it in its haddock) defined in Build.hs.
- a reorganization of toAction which transforms a task into an action. This was using very redundantly the Task constructor, and the task -> action is likely to change with component builds.
- rename W and M in ConstructPlan to more sensible names. Minor other changes there.

Overall, I mostly realized that contrary to my plan in https://github.com/commercialhaskell/stack/issues/4745#issuecomment-743739777, it's going to be hard to do anything before actually changing the Setup.hs part, so I'm going to tackle this first, then all the Package/ConstructPlan/Installed can get a sensible rework.
The Execute.hs file is a beast, it's really hard to navigate, so I'm likely to refactor it a bit more.

This can be merged for now though, because I think it eases the reading and the understanding of the codebase on its own.
 