### PR TITLE
Allow passing RTS options to GHC in stack.yaml

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,7 +29,7 @@ Bug fixes:
   [pantry#33](https://github.com/commercialhaskell/pantry/issues/33)
 * When building the sanity check for a new GHC install, make sure to clear
   `GHC_PACKAGE_PATH`.
-
+* Specifying GHC RTS flags in the `stack.yaml` no longer fails with an error. [#5568](https://github.com/commercialhaskell/stack/pull/5568)
 
 ## v2.7.1
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,6 +8,7 @@ docker:
   #repo: fpco/alpine-haskell-stack:8.10.4
   repo: fpco/alpine-haskell-stack@sha256:1024fe4b3b082a8df64d00e8563b3151220ed90af09604a8f7e1d44040500c30
 
+
 nix:
   # --nix on the command-line to enable.
   packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,6 @@ docker:
   #repo: fpco/alpine-haskell-stack:8.10.4
   repo: fpco/alpine-haskell-stack@sha256:1024fe4b3b082a8df64d00e8563b3151220ed90af09604a8f7e1d44040500c30
 
-
 nix:
   # --nix on the command-line to enable.
   packages:

--- a/test/integration/tests/5180-ghc-rts-flags/Main.hs
+++ b/test/integration/tests/5180-ghc-rts-flags/Main.hs
@@ -1,0 +1,4 @@
+import StackTest
+
+main :: IO ()
+main = stack ["build"]

--- a/test/integration/tests/5180-ghc-rts-flags/Main.hs
+++ b/test/integration/tests/5180-ghc-rts-flags/Main.hs
@@ -1,4 +1,6 @@
 import StackTest
 
 main :: IO ()
-main = stack ["build"]
+main = do
+    stack ["clean"]
+    stack ["build"]

--- a/test/integration/tests/5180-ghc-rts-flags/files/files.cabal
+++ b/test/integration/tests/5180-ghc-rts-flags/files/files.cabal
@@ -1,0 +1,11 @@
+name:                files
+version:             0.1.0.0
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  exposed-modules:     Lib
+  build-depends:       base >= 4.7 && < 5, mtl
+  default-language:    Haskell2010
+

--- a/test/integration/tests/5180-ghc-rts-flags/files/src/Lib.hs
+++ b/test/integration/tests/5180-ghc-rts-flags/files/src/Lib.hs
@@ -1,0 +1,4 @@
+module Lib where
+
+main :: IO ()
+main = putStrLn "hello world"

--- a/test/integration/tests/5180-ghc-rts-flags/files/stack.yaml
+++ b/test/integration/tests/5180-ghc-rts-flags/files/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-14.27
+packages:
+- .
+
+ghc-options:
+  "$locals": +RTS -A128M -RTS

--- a/test/integration/tests/5180-ghc-rts-flags/files/stack.yaml
+++ b/test/integration/tests/5180-ghc-rts-flags/files/stack.yaml
@@ -3,4 +3,4 @@ packages:
 - .
 
 ghc-options:
-  "$locals": +RTS -A128M -RTS
+  "$locals": -j8 +RTS -s -A128M


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I added an integration test that ensures `stack` builds successfully when passing RTS options to GHC.

Fixes #5180 