### PR TITLE
Add a new option for custom preprocessor extensions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,10 @@ Other enhancements:
 * `stack list` is a new command to list package versions in a snapshot.
   See [#5431](https://github.com/commercialhaskell/stack/pull/5431)
 
+* `custom-preprocessor-extensions` is a new configuration option for allowing
+  stack to be aware of any custom preprocessors you have added to `Setup.hs`.
+  See [#3491](https://github.com/commercialhaskell/stack/issues/3491)
+
 Bug fixes:
 
 * `stack new` now suppports branches other than `master` as default for

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -74,9 +74,9 @@ extra-deps:
 
 ## I need to use a package (or version of a package) that is not available on hackage, what should I do?
 
-Add it to the 
-[`extra-deps`](yaml_configuration.md#extra-deps) list in your project's 
-`stack.yaml`, specifying the package's source code location relative to the 
+Add it to the
+[`extra-deps`](yaml_configuration.md#extra-deps) list in your project's
+`stack.yaml`, specifying the package's source code location relative to the
 directory where your `stack.yaml` file lives, e.g.
 
 ```yaml
@@ -89,9 +89,9 @@ extra-deps:
 - patched/diagrams
 ```
 
-The above example specifies that the `proprietary-dep` package is found in the 
-project's `third-party` folder, that the `conduit` package is found in the 
-project's `github-version-of` folder, and that the `diagrams` package is found 
+The above example specifies that the `proprietary-dep` package is found in the
+project's `third-party` folder, that the `conduit` package is found in the
+project's `github-version-of` folder, and that the `diagrams` package is found
 in the project's `patched` folder. This autodetects changes and reinstalls the
 package.
 
@@ -171,9 +171,21 @@ test<%= i %> = <%= i %>
 ```
 
 To ensure that Stack picks up changes to this file for rebuilds, add
+the following lines to your stack.yaml file:
+
+```yaml
+    custom-preprocessor-extensions:
+    - erb
+
+    require-stack-version: ">= 2.6.0"
+```
+
+And for backwards compatability with older versions of stack, also add
 the following line to your .cabal file:
 
     extra-source-files:   B.erb
+
+You could also use the [`--custom-preprocessor-extensions` flag](yaml_configuration.md#custom-preprocessor-extensions)
 
 ## I already have GHC installed, can I still use stack?
 
@@ -578,7 +590,7 @@ This probably means a GHC bindist has not yet been added for OS key 'linux64-ncu
 Supported versions: ghc-7.10.3, ghc-8.0.1, ghc-8.0.2, ghc-8.2.1, ghc-8.2.2
 ```
 
-Most Linux distributions have standardized on providing libtinfo.so.6 (either directly or as a symlink to libncursesw.so.6). As such, there aren't GHC 8.6.* bindists that link to libncursesw.so.6 available. 
+Most Linux distributions have standardized on providing libtinfo.so.6 (either directly or as a symlink to libncursesw.so.6). As such, there aren't GHC 8.6.* bindists that link to libncursesw.so.6 available.
 
 So creating a symlink to libncursesw.so.6 as libtinfo.so.6 can prevent this error (root privileges might be required).
 ```

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -274,6 +274,17 @@ as a reminder for the user to review the configuration and make any changes if
 needed. The user can delete this message if the generated configuration is
 acceptable.
 
+### custom-preprocessor-extensions
+
+In order for stack to be aware of any custom preprocessors you are using, add their extensions here
+
+```yaml
+custom-preprocessor-extensions:
+- erb
+```
+
+TODO: Add a simple example of how to use custom preprocessors.
+
 ## Non-project-specific config
 
 Non-project config options may go in the global config (`/etc/stack/config.yaml`) or the user config (`~/.stack/config.yaml`).

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -230,6 +230,7 @@ configFromConfigMonoid
 
          configExtraIncludeDirs = configMonoidExtraIncludeDirs
          configExtraLibDirs = configMonoidExtraLibDirs
+         configCustomPreprocessorExts = configMonoidCustomPreprocessorExts
          configOverrideGccPath = getFirst configMonoidOverrideGccPath
 
          -- Only place in the codebase where platform is hard-coded. In theory

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -9,7 +9,7 @@ module Stack.Constants
     (buildPlanDir
     ,buildPlanCacheDir
     ,haskellFileExts
-    ,haskellPreprocessorExts
+    ,haskellDefaultPreprocessorExts
     ,stackDotYaml
     ,stackWorkEnvVar
     ,stackRootEnvVar
@@ -142,8 +142,8 @@ haskellFileExts :: [Text]
 haskellFileExts = ["hs", "hsc", "lhs"]
 
 -- | Extensions for modules that are preprocessed by common preprocessors.
-haskellPreprocessorExts :: [Text]
-haskellPreprocessorExts = ["gc", "chs", "hsc", "x", "y", "ly", "cpphs"]
+haskellDefaultPreprocessorExts :: [Text]
+haskellDefaultPreprocessorExts = ["gc", "chs", "hsc", "x", "y", "ly", "cpphs"]
 
 -- | Name of the 'stack' program, uppercased
 stackProgNameUpper :: String

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -20,7 +20,7 @@ import qualified System.FilePath as FilePath
 configOptsParser :: FilePath -> GlobalOptsContext -> Parser ConfigMonoid
 configOptsParser currentDir hide0 =
     (\stackRoot workDir buildOpts dockerOpts nixOpts systemGHC installGHC arch
-        ghcVariant ghcBuild jobs includes libs overrideGccPath overrideHpack
+        ghcVariant ghcBuild jobs includes libs preprocs overrideGccPath overrideHpack
         skipGHCCheck skipMsys localBin setupInfoLocations modifyCodePage
         allowDifferentUser dumpLogs colorWhen snapLoc -> mempty
             { configMonoidStackRoot = stackRoot
@@ -37,6 +37,7 @@ configOptsParser currentDir hide0 =
             , configMonoidJobs = jobs
             , configMonoidExtraIncludeDirs = includes
             , configMonoidExtraLibDirs = libs
+            , configMonoidCustomPreprocessorExts = preprocs
             , configMonoidOverrideGccPath = overrideGccPath
             , configMonoidOverrideHpack = overrideHpack
             , configMonoidSkipMsys = skipMsys
@@ -101,6 +102,12 @@ configOptsParser currentDir hide0 =
            <> metavar "DIR"
            <> completer dirCompleter
            <> help "Extra directories to check for libraries"
+           <> hide
+            ))
+    <*> many (strOption
+            ( long "custom-preprocessor-extensions"
+           <> metavar "EXT"
+           <> help "Extensions used for custom preprocessors"
            <> hide
             ))
     <*> optionalFirst (absFileOption

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -1271,8 +1271,8 @@ logPossibilities dirs mn = do
         , flow "but did find:"
         , line <> bulletedList (map pretty possibilities)
         , flow "If you are using a custom preprocessor for this module"
-        , flow "with its own file extension, consider adding the file(s)"
-        , flow "to your .cabal under extra-source-files."
+        , flow "with its own file extension, consider adding the extension"
+        , flow "to the 'custom-preprocessor-extensions' field in stack.yaml."
         ]
   where
     makePossibilities name =

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -320,6 +320,8 @@ data Config =
          -- ^ --extra-include-dirs arguments
          ,configExtraLibDirs        :: ![FilePath]
          -- ^ --extra-lib-dirs arguments
+         ,configCustomPreprocessorExts :: ![Text]
+         -- ^ List of custom preprocessors to complete the hard coded ones
          ,configConcurrentTests     :: !Bool
          -- ^ Run test suites concurrently
          ,configTemplateParams      :: !(Map Text Text)
@@ -798,6 +800,8 @@ data ConfigMonoid =
     -- ^ See: 'configExtraIncludeDirs'
     ,configMonoidExtraLibDirs        :: ![FilePath]
     -- ^ See: 'configExtraLibDirs'
+    ,configMonoidCustomPreprocessorExts :: ![Text]
+    -- ^ See: 'configCustomPreprocessorExts'
     , configMonoidOverrideGccPath    :: !(First (Path Abs File))
     -- ^ Allow users to override the path to gcc
     ,configMonoidOverrideHpack       :: !(First FilePath)
@@ -915,6 +919,7 @@ parseConfigMonoidObject rootDir obj = do
         obj ..:?  configMonoidExtraIncludeDirsName ..!= []
     configMonoidExtraLibDirs <- map (toFilePath rootDir FilePath.</>) <$>
         obj ..:?  configMonoidExtraLibDirsName ..!= []
+    configMonoidCustomPreprocessorExts <- obj ..:?  configMonoidCustomPreprocessorExtsName ..!= []
     configMonoidOverrideGccPath <- First <$> obj ..:? configMonoidOverrideGccPathName
     configMonoidOverrideHpack <- First <$> obj ..:? configMonoidOverrideHpackName
     configMonoidConcurrentTests <- First <$> obj ..:? configMonoidConcurrentTestsName
@@ -1047,6 +1052,9 @@ configMonoidExtraIncludeDirsName = "extra-include-dirs"
 
 configMonoidExtraLibDirsName :: Text
 configMonoidExtraLibDirsName = "extra-lib-dirs"
+
+configMonoidCustomPreprocessorExtsName  :: Text
+configMonoidCustomPreprocessorExtsName  = "custom-preprocessor-extensions"
 
 configMonoidOverrideGccPathName :: Text
 configMonoidOverrideGccPathName = "with-gcc"


### PR DESCRIPTION
Instead of just having a hard-coded list of preprocessor extensions, this adds a configuration option for custom preprocessor extensions.

Fixes #3491 as suggested in https://github.com/commercialhaskell/stack/issues/3491#issuecomment-336742261

TODO:
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
* [ ] Add tests

#### Please also shortly describe how you tested your change. Bonus points for added tests!
I have manually tested the option on an external repo. It updates on changes as expected.
