### PR TITLE
Docs: remove obsolete sidenote re: lack of `stack run`

### DIFF
--- a/doc/build_command.md
+++ b/doc/build_command.md
@@ -96,8 +96,6 @@ of different syntaxes supported for this list:
       the local packages." This will result in an error if multiple packages
       have a component with the same name. To continue the above example,
       `stack build :mytestsuite`.
-        * Side note: the commonly requested `run` command is not available
-          because it's a simple combination of `stack build :exename && stack exec exename`
 
 * *directory*, e.g. `stack build foo/bar`, will find all local packages that
   exist in the given directory hierarchy and then follow the same procedure as


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
