### PR TITLE
Nix: support passing ghcVersion to shell.nix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,9 @@ Behavior changes:
 
 Other enhancements:
 
+* Nix integration now passes `ghcVersion` (in addition to existing `ghc`) to 
+  `shell-file` as an identifier that can be looked up in a compiler attribute set.
+
 * `stack list` is a new command to list package versions in a snapshot.
   See [#5431](https://github.com/commercialhaskell/stack/pull/5431)
 

--- a/src/Stack/Config/Nix.hs
+++ b/src/Stack/Config/Nix.hs
@@ -5,6 +5,7 @@
 module Stack.Config.Nix
        (nixOptsFromMonoid
        ,nixCompiler
+       ,nixCompilerVersion
        ,StackNixException(..)
        ) where
 
@@ -73,6 +74,16 @@ nixCompiler compilerVersion =
               <> T.pack (versionString version) <> "\"\
               \else haskell.compiler.${builtins.head compilers})"
             _ -> "haskell.compiler.ghc" <> T.concat (x : y : minor)
+        _ -> Left $ stringException "GHC major version not specified"
+    WCGhcjs{} -> Left $ stringException "Only GHC is supported by stack --nix"
+    WCGhcGit{} -> Left $ stringException "Only GHC is supported by stack --nix"
+
+nixCompilerVersion :: WantedCompiler -> Either StringException T.Text
+nixCompilerVersion compilerVersion =
+  case compilerVersion of
+    WCGhc version ->
+      case T.split (== '.') (fromString $ versionString version) of
+        x : y : minor -> Right $ "ghc" <> T.concat (x : y : minor)
         _ -> Left $ stringException "GHC major version not specified"
     WCGhcjs{} -> Left $ stringException "Only GHC is supported by stack --nix"
     WCGhcGit{} -> Left $ stringException "Only GHC is supported by stack --nix"


### PR DESCRIPTION
This is handy for two reasons:

- ghc currently passed relies on importing nixpkgs from $NIX_PATH
  that is against best practices
- one might want to refer to a compiler outside nixpkgs, for example
  haskell.nix

I've tested it locally and it works as I expect it.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
