### PR TITLE
Add Windows registry DisplayVersion (#5643)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ Other enhancements:
 * `stack upload` supports authentication with a Hackage API key (via
   `HACKAGE_KEY` environment variable).
 
+* `DisplayVersion` in the Windows registry is now set by the installer,
+  enabling tools like `winget` to properly read the version number.
+
 Bug fixes:
 
 * Ensure that `extra-path` works for case-insensitive `PATH`s on Windows.

--- a/etc/scripts/build-stack-installer.hs
+++ b/etc/scripts/build-stack-installer.hs
@@ -16,7 +16,7 @@ import Development.NSIS.Plugins.EnvVarUpdate
 
 main :: IO ()
 main = do
-  [srcPath, execPath, nsiPath] <- getArgs
+  [srcPath, execPath, nsiPath, stackVersionStr] <- getArgs
 
   writeFile (fromString nsiPath) $ nsis $ do
     _ <- constantStr "Name" "Haskell Stack"
@@ -43,6 +43,7 @@ main = do
 
       -- Write the uninstall keys for Windows
       writeRegStr HKCU "Software/Microsoft/Windows/CurrentVersion/Uninstall/$Name" "DisplayName" "$Name"
+      writeRegStr HKCU "Software/Microsoft/Windows/CurrentVersion/Uninstall/$Name" "DisplayVersion" (str stackVersionStr)
       writeRegStr HKCU "Software/Microsoft/Windows/CurrentVersion/Uninstall/$Name" "UninstallString" "\"$INSTDIR/uninstall-stack.exe\""
       writeRegDWORD HKCU "Software/Microsoft/Windows/CurrentVersion/Uninstall/$Name" "NoModify" 1
       writeRegDWORD HKCU "Software/Microsoft/Windows/CurrentVersion/Uninstall/$Name" "NoRepair" 1

--- a/etc/scripts/release.hs
+++ b/etc/scripts/release.hs
@@ -259,6 +259,7 @@ rules global@Global{..} args = do
             [ binaryExeFileName
             , binaryInstallerFileName
             , out
+            , stackVersionStr global
             ] :: Action ()
 
     releaseBinDir </> binaryName </> stackExeFileName %> \out -> do


### PR DESCRIPTION
Fixes #5643.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

* I ran `stack etc/scripts/release.hs release` locally and installed stack again through the generated installer. I then verified in the registry that `DisplayVersion` is set correctly, and that `winget list stack` now properly shows the installed version (2.7.4).
