### PR TITLE
Fix typo in doc/nix_integration.md

### DIFF
--- a/doc/nix_integration.md
+++ b/doc/nix_integration.md
@@ -119,7 +119,7 @@ behind the scenes).
 `stack setup` will start a nix-shell, so it will gather all the required
 packages, but given nix handles GHC installation, instead of stack, this will
 happen when running `stack build` if no setup has been performed
-before. Therefore it is not longer necessary to run `stack setup` unless you
+before. Therefore it is no longer necessary to run `stack setup` unless you
 want to cache a GHC installation before running the build.
 
 If `enable:` is omitted or set to `false`, you can still build in a nix-shell by


### PR DESCRIPTION
s/not/no

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
