### PR TITLE
Drop unneeded regex-applicative-text dep

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -104,7 +104,6 @@ dependencies:
 - primitive
 - process
 - project-template
-- regex-applicative-text
 - retry
 - rio >= 0.1.18.0
 - rio-prettyprint >= 0.1.1.0

--- a/stack.cabal
+++ b/stack.cabal
@@ -3,8 +3,6 @@ cabal-version: 2.0
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 77dce7b7a1439cd2e0a568e2821a6dcb8139f3c9a6a2afbf0b768e7dcf53ec53
 
 name:           stack
 version:        2.7.4
@@ -284,7 +282,6 @@ library
     , primitive
     , process
     , project-template
-    , regex-applicative-text
     , retry
     , rio >=0.1.18.0
     , rio-prettyprint >=0.1.1.0
@@ -408,7 +405,6 @@ executable stack
     , primitive
     , process
     , project-template
-    , regex-applicative-text
     , retry
     , rio >=0.1.18.0
     , rio-prettyprint >=0.1.1.0
@@ -531,7 +527,6 @@ executable stack-integration-test
     , primitive
     , process
     , project-template
-    , regex-applicative-text
     , retry
     , rio >=0.1.18.0
     , rio-prettyprint >=0.1.1.0
@@ -660,7 +655,6 @@ test-suite stack-test
     , process
     , project-template
     , raw-strings-qq
-    , regex-applicative-text
     , retry
     , rio >=0.1.18.0
     , rio-prettyprint >=0.1.1.0


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
