### PR TITLE
Fix path to Hadrian build script for GHC source builds

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,8 @@ Other enhancements:
 
 Bug fixes:
 
+* GHC source builds work properly for recent GHC versions again. See
+  [#5528](https://github.com/commercialhaskell/stack/issues/5528)
 
 ## v2.7.1
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -531,7 +531,7 @@ extra-deps:
 #### Bootstrapping compiler
 
 Building GHC from source requires a working GHC (known as the bootstrap
-compiler). As we use a Stack based version of Hadrian (`hadrian/build.stack.sh` in
+compiler). As we use a Stack based version of Hadrian (`hadrian/build-stack` in
 GHC sources), the bootstrap compiler is configured into `hadrian/stack.yaml` and
 fully managed by Stack.
 

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -535,11 +535,11 @@ ghcShowOptionsOutput =
 
 -- | Relative path inside a GHC repo to the Hadrian build batch script
 hadrianCmdWindows :: Path Rel File
-hadrianCmdWindows = $(mkRelFile "hadrian/build.stack.bat")
+hadrianCmdWindows = $(mkRelFile "hadrian/build-stack.bat")
 
 -- | Relative path inside a GHC repo to the Hadrian build shell script
 hadrianCmdPosix :: Path Rel File
-hadrianCmdPosix = $(mkRelFile "hadrian/build.stack.sh")
+hadrianCmdPosix = $(mkRelFile "hadrian/build-stack")
 
 -- | Used in Stack.Setup for detecting libtinfo, see comments at use site
 usrLibDirs :: [Path Abs Dir]

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -115,8 +115,8 @@ module Stack.Constants
     ,relFileStackDotTmpDotExe
     ,relFileStackDotTmp
     ,ghcShowOptionsOutput
-    ,hadrianCmdWindows
-    ,hadrianCmdPosix
+    ,hadrianScriptsWindows
+    ,hadrianScriptsPosix
     ,usrLibDirs
     ,testGhcEnvRelFile
     ,relFileBuildLock
@@ -533,13 +533,15 @@ ghcShowOptionsOutput :: [String]
 ghcShowOptionsOutput =
   $(TH.runIO (readProcess "ghc" ["--show-options"] "") >>= TH.lift . lines)
 
--- | Relative path inside a GHC repo to the Hadrian build batch script
-hadrianCmdWindows :: Path Rel File
-hadrianCmdWindows = $(mkRelFile "hadrian/build-stack.bat")
+-- | Relative paths inside a GHC repo to the Hadrian build batch script.
+-- The second path is maintained for compatibility with older GHC versions.
+hadrianScriptsWindows :: [Path Rel File]
+hadrianScriptsWindows = [$(mkRelFile "hadrian/build-stack.bat"), $(mkRelFile "hadrian/build.stack.bat")]
 
--- | Relative path inside a GHC repo to the Hadrian build shell script
-hadrianCmdPosix :: Path Rel File
-hadrianCmdPosix = $(mkRelFile "hadrian/build-stack")
+-- | Relative paths inside a GHC repo to the Hadrian build shell script
+-- The second path is maintained for compatibility with older GHC versions.
+hadrianScriptsPosix :: [Path Rel File]
+hadrianScriptsPosix = [$(mkRelFile "hadrian/build-stack"), $(mkRelFile "hadrian/build.stack.sh")]
 
 -- | Used in Stack.Setup for detecting libtinfo, see comments at use site
 usrLibDirs :: [Path Abs Dir]

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -841,7 +841,7 @@ buildGhcFromSource getSetupInfo' installed (CompilerRepository url) commitId fla
              | otherwise   = hadrianScriptsPosix
 
          foundHadrianPaths <- filterM doesFileExist $ (cwd </>) <$> hadrianScripts
-         let hadrianPath = fromMaybe (error "No Hadrian build script found") $ listToMaybe foundHadrianPaths
+         hadrianPath <- maybe (throwString "No Hadrian build script found") pure $ listToMaybe foundHadrianPaths
 
          logSticky $ "Building GHC from source with `"
             <> RIO.display flavour

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -836,9 +836,12 @@ buildGhcFromSource getSetupInfo' installed (CompilerRepository url) commitId fla
                , "--flavour=" <> flavour -- selected flavour
                , "binary-dist"
                ]
-           hadrianCmd
-             | osIsWindows = hadrianCmdWindows
-             | otherwise   = hadrianCmdPosix
+           hadrianScripts
+             | osIsWindows = hadrianScriptsWindows
+             | otherwise   = hadrianScriptsPosix
+
+         foundHadrianPaths <- filterM doesFileExist $ (cwd </>) <$> hadrianScripts
+         let hadrianPath = fromMaybe (error "No Hadrian build script found") $ listToMaybe foundHadrianPaths
 
          logSticky $ "Building GHC from source with `"
             <> RIO.display flavour
@@ -847,7 +850,7 @@ buildGhcFromSource getSetupInfo' installed (CompilerRepository url) commitId fla
          -- We need to provide an absolute path to the script since
          -- the process package only sets working directory _after_
          -- discovering the executable
-         proc (toFilePath (cwd </> hadrianCmd)) hadrianArgs runProcess_
+         proc (toFilePath hadrianPath) hadrianArgs runProcess_
 
          -- find the bindist and install it
          bindistPath <- parseRelDir "_build/bindist"


### PR DESCRIPTION
The build script has been renamed from `build.stack.sh` to `build-stack` (and `build-stack.bat` on Windows).

Fixes #5528.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md (no user-facing changes, so not necessary)
* [x] The documentation has been updated, if necessary.

The fix has been tested manually with recent GHC versions.