### PR TITLE
Allow stack to build with lts-19.1 (GHC 9.0.2)

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -1218,7 +1219,11 @@ withSingleContext ActionContext {..} ee@ExecuteEnv {..} task@Task {..} allDeps m
                             let macroDeps = mapMaybe snd matchedDeps
                                 cppMacrosFile = setupDir </> relFileSetupMacrosH
                                 cppArgs = ["-optP-include", "-optP" ++ toFilePath cppMacrosFile]
+#if MIN_VERSION_Cabal(3,4,0)
+                            writeBinaryFileAtomic cppMacrosFile (encodeUtf8Builder (T.pack (C.generatePackageVersionMacros (packageVersion package) macroDeps)))
+#else
                             writeBinaryFileAtomic cppMacrosFile (encodeUtf8Builder (T.pack (C.generatePackageVersionMacros macroDeps)))
+#endif
                             return (packageDBArgs ++ depsArgs ++ cppArgs)
 
                         -- This branch is usually taken for builds, and

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ConstraintKinds    #-}
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts   #-}
@@ -224,7 +225,11 @@ selectPackageBuildPlan platform compiler pool gpd =
     flagCombinations :: NonEmpty [(FlagName, Bool)]
     flagCombinations = mapM getOptions (genPackageFlags gpd)
       where
+#if MIN_VERSION_Cabal(3,4,0)
+        getOptions :: C.PackageFlag -> NonEmpty (FlagName, Bool)
+#else
         getOptions :: C.Flag -> NonEmpty (FlagName, Bool)
+#endif
         getOptions f
             | flagManual f = (fname, flagDefault f) :| []
             | flagDefault f = (fname, True) :| [(fname, False)]

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -17,9 +18,15 @@ module Stack.ConfigCmd
        ,cfgCmdName) where
 
 import           Stack.Prelude
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+#endif
 import           Data.ByteString.Builder (byteString)
 import qualified Data.Map.Merge.Strict as Map
+#if !MIN_VERSION_aeson(2,0,0)
 import qualified Data.HashMap.Strict as HMap
+#endif
 import qualified Data.Text as T
 import qualified Data.Yaml as Yaml
 import qualified Options.Applicative as OA
@@ -74,7 +81,11 @@ cfgCmdSet cmd = do
         liftIO (Yaml.decodeFileEither (toFilePath configFilePath)) >>= either throwM return
     newValue <- cfgCmdSetValue (parent configFilePath) cmd
     let cmdKey = cfgCmdSetOptionName cmd
+#if MIN_VERSION_aeson(2,0,0)
+        config' = KeyMap.insert (Key.fromText cmdKey) newValue config
+#else
         config' = HMap.insert cmdKey newValue config
+#endif
     if config' == config
         then logInfo
                  (fromString (toFilePath configFilePath) <>

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -32,6 +32,9 @@ import           Data.List (find, isPrefixOf, unzip)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
+#if MIN_VERSION_Cabal(3,4,0)
+import           Distribution.CabalSpecVersion
+#endif
 import           Distribution.Compiler
 import           Distribution.ModuleName (ModuleName)
 import qualified Distribution.ModuleName as Cabal
@@ -128,7 +131,11 @@ resolvePackage packageConfig gpkg =
         (resolvePackageDescription packageConfig gpkg)
 
 packageFromPackageDescription :: PackageConfig
+#if MIN_VERSION_Cabal(3,4,0)
+                              -> [PackageFlag]
+#else
                               -> [D.Flag]
+#endif
                               -> PackageDescriptionPair
                               -> Package
 packageFromPackageDescription packageConfig pkgFlags (PackageDescriptionPair pkgNoMod pkg) =
@@ -190,7 +197,11 @@ packageFromPackageDescription packageConfig pkgFlags (PackageDescriptionPair pkg
           (library pkg)
     , packageBuildType = buildType pkg
     , packageSetupDeps = msetupDeps
+#if MIN_VERSION_Cabal(3,4,0)
+    , packageCabalSpec = specVersion pkg
+#else
     , packageCabalSpec = either orLaterVersion id $ specVersionRaw pkg
+#endif
     }
   where
     extraLibNames = S.union subLibNames foreignLibNames
@@ -696,7 +707,11 @@ packageDescModulesAndFiles pkg = do
 
 -- | Resolve globbing of files (e.g. data files) to absolute paths.
 resolveGlobFiles
+#if MIN_VERSION_Cabal(3,4,0)
+  :: CabalSpecVersion -- ^ cabal file version
+#else
   :: Version -- ^ cabal file version
+#endif
   -> [String]
   -> RIO Ctx (Set (Path Abs File))
 resolveGlobFiles cabalFileVersion =
@@ -862,7 +877,11 @@ data PackageDescriptionPair = PackageDescriptionPair
 resolvePackageDescription :: PackageConfig
                           -> GenericPackageDescription
                           -> PackageDescriptionPair
+#if MIN_VERSION_Cabal(3,4,0)
+resolvePackageDescription packageConfig (GenericPackageDescription desc _ defaultFlags mlib subLibs foreignLibs' exes tests benches) =
+#else
 resolvePackageDescription packageConfig (GenericPackageDescription desc defaultFlags mlib subLibs foreignLibs' exes tests benches) =
+#endif
     PackageDescriptionPair
       { pdpOrigBuildable = go False
       , pdpModifiedBuildable = go True
@@ -935,9 +954,17 @@ resolvePackageDescription packageConfig (GenericPackageDescription desc defaultF
 -- | Make a map from a list of flag specifications.
 --
 -- What is @flagManual@ for?
+#if MIN_VERSION_Cabal(3,4,0)
+flagMap :: [PackageFlag] -> Map FlagName Bool
+#else
 flagMap :: [Flag] -> Map FlagName Bool
+#endif
 flagMap = M.fromList . map pair
+#if MIN_VERSION_Cabal(3,4,0)
+  where pair :: PackageFlag -> (FlagName, Bool)
+#else
   where pair :: Flag -> (FlagName, Bool)
+#endif
         pair = flagName &&& flagDefault
 
 data ResolveConditions = ResolveConditions
@@ -986,7 +1013,11 @@ resolveConditions rc addDeps (CondNode lib deps cs) = basic <> children
                   case v of
                     OS os -> os == rcOS rc
                     Arch arch -> arch == rcArch rc
+#if MIN_VERSION_Cabal(3,4,0)
+                    PackageFlag flag ->
+#else
                     Flag flag ->
+#endif
                       fromMaybe False $ M.lookup flag (rcFlags rc)
                       -- NOTE:  ^^^^^ This should never happen, as all flags
                       -- which are used must be declared. Defaulting to
@@ -1394,7 +1425,13 @@ applyForceCustomBuild cabalVersion package
           }
     | otherwise = package
   where
+#if MIN_VERSION_Cabal(3,4,0)
+    cabalVersionRange =
+      orLaterVersion $ mkVersion $ cabalSpecToVersionDigits $
+        packageCabalSpec package
+#else
     cabalVersionRange = packageCabalSpec package
+#endif
     forceCustomBuild =
       packageBuildType package == Simple &&
       not (cabalVersion `withinRange` cabalVersionRange)

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -18,6 +18,9 @@ import           Distribution.Compiler      (CompilerFlavor (..))
 import           Distribution.ModuleName    (ModuleName)
 import qualified Distribution.PackageDescription as PD
 import qualified Distribution.Types.CondTree as C
+#if MIN_VERSION_Cabal(3,4,0)
+import           Distribution.Types.ModuleReexport
+#endif
 import           Distribution.Types.PackageName (mkPackageName)
 import           Distribution.Types.VersionRange (withinRange)
 import           Distribution.System        (Platform (..))
@@ -280,7 +283,11 @@ allExposedModules gpd = do
       mlibrary = snd . C.simplifyCondTree checkCond <$> PD.condLibrary gpd
   pure $ case mlibrary  of
     Just lib -> PD.exposedModules lib ++
+#if MIN_VERSION_Cabal(3,4,0)
+                map moduleReexportName (PD.reexportedModules lib)
+#else
                 map PD.moduleReexportName (PD.reexportedModules lib)
+#endif
     Nothing  -> mempty
 
 -- | The Stackage project introduced the concept of hidden packages,

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
@@ -15,6 +16,9 @@ import qualified RIO.Text as T
 import           Data.Aeson (ToJSON (..), FromJSON (..), (.=), (.:), object, withObject)
 import qualified Data.Map as M
 import qualified Data.Set as Set
+#if MIN_VERSION_Cabal(3,4,0)
+import           Distribution.CabalSpecVersion
+#endif
 import           Distribution.Parsec (PError (..), PWarning (..), showPos)
 import qualified Distribution.SPDX.License as SPDX
 import           Distribution.License (License)
@@ -114,7 +118,11 @@ data Package =
           ,packageBuildType :: !BuildType                 -- ^ Package build-type.
           ,packageSetupDeps :: !(Maybe (Map PackageName VersionRange))
                                                           -- ^ If present: custom-setup dependencies
+#if MIN_VERSION_Cabal(3,4,0)
+          ,packageCabalSpec :: !CabalSpecVersion          -- ^ Cabal spec range
+#else
           ,packageCabalSpec :: !VersionRange              -- ^ Cabal spec range
+#endif
           }
  deriving (Show,Typeable)
 

--- a/src/Stack/Types/Resolver.hs
+++ b/src/Stack/Types/Resolver.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -19,7 +20,12 @@ module Stack.Types.Resolver
 import           Pantry.Internal.AesonExtended
                  (FromJSON, parseJSON,
                   withObject, (.:), withText)
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+#else
 import qualified Data.HashMap.Strict as HashMap
+#endif
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Text as T
 import           Data.Text.Read (decimal)
@@ -86,8 +92,13 @@ instance FromJSON Snapshots where
     parseJSON = withObject "Snapshots" $ \o -> Snapshots
         <$> (o .: "nightly" >>= parseNightly)
         <*> fmap IntMap.unions (mapM (parseLTS . snd)
+#if MIN_VERSION_aeson(2,0,0)
+                $ filter (isLTS . Key.toText . fst)
+                $ KeyMap.toList o)
+#else
                 $ filter (isLTS . fst)
                 $ HashMap.toList o)
+#endif
       where
         parseNightly t =
             case parseSnapName t of

--- a/stack-ghc-902.yaml
+++ b/stack-ghc-902.yaml
@@ -1,0 +1,27 @@
+resolver: lts-19.1
+
+packages:
+- .
+
+docker:
+  enable: false
+  repo: fpco/alpine-haskell-stack:8.10.4
+
+nix:
+  # --nix on the command-line to enable.
+  packages:
+    - zlib
+    - unzip
+flags:
+  stack:
+    developer-mode: true
+
+ghc-options:
+   "$locals": -fhide-source-paths
+
+extra-deps:
+- mustache-2.4.0@sha256:09a2eac7b8d093231cd8c5355dc87d7f882be77aebf88de18c4d9e612beca453,3345
+- unordered-containers-0.2.16.0@sha256:859ec9a017e51194755cb8a445b767afc5ce0ac991cd50b0f96abd31b3687aab,5217
+drop-packages:
+# See https://github.com/commercialhaskell/stack/pull/4712
+- cabal-install

--- a/stack.cabal
+++ b/stack.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 
@@ -462,6 +462,8 @@ executable stack-integration-test
   other-modules:
       StackTest
       Paths_stack
+  autogen-modules:
+      Paths_stack
   hs-source-dirs:
       test/integration
       test/integration/lib
@@ -589,6 +591,8 @@ test-suite stack-test
       Stack.PackageDumpSpec
       Stack.Types.TemplateNameSpec
       Stack.UploadSpec
+      Paths_stack
+  autogen-modules:
       Paths_stack
   hs-source-dirs:
       src/test


### PR DESCRIPTION
Uses C pre-processor (CPP) directives to not disturb the existing code that builds with versions of GHC before 9.0.2.

Tested by building `stack` on Windows 11. The built `stack` executable was, in turn, then tested by using it to build `stack` on Windows 11.

After building:
~~~
❯ stack --version
Version 2.7.6, Git revision 79cdfa1b6ddc5b9c06ad8dea1930d4868fe91b56 (8411 commits) RELEASE-CANDIDATE x86_64
Compiled with:
- Cabal-3.4.1.0
...
- aeson-2.0.3.0
...
- base-4.15.1.0
...
- hpack-0.34.6
...
- mintty-0.1.3
...
- pantry-0.5.4
...
~~~

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

I think documentation of the use of `stack` is unaffected.

One motivation for this was seeing that @snoyberg had updated `pantry-0.5.4` to support `aeson-2.0.0.0`.