### PR TITLE
Bump rio version for extra-path bug

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,8 @@ Other enhancements:
 
 Bug fixes:
 
+* Ensure that `extra-path` works for case-insensitive `PATH`s on Windows.
+  See [rio#237](https://github.com/commercialhaskell/rio/pull/237)
 
 ## v2.7.3
 

--- a/package.yaml
+++ b/package.yaml
@@ -105,7 +105,7 @@ dependencies:
 - process
 - project-template
 - retry
-- rio >= 0.1.18.0
+- rio >= 0.1.21.0
 - rio-prettyprint >= 0.1.1.0
 - semigroups
 - split

--- a/stack-ghc-88.yaml
+++ b/stack-ghc-88.yaml
@@ -30,7 +30,7 @@ extra-deps:
 - pantry-0.5.2@rev:0
 - casa-client-0.0.1@rev:0
 - casa-types-0.0.1@rev:0
-- rio-0.1.19.0@rev:0
+- rio-0.1.21.0@rev:0
 - rio-prettyprint-0.1.1.0@rev:0
 
 drop-packages:

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -21,6 +21,7 @@ ghc-options:
 
 extra-deps:
 - pantry-0.5.2@rev:0
+- rio-0.1.21.0@rev:0
 
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712

--- a/stack.cabal
+++ b/stack.cabal
@@ -283,7 +283,7 @@ library
     , process
     , project-template
     , retry
-    , rio >=0.1.18.0
+    , rio >=0.1.21.0
     , rio-prettyprint >=0.1.1.0
     , semigroups
     , split
@@ -406,7 +406,7 @@ executable stack
     , process
     , project-template
     , retry
-    , rio >=0.1.18.0
+    , rio >=0.1.21.0
     , rio-prettyprint >=0.1.1.0
     , semigroups
     , split
@@ -528,7 +528,7 @@ executable stack-integration-test
     , process
     , project-template
     , retry
-    , rio >=0.1.18.0
+    , rio >=0.1.21.0
     , rio-prettyprint >=0.1.1.0
     , semigroups
     , split
@@ -656,7 +656,7 @@ test-suite stack-test
     , project-template
     , raw-strings-qq
     , retry
-    , rio >=0.1.18.0
+    , rio >=0.1.21.0
     , rio-prettyprint >=0.1.1.0
     , semigroups
     , smallcheck

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,9 @@ resolver: lts-17.15
 packages:
 - .
 
+extra-deps:
+- rio-0.1.21.0@rev:0
+
 docker:
   enable: false
   #repo: fpco/alpine-haskell-stack:8.10.4


### PR DESCRIPTION
CC @hasufell 

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
