### PR TITLE
Use findExecutablesInDirectories during stack setup

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,9 @@ Bug fixes:
 * When building the sanity check for a new GHC install, make sure to clear
   `GHC_PACKAGE_PATH`.
 * Specifying GHC RTS flags in the `stack.yaml` no longer fails with an error. [#5568](https://github.com/commercialhaskell/stack/pull/5568)
+* `stack setup` will look in sandboxed directories for executables, not
+  relying on `findExecutables. See
+  [GHC issue 20074](https://gitlab.haskell.org/ghc/ghc/-/issues/20074)
 
 ## v2.7.1
 


### PR DESCRIPTION
Avoids finding spurious other executables. See:

https://gitlab.haskell.org/ghc/ghc/-/issues/20074

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
