### PR TITLE
Cache stack.yaml  from a variable properly

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-${{ hashFiles('${{ matrix.stack-yaml }}') }}-${{ matrix.extra-suffix }}
+          key: ${{ runner.os }}-${{ hashFiles( matrix.stack-yaml ) }}-${{ matrix.extra-suffix }}
       - shell: bash
         run: |
           set -ex


### PR DESCRIPTION
Found this when taking Stack's github actions as an example for my project :)
E.g. on https://github.com/commercialhaskell/stack/runs/2238843841?check_suite_focus=true checking the "Cache dependencies" step logs shows:

```
Cache not found for input keys: Linux---bust1.
```

Which clearly has no hashes in cache name

Could this be related to #5511 @snoyberg ?