### PR TITLE
FIX #5434: use stack.yaml's package flags in stack ghci

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -36,6 +36,8 @@ Bug fixes:
   [GHC issue 20074](https://gitlab.haskell.org/ghc/ghc/-/issues/20074)
 * Track changes to `setup-config` properly to avoid reconfiguring on every change.
   See [#5578](https://github.com/commercialhaskell/stack/issues/5578)
+* `stack ghci` now uses package flags in `stack.yaml`
+  [#5434](https://github.com/commercialhaskell/stack/issues/5434)
 
 ## v2.7.1
 

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -644,11 +644,12 @@ loadGhciPkgDesc buildOptsCLI name cabalfp target = do
           (cpCabalConfigOpts . ppCommon <$> M.lookup name smProject)
           <|>
           (cpCabalConfigOpts . dpCommon <$> M.lookup name smDeps)
+        sourceMapFlags = maybe mempty (cpFlags . ppCommon) $ M.lookup name smProject
         config =
             PackageConfig
             { packageConfigEnableTests = True
             , packageConfigEnableBenchmarks = True
-            , packageConfigFlags = getLocalFlags buildOptsCLI name
+            , packageConfigFlags = getLocalFlags buildOptsCLI name `M.union` sourceMapFlags
             , packageConfigGhcOptions = sourceMapGhcOptions
             , packageConfigCabalConfigOpts = sourceMapCabalConfigOpts
             , packageConfigCompilerVersion = compilerVersion


### PR DESCRIPTION
This pull request is a fix for https://github.com/commercialhaskell/stack/issues/5434

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I tested like below.
- added package flags (stack:disable-git-info and stack:hide-dependency-versions) to stack.yaml
- execute `stack exec stack -- ghci`
- show BuildInfo.versionString' and confirmed flags in stack.yaml were used
