### PR TITLE
Clear Stack.Types.Build.missingExeError redundancy

### DIFF
--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -314,15 +314,17 @@ instance Show StackBuildException where
 
 missingExeError :: Bool -> String -> String
 missingExeError isSimpleBuildType msg =
-    unlines $ msg :
-        case possibleCauses of
-            [] -> []
-            [cause] -> ["One possible cause of this issue is:\n* " <> cause]
-            _ -> "Possible causes of this issue:" : map ("* " <>) possibleCauses
+    unlines $ msg : "Possible causes of this issue:" :
+              map ("* " <>) possibleCauses
   where
     possibleCauses =
-        "No module named \"Main\". The 'main-is' source file should usually have a header indicating that it's a 'Main' module." :
-        "A cabal file that refers to nonexistent other files (e.g. a license-file that doesn't exist). Running 'cabal check' may point out these issues." :
+        "No module named \"Main\". The 'main-is' source file should usually \
+        \have a header indicating that it's a 'Main' module." :
+
+        "A cabal file that refers to nonexistent other files (e.g. a \
+        \license-file that doesn't exist). Running 'cabal check' may point \
+        \out these issues." :
+
         if isSimpleBuildType
             then []
             else ["The Setup.hs file is changing the installation target dir."]


### PR DESCRIPTION
Clears the redundancy identified by GHC 9.2.2, namely:

~~~
src\Stack\Types\Build.hs:319:13: warning: [-Woverlapping-patterns]
Pattern match is redundant
In a case alternative: [] -> ...
|
319 | [] -> []
| ^^^^^^^^

src\Stack\Types\Build.hs:320:13: warning: [-Woverlapping-patterns]
Pattern match is redundant
In a case alternative: [cause] -> ...
|
320 | [cause] -> ["One possible cause of this issue is:\n* " <> cause]
| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
~~~

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on the CI.
