### PR TITLE
Remove indentation for error output

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,6 +38,11 @@ Other enhancements:
 * Added `--candidate` flag to `upload` command to upload a package candidate
   rather than publishing the package.
 
+* Error output using `--no-interleaved-output` no longer prepends indentating
+  whitespace. This allows emacs compilation-mode and vim quickfix to locate
+  and track errors. See
+  [#5523](https://github.com/commercialhaskell/stack/pull/5523)
+
 Bug fixes:
 
 * `stack new` now suppports branches other than `master` as default for

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -356,9 +356,9 @@ showBuildError isBuildingSetup exitCode mtaskProvides execName fullArgs logFiles
      logLocations ++
      (if null bss
           then ""
-          else "\n\n" ++ doubleIndent (map T.unpack bss))
+          else "\n\n" ++ removeTrailingSpaces (map T.unpack bss))
    where
-    doubleIndent = dropWhileEnd isSpace . unlines . fmap (\line -> "    " ++ line)
+    removeTrailingSpaces = dropWhileEnd isSpace . unlines
     dropQuotes = filter ('\"' /=)
 
 instance Exception StackBuildException


### PR DESCRIPTION
Closes #5430 

Indenting the error output of builds makes it so that emacs and vim cannot detect and track errors in the output.

I tested this by running this version of stack inside of my emacs and building a project that produces errors. I confirmed that compilation-mode works with `--no-interleaved-output` turned on.
