### PR TITLE
Upgrade to Cabal 3.4.0.0

### DIFF
--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -358,7 +358,7 @@ checkComponentsBuildable lps =
 checkSubLibraryDependencies :: HasLogFunc env => [ProjectPackage] -> RIO env ()
 checkSubLibraryDependencies proj = do
   forM_ proj $ \p -> do
-    C.GenericPackageDescription _ _ lib subLibs foreignLibs exes tests benches <- liftIO $ cpGPD . ppCommon $ p
+    C.GenericPackageDescription _ _ _ lib subLibs foreignLibs exes tests benches <- liftIO $ cpGPD . ppCommon $ p
 
     let dependencies = concatMap getDeps subLibs <>
                        concatMap getDeps foreignLibs <>

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1214,7 +1214,7 @@ withSingleContext ActionContext {..} ee@ExecuteEnv {..} task@Task {..} allDeps m
                             let macroDeps = mapMaybe snd matchedDeps
                                 cppMacrosFile = setupDir </> relFileSetupMacrosH
                                 cppArgs = ["-optP-include", "-optP" ++ toFilePath cppMacrosFile]
-                            writeBinaryFileAtomic cppMacrosFile (encodeUtf8Builder (T.pack (C.generatePackageVersionMacros macroDeps)))
+                            writeBinaryFileAtomic cppMacrosFile (encodeUtf8Builder (T.pack (C.generatePackageVersionMacros (packageVersion package) macroDeps)))
                             return (packageDBArgs ++ depsArgs ++ cppArgs)
 
                         -- This branch is usually taken for builds, and

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -224,7 +224,7 @@ selectPackageBuildPlan platform compiler pool gpd =
     flagCombinations :: NonEmpty [(FlagName, Bool)]
     flagCombinations = mapM getOptions (genPackageFlags gpd)
       where
-        getOptions :: C.Flag -> NonEmpty (FlagName, Bool)
+        getOptions :: C.PackageFlag -> NonEmpty (FlagName, Bool)
         getOptions f
             | flagManual f = (fname, flagDefault f) :| []
             | flagDefault f = (fname, True) :| [(fname, False)]

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -32,6 +32,7 @@ import           Data.List (find, isPrefixOf, unzip)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
+import           Distribution.CabalSpecVersion (CabalSpecVersion, cabalSpecMinimumLibraryVersion)
 import           Distribution.Compiler
 import           Distribution.ModuleName (ModuleName)
 import qualified Distribution.ModuleName as Cabal
@@ -190,7 +191,7 @@ packageFromPackageDescription packageConfig pkgFlags (PackageDescriptionPair pkg
           (library pkg)
     , packageBuildType = buildType pkg
     , packageSetupDeps = msetupDeps
-    , packageCabalSpec = either orLaterVersion id $ specVersionRaw pkg
+    , packageCabalSpec = orLaterVersion $ mkVersion $ cabalSpecMinimumLibraryVersion $ specVersion pkg
     }
   where
     extraLibNames = S.union subLibNames foreignLibNames
@@ -696,7 +697,7 @@ packageDescModulesAndFiles pkg = do
 
 -- | Resolve globbing of files (e.g. data files) to absolute paths.
 resolveGlobFiles
-  :: Version -- ^ cabal file version
+  :: CabalSpecVersion -- ^ cabal file version
   -> [String]
   -> RIO Ctx (Set (Path Abs File))
 resolveGlobFiles cabalFileVersion =

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -128,7 +128,7 @@ resolvePackage packageConfig gpkg =
         (resolvePackageDescription packageConfig gpkg)
 
 packageFromPackageDescription :: PackageConfig
-                              -> [D.Flag]
+                              -> [PackageFlag]
                               -> PackageDescriptionPair
                               -> Package
 packageFromPackageDescription packageConfig pkgFlags (PackageDescriptionPair pkgNoMod pkg) =
@@ -935,9 +935,9 @@ resolvePackageDescription packageConfig (GenericPackageDescription desc defaultF
 -- | Make a map from a list of flag specifications.
 --
 -- What is @flagManual@ for?
-flagMap :: [Flag] -> Map FlagName Bool
+flagMap :: [PackageFlag] -> Map FlagName Bool
 flagMap = M.fromList . map pair
-  where pair :: Flag -> (FlagName, Bool)
+  where pair :: PackageFlag -> (FlagName, Bool)
         pair = flagName &&& flagDefault
 
 data ResolveConditions = ResolveConditions
@@ -986,7 +986,7 @@ resolveConditions rc addDeps (CondNode lib deps cs) = basic <> children
                   case v of
                     OS os -> os == rcOS rc
                     Arch arch -> arch == rcArch rc
-                    Flag flag ->
+                    PackageFlag flag ->
                       fromMaybe False $ M.lookup flag (rcFlags rc)
                       -- NOTE:  ^^^^^ This should never happen, as all flags
                       -- which are used must be declared. Defaulting to

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -863,7 +863,7 @@ data PackageDescriptionPair = PackageDescriptionPair
 resolvePackageDescription :: PackageConfig
                           -> GenericPackageDescription
                           -> PackageDescriptionPair
-resolvePackageDescription packageConfig (GenericPackageDescription desc defaultFlags mlib subLibs foreignLibs' exes tests benches) =
+resolvePackageDescription packageConfig (GenericPackageDescription desc _ defaultFlags mlib subLibs foreignLibs' exes tests benches) =
     PackageDescriptionPair
       { pdpOrigBuildable = go False
       , pdpModifiedBuildable = go True

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -18,6 +18,7 @@ import           Distribution.Compiler      (CompilerFlavor (..))
 import           Distribution.ModuleName    (ModuleName)
 import qualified Distribution.PackageDescription as PD
 import qualified Distribution.Types.CondTree as C
+import qualified Distribution.Types.ModuleReexport as ModuleReexport
 import           Distribution.Types.PackageName (mkPackageName)
 import           Distribution.Types.VersionRange (withinRange)
 import           Distribution.System        (Platform (..))
@@ -280,7 +281,7 @@ allExposedModules gpd = do
       mlibrary = snd . C.simplifyCondTree checkCond <$> PD.condLibrary gpd
   pure $ case mlibrary  of
     Just lib -> PD.exposedModules lib ++
-                map PD.moduleReexportName (PD.reexportedModules lib)
+                map ModuleReexport.moduleReexportName (PD.reexportedModules lib)
     Nothing  -> mempty
 
 -- | The Stackage project introduced the concept of hidden packages,

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,6 +20,9 @@ flags:
 ghc-options:
    "$locals": -fhide-source-paths
 
+extra-deps:
+- Cabal-3.4.0.0
+
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712
 - cabal-install


### PR DESCRIPTION
Upgrades Stack to use Cabal 3.4.0.0

Resolves https://github.com/commercialhaskell/stack/issues/5558

Doesn't quite fix the haddock issue; where does Stack decide the cabal-the-tool version?