### PR TITLE
Add `stack ls tools` subcommand

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,7 @@ Other enhancements:
 * Bump to `hpack-0.35.0`.
 * On Windows, the installer now sets `DisplayVersion` in the registry, enabling
   tools like `winget` to properly read the version number.
+* `tools` subcommand added to `stack ls`, to list stack's installed tools.
 
 Bug fixes:
 

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -155,7 +155,7 @@ paths =
     , ( "PATH environment variable"
       , "bin-path"
       , WithoutHaddocks $ T.pack . intercalate [FP.searchPathSeparator] . view exeSearchPathL)
-    , ( "Install location for GHC and other core tools"
+    , ( "Install location for GHC and other core tools (see 'stack ls tools' command)"
       , "programs"
       , WithoutHaddocks $ view (configL.to configLocalPrograms.to toFilePathNoTrailingSep.to T.pack))
     , ( "Compiler binary (e.g. ghc)"

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -15,6 +15,7 @@ module Stack.Setup.Installed
     , toolString
     , toolNameString
     , parseToolText
+    , filterTools
     , extraDirs
     , installDir
     , tempInstallDir
@@ -39,6 +40,22 @@ data Tool
     = Tool PackageIdentifier -- ^ e.g. ghc-7.8.4, msys2-20150512
     | ToolGhcGit !Text !Text   -- ^ e.g. ghc-git-COMMIT_ID-FLAVOUR
     deriving (Eq)
+
+-- | 'Tool' values are ordered by name (being @ghc-git@, for @ToolGhcGit _ _@)
+-- alphabetically and then by version (later versions are ordered before
+-- earlier versions, where applicable).
+instance Ord Tool where
+  compare (Tool pkgId1) (Tool pkgId2) = if pkgName1 == pkgName2
+      then compare pkgVersion2 pkgVersion1 -- Later versions ordered first
+      else compare pkgName1 pkgName2
+    where
+      PackageIdentifier pkgName1 pkgVersion1 = pkgId1
+      PackageIdentifier pkgName2 pkgVersion2 = pkgId2
+  compare (Tool pkgId) (ToolGhcGit _ _) = compare (pkgName pkgId) "ghc-git"
+  compare (ToolGhcGit _ _) (Tool pkgId) = compare "ghc-git" (pkgName pkgId)
+  compare (ToolGhcGit c1 f1) (ToolGhcGit c2 f2) = if f1 == f2
+      then compare c1 c2
+      else compare f1 f2
 
 toolString :: Tool -> String
 toolString (Tool ident) = packageIdentifierString ident
@@ -82,6 +99,15 @@ listInstalled programsPath = do
     toTool fp = do
         x <- T.stripSuffix ".installed" $ T.pack $ toFilePath $ filename fp
         parseToolText x
+
+filterTools :: PackageName       -- ^ package to find
+            -> (Version -> Bool) -- ^ which versions are acceptable
+            -> [Tool]            -- ^ tools to filter
+            -> [PackageIdentifier]
+filterTools name goodVersion installed =
+    [ pkgId | Tool pkgId <- installed
+            , pkgName pkgId == name
+            , goodVersion (pkgVersion pkgId) ]
 
 getCompilerVersion
   :: (HasProcessContext env, HasLogFunc env)

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -244,7 +244,7 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
                     Stack.Path.path
                     Stack.Path.pathParser
         addCommand' "ls"
-                    "List command. (Supports snapshots, dependencies and stack's styles)"
+                    "List command. (Supports snapshots, dependencies, stack's styles and installed tools)"
                     lsCmd
                     lsParser
         addCommand' "unpack"


### PR DESCRIPTION
This proposed pull request adds a `tools` subcommand to the `stack ls` command, in order to list stack's installed tools (in order) at the command line. A `--filter TOOL_NAME` option is provided to filter the tools listed by name (the default being no filter).

The existing help for `stack path --programs` is extended to refer to the existence of `stack ls tools`.

The primary motivation for this was to allow Windows users to find easily the full name of the stack-supplied MSYS2 tool(s) (by using `stack ls tools --filter msys2`) - without having to investigate the structure under the stack root. The full name is useful to know in setting the `PKG_CONFIG_PATH` environment variable manually. (See #1586.)

However, it would also allow all users to find easily the installed version(s) of GHC (by using `stack ls tools --filter ghc`), listed with the most recent version first.

`Stack.Setup.getInstalledTool` is modified to eliminate code repetition that would otherwise result (the core of the existing code becoming `Stack.Setup.Installed.filterTools`.)

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building, and using, `stack`.
