### PR TITLE
Fix how cpp-options are passed to ghci wrt #5532

### DIFF
--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -358,7 +358,7 @@ data BioInput = BioInput
 generateBuildInfoOpts :: BioInput -> BuildInfoOpts
 generateBuildInfoOpts BioInput {..} =
     BuildInfoOpts
-        { bioOpts = ghcOpts ++ cppOptions biBuildInfo
+        { bioOpts = ghcOpts ++ fmap ("-optP" <>) (cppOptions biBuildInfo)
         -- NOTE for future changes: Due to this use of nubOrd (and other uses
         -- downstream), these generated options must not rely on multiple
         -- argument sequences.  For example, ["--main-is", "Foo.hs", "--main-


### PR DESCRIPTION
`-DFOO` options can be passed directly to ghc, but
cpp-options may include flags for the preprocessor,
such as `-std=c99`, so we need to pass it via `-optP`.

Fixes #5532

@fendor