### PR TITLE
Fix #5618 Improve documentation of `stack new`

### DIFF
--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -110,12 +110,17 @@ initOptsParser =
   where
     searchDirs =
       many (textArgument
-              (metavar "DIR" <>
+              (metavar "DIR(S)" <>
                completer dirCompleter <>
-               help "Directories to include, default is current directory."))
+               help "Directory, or directories, to include in the search for \
+                    \.cabal files, when initialising. The default is the \
+                    \current directory."))
     ignoreSubDirs = switch (long "ignore-subdirs" <>
-                           help "Do not search for .cabal files in sub directories")
+                           help "Do not search for .cabal files in \
+                                \subdirectories, when initialising.")
     overwrite = switch (long "force" <>
-                       help "Force overwriting an existing stack.yaml")
+                       help "Force an initialisation that overwrites any \
+                            \existing stack.yaml file.")
     omitPackages = switch (long "omit-packages" <>
-                           help "Exclude conflicting or incompatible user packages")
+                           help "Exclude conflicting or incompatible user \
+                                \packages, when initialising.")

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -216,9 +216,10 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                          (buildOptsParser Haddock)
         addCommand' "new"
          (unwords [ "Create a new project from a template."
-                  , "Run `stack templates' to see available templates."
+                  , "Run `stack templates' to see available templates. Will"
+                  , "also initialise if there is no stack.yaml file."
                   , "Note: you can also specify a local file or a"
-                  , "remote URL as a template."
+                  , "remote URL as a template; or force an initialisation."
                   ] )
                     newCmd
                     newOptsParser
@@ -836,8 +837,8 @@ initCmd initOpts = do
     withGlobalProject $ withConfig YesReexec (initProject pwd initOpts (globalResolver go))
 
 -- | Create a project directory structure and initialize the stack config.
-newCmd :: (NewOpts,InitOpts) -> RIO Runner ()
-newCmd (newOpts,initOpts) =
+newCmd :: (NewOpts, InitOpts) -> RIO Runner ()
+newCmd (newOpts, initOpts) =
     withGlobalProject $ withConfig YesReexec $ do
         dir <- new newOpts (forceOverwrite initOpts)
         exists <- doesFileExist $ dir </> stackDotYaml


### PR DESCRIPTION
The existing option parser of `stack new` borrows from the parser of `stack init`. This pull request extends the documentation of `stack init --help`, so that `stack new --help` makes more sense. The introduction to `stack new` also now mentions that initialisation may be involved or can be forced.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
