### PR TITLE
Fix #5543 Filter all LTSs to yield supported LTSs

### DIFF
--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -477,14 +477,20 @@ checkBundleResolver initOpts snapshotLoc snapCandidate pkgDirs = do
 getRecommendedSnapshots :: Snapshots -> NonEmpty SnapName
 getRecommendedSnapshots snapshots =
     -- in order - Latest LTS, Latest Nightly, all LTS most recent first
-    case NonEmpty.nonEmpty ltss of
+    case NonEmpty.nonEmpty supportedLtss of
         Just (mostRecent :| older)
             -> mostRecent :| (nightly : older)
         Nothing
             -> nightly :| []
   where
     ltss = map (uncurry LTS) (IntMap.toDescList $ snapshotsLts snapshots)
+    supportedLtss = filter (>= minSupportedLts) ltss
     nightly = Nightly (snapshotsNightly snapshots)
+
+-- |Yields the minimum LTS supported by stack.
+minSupportedLts :: SnapName
+minSupportedLts = LTS 3 0 -- See https://github.com/commercialhaskell/stack/blob/master/ChangeLog.md
+                          -- under stack version 2.1.1.
 
 data InitOpts = InitOpts
     { searchDirs     :: ![T.Text]


### PR DESCRIPTION
Currently, `Stack.Init.getRecommendedSnapshots` yields all the snapshots at https://s3.amazonaws.com/haddock.stackage.org/snapshots.json. This pull request filters out the LTS that `stack` documents that it does not support.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building `stack` and using as described in #5543.
