### PR TITLE
Add a --no-run flag to the script command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@ Behavior changes:
 
 Other enhancements:
 
+* Add a `--no-run` flag to the `script` command when compiling.
+
 Bug fixes:
 
 * GHC source builds work properly for recent GHC versions again. See

--- a/src/Stack/Options/ScriptParser.hs
+++ b/src/Stack/Options/ScriptParser.hs
@@ -13,6 +13,7 @@ data ScriptOpts = ScriptOpts
   , soCompile :: !ScriptExecute
   , soGhcOptions :: ![String]
   , soScriptExtraDeps :: ![PackageIdentifierRevision]
+  , soShouldRun :: !ShouldRun
   }
   deriving Show
 
@@ -20,6 +21,9 @@ data ScriptExecute
   = SEInterpret
   | SECompile
   | SEOptimize
+  deriving Show
+
+data ShouldRun = YesRun | NoRun
   deriving Show
 
 scriptOptsParser :: Parser ScriptOpts
@@ -48,5 +52,6 @@ scriptOptsParser = ScriptOpts
           (long "extra-dep" <>
             metavar "PACKAGE-VERSION" <>
             help "Extra dependencies to be added to the snapshot"))
+    <*> (flag' NoRun (long "no-run" <> help "Don't run, just compile.") <|> pure YesRun)
   where
     extraDepRead = eitherReader $ mapLeft show . parsePackageIdentifierRevision . fromString


### PR DESCRIPTION
This is a feature I've wanted for a while but never got around to writing. For the `--optimize` and `--compile` versions of `stack script`, it can be nice to simply build the executable without running. This introduces such as `--no-run` flag.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
