### PR TITLE
Fix for local dependency build issue

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -907,11 +907,6 @@ ensureConfig newConfigCache pkgDir ExecuteEnv {..} announce cabal cabalfp task =
             TTLocalMutable{} -> writeConfigCache pkgDir newConfigCache
             TTRemotePackage{} -> return ()
         writeCabalMod pkgDir newCabalMod
-        -- This file gets updated one more time by the configure step, so get
-        -- the most recent value. We could instead change our logic above to
-        -- check if our config mod file is newer than the file above, but this
-        -- seems reasonable too.
-        getNewSetupConfigMod >>= writeSetupConfigMod pkgDir
 
     return needConfig
   where


### PR DESCRIPTION
Fix for bug where a local dependency that has been built from a local consumer project would be installed in the package db for the consumer project but not in the local dependency's own package db. This results in an error where ghc-pkg is unable to find the cached local package in its own package db and the build fails. This can be resolved by running `stack clean` and then `stack build` for the local dependency, but then a build for the consumer of the package will fail as it tries to find the local dependency in its own package db. The only fix is then to again run `stack clean` for the local dependency and then run `stack build` for the consumer of the dependency.

This fix is extremely simple: remove one line that modifies the setup-config file and causes the trouble. A more satisfying fix for this issue may be to figure out how to adjust the package db search so that cached builds can be used both by the local package and any consumers of the local package.

I'm happy to provide a simple repro case and a short message for the change log.

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.
