### PR TITLE
Fix failure to find package when a dependency is shared between projects (#5680)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,8 @@ Bug fixes:
   See [rio#237](https://github.com/commercialhaskell/rio/pull/237)
 * Fix handling of overwritten `ghc` and `ghc-pkg` locations.
   [#5597](https://github.com/commercialhaskell/stack/pull/5597)
+* Fix failure to find package when a dependency is shared between projects.
+  [#5680](https://github.com/commercialhaskell/stack/issues/5680)
 
 ## v2.7.3
 

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -12,6 +12,7 @@ module Stack.Build.Cache
     , tryGetConfigCache
     , tryGetCabalMod
     , tryGetSetupConfigMod
+    , tryGetPackageProjectRoot
     , getInstalledExes
     , tryGetFlagCache
     , deleteCaches
@@ -22,6 +23,7 @@ module Stack.Build.Cache
     , writeConfigCache
     , writeCabalMod
     , writeSetupConfigMod
+    , writePackageProjectRoot
     , TestStatus (..)
     , setTestStatus
     , getTestStatus
@@ -34,6 +36,7 @@ module Stack.Build.Cache
 import           Stack.Prelude
 import           Crypto.Hash (hashWith, SHA256(..))
 import qualified Data.ByteArray as Mem (convert)
+import           Data.ByteString.Builder (byteString)
 import qualified Data.Map as M
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -154,6 +157,18 @@ tryGetFileMod fp =
   liftIO $ either (const Nothing) (Just . modificationTime) <$>
       tryIO (getFileStatus fp)
 
+-- | Try to read the project root from the last build of a package
+tryGetPackageProjectRoot :: HasEnvConfig env
+               => Path Abs Dir -> RIO env (Maybe ByteString)
+tryGetPackageProjectRoot dir = do
+  fp <- toFilePath <$> configPackageProjectRoot dir
+  tryReadFileBinary fp
+
+tryReadFileBinary :: MonadIO m => FilePath -> m (Maybe ByteString)
+tryReadFileBinary fp =
+  liftIO $ either (const Nothing) Just <$>
+      tryIO (readFileBinary fp)
+
 -- | Write the dirtiness cache for this package's files.
 writeBuildCache :: HasEnvConfig env
                 => Path Abs Dir
@@ -196,6 +211,16 @@ writeSetupConfigMod dir (Just x) = do
     fp <- configSetupConfigMod dir
     writeBinaryFileAtomic fp "Just used for its modification time"
     liftIO $ setFileTimes (toFilePath fp) x x
+
+-- | See 'tryGetPackageProjectRoot'
+writePackageProjectRoot
+  :: HasEnvConfig env
+  => Path Abs Dir
+  -> ByteString
+  -> RIO env ()
+writePackageProjectRoot dir projectRoot = do
+    fp <- configPackageProjectRoot dir
+    writeBinaryFileAtomic fp (byteString projectRoot)
 
 -- | Delete the caches for the project.
 deleteCaches :: HasEnvConfig env => Path Abs Dir -> RIO env ()

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -849,7 +849,7 @@ ensureConfig newConfigCache pkgDir ExecuteEnv {..} announce cabal cabalfp task =
           liftIO $ either (const Nothing) (Just . modificationTime) <$>
           tryJust (guard . isDoesNotExistError) (getFileStatus (toFilePath setupConfigfp))
     newSetupConfigMod <- getNewSetupConfigMod
-    newProjectRoot <- (S8.pack . toFilePath) <$> view projectRootL
+    newProjectRoot <- S8.pack . toFilePath <$> view projectRootL
     -- See https://github.com/commercialhaskell/stack/issues/3554
     taskAnyMissingHack <- view $ actualCompilerVersionL.to getGhcVersion.to (< mkVersion [8, 4])
     needConfig <-

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -849,6 +849,7 @@ ensureConfig newConfigCache pkgDir ExecuteEnv {..} announce cabal cabalfp task =
           liftIO $ either (const Nothing) (Just . modificationTime) <$>
           tryJust (guard . isDoesNotExistError) (getFileStatus (toFilePath setupConfigfp))
     newSetupConfigMod <- getNewSetupConfigMod
+    newProjectRoot <- (S8.pack . toFilePath) <$> view projectRootL
     -- See https://github.com/commercialhaskell/stack/issues/3554
     taskAnyMissingHack <- view $ actualCompilerVersionL.to getGhcVersion.to (< mkVersion [8, 4])
     needConfig <-
@@ -870,10 +871,12 @@ ensureConfig newConfigCache pkgDir ExecuteEnv {..} announce cabal cabalfp task =
                 -- Cabal's setup-config is created per OS/Cabal version, multiple
                 -- projects using the same package could get a conflict because of this
                 mOldSetupConfigMod <- tryGetSetupConfigMod pkgDir
+                mOldProjectRoot <- tryGetPackageProjectRoot pkgDir
 
                 return $ fmap ignoreComponents mOldConfigCache /= Just (ignoreComponents newConfigCache)
                       || mOldCabalMod /= Just newCabalMod
                       || mOldSetupConfigMod /= newSetupConfigMod
+                      || mOldProjectRoot /= Just newProjectRoot
     let ConfigureOpts dirs nodirs = configCacheOpts newConfigCache
 
     when (taskBuildTypeConfig task) ensureConfigureScript
@@ -912,6 +915,7 @@ ensureConfig newConfigCache pkgDir ExecuteEnv {..} announce cabal cabalfp task =
         -- check if our config mod file is newer than the file above, but this
         -- seems reasonable too.
         getNewSetupConfigMod >>= writeSetupConfigMod pkgDir
+        writePackageProjectRoot pkgDir newProjectRoot
 
     return needConfig
   where

--- a/src/Stack/Constants/Config.hs
+++ b/src/Stack/Constants/Config.hs
@@ -11,6 +11,7 @@ module Stack.Constants.Config
   , projectDockerSandboxDir
   , configCabalMod
   , configSetupConfigMod
+  , configPackageProjectRoot
   , buildCachesDir
   , testSuccessFile
   , testBuiltFile
@@ -83,6 +84,15 @@ configSetupConfigMod :: (MonadThrow m, MonadReader env m, HasEnvConfig env)
 configSetupConfigMod dir =
     liftM
         (</> $(mkRelFile "stack-setup-config-mod"))
+        (distDirFromDir dir)
+
+-- | The filename used for the project root from the last build of a package
+configPackageProjectRoot :: (MonadThrow m, MonadReader env m, HasEnvConfig env)
+                     => Path Abs Dir      -- ^ Package directory.
+                     -> m (Path Abs File)
+configPackageProjectRoot dir =
+    liftM
+        (</> $(mkRelFile "stack-project-root"))
         (distDirFromDir dir)
 
 -- | Directory for HPC work.

--- a/test/integration/lib/StackTest.hs
+++ b/test/integration/lib/StackTest.hs
@@ -289,14 +289,19 @@ removeDirIgnore fp = removeDirectoryRecursive fp `catch` \e ->
     then return ()
     else throwIO e
 
--- | Changes working directory to Stack source directory
-withSourceDirectory :: HasCallStack => IO () -> IO ()
-withSourceDirectory action = do
-  dir <- stackSrc
+-- | Changes to the specified working directory.
+withCwd :: HasCallStack => FilePath -> IO () -> IO ()
+withCwd dir action = do
   currentDirectory <- getCurrentDirectory
   let enterDir = setCurrentDirectory dir
       exitDir = setCurrentDirectory currentDirectory
   bracket_ enterDir exitDir action
+
+-- | Changes working directory to Stack source directory.
+withSourceDirectory :: HasCallStack => IO () -> IO ()
+withSourceDirectory action = do
+  dir <- stackSrc
+  withCwd dir action
 
 -- | Mark a test as superslow, only to be run when explicitly requested.
 superslow :: HasCallStack => IO () -> IO ()

--- a/test/integration/tests/5680-share-package-across-projects/Main.hs
+++ b/test/integration/tests/5680-share-package-across-projects/Main.hs
@@ -1,0 +1,8 @@
+import StackTest
+
+main :: IO ()
+main = do
+    stackEnv <- stackExe
+    withCwd "package-a" $ stack ["build"]
+    withCwd "package-b" $ stack ["build"]
+    withCwd "package-a" $ stack ["build"]

--- a/test/integration/tests/5680-share-package-across-projects/files/package-a/package.yaml
+++ b/test/integration/tests/5680-share-package-across-projects/files/package-a/package.yaml
@@ -1,0 +1,6 @@
+name:                package-a
+version:             0.1.0.0
+dependencies:
+- base >= 4.7 && < 5
+library:
+  source-dirs: src

--- a/test/integration/tests/5680-share-package-across-projects/files/package-a/src/Lib.hs
+++ b/test/integration/tests/5680-share-package-across-projects/files/package-a/src/Lib.hs
@@ -4,4 +4,3 @@ module Lib
 
 someFunc :: IO ()
 someFunc = putStrLn "someFunc"
--- @@@ Sun Feb 20 11:53:41 PST 2022

--- a/test/integration/tests/5680-share-package-across-projects/files/package-a/src/Lib.hs
+++ b/test/integration/tests/5680-share-package-across-projects/files/package-a/src/Lib.hs
@@ -1,0 +1,7 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"
+-- @@@ Sun Feb 20 11:53:41 PST 2022

--- a/test/integration/tests/5680-share-package-across-projects/files/package-a/stack.yaml
+++ b/test/integration/tests/5680-share-package-across-projects/files/package-a/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-17.15
+packages:
+- .
+- ../package-c

--- a/test/integration/tests/5680-share-package-across-projects/files/package-b/package.yaml
+++ b/test/integration/tests/5680-share-package-across-projects/files/package-b/package.yaml
@@ -1,0 +1,6 @@
+name:                package-b
+version:             0.1.0.0
+dependencies:
+- base >= 4.7 && < 5
+library:
+  source-dirs: src

--- a/test/integration/tests/5680-share-package-across-projects/files/package-b/src/Lib.hs
+++ b/test/integration/tests/5680-share-package-across-projects/files/package-b/src/Lib.hs
@@ -4,4 +4,3 @@ module Lib
 
 someFunc :: IO ()
 someFunc = putStrLn "someFunc"
--- @@@ Sun Feb 20 14:47:55 PST 2022

--- a/test/integration/tests/5680-share-package-across-projects/files/package-b/src/Lib.hs
+++ b/test/integration/tests/5680-share-package-across-projects/files/package-b/src/Lib.hs
@@ -1,0 +1,7 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"
+-- @@@ Sun Feb 20 14:47:55 PST 2022

--- a/test/integration/tests/5680-share-package-across-projects/files/package-b/stack.yaml
+++ b/test/integration/tests/5680-share-package-across-projects/files/package-b/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-17.15
+packages:
+- .
+- ../package-c

--- a/test/integration/tests/5680-share-package-across-projects/files/package-c/package.yaml
+++ b/test/integration/tests/5680-share-package-across-projects/files/package-c/package.yaml
@@ -1,0 +1,6 @@
+name:                package-c
+version:             0.1.0.0
+dependencies:
+- base >= 4.7 && < 5
+library:
+  source-dirs: src

--- a/test/integration/tests/5680-share-package-across-projects/files/package-c/src/Lib.hs
+++ b/test/integration/tests/5680-share-package-across-projects/files/package-c/src/Lib.hs
@@ -4,7 +4,3 @@ module Lib
 
 someFunc :: IO ()
 someFunc = putStrLn "someFunc"
--- @@@ Sun Feb 20 14:48:26 PST 2022
--- @@@ Sun Feb 20 14:48:34 PST 2022
--- @@@ Sun Feb 20 14:49:09 PST 2022
--- @@@ Sun Feb 20 14:52:06 PST 2022

--- a/test/integration/tests/5680-share-package-across-projects/files/package-c/src/Lib.hs
+++ b/test/integration/tests/5680-share-package-across-projects/files/package-c/src/Lib.hs
@@ -1,0 +1,10 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"
+-- @@@ Sun Feb 20 14:48:26 PST 2022
+-- @@@ Sun Feb 20 14:48:34 PST 2022
+-- @@@ Sun Feb 20 14:49:09 PST 2022
+-- @@@ Sun Feb 20 14:52:06 PST 2022

--- a/test/integration/tests/5680-share-package-across-projects/files/package-c/stack.yaml
+++ b/test/integration/tests/5680-share-package-across-projects/files/package-c/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-17.15
+packages:
+- .


### PR DESCRIPTION
This fixes a regression that was introduced in f64188016aea9fb34554f29858423aec0860ae4e (the fix for #5578).  Now, a package will be reconfigured if the project it's being built from (and therefore the local package database it gets installed to) changes.

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] ~~The documentation has been updated, if necessary.~~ (N/A)

How I tested:
* A new integration test is added in `test/integration/tests/5680-share-package-across-projects`
