### PR TITLE
Fix cloning per subdirectory wrt #5411

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@ Major changes:
 
 Behavior changes:
 
+* cloning git repositories isn't per sub-directory anymore, see [#5411](https://github.com/commercialhaskell/stack/issues/5411)
+
 Other enhancements:
 
 * `stack setup` supports installing GHC for macOS aarch64 (M1)

--- a/package.yaml
+++ b/package.yaml
@@ -92,7 +92,7 @@ dependencies:
 - network-uri
 - open-browser
 - optparse-applicative >= 0.14.3.0
-- pantry >= 0.5.2
+- pantry >= 0.5.3
 - casa-client
 - casa-types
 - path

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -836,15 +836,8 @@ buildGhcFromSource getSetupInfo' installed (CompilerRepository url) commitId fla
    if compilerTool `elem` installed
      then return (compilerTool,CompilerBuildStandard)
      else do
-       let repo = Repo
-            { repoCommit = commitId
-            , repoUrl    = url
-            , repoType   = RepoGit
-            , repoSubdir = mempty
-            }
-
        -- clone the repository and execute the given commands
-       Pantry.withRepo repo $ do
+       Pantry.withRepo (Pantry.SimpleRepo url commitId RepoGit) $ do
          -- withRepo is guaranteed to set workingDirL, so let's get it
          mcwd <- traverse parseAbsDir =<< view workingDirL
          let cwd = fromMaybe (error "Invalid working directory") mcwd

--- a/stack-ghc-88.yaml
+++ b/stack-ghc-88.yaml
@@ -32,6 +32,7 @@ extra-deps:
 - casa-types-0.0.1@rev:0
 - rio-0.1.21.0@rev:0
 - rio-prettyprint-0.1.1.0@rev:0
+- pantry-0.5.3@rev:0
 
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -20,7 +20,7 @@ ghc-options:
    "$locals": -fhide-source-paths
 
 extra-deps:
-- pantry-0.5.2@rev:0
+- pantry-0.5.3@rev:0
 - rio-0.1.21.0@rev:0
 
 drop-packages:

--- a/stack.cabal
+++ b/stack.cabal
@@ -272,7 +272,7 @@ library
     , network-uri
     , open-browser
     , optparse-applicative >=0.14.3.0
-    , pantry >=0.5.2
+    , pantry >=0.5.3
     , path
     , path-io
     , persistent
@@ -395,7 +395,7 @@ executable stack
     , network-uri
     , open-browser
     , optparse-applicative >=0.14.3.0
-    , pantry >=0.5.2
+    , pantry >=0.5.3
     , path
     , path-io
     , persistent
@@ -517,7 +517,7 @@ executable stack-integration-test
     , open-browser
     , optparse-applicative >=0.14.3.0
     , optparse-generic
-    , pantry >=0.5.2
+    , pantry >=0.5.3
     , path
     , path-io
     , persistent
@@ -644,7 +644,7 @@ test-suite stack-test
     , network-uri
     , open-browser
     , optparse-applicative >=0.14.3.0
-    , pantry >=0.5.2
+    , pantry >=0.5.3
     , path
     , path-io
     , persistent

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,8 @@ packages:
 
 extra-deps:
 - rio-0.1.21.0@rev:0
+- pantry-0.5.3@rev:0
+
 
 docker:
   enable: false


### PR DESCRIPTION
Fixes #5411

Depends on https://github.com/commercialhaskell/pantry/pull/41

----

on cardano-wallet:
```
$ /home/hasufell/git/stack/dist-newstyle/build/x86_64-linux/ghc-8.10.7/stack-2.7.4/build/stack/stack build
Cloning 46ce81050f4015abd40c6bdf0a1ed30fa54e375a from https://github.com/input-output-hk/cardano-addresses
Cloning 7497a29cb998721a9068d5725d49461f2bba0e7a from https://github.com/input-output-hk/optparse-applicative
Cloning cb0f19c85e5bb5299839ad4ed66af6fa61322cc4 from https://github.com/input-output-hk/cardano-base
Cloning 07397f0e50da97eaa0575d93bee7ac4b2b2576ec from https://github.com/input-output-hk/cardano-crypto
Cloning 6aa1cd0a64a464371b94d4ac182e7e2cddc83a36 from https://github.com/input-output-hk/cardano-ledger-specs
Cloning 4c59442958072657812c6c0bb8e0b4ab85ce1ba2 from https://github.com/input-output-hk/cardano-node
Cloning 12925934c533b3a6e009b61ede555f8f26bac037 from https://github.com/input-output-hk/cardano-sl-x509
Cloning ee59880f47ab835dbd73bea0847dab7869fc20d8 from https://github.com/input-output-hk/flat
Cloning cde90a2b27f79187ca8310b6549331e59595e7ba from https://github.com/input-output-hk/goblins
Cloning edf6945007177a638fbeb8802397f3a6f4e47c14 from https://github.com/input-output-hk/hedgehog-extras
Cloning 808724ff8a19a33d0ed06f9ef59fbd900b08553c from https://github.com/input-output-hk/iohk-monitoring-framework
Cloning 6a92d7853ea514be8b70bab5e72077bf5a510596 from https://github.com/shmish111/purescript-bridge.git
Cloning 877ce057ff6fb086474c8eaad53f2b7f0e0fce6b from https://github.com/input-output-hk/ouroboros-network
Cloning edc6d4672c41de4485444122ff843bc86ff421a0 from https://github.com/input-output-hk/plutus
Cloning a76104490499aa72d40c2790d10e9383e0dbde63 from https://github.com/shmish111/servant-purescript.git
Cloning 3825d3abf75f83f406c1f7161883c438dac7277d from https://github.com/input-output-hk/Win32-network
Preparing to install GHC (tinfo6) to an isolated location.
This will not interfere with any system-level installation.
Downloaded ghc-tinfo6-8.10.5.
Installed GHC.
WARNING: Ignoring text's bounds on ghc-prim (>=0.2 && <0.6); using ghc-prim-0.6.1.
Reason: allow-newer enabled.
WARNING: Ignoring text's bounds on template-haskell (>=2.5 && <2.16); using template-haskell-2.16.0.0.
Reason: allow-newer enabled.
WARNING: Ignoring recursion-schemes's bounds on th-abstraction (>=0.2.4 && <0.4); using th-abstraction-0.4.2.0.
Reason: allow-newer enabled.
WARNING: Ignoring size-based's bounds on template-haskell (>=2.5 && <2.16); using template-haskell-2.16.0.0.
Reason: allow-newer enabled.
WARNING: Ignoring lens's bounds on Cabal (>=1.10 && <3.3); using Cabal-3.4.0.0.
Reason: allow-newer enabled.
WARNING: Ignoring ral's bounds on fin (^>=0.1.1); using fin-0.2.
Reason: allow-newer enabled.
WARNING: Ignoring Unique's bounds on extra (>=1.6.2 && <1.7); using extra-1.7.9.
Reason: allow-newer enabled.
WARNING: Ignoring Unique's bounds on hashable (>=1.2.6 && <1.3); using hashable-1.3.0.0.
Reason: allow-newer enabled.
WARNING: Ignoring ouroboros-consensus-byron's bounds on formatting (>=6.3 && <6.4); using formatting-7.1.3.
Reason: allow-newer enabled.
WARNING: Ignoring async-timer's bounds on unliftio-core (>=0.1.1.0 && <0.2); using unliftio-core-0.2.0.1.
Reason: allow-newer enabled.
[1 of 2] Compiling Main             ( /home/hasufell/.stack/setup-exe-src/setup-mPHDZzAJ.hs, /home/hasufell/.stack/setup-exe-src/setup-mPHDZzAJ.o )
[2 of 2] Compiling StackSetupShim   ( /home/hasufell/.stack/setup-exe-src/setup-shim-mPHDZzAJ.hs, /home/hasufell/.stack/setup-exe-src/setup-shim-mPHDZzAJ.o )
Linking /home/hasufell/.stack/setup-exe-cache/x86_64-linux-tinfo6/tmp-Cabal-simple_mPHDZzAJ_3.2.1.0_ghc-8.10.5 ...
StateVar                         > configure
...
```