### PR TITLE
Add a GitHub Actions workflow for ARM64

### DIFF
--- a/.github/workflows/arm64-release.yml
+++ b/.github/workflows/arm64-release.yml
@@ -1,0 +1,34 @@
+name: ARM64 Release
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - stable
+      - rc/**
+    tags:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  arm64:
+    name: Publish bindist
+    runs-on: [self-hosted, linux, ARM64]
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v2
+      - shell: bash
+        run: |
+          set -ex
+
+          docker build . -f etc/dockerfiles/arm64.Dockerfile -t stack --build-arg USERID=$(id -u) --build-arg GROUPID=$(id -g)
+          rm -rf _release
+          mkdir -p _release
+          docker run --rm -v $(pwd):/src -w /src stack bash -c "/home/stack/release build"
+
+      - name: Upload bindist
+        uses: actions/upload-artifact@v2
+        with:
+          name: Linux-ARM64
+          path: _release/stack-*

--- a/etc/dockerfiles/arm64.Dockerfile
+++ b/etc/dockerfiles/arm64.Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:20.04
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
+    curl build-essential curl libffi-dev libffi7 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 libnuma-dev xz-utils \
+    g++ gcc libc6-dev libffi-dev libgmp-dev make zlib1g-dev git gnupg netbase
+
+RUN cd /tmp && \
+    curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-9.0.1/clang+llvm-9.0.1-aarch64-linux-gnu.tar.xz --output /tmp/llvm.tar.xz && \
+    unxz /tmp/llvm.tar.xz && \
+    tar xfv /tmp/llvm.tar --strip-components 1 -C /usr && \
+    rm /tmp/llvm.tar
+
+RUN curl -sSL https://github.com/commercialhaskell/stack/releases/download/v2.7.1/stack-2.7.1-linux-aarch64.bin > /usr/local/bin/stack && \
+    chmod +x /usr/local/bin/stack
+
+ARG USERID
+ARG GROUPID
+
+RUN useradd --uid $USERID stack && mkdir -p /home/stack && chown -R stack /home/stack && usermod -aG $GROUPID stack
+USER stack
+WORKDIR /home/stack
+
+RUN stack setup ghc-8.10.4
+RUN stack update
+
+COPY stack.yaml package.yaml /src/
+USER root
+RUN chown -R stack /src
+USER stack
+RUN cd /src && stack build --only-snapshot --test && stack build shake
+
+COPY etc/scripts/release.hs /src
+RUN stack script --resolver lts-17.10 --compile /src/release.hs -- --version && cp /src/release /home/stack

--- a/etc/scripts/release.hs
+++ b/etc/scripts/release.hs
@@ -36,6 +36,9 @@ import Distribution.Text
 import Distribution.System
 import Distribution.Package
 import Distribution.PackageDescription hiding (options)
+#if MIN_VERSION_Cabal(3, 0, 0)
+import Distribution.Utils.ShortText (fromShortText)
+#endif
 import Distribution.Verbosity
 import System.Console.GetOpt
 import System.Directory
@@ -49,6 +52,11 @@ import Data.List.Extra
 import Development.Shake
 import Development.Shake.FilePath
 import Prelude -- Silence AMP warning
+
+#if !MIN_VERSION_Cabal(3, 0, 0)
+fromShortText :: String -> String
+fromShortText = id
+#endif
 
 -- | Entrypoint.
 main :: IO ()
@@ -214,8 +222,8 @@ rules global@Global{..} args = do
                             (command_ [] "c:\\Program Files\\Microsoft SDKs\\Windows\\v7.1\\Bin\\signtool.exe"
                                 ["sign"
                                 ,"/v"
-                                ,"/d", synopsis gStackPackageDescription
-                                ,"/du", homepage gStackPackageDescription
+                                ,"/d", fromShortText $ synopsis gStackPackageDescription
+                                ,"/du", fromShortText $ homepage gStackPackageDescription
                                 ,"/n", certName
                                 ,"/t", "http://timestamp.verisign.com/scripts/timestamp.dll"
                                 ,out])


### PR DESCRIPTION
This also updates release.hs to use a more recent resolver, since
otherwise we'll have trouble on ARM64 with conflicting LLVM
installations. Unlike #5552, I took the simple workaround here of
installing GHC 8.6.5 in addition to the more recent GHC needed by
release.hs.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
