### PR TITLE
Bump to providing `hpack-0.35.0`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@ Behavior changes:
 
 Other enhancements:
 
+* Bump to `hpack-0.35.0`.
+
 Bug fixes:
 
 * Fix `stack clean --full`, so that the files to be deleted are not in use. See

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -1219,7 +1219,7 @@ getShortestDepsPath (MonoidMap parentsMap) wanted' name =
       where
         (targets, recurses) = partition (\(n, _) -> n `Set.member` wanted') (M.toList paths)
     chooseBest :: DepsPath -> DepsPath -> DepsPath
-    chooseBest x y = if x > y then x else y
+    chooseBest x y = max x y
     -- Extend a path to all its parents.
     extendPath :: (PackageName, DepsPath) -> [(PackageName, DepsPath)]
     extendPath (n, dp) =

--- a/stack-ghc-902.yaml
+++ b/stack-ghc-902.yaml
@@ -24,6 +24,8 @@ ghc-options:
 extra-deps:
 # mustache absent from lts-19.4
 - mustache-2.4.1@sha256:dc92ddbf90e3a64c3f2ec7785cf2937d6dcf6ffcebbc38ad9c8b33b6a70bb298,3180
+# lts-19.4 is limited to hpack-0.34.7
+- hpack-0.35.0@sha256:8cd6146fae269390f41dc7237ebd2c479074d4163806d349a41f5a7751d6cea5,4726
 
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712

--- a/stack.cabal
+++ b/stack.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.6.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -306,6 +306,7 @@ library
     , yaml
     , zip-archive
     , zlib
+  default-language: Haskell2010
   if os(windows)
     cpp-options: -DWINDOWS
     build-depends:
@@ -331,7 +332,6 @@ library
         src/unix/
     c-sources:
         src/unix/cbits/uname.c
-  default-language: Haskell2010
 
 executable stack
   main-is: Main.hs
@@ -430,6 +430,7 @@ executable stack
     , yaml
     , zip-archive
     , zlib
+  default-language: Haskell2010
   if os(windows)
     cpp-options: -DWINDOWS
     build-depends:
@@ -454,7 +455,6 @@ executable stack
     cpp-options: -DHIDE_DEP_VERSIONS
   if flag(supported-build)
     cpp-options: -DSUPPORTED_BUILD
-  default-language: Haskell2010
 
 executable stack-integration-test
   main-is: IntegrationSpec.hs
@@ -553,6 +553,7 @@ executable stack-integration-test
     , yaml
     , zip-archive
     , zlib
+  default-language: Haskell2010
   if os(windows)
     cpp-options: -DWINDOWS
     build-depends:
@@ -570,7 +571,6 @@ executable stack-integration-test
     buildable: False
   if flag(static)
     ld-options: -static -pthread
-  default-language: Haskell2010
 
 test-suite stack-test
   type: exitcode-stdio-1.0
@@ -685,6 +685,7 @@ test-suite stack-test
     , yaml
     , zip-archive
     , zlib
+  default-language: Haskell2010
   if os(windows)
     cpp-options: -DWINDOWS
     build-depends:
@@ -698,6 +699,5 @@ test-suite stack-test
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=True
   else
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=False
-  default-language: Haskell2010
   build-tool-depends:
       hspec-discover:hspec-discover

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,8 +4,9 @@ packages:
 - .
 
 extra-deps:
-- rio-0.1.21.0@rev:0
+- hpack-0.35.0@rev:0
 - pantry-0.5.3@rev:0
+- rio-0.1.21.0@rev:0
 
 
 docker:


### PR DESCRIPTION
`hpack-0.35.0`, released 24 April 2022, has some important extensions to the `package.yaml` format. See https://hackage.haskell.org/package/hpack-0.35.0/changelog.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building, and using, `stack`.
