### PR TITLE
Fixes #732: Combine multiple stack.yaml files

### DIFF
--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -65,7 +65,7 @@ cfgCmdSet cmd = do
                      mstackYamlOption <- view $ globalOptsL.to globalStackYaml
                      mstackYaml <- getProjectConfig mstackYamlOption
                      case mstackYaml of
-                         PCProject stackYaml -> return stackYaml
+                         PCProject (stackYaml :| _) -> return stackYaml
                          PCGlobalProject -> liftM (</> stackDotYaml) (getImplicitGlobalProjectDir conf)
                          PCNoProject _extraDeps -> throwString "config command used when no project configuration available" -- maybe modify the ~/.stack/config.yaml file instead?
                  CommandScopeGlobal -> return (configUserConfigPath conf)

--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -53,7 +53,7 @@ globalOptsParser currentDir kind defLogLevel =
          metavar "INT" <>
          help "Specify the width of the terminal, used for pretty-print messages" <>
          hide)) <*>
-    optionalFirst
+    many
         (strOption
             (long "stack-yaml" <>
              metavar "STACK-YAML" <>
@@ -79,9 +79,9 @@ globalOptsFromMonoid defaultTerminal GlobalOptsMonoid{..} = do
         First (Just dir) -> resolveDir' dir
     resolvePaths (Just root) ur
   stackYaml <-
-    case getFirst globalMonoidStackYaml of
-      Nothing -> pure SYLDefault
-      Just fp -> SYLOverride <$> resolveFile' fp
+    case globalMonoidStackYaml of
+      [] -> pure SYLDefault
+      mainFp:fps -> SYLOverride <$> mapM resolveFile' (mainFp :| fps)
   pure GlobalOpts
     { globalReExecVersion = getFirst globalMonoidReExecVersion
     , globalDockerEntrypoint = getFirst globalMonoidDockerEntrypoint

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -68,7 +68,7 @@ scriptCmd opts = do
     -- interpreter mode, only error messages are shown. See:
     -- https://github.com/commercialhaskell/stack/issues/3007
     view (globalOptsL.to globalStackYaml) >>= \case
-      SYLOverride fp -> logError $
+      SYLOverride (fp :| _) -> logError $
         "Ignoring override stack.yaml file for script command: " <>
         fromString (toFilePath fp)
       SYLGlobalProject -> logError "Ignoring SYLGlobalProject for script command"

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -231,7 +231,7 @@ sourceUpgrade builtHash (SourceOpts gitRepo) =
 
     let modifyGO dir go = go
           { globalResolver = Nothing -- always use the resolver settings in the stack.yaml file
-          , globalStackYaml = SYLOverride $ dir </> stackDotYaml
+          , globalStackYaml = SYLOverride $ (:| []) $ dir </> stackDotYaml
           }
         boptsCLI = defaultBuildOptsCLI
           { boptsCLITargets = ["stack"]


### PR DESCRIPTION
This PR implements support for combining mulitple stack.yaml files. Consider a command line like
`stack --stack-yaml stack.yaml --stack-yaml stack.docker.yaml --stack-yaml stack.local.yaml ...`.
The first file (stack.yaml) in the list is the "main" file holding our project config like it used to be while the following files supplement that project configuration. In particular they may
* add new or adjust existing extra dependencies.
* set the resolver.
* set the compiler.
* set flags.

Fixes #732

The following has been done according to the contribution guidelines:
* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
