### PR TITLE
 Minor refactoring and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ tags
 .hspec-failures
 better-cache/
 stack*.yaml.lock
+stack.code-workspace

--- a/package.yaml
+++ b/package.yaml
@@ -242,6 +242,7 @@ library:
   - Stack.Types.Compiler
   - Stack.Types.Config
   - Stack.Types.Config.Build
+  - Stack.Types.ConstructPlan
   - Stack.Types.Docker
   - Stack.Types.GhcPkgId
   - Stack.Types.NamedComponent

--- a/src/Control/Concurrent/Execute.hs
+++ b/src/Control/Concurrent/Execute.hs
@@ -33,6 +33,8 @@ data ActionType
     deriving (Show, Eq, Ord)
 data ActionId = ActionId !PackageIdentifier !ActionType
     deriving (Show, Eq, Ord)
+-- | This is mainly the result of one or more 'Task' in "Stack.Types.Build".
+-- Its actual content is completely contained in actionDo.
 data Action = Action
     { actionId :: !ActionId
     , actionDeps :: !(Set ActionId)

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -29,6 +29,8 @@ import           Stack.Types.GhcPkgId
 import           Stack.Types.Package
 import           Stack.Types.SourceMap
 
+-- | Returns all the stack.yaml-specified project and dependencies
+-- as a map of package names and package/file locations.
 toInstallMap :: MonadIO m => SourceMap -> m InstallMap
 toInstallMap sourceMap = do
     projectInstalls <-

--- a/src/Stack/Build/Precompiled.hs
+++ b/src/Stack/Build/Precompiled.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Cache management during a build.
+-- Handle all the pre-installed, precompiled & prebuilt stuff.
+module Stack.Build.Precompiled
+(
+    copyPreCompiled
+    , getPrecompiled
+    , loadInstalledPkg
+    , getExecutableBuildStatuses
+) where
+
+import           Stack.Prelude
+import           Stack.GhcPkg
+import           Stack.Types.Build
+import           Stack.Types.Package
+import           Stack.Types.Config
+import           Stack.Types.Execute
+import           Stack.Types.GhcPkgId
+import           Stack.Build.Cache
+import           Stack.PackageDump
+import qualified Data.Text as T
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Path.Extra
+import Path
+import qualified Data.Conduit.List as CL
+import RIO.Process
+import Path.IO
+import System.PosixCompat.Files
+import Distribution.System
+import Stack.Constants
+import Stack.Constants.Config
+
+getPrecompiled :: HasEnvConfig env =>
+    TaskType
+    -> BaseConfigOpts
+    -> ConfigCache
+    -> RIO env (Maybe (PrecompiledCache Abs))
+getPrecompiled taskTypeVal envConfigOpts cache =
+    case taskTypeVal of
+        TTRemotePackage Immutable _ loc -> do
+            mpc <- readPrecompiledCache
+                   loc
+                   (configCacheOpts cache)
+                   (configCacheHaddock cache)
+                   (configCacheDeps cache)
+            case mpc of
+                Nothing -> return Nothing
+                -- Only pay attention to precompiled caches that refer to packages within
+                -- the snapshot.
+                Just pc | maybe False
+                                (bcoSnapInstallRoot envConfigOpts `isProperPrefixOf`)
+                                (pcLibrary pc) ->
+                    return Nothing
+                -- If old precompiled cache files are left around but snapshots are deleted,
+                -- it is possible for the precompiled file to refer to the very library
+                -- we're building, and if flags are changed it may try to copy the library
+                -- to itself. This check prevents that from happening.
+                Just pc -> do
+                    let allM _ [] = return True
+                        allM f (x:xs) = do
+                            b <- f x
+                            if b then allM f xs else return False
+                    b <- liftIO $ allM doesFileExist $ maybe id (:) (pcLibrary pc) $ pcExes pc
+                    return $ if b then Just pc else Nothing
+        _ -> return Nothing
+
+copyPreCompiled :: HasEnvConfig env =>
+    PackageName
+    -> ExecuteEnv
+    -> Task
+    -> PrecompiledCache b0
+    -> RIO env (Maybe Installed)
+copyPreCompiled pname execEnv task (PrecompiledCache mlib sublibs exes) = do
+    wc <- view $ actualCompilerVersionL.whichCompilerL
+    announceTask execEnv task "using precompiled package"
+    -- We need to copy .conf files for the main library and all sublibraries which exist in the cache,
+    -- from their old snapshot to the new one. However, we must unregister any such library in the new
+    -- snapshot, in case it was built with different flags.
+    let
+      subLibNames = map T.unpack . Set.toList $ case taskType task of
+        TTLocalMutable lp -> packageInternalLibraries $ lpPackage lp
+        TTRemotePackage _ p _ -> packageInternalLibraries p
+      PackageIdentifier name version = taskProvides task
+      mainLibName = packageNameString name
+      mainLibVersion = versionString version
+      ghcPkgName = mainLibName ++ "-" ++ mainLibVersion
+      -- z-package-z-internal for internal lib internal of package package
+      toCabalInternalLibName n = concat ["z-", mainLibName, "-z-", n, "-", mainLibVersion]
+      allToUnregister = map (const ghcPkgName) (maybeToList mlib) ++ map toCabalInternalLibName subLibNames
+      allToRegister = maybeToList mlib ++ sublibs
+    unless (null allToRegister) $ do
+        withMVar installLock $ \() -> do
+            -- We want to ignore the global and user databases.
+            -- Unfortunately, ghc-pkg doesn't take such arguments on the
+            -- command line. Instead, we'll set GHC_PACKAGE_PATH. See:
+            -- https://github.com/commercialhaskell/stack/issues/1146
+            let modifyEnv = Map.insert
+                  (ghcPkgPathEnvVar wc)
+                  (T.pack $ toFilePathNoTrailingSep $ bcoSnapDB configOpts)
+            withModifyEnvVars modifyEnv $ do
+              GhcPkgExe ghcPkgExe <- getGhcPkgExe
+              -- first unregister everything that needs to be unregistered
+              forM_ allToUnregister $ \pName -> catchAny
+                  (readProcessNull (toFilePath ghcPkgExe) [ "unregister", "--force", pName])
+                  (const (return ()))
+              -- now, register the cached conf files
+              forM_ allToRegister $ \libpath ->
+                proc (toFilePath ghcPkgExe) [ "register", "--force", toFilePath libpath] readProcess_
+    liftIO $ forM_ exes $ \exe -> do
+        ensureDir bindir
+        let dst = bindir </> filename exe
+        createLink (toFilePath exe) (toFilePath dst) `catchIO` \_ -> copyFile exe dst
+    case (mlib, exes) of
+        (Nothing, _:_) -> markExeInstalled (taskLocation task) taskProvidesVal
+        _ -> return ()
+    -- Find the package in the database
+    let pkgDbs = [bcoSnapDB configOpts]
+    case mlib of
+        Nothing -> return $ Just $ Executable taskProvidesVal
+        Just _ -> do
+            mpkgid <- loadInstalledPkg pkgDbs snapshotDumpPkg pname
+            return $ Just $
+                case mpkgid of
+                    Nothing -> assert False $ Executable taskProvidesVal
+                    Just pkgid -> Library taskProvidesVal pkgid Nothing
+  where
+    installLock = eeInstallLock execEnv
+    snapshotDumpPkg = eeSnapshotDumpPkgs execEnv
+    configOpts = eeBaseConfigOpts execEnv
+    taskProvidesVal = taskProvides task
+    bindir = bcoSnapInstallRoot configOpts </> bindirSuffix
+
+loadInstalledPkg :: (HasCompiler env,
+    HasProcessContext env, HasLogFunc env) =>
+    [Path Abs Dir]
+    -> TVar (Map GhcPkgId DumpPackage)
+    -> PackageName
+    -> RIO env (Maybe GhcPkgId)
+loadInstalledPkg pkgDbs tvar name = do
+    pkgexe <- getGhcPkgExe
+    dps <- ghcPkgDescribe pkgexe name pkgDbs $ conduitDumpPackage .| CL.consume
+    case dps of
+        [] -> return Nothing
+        [dp] -> do
+            liftIO $ atomically $ modifyTVar' tvar (Map.insert (dpGhcPkgId dp) dp)
+            return $ Just (dpGhcPkgId dp)
+        _ -> error $ "singleBuild: invariant violated: multiple results when describing installed package " ++ show (name, dps)
+
+-- | Get the build status of all the package executables.
+-- As opposed to libraries, we do not have a way to get installed packages through
+-- ghc-pkg for executables, so we test whether their expected output file exists
+-- e.g.
+--
+-- .stack-work/dist/x86_64-osx/Cabal-1.22.4.0/build/alpha/alpha
+-- .stack-work/dist/x86_64-osx/Cabal-1.22.4.0/build/alpha/alpha.exe
+-- .stack-work/dist/x86_64-osx/Cabal-1.22.4.0/build/alpha/alpha.jsexe/ (NOTE: a dir)
+getExecutableBuildStatuses
+    :: HasEnvConfig env
+    => Package -> Path Abs Dir -> RIO env (Map Text ExecutableBuildStatus)
+getExecutableBuildStatuses package pkgDir = do
+    distDir <- distDirFromDir pkgDir
+    platform <- view platformL
+    fmap
+        Map.fromList
+        (mapM (checkExeStatus platform distDir) (Set.toList (packageExes package)))
+
+-- | Check whether the given executable is defined in the given dist directory.
+checkExeStatus
+    :: HasLogFunc env
+    => Platform
+    -> Path b Dir
+    -> Text
+    -> RIO env (Text, ExecutableBuildStatus)
+checkExeStatus platform distDir name = do
+    exename <- parseRelDir (T.unpack name)
+    exists <- checkPath (distDir </> relDirBuild </> exename)
+    pure
+        ( name
+        , if exists
+              then ExecutableBuilt
+              else ExecutableNotBuilt)
+  where
+    checkPath base =
+        case platform of
+            Platform _ Windows -> do
+                fileandext <- parseRelFile (file ++ ".exe")
+                doesFileExist (base </> fileandext)
+            _ -> do
+                fileandext <- parseRelFile file
+                doesFileExist (base </> fileandext)
+      where
+        file = T.unpack name

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -380,7 +380,7 @@ loadLocalPackage pp = do
         , lpDirtyFiles = dirtyFiles
         , lpNewBuildCaches = newBuildCaches
         , lpCabalFile = ppCabalFP pp
-        , lpWanted = isWanted
+        , lpShouldBeBuilt = isWanted
         , lpComponents = nonLibComponents
         -- TODO: refactor this so that it's easier to be sure that these
         -- components are indeed unbuildable.

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -132,7 +132,7 @@ createDependencyGraph
 createDependencyGraph dotOpts = do
   sourceMap <- view sourceMapL
   locals <- for (toList $ smProject sourceMap) loadLocalPackage
-  let graph = Map.fromList $ projectPackageDependencies dotOpts (filter lpWanted locals)
+  let graph = Map.fromList $ projectPackageDependencies dotOpts (filter lpShouldBeBuilt locals)
   globalDump <- view $ to dcGlobalDump
   -- TODO: Can there be multiple entries for wired-in-packages? If so,
   -- this will choose one arbitrarily..

--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -151,7 +151,8 @@ instance Show PackageDumpException where
     show (Couldn'tParseField name ls) =
         "Couldn't parse the field " ++ show name ++ " from lines: " ++ show ls
 
--- | Convert a stream of bytes into a stream of @DumpPackage@s
+-- | Convert a stream of bytes into a stream of @DumpPackage@s.
+-- Essentially parses the output of @ghc-pkg dump@.
 conduitDumpPackage :: MonadThrow m
                    => ConduitM Text DumpPackage m ()
 conduitDumpPackage = (.| CL.catMaybes) $ eachSection $ do

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -307,7 +307,7 @@ readLocalPackage pkgDir = do
     let package = resolvePackage config gpd
     return LocalPackage
         { lpPackage = package
-        , lpWanted = False -- HACK: makes it so that sdist output goes to a log instead of a file.
+        , lpShouldBeBuilt = False -- HACK: makes it so that sdist output goes to a log instead of a file.
         , lpCabalFile = cabalfp
         -- NOTE: these aren't the 'correct values, but aren't used in
         -- the usage of this function in this module.

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1960,7 +1960,11 @@ newtype GhcPkgExe = GhcPkgExe (Path Abs File)
 getGhcPkgExe :: HasCompiler env => RIO env GhcPkgExe
 getGhcPkgExe = view $ compilerPathsL.to cpPkg
 
--- | Dump information for a single package
+-- | Dump information for a single package.
+-- This is essentially a replicate of
+-- <https://hackage.haskell.org/package/Cabal-3.2.1.0/docs/Distribution-InstalledPackageInfo.html#t:InstalledPackageInfo the cabal ghc-pkg dump type>.
+-- The real format from which it is parsed is the GHC package database (@ghc-pkg describe x@)
+-- <https://downloads.haskell.org/~ghc/8.10.4/docs/html/users_guide/packages.html#installedpackageinfo-a-package-specification see this>.
 data DumpPackage = DumpPackage
     { dpGhcPkgId :: !GhcPkgId
     , dpPackageIdent :: !PackageIdentifier

--- a/src/Stack/Types/ConstructPlan.hs
+++ b/src/Stack/Types/ConstructPlan.hs
@@ -1,0 +1,314 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Stack.Types.ConstructPlan where
+
+import Stack.Prelude
+import Stack.Types.Config
+    (DumpPackage,  Curator,
+      EnvConfig,
+      HasBuildConfig,
+      HasCompiler(..),
+      HasConfig(..),
+      HasEnvConfig(..),
+      HasGHCVariant,
+      HasPlatform,
+      HasRunner(..),
+      HasSourceMap(..) )
+import Stack.Types.GhcPkgId ( GhcPkgId )
+import Stack.Types.Version ( latestApplicableVersion )
+import Stack.Types.Build
+    ( psVersion,
+      InstallLocation(..),
+      Installed(..),
+      LocalPackage(lpPackage, lpDirtyFiles, lpForceDirty),
+      BaseConfigOpts,
+      Task(taskType),
+      TaskType(TTRemotePackage, TTLocalMutable) )
+import Stack.Types.Package
+    (ExeName(ExeName),  installedVersion,
+      runMemoizedWith,
+      InstalledMap,
+      Package(packageLibraries, packageInternalLibraries),
+      PackageLibraries(NoLibraries, HasLibraries),
+      PackageSource(..) )
+import qualified Data.Map.Strict as Map
+import Control.Monad.Trans.RWS.Strict (RWST)
+import Distribution.Version (VersionRange)
+import Data.Monoid.Map ( MonoidMap )
+import Generics.Deriving.Monoid (memptydefault, mappenddefault)
+import RIO.PrettyPrint ( HasStylesUpdate(..), HasTerm(..) )
+import RIO.Process ( HasProcessContext(..) )
+import qualified Data.Text as T
+import Data.List (intercalate)
+import qualified Data.Set as Set
+
+data PackageInfo
+  = -- | This indicates that the package is already installed, and
+    -- that we shouldn't build it from source. This is only the case
+    -- for global packages.
+    PIOnlyInstalled InstallLocation Installed
+  | -- | This indicates that the package isn't installed, and we know
+    -- where to find its source.
+    PIOnlySource PackageSource
+  | -- | This indicates that the package is installed and we know
+    -- where to find its source. We may want to reinstall from source.
+    PIBoth PackageSource Installed
+  deriving (Show)
+
+psForceDirty :: PackageSource -> Bool
+psForceDirty (PSFilePath lp) = lpForceDirty lp
+psForceDirty PSRemote{} = False
+
+psDirty
+  :: (MonadIO m, HasEnvConfig env, MonadReader env m)
+  => PackageSource
+  -> m (Maybe (Set FilePath))
+psDirty (PSFilePath lp) = runMemoizedWith $ lpDirtyFiles lp
+psDirty PSRemote {} = pure Nothing -- files never change in a remote package
+
+psLocal :: PackageSource -> Bool
+psLocal (PSFilePath _ ) = True
+psLocal PSRemote{} = False
+
+psLocation :: PackageSource -> InstallLocation
+psLocation (PSFilePath _) = Local
+psLocation PSRemote{} = Snap
+
+combineSourceInstalled :: PackageSource
+                       -> (InstallLocation, Installed)
+                       -> PackageInfo
+combineSourceInstalled ps (location, installed) =
+    assert (psVersion ps == installedVersion installed) $
+    case location of
+        -- Always trust something in the snapshot
+        Snap -> PIOnlyInstalled location installed
+        Local -> PIBoth ps installed
+
+type CombinedMap = Map PackageName PackageInfo
+
+combineMap :: Map PackageName PackageSource -> InstalledMap -> CombinedMap
+combineMap = Map.mergeWithKey
+    (\_ s i -> Just $ combineSourceInstalled s i)
+    (fmap PIOnlySource)
+    (fmap (uncurry PIOnlyInstalled))
+
+-- | This is the result when you add a package to
+-- the 'PlanDraft'. You look for a pre-installed
+-- one or create a new task to install it. 
+data AddDepRes
+    = ADRToInstall !Task
+    | ADRFound !InstallLocation !Installed
+    deriving Show
+
+type ParentMap = MonoidMap PackageName (First Version, [(PackageIdentifier, VersionRange)])
+ 
+-- | This is a temporary object used to build the final 'Plan' object.
+-- It's the outcome of running the 'ConstructPlanMonad'.
+--
+-- The monoid/semigroup generic instances enable the common @tell mempty{pdX = ..}@
+-- idiom in the 'ConstructPlanMonad' without losing information.
+data PlanDraft = PlanDraft
+    { pdFinals :: !(Map PackageName (Either ConstructPlanException Task))
+    -- ^ The finals exist because we want to run benchmarks and tests
+    -- after having built all the libraries/executables. So this should be all about
+    -- benchmark and tests.
+    , pdInstall :: !(Map Text InstallLocation)
+    -- ^ executable to be installed, and location where the binary is placed
+    , pdDirty :: !(Map PackageName Text)
+    -- ^ why a local package is considered dirty
+    , pdWarnings :: !([Text] -> [Text])
+    -- ^ Warnings
+    , pdParents :: !ParentMap
+    -- ^ Which packages a given package depends on, along with the package's version
+    } deriving Generic
+instance Semigroup PlanDraft where
+    (<>) = mappenddefault
+instance Monoid PlanDraft where
+    mempty = memptydefault
+    mappend = (<>)
+
+-- | A monad transformer reading an environment of type 'Ctx',
+-- collecting an output of type 'PlanDraft' and updating a state of type 
+-- 'ConstructPlanState' to an inner monad 'IO'.
+--      - <https://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-Reader-Class.html R stands for read>,
+--      - <http://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-Writer-Class.html W stands for write>,
+--      - <http://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-State-Class.html S stands for state>,
+type ConstructPlanMonad = RWST -- TODO replace with more efficient WS stack on top of StackT
+    Ctx
+    PlanDraft
+    ConstructPlanState
+    IO
+
+type ConstructPlanState = Map PackageName (Either ConstructPlanException AddDepRes) 
+
+getLatestApplicableVersionAndRev :: PackageName -> VersionRange -> ConstructPlanMonad (Maybe (Version, BlobKey))
+getLatestApplicableVersionAndRev depname range = do
+  ctx <- ask
+  vsAndRevs <- runRIO ctx $ getHackagePackageVersions YesRequireHackageIndex UsePreferredVersions depname
+  pure $ do
+    lappVer <- latestApplicableVersion range $ Map.keysSet vsAndRevs
+    revs <- Map.lookup lappVer vsAndRevs
+    (cabalHash, _) <- Map.maxView revs
+    Just (lappVer, cabalHash)
+
+adrHasLibrary :: AddDepRes -> Bool
+adrHasLibrary addDepRes = case addDepRes of
+  (ADRToInstall task) -> taskHasLibrary task
+  (ADRFound _ Library{}) -> True
+  (ADRFound _ Executable{}) -> False
+  where
+    taskHasLibrary :: Task -> Bool
+    taskHasLibrary task =
+      case taskType task of
+        TTLocalMutable lp -> packageHasLibrary $ lpPackage lp
+        TTRemotePackage _ p _ -> packageHasLibrary p
+    -- make sure we consider internal libraries as libraries too
+    packageHasLibrary :: Package -> Bool
+    packageHasLibrary p =
+      not (Set.null (packageInternalLibraries p)) ||
+      case packageLibraries p of
+        HasLibraries _ -> True
+        NoLibraries -> False
+
+data Ctx = Ctx
+    { baseConfigOpts :: !BaseConfigOpts
+    , loadPackage    :: !(PackageLocationImmutable -> Map FlagName Bool -> [Text] -> [Text] -> ConstructPlanMonad Package)
+    , combinedMap    :: !CombinedMap
+    , ctxEnvConfig   :: !EnvConfig
+    , callStack      :: ![PackageName]
+    , wanted         :: !(Set PackageName)
+    , localNames     :: !(Set PackageName)
+    , mcurator       :: !(Maybe Curator)
+    , pathEnvVar     :: !Text
+    }
+
+instance HasPlatform Ctx
+instance HasGHCVariant Ctx
+instance HasLogFunc Ctx where
+    logFuncL = configL.logFuncL
+instance HasRunner Ctx where
+    runnerL = configL.runnerL
+instance HasStylesUpdate Ctx where
+  stylesUpdateL = runnerL.stylesUpdateL
+instance HasTerm Ctx where
+  useColorL = runnerL.useColorL
+  termWidthL = runnerL.termWidthL
+instance HasConfig Ctx
+instance HasPantryConfig Ctx where
+    pantryConfigL = configL.pantryConfigL
+instance HasProcessContext Ctx where
+    processContextL = configL.processContextL
+instance HasBuildConfig Ctx
+instance HasSourceMap Ctx where
+    sourceMapL = envConfigL.sourceMapL
+instance HasCompiler Ctx where
+    compilerPathsL = envConfigL.compilerPathsL
+instance HasEnvConfig Ctx where
+    envConfigL = lens ctxEnvConfig (\x y -> x { ctxEnvConfig = y })
+
+-- | State to be maintained during the calculation of local packages
+-- to unregister.
+data UnregisterState = UnregisterState
+    { usToUnregister :: !(Map GhcPkgId (PackageIdentifier, Text))
+    , usKeep :: ![DumpPackage]
+    , usAnyAdded :: !Bool
+    }
+
+-- | Only used when throwing an exception in 'errorOnSnapshot'
+data NotOnlyLocal = NotOnlyLocal [PackageName] [Text]
+
+instance Show NotOnlyLocal where
+  show (NotOnlyLocal packages exes) = concat
+    [ "Specified only-locals, but I need to build snapshot contents:\n"
+    , if null packages then "" else concat
+        [ "Packages: "
+        , intercalate ", " (map packageNameString packages)
+        , "\n"
+        ]
+    , if null exes then "" else concat
+        [ "Executables: "
+        , intercalate ", " (map T.unpack exes)
+        , "\n"
+        ]
+    ]
+instance Exception NotOnlyLocal
+
+-- | Warn about tools in the snapshot definition. States the tool name
+-- expected and the package name using it.
+data ToolWarning = ToolWarning ExeName PackageName
+  deriving Show
+
+toolWarningText :: ToolWarning -> Text
+toolWarningText (ToolWarning (ExeName toolName) pkgName') =
+    "No packages found in snapshot which provide a " <>
+    T.pack (show toolName) <>
+    " executable, which is a build-tool dependency of " <>
+    T.pack (packageNameString pkgName')
+
+data DepsPath = DepsPath
+    { dpLength :: Int -- ^ Length of dpPath
+    , dpNameLength :: Int -- ^ Length of package names combined
+    , dpPath :: [PackageIdentifier] -- ^ A path where the packages later
+                                    -- in the list depend on those that
+                                    -- come earlier
+    }
+    deriving (Eq, Ord, Show)
+
+startDepsPath :: PackageIdentifier -> DepsPath
+startDepsPath ident = DepsPath
+    { dpLength = 1
+    , dpNameLength = length (packageNameString (pkgName ident))
+    , dpPath = [ident]
+    }
+
+extendDepsPath :: PackageIdentifier -> DepsPath -> DepsPath
+extendDepsPath ident dp = DepsPath
+    { dpLength = dpLength dp + 1
+    , dpNameLength = dpNameLength dp + length (packageNameString (pkgName ident))
+    , dpPath = [ident]
+    }
+
+-- | This datatype contains all the potential errors when constructing the
+-- 'Plan'. Its structure is awkward given the pretty similar cases in 
+-- its 'DependencyPlanFailures' constructor part : 'BadDependency'
+data ConstructPlanException
+    = DependencyCycleDetected [PackageName]
+    -- ^ Circular reference between package dependencies.
+    -- e.g. A depends on B and B depends on A where A and B are package names.
+    -- This is meant to be global, it also exists in 'DependencyPlanFailures' at the
+    -- 'Package' dependencies level.
+    | DependencyPlanFailures Package (Map PackageName (VersionRange, LatestApplicableVersion, BadDependency))
+    -- ^ This is used to group all the potential errors while
+    -- adding the dependency of a given 'Package'.
+    -- The 'BadDependency' type replicate 'UnknownPackage' constructor and
+    -- 'DependencyCycleDetected' constructor to some extent.
+    | UnknownPackage PackageName -- TODO perhaps this constructor will be removed, and BadDependency will handle it all
+    -- ^ Recommend adding to extra-deps, give a helpful version number?
+    -- This happens when you reference a package in your cabal file (or package.yaml)
+    -- which does not exist in the snapshot + added deps.
+    -- It's the equivalent of 'NotInBuildPlan' for a 'BadDependency'.
+    deriving (Typeable, Eq, Show)
+
+-- | The latest applicable version and it's latest cabal file revision.
+-- For display purposes only, Nothing if package not found
+type LatestApplicableVersion = Maybe (Version, BlobKey)
+
+-- | Reason why a dependency was not used
+data BadDependency
+    = NotInBuildPlan
+    | Couldn'tResolveItsDependencies Version
+    | DependencyMismatch Version
+    | HasNoLibrary
+    -- ^ See description of 'DepType'
+    | BDDependencyCycleDetected ![PackageName]
+    deriving (Typeable, Eq, Ord, Show)
+
+-- TODO: Consider intersecting version ranges for multiple deps on a
+-- package.  This is why VersionRange is in the parent map.

--- a/src/Stack/Types/Execute.hs
+++ b/src/Stack/Types/Execute.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | These are the types for the Execute module. It's separated from the Control.Concurrent.Execute
+-- because it's entirely stack specific and could never be generalized.
+module Stack.Types.Execute
+(
+    ExecuteEnv(..)
+    , ExecutableBuildStatus(..)
+    , packageNamePrefix
+    , announceTask
+    , OutputType(..)
+)
+where
+
+import           Stack.Prelude
+import           Stack.Types.Build
+import           Stack.Types.Config
+import           Stack.Types.GhcPkgId
+import Data.List ( repeat )
+import qualified RIO
+
+data ExecuteEnv = ExecuteEnv
+    { eeConfigureLock  :: !(MVar ())
+    , eeInstallLock    :: !(MVar ())
+    , eeBuildOpts      :: !BuildOpts
+    , eeBuildOptsCLI   :: !BuildOptsCLI
+    , eeBaseConfigOpts :: !BaseConfigOpts
+    , eeGhcPkgIds      :: !(TVar (Map PackageIdentifier Installed))
+    -- ^ The map of installed packages, pinned by their 'PackageIdentifier'.
+    -- This is a TVar to prevent errors while concurrently executing installs
+    -- and trying to update the value.
+    , eeTempDir        :: !(Path Abs Dir)
+    , eeSetupHs        :: !(Path Abs File)
+    -- ^ Temporary Setup.hs for simple builds
+    , eeSetupShimHs    :: !(Path Abs File)
+    -- ^ Temporary SetupShim.hs, to provide access to initial-build-steps
+    , eeSetupExe       :: !(Maybe (Path Abs File))
+    -- ^ Compiled version of eeSetupHs
+    , eeCabalPkgVer    :: !Version
+    , eeTotalWanted    :: !Int
+    , eeLocals         :: ![LocalPackage]
+    , eeGlobalDB       :: !(Path Abs Dir)
+    , eeGlobalDumpPkgs :: !(Map GhcPkgId DumpPackage)
+    , eeSnapshotDumpPkgs :: !(TVar (Map GhcPkgId DumpPackage))
+    , eeLocalDumpPkgs  :: !(TVar (Map GhcPkgId DumpPackage))
+    , eeLogFiles       :: !(TChan (Path Abs Dir, Path Abs File))
+    , eeCustomBuilt    :: !(IORef (Set PackageName))
+    -- ^ Stores which packages with custom-setup have already had their
+    -- Setup.hs built.
+    , eeLargestPackageName :: !(Maybe Int)
+    -- ^ For nicer interleaved output: track the largest package name size
+    , eePathEnvVar :: !Text
+    -- ^ Value of the PATH environment variable
+    }
+
+-- | Has an executable been built or not?
+data ExecutableBuildStatus
+    = ExecutableBuilt
+    | ExecutableNotBuilt
+  deriving (Show, Eq, Ord)
+
+-- | Make a padded prefix for log messages
+packageNamePrefix :: ExecuteEnv -> PackageName -> Utf8Builder
+packageNamePrefix ee name' =
+  let name = packageNameString name'
+      paddedName =
+        case eeLargestPackageName ee of
+          Nothing -> name
+          Just len -> assert (len >= length name) $ RIO.take len $ name ++ repeat ' '
+   in fromString paddedName <> "> "
+
+announceTask :: HasLogFunc env => ExecuteEnv -> Task -> Utf8Builder -> RIO env ()
+announceTask ee task action = logInfo $
+    packageNamePrefix ee (pkgName (taskProvides task)) <>
+    action
+
+-- | How we deal with output from GHC, either dumping to a log file or the
+-- console (with some prefix).
+data OutputType
+  = OTLogFile !(Path Abs File) !Handle
+  | OTConsole !(Maybe Utf8Builder)

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -92,29 +92,99 @@ newtype ExeName = ExeName { unExeName :: Text }
     deriving (Show, Eq, Ord, Hashable, IsString, Generic, NFData, Data, Typeable)
 
 -- | Some package info.
+-- A lot of the fields are derived from Cabal:
+--
+--    - <https://hackage.haskell.org/package/Cabal-3.2.1.0/docs/Distribution-Types-PackageId.html#t:PackageIdentifier PackageIdentifier>
+--    - <https://hackage.haskell.org/package/Cabal-3.2.1.0/docs/Distribution-PackageDescription.html#v:PackageDescription PackageDescription>
+--    - <https://hackage.haskell.org/package/Cabal-3.2.1.0/docs/Distribution-PackageDescription.html#v:buildTypeRaw buildTypeRaw function (and buildType, but it's about the same)>
 data Package =
-  Package {packageName :: !PackageName                    -- ^ Name of the package.
-          ,packageVersion :: !Version                     -- ^ Version of the package
-          ,packageLicense :: !(Either SPDX.License License) -- ^ The license the package was released under.
-          ,packageFiles :: !GetPackageFiles               -- ^ Get all files of the package.
-          ,packageDeps :: !(Map PackageName DepValue)     -- ^ Packages that the package depends on, both as libraries and build tools.
-          ,packageUnknownTools :: !(Set ExeName)          -- ^ Build tools specified in the legacy manner (build-tools:) that failed the hard-coded lookup.
-          ,packageAllDeps :: !(Set PackageName)           -- ^ Original dependencies (not sieved).
-          ,packageGhcOptions :: ![Text]                   -- ^ Ghc options used on package.
-          ,packageCabalConfigOpts :: ![Text]              -- ^ Additional options passed to ./Setup.hs configure
-          ,packageFlags :: !(Map FlagName Bool)           -- ^ Flags used on package.
-          ,packageDefaultFlags :: !(Map FlagName Bool)    -- ^ Defaults for unspecified flags.
-          ,packageLibraries :: !PackageLibraries          -- ^ does the package have a buildable library stanza?
-          ,packageInternalLibraries :: !(Set Text)        -- ^ names of internal libraries
-          ,packageTests :: !(Map Text TestSuiteInterface) -- ^ names and interfaces of test suites
-          ,packageBenchmarks :: !(Set Text)               -- ^ names of benchmarks
-          ,packageExes :: !(Set Text)                     -- ^ names of executables
-          ,packageOpts :: !GetPackageOpts                 -- ^ Args to pass to GHC.
-          ,packageHasExposedModules :: !Bool              -- ^ Does the package have exposed modules?
-          ,packageBuildType :: !BuildType                 -- ^ Package build-type.
+  Package {packageName :: !PackageName
+          -- ^ Name of the package.
+          -- This is PackageIdentifier pkgName in Cabal. 
+          ,packageVersion :: !Version
+          -- ^ Version of the package.
+          -- This is PackageIdentifier pkgVersion in Cabal.
+          ,packageLicense :: !(Either SPDX.License License)
+          -- ^ The license the package was released under.
+          -- This is PackageDescription licenseRaw in Cabal. 
+          ,packageFiles :: !GetPackageFiles
+          -- ^ Get all files of the package.
+          ,packageDeps :: !(Map PackageName DepValue)
+          -- ^ Packages that the package depends on, both as libraries and build tools.
+          -- Derived from Cabal:
+          --
+          --    - allBuildInfo (allBuildInfo') function (see main comment)
+          --    - <https://hackage.haskell.org/package/Cabal-3.2.1.0/docs/Distribution-PackageDescription.html#v:targetBuildDepends targetBuildDepends function>
+          --
+          -- see packageDependencies and packageDescTools for more details.
+          -- Note that this filters out _itself_ and all the non buildables. 
+          ,packageUnknownTools :: !(Set ExeName)
+          -- ^ Build tools specified in the legacy manner (build-tools:) that failed the hard-coded lookup.
+          -- Likely derived from Cabal see the field just before.
+          ,packageAllDeps :: !(Set PackageName)
+          -- ^ Original dependencies (not sieved).
+          -- The keyset of package deps.
+          ,packageGhcOptions :: ![Text]
+          -- ^ Ghc options used on package.
+          -- Comes from 'PackageConfig' 'packageConfigGhcOptions'.
+          -- Likely derived from Cabal in
+          --
+          --    - buildTypeRaw function (see main comment)
+          --    - <https://hackage.haskell.org/package/Cabal-3.2.1.0/docs/Distribution-PackageDescription.html#v:options options function>
+          --
+          -- see 'generateBuildInfoOpts', and then all the way from loadPackage.
+          ,packageCabalConfigOpts :: ![Text]
+          -- ^ Additional options passed to ./Setup.hs configure
+          -- Comes from 'PackageConfig' 'packageConfigCabalConfigOpts'.
+          ,packageFlags :: !(Map FlagName Bool)
+          -- ^ Flags used on package.
+          ,packageDefaultFlags :: !(Map FlagName Bool)
+          -- ^ Defaults for unspecified flags.
+          ,packageLibraries :: !PackageLibraries
+          -- ^ Does the package have a buildable library stanza?
+          -- Derived from the library and foreignLibs in Cabal.
+          -- If no main library or no buildable, we consider there is none.
+          --
+          --    - <https://hackage.haskell.org/package/Cabal-3.2.1.0/docs/Distribution-PackageDescription.html#v:foreignLibs foreignLibs>
+          --
+          ,packageInternalLibraries :: !(Set Text)
+          -- ^ names of internal libraries
+          -- Derived from Cabal in:
+          --
+          --    - <https://hackage.haskell.org/package/Cabal-3.2.1.0/docs/Distribution-PackageDescription.html#v:subLibraries subLibraries>
+          --
+          ,packageTests :: !(Map Text TestSuiteInterface)
+          -- ^ names and interfaces of test suites
+          -- Derived from Cabal in:
+          --
+          --    - <https://hackage.haskell.org/package/Cabal-3.2.1.0/docs/Distribution-PackageDescription.html#v:testSuites testSuites>
+          --
+          ,packageBenchmarks :: !(Set Text)
+          -- ^ names of benchmarks
+          -- Derived from Cabal through:
+          --
+          --    - <https://hackage.haskell.org/package/Cabal-3.2.1.0/docs/Distribution-PackageDescription.html#v:benchmarks benchmarks>
+          --
+          ,packageExes :: !(Set Text)
+          -- ^ names of executables
+          -- Derived from Cabal through:
+          --
+          --    - <https://hackage.haskell.org/package/Cabal-3.2.1.0/docs/Distribution-PackageDescription.html#v:executables executables>
+          --
+          ,packageOpts :: !GetPackageOpts
+          -- ^ Args to pass to GHC.
+          ,packageHasExposedModules :: !Bool
+          -- ^ Does the package have exposed modules?
+          -- Derived from Cabal's exposed modules list
+          -- in the main lib.
+          ,packageBuildType :: !BuildType
+          -- ^ Package build-type.
+          -- This is in Cabal in <https://hackage.haskell.org/package/Cabal-3.2.1.0/docs/Distribution-PackageDescription.html#v:buildType buildType>
           ,packageSetupDeps :: !(Maybe (Map PackageName VersionRange))
-                                                          -- ^ If present: custom-setup dependencies
-          ,packageCabalSpec :: !VersionRange              -- ^ Cabal spec range
+          -- ^ If present: custom-setup dependencies
+          -- Derived from Cabal 'SetupBuildInfo'.
+          ,packageCabalSpec :: !VersionRange
+          -- ^ Cabal spec range
           }
  deriving (Show,Typeable)
 
@@ -149,6 +219,8 @@ packageIdentifier pkg =
 packageDefinedFlags :: Package -> Set FlagName
 packageDefinedFlags = M.keysSet . packageDefaultFlags
 
+-- | The map of package names and their location & version.
+-- It does not contain any installed information.
 type InstallMap = Map PackageName (InstallLocation, Version)
 
 -- | Files that the package depends on, relative to package directory.
@@ -210,7 +282,7 @@ data PackageWarning
       -- ^ Modules not found in file system, which are listed in cabal file
     -}
 
--- | Package build configuration
+-- | Package build configuration.
 data PackageConfig =
   PackageConfig {packageConfigEnableTests :: !Bool                -- ^ Are tests enabled?
                 ,packageConfigEnableBenchmarks :: !Bool           -- ^ Are benchmarks enabled?
@@ -263,8 +335,8 @@ data LocalPackage = LocalPackage
     , lpUnbuildable   :: !(Set NamedComponent)
     -- ^ Components explicitly requested for build, that are marked
     -- "buildable: false".
-    , lpWanted        :: !Bool -- FIXME Should completely drop this "wanted" terminology, it's unclear
-    -- ^ Whether this package is wanted as a target.
+    , lpShouldBeBuilt :: !Bool
+    -- ^ Whether this package should be built or not.
     , lpTestDeps      :: !(Map PackageName VersionRange)
     -- ^ Used for determining if we can use --enable-tests in a normal build.
     , lpBenchDeps     :: !(Map PackageName VersionRange)
@@ -414,8 +486,13 @@ dotCabalGetPath dcp =
         DotCabalFilePath fp -> fp
         DotCabalCFilePath fp -> fp
 
+-- | This is a type derived from a '[DumpPackage]'.
+-- It's essentially a reorganization of the @ghc-pkg dump@
+-- command.
 type InstalledMap = Map PackageName (InstallLocation, Installed)
 
+-- | This is the output of the build process executed in the
+-- @realBuild@ function in the Execute module.
 data Installed
     = Library PackageIdentifier GhcPkgId (Maybe (Either SPDX.License License))
     | Executable PackageIdentifier

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -553,7 +553,7 @@ cleanCmd = withConfig NoReexec . withBuildConfig . clean
 -- | Helper for build and install commands
 buildCmd :: BuildOptsCLI -> RIO Runner ()
 buildCmd opts = do
-  when (any (("-prof" `elem`) . either (const []) id . parseArgs Escaping) (boptsCLIGhcOptions opts)) $ do
+  when (any (("-prof" `elem`) . fromRight [] . parseArgs Escaping) (boptsCLIGhcOptions opts)) $ do
     logError "Error: When building with stack, you should not use the -prof GHC option"
     logError "Instead, please use --library-profiling and --executable-profiling"
     logError "See: https://github.com/commercialhaskell/stack/issues/1015"

--- a/stack.cabal
+++ b/stack.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e0fafccff758c3515731220888162806b25dd39ae06a130f30cba3f9955f20dc
+-- hash: 921d1d75f45e1413bf27bb605231ab84c688fd4a5e8c3c02486759fd6ccba8eb
 
 name:           stack
 version:        2.6.0
@@ -197,6 +197,7 @@ library
       Stack.Types.Compiler
       Stack.Types.Config
       Stack.Types.Config.Build
+      Stack.Types.ConstructPlan
       Stack.Types.Docker
       Stack.Types.GhcPkgId
       Stack.Types.NamedComponent
@@ -218,7 +219,9 @@ library
       Paths_stack
   other-modules:
       Path.Extended
+      Stack.Build.Precompiled
       Stack.Types.Cache
+      Stack.Types.Execute
   autogen-modules:
       Paths_stack
   hs-source-dirs:


### PR DESCRIPTION
- Rename lpWanted to lpShouldBeBuilt
- Move printPlan and displayTask in thee Build.hs file (where Plan and Task are defined)
- Isolate the merging of planTasks and planFinals into their own function (and remove mergeWithKeys as it's recommended to not use it in its haddock) defined in Build.hs.
- A reorganization of toAction which transforms a task into an action. This was using very redundantly the Task constructor, and the task -> action is likely to change with component builds.
- Rename W and M in ConstructPlan to more sensible names. Minor other changes there (changed the misnamed packageDepsWithTools).
- Refactor Execute.hs and split the Precompiled/installed stuff into their own module.
- Various haddock additions.
- Remove PackageDepsOracle (unused)
- Split ConstructPlan in 2 modules (the current one and its types)

@qrilka  Note that I added small things since the pull request on master. Notably there was a non pure packageDepsWithTools accessor to package deps, which was only used once and had nothing to do with the actual accessing of package deps.
I have another pull request almost ready after this one which does some actual rework on Setup.hs, the Package datatype and the sublibrary dependencies.
