### PR TITLE
Alter command types to be less abstract

### DIFF
--- a/src/Options/Applicative/Complicated.hs
+++ b/src/Options/Applicative/Complicated.hs
@@ -20,12 +20,12 @@ import           Options.Applicative.Types
 import           Options.Applicative.Builder.Extra
 import           Options.Applicative.Builder.Internal
 import           Stack.Prelude
+import           Stack.Types.Config
 import           System.Environment
 
 -- | Generate and execute a complicated options parser.
 complicatedOptions
-  :: Monoid a
-  => Version
+  :: Version
   -- ^ numeric version
   -> Maybe String
   -- ^ version string
@@ -37,14 +37,14 @@ complicatedOptions
   -- ^ program description (displayed between usage and options listing in the help output)
   -> String
   -- ^ footer
-  -> Parser a
+  -> Parser GlobalOptsMonoid
   -- ^ common settings
-  -> Maybe (ParserFailure ParserHelp -> [String] -> IO (a,(b,a)))
+  -> Maybe (ParserFailure ParserHelp -> [String] -> IO (GlobalOptsMonoid,(RIO env (),GlobalOptsMonoid)))
   -- ^ optional handler for parser failure; 'handleParseResult' is called by
   -- default
-  -> ExceptT b (Writer (Mod CommandFields (b,a))) ()
+  -> ExceptT (RIO env ()) (Writer (Mod CommandFields (RIO env (),GlobalOptsMonoid))) ()
   -- ^ commands (use 'addCommand')
-  -> IO (a,b)
+  -> IO (GlobalOptsMonoid, RIO env ())
 complicatedOptions numericVersion stringVersion numericHpackVersion h pd footerStr commonParser mOnFailure commandParser =
   do args <- getArgs
      (a,(b,c)) <- case execParserPure (prefs noBacktrack) parser args of

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -13,8 +13,6 @@ module Main (main) where
 import           BuildInfo
 import           Stack.Prelude hiding (Display (..))
 import           Conduit (runConduitRes, sourceLazy, sinkFileCautious)
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Writer.Lazy (Writer)
 import           Data.Attoparsec.Args (parseArgs, EscapingMode (Escaping))
 import           Data.Attoparsec.Interpreter (getInterpreterArgs)
 import           Data.List
@@ -414,24 +412,24 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
       where
         -- addCommand hiding global options
         addCommand' :: String -> String -> (a -> RIO Runner ()) -> Parser a
-                    -> AddCommand
+                    -> AddCommand Runner
         addCommand' cmd title constr =
             addCommand cmd title globalFooter constr (\_ gom -> gom) (globalOpts OtherCmdGlobalOpts)
 
-        addSubCommands' :: String -> String -> AddCommand
-                        -> AddCommand
+        addSubCommands' :: String -> String -> AddCommand Runner
+                        -> AddCommand Runner
         addSubCommands' cmd title =
             addSubCommands cmd title globalFooter (globalOpts OtherCmdGlobalOpts)
 
         -- Additional helper that hides global options and shows build options
         addBuildCommand' :: String -> String -> (a -> RIO Runner ()) -> Parser a
-                         -> AddCommand
+                         -> AddCommand Runner
         addBuildCommand' cmd title constr =
             addCommand cmd title globalFooter constr (\_ gom -> gom) (globalOpts BuildCmdGlobalOpts)
 
         -- Additional helper that hides global options and shows some ghci options
         addGhciCommand' :: String -> String -> (a -> RIO Runner ()) -> Parser a
-                         -> AddCommand
+                         -> AddCommand Runner
         addGhciCommand' cmd title constr =
             addCommand cmd title globalFooter constr (\_ gom -> gom) (globalOpts GhciCmdGlobalOpts)
 
@@ -447,9 +445,6 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
         where hide = kind /= OuterGlobalOpts
 
     globalFooter = "Run 'stack --help' for global options that apply to all subcommands."
-
-type AddCommand =
-    ExceptT (RIO Runner ()) (Writer (Mod CommandFields (RIO Runner (), GlobalOptsMonoid))) ()
 
 -- | fall-through to external executables in `git` style if they exist
 -- (i.e. `stack something` looks for `stack-something` before


### PR DESCRIPTION
I was hacking around on Stack today, familiarising myself with some of the startup code and playing around adding some logging. I noticed this type, and found it to be adding quite a lot of indirection. Once I figured out what it was doing I thought it seemed logical to make some of the type aliases concrete, as they are only operating on a single type. I think this makes the type signatures less confusing here. I've also moved out a type alias to a place that seems like a suitable home :smile: 

-------

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

I believe this change should be covered off by the type checker :+1: it is just changing / moving some types.