### PR TITLE
Initialize custom-setup deps for stack dist

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,11 @@ Behavior changes:
   one package. See
   [#5421](https://github.com/commercialhaskell/stack/issues/5421)
 
+* `custom-setup` dependencies are now properly initialized for `stack dist`.
+  This makes `explicit-setup-deps` no longer required and that option was
+  removed. See
+  [#4006](https://github.com/commercialhaskell/stack/issues/4006)
+
 Other enhancements:
 
 Bug fixes:

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -781,31 +781,6 @@ is to modify.
 modify-code-page: false
 ```
 
-### explicit-setup-deps
-
-(Since 0.1.6)
-
-Decide whether a custom `Setup.hs` script should be run with an explicit list of
-dependencies, based on the dependencies of the package itself. It associates the
-name of a local package with a boolean. When it's `true`, the `Setup.hs` script
-is built with an explicit list of packages. When it's `false` (default), the
-`Setup.hs` script is built without access to the local DB, but can access any
-package in the snapshot / global DB.
-
-Note that in the future, this will be unnecessary, once Cabal provides full
-support for explicit Setup.hs dependencies.
-
-```yaml
-explicit-setup-deps:
-    "*": true # change the default
-    entropy: false # override the new default for one package
-```
-
-NOTE: since 1.4.0, Stack has support for Cabal's `custom-setup` block
-(introduced in Cabal 1.24). If a `custom-setup` block is provided in a `.cabal`
-file, it will override the setting of `explicit-setup-deps`, and instead rely
-on the stated dependencies.
-
 ### allow-newer
 
 (Since 0.1.7)

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -9,6 +9,7 @@
 
 module Stack.Build
   (build
+  ,buildLocalTargets
   ,loadPackage
   ,mkBaseConfigOpts
   ,queryBuildInfo
@@ -39,6 +40,7 @@ import           Stack.Build.Execute
 import           Stack.Build.Installed
 import           Stack.Build.Source
 import           Stack.Package
+import           Stack.Setup (withNewLocalBuildTargets)
 import           Stack.Types.Build
 import           Stack.Types.Config
 import           Stack.Types.NamedComponent
@@ -116,6 +118,10 @@ build msetLocalFiles = do
                          installedMap
                          (smtTargets $ smTargets sourceMap)
                          plan
+
+buildLocalTargets :: HasEnvConfig env => NonEmpty Text -> RIO env (Either SomeException ())
+buildLocalTargets targets =
+  tryAny $ withNewLocalBuildTargets (NE.toList targets) $ build Nothing
 
 justLocals :: Plan -> [PackageIdentifier]
 justLocals =

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -329,7 +329,6 @@ configFromConfigMonoid
          configSetupInfoInline = configMonoidSetupInfoInline
          configPvpBounds = fromFirst (PvpBounds PvpBoundsNone False) configMonoidPvpBounds
          configModifyCodePage = fromFirstTrue configMonoidModifyCodePage
-         configExplicitSetupDeps = configMonoidExplicitSetupDeps
          configRebuildGhcOptions = fromFirstFalse configMonoidRebuildGhcOptions
          configApplyGhcOptions = fromFirst AGOLocals configMonoidApplyGhcOptions
          configAllowNewer = fromFirst False configMonoidAllowNewer


### PR DESCRIPTION
Resolves #4006

This `explicit-setup-deps` unnecessary and thus it was removed

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Tested manually
