### PR TITLE
`stack setup` installs GHC for aarch64 on M1 Macs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@ Behavior changes:
 
 Other enhancements:
 
+* `stack setup` supports installing GHC for macOS aarch64 (M1)
+
 Bug fixes:
 
 * Ensure that `extra-path` works for case-insensitive `PATH`s on Windows.

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -1266,6 +1266,7 @@ getOSKey platform =
         Platform Arm                   Cabal.Linux   -> return "linux-armv7"
         Platform AArch64               Cabal.Linux   -> return "linux-aarch64"
         Platform Sparc                 Cabal.Linux   -> return "linux-sparc"
+        Platform AArch64               Cabal.OSX     -> return "macosx-aarch64"
         Platform arch os -> throwM $ UnsupportedSetupCombo os arch
 
 downloadOrUseLocal


### PR DESCRIPTION
**THIS IS UNTESTED** because I don't have an M1 Mac.  However, `stack --arch=aarch64 --resolver=ghc-8.10.5 setup` does download the correct bindist and tries to install it on my Intel Mac (but of course this fails with "Bad CPU type in executable").

Note: this will _only_ work with GHC 8.10.5 right now, since that's the only GHC version with an aarch64 bindist for macOS.  You can use `stack --resolver=ghc-8.10.5 setup` to test.

One potential downside of this change: `stack setup` on M1 Macs will not, by default, work with any GHC <8.10.5, since there aren't aarch64 bindists available (before this change, `stack setup` always uses the x86 bindist even on M1 Macs, so this wasn't an issue).  Users will have to use `--arch=x86_64` to force the use of Rosetta.  Mac users are pretty accustomed to system or OS upgrades breaking old GHC versions, so not sure if this matters.

We could potentially implement automatic fallback to x86, if that turns out to be desirable.  I personally think I would want to explicitly enable Rosetta emulation if I had an M1 Mac, but I could see others preferring it to be implicit and I'm not sure there's a really clear case to be made for either way.  There will almost certainly come a day when Apple completely stops supporting Intel, even through emulation (as they did with PowerPC and Motorola 68000), at which point a fallback would stop working.
