### PR TITLE
Correct a typo in src/Stack/New.hs

### DIFF
--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -421,7 +421,7 @@ instance Show NewException where
     show (AttemptedOverwrites fps) =
         "The template would create the following files, but they already exist:\n" <>
         unlines (map (("  " ++) . toFilePath) fps) <>
-        "Use --force to ignore this, and overwite these files."
+        "Use --force to ignore this, and overwrite these files."
     show (FailedToDownloadTemplatesHelp ex) =
         "Failed to download `stack templates` help. The HTTP error was: " <> show ex
     show (BadTemplatesHelpEncoding url err) =


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.
