### PR TITLE
Use `uname -m` instead of `arch` comamnd

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -71,9 +71,9 @@ post_install_separator() {
 
 # determines the the CPU's instruction set
 get_isa() {
-  if arch | grep -Eq 'armv[78]l?' ; then
+  if uname -m | grep -Eq 'armv[78]l?' ; then
     echo arm
-  elif arch | grep -q aarch64 ; then
+  elif uname -m | grep -q aarch64 ; then
     echo aarch64
   else
     echo x86


### PR DESCRIPTION
`arch` command is not installed at default.
see coreutils document:

> arch is not installed by default, so portable scripts should
> not rely on its existence.

https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html

ref: https://github.com/google/fscrypt/issues/92#issuecomment-365712796

closes: #5629

---

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!