### PR TITLE
Fixed a bug with ignoring `cpPkg` and `cpCompiler` fields.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@ Bug fixes:
 
 * Ensure that `extra-path` works for case-insensitive `PATH`s on Windows.
   See [rio#237](https://github.com/commercialhaskell/rio/pull/237)
+* Fix handling of overwritten `ghc` and `ghc-pkg` locations.
+  [#5597](https://github.com/commercialhaskell/stack/pull/5597)
 
 ## v2.7.3
 

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -886,11 +886,11 @@ ensureConfig newConfigCache pkgDir ExecuteEnv {..} announce cabal cabalfp task =
         let programNames =
               case cpWhich cp of
                 Ghc ->
-                  [ "--with-ghc=" ++ toFilePath (cpCompiler cp)
-                  , "--with-ghc-pkg=" ++ toFilePath pkgPath
+                  [ ("ghc", toFilePath (cpCompiler cp))
+                  , ("ghc-pkg", toFilePath pkgPath)
                   ]
-        exes <- forM programNames $ \name -> do
-            mpath <- findExecutable name
+        exes <- forM programNames $ \(name, file) -> do
+            mpath <- findExecutable file
             return $ case mpath of
                 Left _ -> []
                 Right x -> return $ concat ["--with-", name, "=", x]


### PR DESCRIPTION
It looks like a user can't override location `ghc` and `ghc-pkg`, because these options are ignored in  `ensureConfig`. 
I prefer to leave `findExecutable` checking and I've just removed obviously mistaken adding "--with-ghc/ghc-pkg=" to the path. 
