### PR TITLE
Remove unnecessary CPP directives

### DIFF
--- a/src/Path/Extended.hs
+++ b/src/Path/Extended.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE CPP #-}
-
-module Path.Extended 
+module Path.Extended
  ( fileExtension
  , addExtension
  , replaceExtension
@@ -11,30 +9,16 @@ import qualified Path
 import           Path (Path, File)
 
 fileExtension :: MonadThrow m => Path b File -> m String
-fileExtension = 
-#if MIN_VERSION_path(0,7,0)
-    Path.fileExtension
-#else
-    pure . Path.fileExtension
-#endif
+fileExtension = Path.fileExtension
 
 addExtension :: MonadThrow m
   => String
   -> Path b File
   -> m (Path b File)
-addExtension =
-#if MIN_VERSION_path(0,7,0)
-    Path.addExtension
-#else
-    Path.addFileExtension
-#endif
+addExtension = Path.addExtension
 
 replaceExtension :: MonadThrow m
   => String
   -> Path b File
   -> m (Path b File)
-#if MIN_VERSION_path(0,7,0)
 replaceExtension ext = Path.replaceExtension ('.' : ext)
-#else
-replaceExtension = flip (Path.-<.>)
-#endif

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -154,14 +154,10 @@ getCmdArgs docker imageInfo isRemoteDocker = do
         -- MSS 2020-04-21 previously used replaceExtension, but semantics changed in path 0.7
         -- In any event, I'm not even sure _why_ we need to drop a file extension here
         -- Originally introduced here: https://github.com/commercialhaskell/stack/commit/6218dadaf5fd7bf312bb1bd0db63b4784ba78cb2
-#if MIN_VERSION_path(0, 7, 0)
         let exeBase =
               case splitExtension exePath of
                 Left _ -> exePath
                 Right (x, _) -> x
-#else
-        exeBase <- exePath -<.> ""
-#endif
         let mountPath = hostBinDir FP.</> toFilePath (filename exeBase)
         return (mountPath, args, [], [Mount (toFilePath exePath) mountPath])
 

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -59,11 +59,7 @@ import qualified Distribution.Types.UnqualComponentName as Cabal
 import           Distribution.Verbosity (silent)
 import           Distribution.Version (mkVersion, orLaterVersion, anyVersion)
 import qualified HiFileParser as Iface
-#if MIN_VERSION_path(0,7,0)
 import           Path as FL hiding (replaceExtension)
-#else
-import           Path as FL
-#endif
 import           Path.Extra
 import           Path.IO hiding (findFiles)
 import           Stack.Build.Installed

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -25,11 +25,7 @@ import           Distribution.Types.PackageName (mkPackageName)
 import           Distribution.Types.VersionRange (withinRange)
 import           Distribution.System        (Platform (..))
 import qualified Pantry.SHA256 as SHA256
-#if MIN_VERSION_path(0,7,0)
 import           Path hiding (replaceExtension)
-#else
-import           Path
-#endif
 import           Path.IO
 import qualified Stack.Build
 import           Stack.Build.Installed


### PR DESCRIPTION
`stack.yaml` currently uses resolver `lts-17.15`, which provides `path-0.7.0`.

This pull request removes unnecessary `#if MIN_VERSION_path(0,7,0)`.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on the CI.
