### PR TITLE
stack upload: Support authentication with Hackage API key

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,9 @@ Other enhancements:
 
 * `stack setup` supports installing GHC for macOS aarch64 (M1)
 
+* `stack upload` supports authentication with a Hackage API key (via
+  `HACKAGE_KEY` environment variable).
+
 Bug fixes:
 
 * Ensure that `extra-path` works for case-insensitive `PATH`s on Windows.

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1668,6 +1668,12 @@ users. Here's a quick rundown:
   [our blog post](https://www.fpcomplete.com/blog/2016/05/stack-security-gnupg-keys).
     * `--no-signature` disables signing of packages
     * `--candidate` upload a [package candidate](http://hackage.haskell.org/upload#candidates)
+    * Hackage API key can be used instead of username and password. Usage example:
+
+    ```bash
+    HACKAGE_KEY=<api_key> stack upload .
+    ```
+
     * `username` and `password` can be read by environment
 
     ```bash

--- a/src/Stack/Upload.hs
+++ b/src/Stack/Upload.hs
@@ -81,7 +81,7 @@ maybeGetHackageKey = lookupEnv (T.unpack "HACKAGE_KEY")
 getCredsWithApiKey :: String -> FilePath -> HackageCreds
 getCredsWithApiKey key fp = HackageCreds {
     hcUsername = ""
-  , hcPassword = fromString key
+  , hcPassword = T.pack key
   , hcCredsFile = fp
 }
 

--- a/src/Stack/Upload.hs
+++ b/src/Stack/Upload.hs
@@ -12,6 +12,8 @@ module Stack.Upload
     , uploadRevision
       -- * Credentials
     , HackageCreds
+    , HackageAuth(..)
+    , HackageKey(..)
     , loadAuth
     , writeFilePrivate
       -- * Internal
@@ -53,6 +55,7 @@ import           System.PosixCompat.Files              (setFileMode)
 
 
 newtype HackageKey = HackageKey Text
+    deriving (Eq, Show)
 
 -- | Username and password to log into Hackage.
 --
@@ -62,10 +65,11 @@ data HackageCreds = HackageCreds
     , hcPassword :: !Text
     , hcCredsFile :: !FilePath
     }
-    deriving Show
+    deriving (Eq, Show)
 
 data HackageAuth = HAKey HackageKey
                  | HACreds HackageCreds
+    deriving (Eq, Show)
 
 instance ToJSON HackageCreds where
     toJSON (HackageCreds u p _) = object

--- a/src/Stack/Upload.hs
+++ b/src/Stack/Upload.hs
@@ -87,7 +87,6 @@ withEnvVariable varName fromPrompt = lookupEnv (T.unpack varName) >>= maybe from
 maybeGetHackageKey :: RIO m (Maybe HackageKey)
 maybeGetHackageKey = fmap (HackageKey . T.pack) <$> (liftIO $ lookupEnv (T.unpack "HACKAGE_KEY"))
 
-
 loadAuth :: HasLogFunc m => Config -> RIO m HackageAuth
 loadAuth config = do
   maybeHackageKey <- maybeGetHackageKey

--- a/src/Stack/Upload.hs
+++ b/src/Stack/Upload.hs
@@ -85,7 +85,7 @@ withEnvVariable :: Text -> IO Text -> IO Text
 withEnvVariable varName fromPrompt = lookupEnv (T.unpack varName) >>= maybe fromPrompt (pure . T.pack)
 
 maybeGetHackageKey :: RIO m (Maybe HackageKey)
-maybeGetHackageKey = fmap (HackageKey . T.pack) <$> (liftIO $ lookupEnv (T.unpack "HACKAGE_KEY"))
+maybeGetHackageKey = liftIO $ fmap (HackageKey . T.pack) <$> lookupEnv "HACKAGE_KEY"
 
 loadAuth :: HasLogFunc m => Config -> RIO m HackageAuth
 loadAuth config = do

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -655,7 +655,7 @@ uploadCmd uploadOpts = do
         config <- view configL
         let hackageUrl = T.unpack $ configHackageBaseUrl config
             uploadVariant = uoptsUploadVariant uploadOpts
-        getCreds <- memoizeRef $ Upload.loadCreds config
+        getCreds <- memoizeRef $ Upload.loadAuth config
         mapM_ (resolveFile' >=> checkSDistTarball sdistOpts) files
         forM_ files $ \file -> do
             tarFile <- resolveFile' file

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -655,21 +655,19 @@ uploadCmd uploadOpts = do
         config <- view configL
         let hackageUrl = T.unpack $ configHackageBaseUrl config
             uploadVariant = uoptsUploadVariant uploadOpts
-        getCreds <- liftIO $ memoizeRef $ Upload.loadCreds config
+        getCreds <- memoizeRef $ Upload.loadCreds config
         mapM_ (resolveFile' >=> checkSDistTarball sdistOpts) files
         forM_ files $ \file -> do
             tarFile <- resolveFile' file
-            liftIO $ do
-              creds <- runMemoized getCreds
-              Upload.upload hackageUrl creds (toFilePath tarFile) uploadVariant
+            creds <- runMemoized getCreds
+            Upload.upload hackageUrl creds (toFilePath tarFile) uploadVariant
         forM_ dirs $ \dir -> do
             pkgDir <- resolveDir' dir
             (tarName, tarBytes, mcabalRevision) <- getSDistTarball (sdoptsPvpBounds sdistOpts) pkgDir
             checkSDistTarball' sdistOpts tarName tarBytes
-            liftIO $ do
-              creds <- runMemoized getCreds
-              Upload.uploadBytes hackageUrl creds tarName uploadVariant tarBytes
-              forM_ mcabalRevision $ uncurry $ Upload.uploadRevision hackageUrl creds
+            creds <- runMemoized getCreds
+            Upload.uploadBytes hackageUrl creds tarName uploadVariant tarBytes
+            forM_ mcabalRevision $ uncurry $ Upload.uploadRevision hackageUrl creds
 
 sdistCmd :: SDistOpts -> RIO Runner ()
 sdistCmd sdistOpts =

--- a/src/test/Stack/UploadSpec.hs
+++ b/src/test/Stack/UploadSpec.hs
@@ -29,6 +29,6 @@ spec = do
       (fileMode status .&. 0o777) `shouldBe` 0o600
 
   it "finds a HACKAGE_KEY env variable" $ do
-    maybeGetHackageKey `shouldReturn` Nothing
+    runRIO () maybeGetHackageKey `shouldReturn` Nothing
     setEnv "HACKAGE_KEY" "api_key"
-    maybeGetHackageKey `shouldReturn` Just "api_key"
+    runRIO () maybeGetHackageKey `shouldReturn` Just (HackageKey "api_key")

--- a/src/test/Stack/UploadSpec.hs
+++ b/src/test/Stack/UploadSpec.hs
@@ -9,6 +9,7 @@ import Stack.Upload
 import Test.Hspec
 import System.Permissions (osIsWindows)
 import System.PosixCompat.Files (getFileStatus, fileMode)
+import System.Environment (setEnv)
 import Data.Bits ((.&.))
 
 spec :: Spec
@@ -26,3 +27,8 @@ spec = do
     unless osIsWindows $ do
       status <- getFileStatus fp
       (fileMode status .&. 0o777) `shouldBe` 0o600
+
+  it "finds a HACKAGE_KEY env variable" $ do
+    maybeGetHackageKey `shouldReturn` Nothing
+    setEnv "HACKAGE_KEY" "api_key"
+    maybeGetHackageKey `shouldReturn` Just "api_key"

--- a/src/test/Stack/UploadSpec.hs
+++ b/src/test/Stack/UploadSpec.hs
@@ -9,7 +9,7 @@ import Stack.Upload
 import Test.Hspec
 import System.Permissions (osIsWindows)
 import System.PosixCompat.Files (getFileStatus, fileMode)
-import System.Environment (setEnv)
+import System.Environment (setEnv, unsetEnv)
 import Data.Bits ((.&.))
 
 spec :: Spec
@@ -30,5 +30,11 @@ spec = do
 
   it "finds a HACKAGE_KEY env variable" $ do
     runRIO () maybeGetHackageKey `shouldReturn` Nothing
-    setEnv "HACKAGE_KEY" "api_key"
-    runRIO () maybeGetHackageKey `shouldReturn` Just (HackageKey "api_key")
+
+    withEnv "HACKAGE_KEY" "api_key"
+      $ runRIO () maybeGetHackageKey `shouldReturn` Just (HackageKey "api_key")
+
+withEnv :: String -> String -> IO a -> IO a
+withEnv k v f = do
+  setEnv k v
+  f `finally` unsetEnv k


### PR DESCRIPTION
Closes #5513

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Usage example:

```bash
$ HACKAGE_KEY=foobar stack upload .
```

> Please also shortly describe how you tested your change.

`stack test` was all green.

Tested scenarios:

1. Key set but wrong: Tried to upload the package with wrong API key set. `stack upload` reported finding the key, and then bounced off Hackage authentication as expected.
2. Key set and correct: Successfully uploaded a package candidate to Hackage. Removed the candidate afterwards.
3. Key not set: `stack upload` asked for username and password. I gave these (correct ones), and uploaded a package candidate to Hackage. Removed the candidate afterwards.

> Bonus points for added tests!

Included a test for the function detecting a set `HACKAGE_KEY` env var.

I want to thank @pbrisbin here for helping me get back on track with this after I got lost trying to understand what GHC was expecting me to write:)