### PR TITLE
Clear GHC 8.10.7 and 9.0.2 compiler warnings

### DIFF
--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude     #-}
 {-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -147,7 +148,9 @@ processLoadResult mdb (reason, lh) = do
         maybe mempty (\db -> ", from " <> displayShow db <> ",") mdb <>
         " due to" <>
         case reason of
+#if !MIN_VERSION_GLASGOW_HASKELL(9,0,1,0)
             Allowed -> " the impossible?!?!"
+#endif
             UnknownPkg -> " it being unknown to the resolver / extra-deps."
             WrongLocation mloc loc -> " wrong location: " <> displayShow (mloc, loc)
             WrongVersion actual wanted ->

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
@@ -153,7 +154,9 @@ makeConcreteResolver (ARResolver r) = pure r
 makeConcreteResolver ar = do
     r <-
         case ar of
+#if !MIN_VERSION_GLASGOW_HASKELL(9,0,1,0)
             ARResolver r -> assert False $ makeConcreteResolver (ARResolver r)
+#endif
             ARGlobal -> do
                 config <- view configL
                 implicitGlobalDir <- getImplicitGlobalProjectDir config
@@ -584,9 +587,10 @@ withBuildConfig inner = do
                            , "# http://docs.haskellstack.org/en/stable/yaml_configuration/\n"
                            , "#\n"
                            , Yaml.encode p]
-                       writeBinaryFileAtomic (parent dest </> relFileReadmeTxt)
-                           "This is the implicit global project, which is used only when 'stack' is run\n\
-                           \outside of a real project.\n"
+                       writeBinaryFileAtomic (parent dest </> relFileReadmeTxt) $
+                           "This is the implicit global project, which is " <>
+                           "used only when 'stack' is run\noutside of a " <>
+                           "real project.\n"
                    return (p, dest)
     mcompiler <- view $ globalOptsL.to globalCompiler
     let project = project'
@@ -961,26 +965,26 @@ packagesParser = many (strOption
                      metavar "PACKAGE(S)" <>
                      help "Additional package(s) that must be installed"))
 
-defaultConfigYaml :: IsString s => s
+defaultConfigYaml :: (IsString s, Semigroup s) => s
 defaultConfigYaml =
-  "# This file contains default non-project-specific settings for 'stack', used\n\
-  \# in all projects.  For more information about stack's configuration, see\n\
-  \# http://docs.haskellstack.org/en/stable/yaml_configuration/\n\
-  \\n\
-  \# The following parameters are used by \"stack new\" to automatically fill fields\n\
-  \# in the cabal config. We recommend uncommenting them and filling them out if\n\
-  \# you intend to use 'stack new'.\n\
-  \# See https://docs.haskellstack.org/en/stable/yaml_configuration/#templates\n\
-  \templates:\n\
-  \  params:\n\
-  \#    author-name:\n\
-  \#    author-email:\n\
-  \#    copyright:\n\
-  \#    github-username:\n\
-  \\n\
-  \# The following parameter specifies stack's output styles; STYLES is a\n\
-  \# colon-delimited sequence of key=value, where 'key' is a style name and\n\
-  \# 'value' is a semicolon-delimited list of 'ANSI' SGR (Select Graphic\n\
-  \# Rendition) control codes (in decimal). Use \"stack ls stack-colors --basic\"\n\
-  \# to see the current sequence.\n\
-  \# stack-colors: STYLES\n"
+  "# This file contains default non-project-specific settings for 'stack', used\n" <>
+  "# in all projects.  For more information about stack's configuration, see\n" <>
+  "# http://docs.haskellstack.org/en/stable/yaml_configuration/\n" <>
+  "\n" <>
+  "# The following parameters are used by \"stack new\" to automatically fill fields\n" <>
+  "# in the cabal config. We recommend uncommenting them and filling them out if\n" <>
+  "# you intend to use 'stack new'.\n" <>
+  "# See https://docs.haskellstack.org/en/stable/yaml_configuration/#templates\n" <>
+  "templates:\n" <>
+  "  params:\n" <>
+  "#    author-name:\n" <>
+  "#    author-email:\n" <>
+  "#    copyright:\n" <>
+  "#    github-username:\n" <>
+  "\n" <>
+  "# The following parameter specifies stack's output styles; STYLES is a\n" <>
+  "# colon-delimited sequence of key=value, where 'key' is a style name and\n" <>
+  "# 'value' is a semicolon-delimited list of 'ANSI' SGR (Select Graphic\n" <>
+  "# Rendition) control codes (in decimal). Use \"stack ls stack-colors --basic\"\n" <>
+  "# to see the current sequence.\n" <>
+  "# stack-colors: STYLES\n"

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections     #-}
 
@@ -16,7 +17,9 @@ import           Data.Maybe
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Distribution.PackageDescription as C
+#if !MIN_VERSION_Cabal(3,4,0)
 import qualified Distribution.Types.UnqualComponentName as C
+#endif
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
 import           Stack.Constants (ghcShowOptionsOutput)

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude  #-}
 {-# LANGUAGE ConstraintKinds    #-}
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -40,7 +41,9 @@ import qualified Distribution.PackageDescription as Cabal
 import qualified Distribution.PackageDescription.Check as Check
 import qualified Distribution.PackageDescription.Parsec as Cabal
 import           Distribution.PackageDescription.PrettyPrint (showGenericPackageDescription)
+#if !MIN_VERSION_Cabal(3,4,0)
 import qualified Distribution.Types.UnqualComponentName as Cabal
+#endif
 import           Distribution.Version (simplifyVersionRange, orLaterVersion, earlierVersion, hasUpperBound, hasLowerBound)
 import           Path
 import           Path.IO hiding (getModificationTime, getPermissions, withSystemTempDir)

--- a/src/Stack/Storage/Project.hs
+++ b/src/Stack/Storage/Project.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude          #-}
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleInstances          #-}
@@ -39,7 +40,9 @@ import Stack.Types.Config (HasBuildConfig, buildConfigL, bcProjectStorage, Proje
 import Stack.Types.GhcPkgId
 
 share [ mkPersist sqlSettings
+#if !MIN_VERSION_persistent(2,13,0)
       , mkDeleteCascade sqlSettings
+#endif
       , mkMigrate "migrateAll"
     ]
     [persistLowerCase|
@@ -54,27 +57,43 @@ ConfigCacheParent sql="config_cache"
   deriving Show
 
 ConfigCacheDirOption
+#if MIN_VERSION_persistent(2,13,0)
+  parent ConfigCacheParentId sql="config_cache_id" OnDeleteCascade
+#else
   parent ConfigCacheParentId sql="config_cache_id"
+#endif
   index Int
   value String sql="option"
   UniqueConfigCacheDirOption parent index
   deriving Show
 
 ConfigCacheNoDirOption
+#if MIN_VERSION_persistent(2,13,0)
+  parent ConfigCacheParentId sql="config_cache_id" OnDeleteCascade
+#else
   parent ConfigCacheParentId sql="config_cache_id"
+#endif
   index Int
   value String sql="option"
   UniqueConfigCacheNoDirOption parent index
   deriving Show
 
 ConfigCacheDep
+#if MIN_VERSION_persistent(2,13,0)
+  parent ConfigCacheParentId sql="config_cache_id" OnDeleteCascade
+#else
   parent ConfigCacheParentId sql="config_cache_id"
+#endif
   value GhcPkgId sql="ghc_pkg_id"
   UniqueConfigCacheDep parent value
   deriving Show
 
 ConfigCacheComponent
+#if MIN_VERSION_persistent(2,13,0)
+  parent ConfigCacheParentId sql="config_cache_id" OnDeleteCascade
+#else
   parent ConfigCacheParentId sql="config_cache_id"
+#endif
   value S.ByteString sql="component"
   UniqueConfigCacheComponent parent value
   deriving Show

--- a/src/Stack/Storage/User.hs
+++ b/src/Stack/Storage/User.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude          #-}
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleInstances          #-}
@@ -52,7 +53,9 @@ import System.Posix.Types (COff (..))
 import System.PosixCompat.Files (getFileStatus, fileSize, modificationTime)
 
 share [ mkPersist sqlSettings
+#if !MIN_VERSION_persistent(2,13,0)
       , mkDeleteCascade sqlSettings
+#endif
       , mkMigrate "migrateAll"
     ]
     [persistLowerCase|
@@ -68,13 +71,21 @@ PrecompiledCacheParent sql="precompiled_cache"
   deriving Show
 
 PrecompiledCacheSubLib
+#if MIN_VERSION_persistent(2,13,0)
+  parent PrecompiledCacheParentId sql="precompiled_cache_id" OnDeleteCascade
+#else
   parent PrecompiledCacheParentId sql="precompiled_cache_id"
+#endif
   value FilePath sql="sub_lib"
   UniquePrecompiledCacheSubLib parent value
   deriving Show
 
 PrecompiledCacheExe
+#if MIN_VERSION_persistent(2,13,0)
+  parent PrecompiledCacheParentId sql="precompiled_cache_id" OnDeleteCaseCascade
+#else
   parent PrecompiledCacheParentId sql="precompiled_cache_id"
+#endif
   value FilePath sql="exe"
   UniquePrecompiledCacheExe parent value
   deriving Show

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude     #-}
 {-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DefaultSignatures     #-}
 {-# LANGUAGE DeriveDataTypeable    #-}
@@ -204,7 +205,9 @@ import           Distribution.PackageDescription (GenericPackageDescription)
 import qualified Distribution.PackageDescription as C
 import           Distribution.System (Platform, Arch)
 import qualified Distribution.Text
+#if !MIN_VERSION_Cabal(3,4,0)
 import qualified Distribution.Types.UnqualComponentName as C
+#endif
 import           Distribution.Version (anyVersion, mkVersion', mkVersion)
 import           Generics.Deriving.Monoid (memptydefault, mappenddefault)
 import           Lens.Micro


### PR DESCRIPTION
This follows on from #5696 but relates to compiler warnings as opposed to just the threshold of the package building.

Clears:

~~~
src\Stack\Storage\Project.hs:42:9: warning: [-Wdeprecations]
    In the use of ‘mkDeleteCascade’
    (imported from Database.Persist.TH):
    Deprecated: "You can now set update and delete cascade behavior directly on the entity in the quasiquoter. This function and class are deprecated and will be removed in the next major ersion."
   |
42 |       , mkDeleteCascade sqlSettings
   |         ^^^^^^^^^^^^^^^
src\Stack\Storage\User.hs:55:9: warning: [-Wdeprecations]
    In the use of ‘mkDeleteCascade’
    (imported from Database.Persist.TH):
    Deprecated: "You can now set update and delete cascade behavior directly on the entity in the quasiquoter. This function and class are deprecated and will be removed in the next major ersion."
   |
55 |       , mkDeleteCascade sqlSettings
   |         ^^^^^^^^^^^^^^^
~~~

where the deprecation occurred from `persistent-2.13.0.0` (first included in LTS resolver lts-18.0 (GHC 8.10.4)).

This is done by adding `OnDeleteCascade` to the cross-referenced fields of type `...Id` in the quasiquoter.

Also clears:

~~~
src\Stack\Options\Completion.hs:19:1: warning: [-Wunused-imports]
    The qualified import of ‘Distribution.Types.UnqualComponentName’ is redundant
      except perhaps to import instances from ‘Distribution.Types.UnqualComponentName’
    To import instances alone, use: import Distribution.Types.UnqualComponentName()
   |
19 | import qualified Distribution.Types.UnqualComponentName as C
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src\Stack\SDist.hs:43:1: warning: [-Wunused-imports]
    The qualified import of ‘Distribution.Types.UnqualComponentName’ is redundant
      except perhaps to import instances from ‘Distribution.Types.UnqualComponentName’
    To import instances alone, use: import Distribution.Types.UnqualComponentName()
   |
43 | import qualified Distribution.Types.UnqualComponentName as Cabal
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src\Stack\Types\Config.hs:207:1: warning: [-Wunused-imports]
    The qualified import of ‘Distribution.Types.UnqualComponentName’ is redundant
      except perhaps to import instances from ‘Distribution.Types.UnqualComponentName’
    To import instances alone, use: import Distribution.Types.UnqualComponentName()
    |
207 | import qualified Distribution.Types.UnqualComponentName as C
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src\Stack\Package.hs:52:1: warning: [-Wunused-imports]
    The import of ‘Distribution.Types.ForeignLib’ is redundant
      except perhaps to import instances from ‘Distribution.Types.ForeignLib’
    To import instances alone, use: import Distribution.Types.ForeignLib()
   |
52 | import           Distribution.Types.ForeignLib
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src\Stack\Package.hs:54:1: warning: [-Wunused-imports]
    The import of ‘Distribution.Types.LibraryName’ is redundant
      except perhaps to import instances from ‘Distribution.Types.LibraryName’
    To import instances alone, use: import Distribution.Types.LibraryName()
   |
54 | import           Distribution.Types.LibraryName (libraryNameString, maybeToLibraryName)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src\Stack\Package.hs:43:1: warning: [-Wunused-imports]
    The qualified import of ‘Distribution.PackageDescription’ is redundant
      except perhaps to import instances from ‘Distribution.PackageDescription’
    To import instances alone, use: import Distribution.PackageDescription()
   |
43 | import qualified Distribution.PackageDescription as D
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
~~~

which arise because `Distribution.PackageDescription` now re-exports certain modules.

Also clears:

~~~
src\Stack\Config.hs:156:13: warning: [-Woverlapping-patterns]
    Pattern match is redundant
    In a case alternative: ARResolver r -> ...
    |
156 |             ARResolver r -> assert False $ makeConcreteResolver (ARResolver r)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src\Stack\Build\Installed.hs:150:13: warning: [-Woverlapping-patterns]
    Pattern match is redundant
    In a case alternative: Allowed -> ...
    |
150 |             Allowed -> " the impossible?!?!"
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
~~~

which arise because GHC 9.0.1 is better at identifying overlapping patterns than earlier versions of GHC.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Tested by building `stack` and then using the built `stack` executable to build `stack`, all on Windows 11.