### PR TITLE
Suggest upgrading stack when stack.yaml requires newer version

### DIFF
--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1212,7 +1212,10 @@ instance Show ConfigException where
         , ") is outside the required\n"
         ,"version range specified in stack.yaml ("
         , T.unpack (versionRangeText requiredRange)
-        , ")." ]
+        , ").\n"
+        , "You can upgrade stack by running:\n\n"
+        , "stack upgrade"
+        ]
     show (NoMatchingSnapshot names) = concat
         [ "None of the following snapshots provides a compiler matching "
         , "your package(s):\n"


### PR DESCRIPTION
It might not be helpful if the project requires an *older* version of stack, but upgrading should cover 99.9% of cases.

Example: `stack.yaml` contains this:
```
require-stack-version: ">= 2.7.1"
```

Checklist:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

I have not tested the change.
