### PR TITLE
Fix "Setup configure" not passing --with-ghc{,-pkg}=<..>

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
 -- | Perform a build
 module Stack.Build.Execute
     ( printPlan
@@ -884,8 +885,8 @@ ensureConfig newConfigCache pkgDir ExecuteEnv {..} announce cabal cabalfp task =
         let exes =
               case cpWhich cp of
                 Ghc ->
-                  [ "--with-ghc=" ++ toFilePath (cpCompiler cp)
-                  , "--with-ghc-pkg=" ++ toFilePath pkgPath
+                  [ "--with-ghc=" ++ toFilePath @Abs @File (cpCompiler cp)
+                  , "--with-ghc-pkg=" ++ toFilePath @Abs @File pkgPath
                   ]
         -- Configure cabal with arguments determined by
         -- Stack.Types.Build.configureOpts

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -881,21 +881,16 @@ ensureConfig newConfigCache pkgDir ExecuteEnv {..} announce cabal cabalfp task =
         announce
         cp <- view compilerPathsL
         let (GhcPkgExe pkgPath) = cpPkg cp
-        let programNames =
+        let exes =
               case cpWhich cp of
                 Ghc ->
                   [ "--with-ghc=" ++ toFilePath (cpCompiler cp)
                   , "--with-ghc-pkg=" ++ toFilePath pkgPath
                   ]
-        exes <- forM programNames $ \name -> do
-            mpath <- findExecutable name
-            return $ case mpath of
-                Left _ -> []
-                Right x -> return $ concat ["--with-", name, "=", x]
         -- Configure cabal with arguments determined by
         -- Stack.Types.Build.configureOpts
         cabal KeepTHLoading $ "configure" : concat
-            [ concat exes
+            [ exes
             , dirs
             , nodirs
             ]


### PR DESCRIPTION
This seemed to be a mostly silent bug. It becomes apparent when there's no `ghc-pkg` in PATH or an incompatible one, which is easy to trigger when using `system-ghc: true`. As a consequence `Setup.hs` will be run with a possibly incorrect GHC, causing a straight build/resolution failure that's rather difficult to debug.

The code already tries to pass these flags, so this just fixes already expected behavior.