### PR TITLE
Cache bust and disable some Mac tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,10 +23,13 @@ jobs:
         include:
         - os: ubuntu-latest
           release-args: "--alpine"
+          cache-bust: ""
         - os: windows-latest
           release-args: ""
+          cache-bust: ""
         - os: macos-latest
           release-args: ""
+          cache-bust: "1"
     steps:
       - name: Clone project
         uses: actions/checkout@v2
@@ -34,7 +37,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-${{ hashFiles('stack.yaml') }}
+          key: ${{ runner.os }}-${{ hashFiles('stack.yaml') }}${{ matrix.cache-bust }}
       - shell: bash
         name: Install deps and run checks
         run: |

--- a/test/integration/lib/StackTest.hs
+++ b/test/integration/lib/StackTest.hs
@@ -252,6 +252,9 @@ exeExt = if isWindows then ".exe" else ""
 isWindows :: Bool
 isWindows = os == "mingw32"
 
+isLinux :: Bool
+isLinux = os == "linux"
+
 -- | Is the OS Alpine Linux?
 getIsAlpine :: IO Bool
 getIsAlpine = doesFileExist "/etc/alpine-release"

--- a/test/integration/tests/1336-1337-new-package-names/Main.hs
+++ b/test/integration/tests/1336-1337-new-package-names/Main.hs
@@ -8,7 +8,7 @@ main :: IO ()
 main =
     if isWindows
         then logInfo "Disabled on Windows (see https://github.com/commercialhaskell/stack/issues/1337#issuecomment-166118678)"
-        else do
+        else when isLinux $ do
             safeNew "1234a-4b-b4-abc-12b34"
             doesExist "./1234a-4b-b4-abc-12b34/stack.yaml"
             stackErr ["new", "1234-abc"]

--- a/test/integration/tests/3850-cached-templates-network-errors/Main.hs
+++ b/test/integration/tests/3850-cached-templates-network-errors/Main.hs
@@ -1,5 +1,5 @@
 import StackTest
-import Control.Monad (unless)
+import Control.Monad (when, unless)
 import Data.List (isInfixOf)
 import Data.Maybe (fromMaybe)
 import System.Directory
@@ -7,7 +7,7 @@ import System.Environment (lookupEnv, setEnv)
 import System.FilePath
 
 main :: IO ()
-main = do
+main = when isLinux $ do
   performCachingTest templateUrl
   performCachingTest githubTemplate
   where
@@ -19,7 +19,7 @@ main = do
       removeDirectoryRecursive "tmp"
       setEnv "HTTPS_PROXY" "http://sdsgsfgslfgsjflgkjs" -- make https requests fail
       stackCheckStderr arguments $ \stderr ->
-        unless ("Using cached local version" `isInfixOf` stderr) 
+        unless ("Using cached local version" `isInfixOf` stderr)
         (error "stack didn't load the cached template")
 
       removeDirectoryRecursive "tmp"
@@ -31,7 +31,7 @@ main = do
     templateUrl :: String
     templateUrl =
       "https://raw.githubusercontent.com/commercialhaskell/stack-templates/986836cc85b0c8c5bbb78d7b94347ba095089b03/tasty-discover.hsfiles"
-  
+
     -- the same template, cached differently
     githubTemplate :: String
     githubTemplate = "github:commercialhaskell/tasty-discover.hsfiles"

--- a/test/integration/tests/git-submodules/Main.hs
+++ b/test/integration/tests/git-submodules/Main.hs
@@ -4,10 +4,10 @@ import System.Exit (exitFailure)
 import System.FilePath ((</>))
 import Data.List (filter)
 import System.IO (hPutStrLn, withFile, IOMode(..))
-import Control.Monad (unless)
+import Control.Monad (when)
 
 main :: IO ()
-main = unless isWindows $ do
+main = when isLinux $ do
     let
       gitInit = do
          runShell "git init ."


### PR DESCRIPTION
We've been hitting GitHub rate limiting on a few tests. This commit both
busts the cache of a broken integration test suite (hopefully), and
disables those test runs on Mac.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
