### PR TITLE
Fix #5714, so files to be deleted by `stack clean --full` are not in use

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,8 @@ Other enhancements:
 
 Bug fixes:
 
+* Fix `stack clean --full`, so that the files to be deleted are not in use. See
+  [#5714](https://github.com/commercialhaskell/stack/issues/5714)
 
 ## v2.7.5
 

--- a/src/Stack/Clean.hs
+++ b/src/Stack/Clean.hs
@@ -16,6 +16,7 @@ import           Stack.Prelude
 import           Data.List ((\\),intercalate)
 import qualified Data.Map.Strict as Map
 import           Path.IO (ignoringAbsence, removeDirRecur)
+import           Stack.Config (withBuildConfig)
 import           Stack.Constants.Config (rootDistDirFromDir, workDirFromDir)
 import           Stack.Types.Config
 import           Stack.Types.SourceMap
@@ -23,9 +24,9 @@ import           Stack.Types.SourceMap
 -- | Deletes build artifacts in the current project.
 --
 -- Throws 'StackCleanException'.
-clean :: HasBuildConfig env => CleanOpts -> RIO env ()
+clean :: CleanOpts -> RIO Config ()
 clean cleanOpts = do
-    toDelete <- dirsToDelete cleanOpts
+    toDelete <- withBuildConfig $ dirsToDelete cleanOpts
     logDebug $ "Need to delete: " <> fromString (show (map toFilePath toDelete))
     failures <- mapM cleanDir toDelete
     when (or failures) exitFailure
@@ -37,7 +38,7 @@ clean cleanOpts = do
         logError "Perhaps you do not have permission to delete these files or they are in use?"
         return True
 
-dirsToDelete :: HasBuildConfig env => CleanOpts -> RIO env [Path Abs Dir]
+dirsToDelete :: CleanOpts -> RIO BuildConfig [Path Abs Dir]
 dirsToDelete cleanOpts = do
     packages <- view $ buildConfigL.to (smwProject . bcSMWanted)
     case cleanOpts of

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -549,7 +549,7 @@ setupCmd sco@SetupCmdOpts{..} = withConfig YesReexec $ withBuildConfig $ do
   setup sco wantedCompiler compilerCheck mstack
 
 cleanCmd :: CleanOpts -> RIO Runner ()
-cleanCmd = withConfig NoReexec . withBuildConfig . clean
+cleanCmd = withConfig NoReexec . clean
 
 -- | Helper for build and install commands
 buildCmd :: BuildOptsCLI -> RIO Runner ()


### PR DESCRIPTION
The existing:
~~~haskell
cleanCmd = withConfig NoReexec . withBuildConfig . clean
~~~
wraps `clean` in `withBuildConfig`, but that ends in `initProjectStorage projectStorageFile` and, so, uses one of the very files (`projectStorageFile`) that `stack clean -full` will attempt (and fail) to delete.

This pull request moves the `withBuildConfig` to wrap only the function that yields the list of files to be deleted (`dirsToDelete cleanOpts`), so that `projectStorageFile` is not in use when the file comes to be deleted.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building `stack` and using `stack clean --full`.
