### PR TITLE
Fix #5727 Remove inconsistency in pretty formatting of `--coverage`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@ Bug fixes:
 
 * Fix `stack clean --full`, so that the files to be deleted are not in use. See
   [#5714](https://github.com/commercialhaskell/stack/issues/5714)
+* Fix an inconsistency in the pretty formatting of the output of
+  `stack build --coverage`
 
 ## v2.7.5
 

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -144,7 +144,7 @@ generateHpcReport pkgDir package tests = do
                         Just includeNames -> "--include" : intersperse "--include" (map (\n -> n ++ ":") includeNames)
                         Nothing -> []
                 mreportPath <- generateHpcReportInternal tixSrc reportDir report extraArgs extraArgs
-                forM_ mreportPath (displayReportPath report . pretty)
+                forM_ mreportPath (displayReportPath "The" report . pretty)
 
 generateHpcReportInternal :: HasEnvConfig env
                           => Path Abs File -> Path Abs Dir -> Text -> [String] -> [String]
@@ -273,7 +273,7 @@ generateHpcReportForTargets opts tixFiles targetNames = do
             then do
                 prettyInfo $ "Opening" <+> pretty reportPath <+> "in the browser."
                 void $ liftIO $ openBrowser (toFilePath reportPath)
-            else displayReportPath report (pretty reportPath)
+            else displayReportPath "The" report (pretty reportPath)
 
 generateHpcUnifiedReport :: HasEnvConfig env => RIO env ()
 generateHpcUnifiedReport = do
@@ -297,7 +297,7 @@ generateHpcUnifiedReport = do
         else do
             let report = "unified report"
             mreportPath <- generateUnionReport report reportDir tixFiles
-            forM_ mreportPath (displayReportPath report . pretty)
+            forM_ mreportPath (displayReportPath "The" report . pretty)
 
 generateUnionReport :: HasEnvConfig env
                     => Text -> Path Abs Dir -> [Path Abs File]
@@ -386,8 +386,8 @@ generateHpcMarkupIndex = do
                 "</tbody></table>") <>
         "</body></html>"
     unless (null rows) $
-        logInfo $ "\nAn index of the generated HTML coverage reports is available at " <>
-            fromString (toFilePath outputFile)
+        displayReportPath "\nAn" "index of the generated HTML coverage reports"
+            (pretty outputFile)
 
 generateHpcErrorReport :: MonadIO m => Path Abs Dir -> Utf8Builder -> m ()
 generateHpcErrorReport dir err = do
@@ -478,9 +478,10 @@ findPackageFieldForBuiltPackage pkgDir pkgId internalLibs field = do
                     T.pack (toFilePath inplaceDir) <> ". Maybe try 'stack clean' on this package?"
 
 displayReportPath :: (HasTerm env)
-                  => Text -> StyleDoc -> RIO env ()
-displayReportPath report reportPath =
-     prettyInfo $ "The" <+> fromString (T.unpack report) <+> "is available at" <+> reportPath
+                  => StyleDoc -> Text -> StyleDoc -> RIO env ()
+displayReportPath prefix report reportPath =
+     prettyInfo $ prefix <+> fromString (T.unpack report) <+>
+                  "is available at" <+> reportPath
 
 findExtraTixFiles :: HasEnvConfig env => RIO env [Path Abs File]
 findExtraTixFiles = do


### PR DESCRIPTION
The fix:
* adapts the existing `Stack.Coverage.displayReportPath` to require the log message prefix to be specified (not assume that it is 'The' in all cases);
* modifies the existing use of `displayReportPath` to specify the initial 'The'; and
* applies modified `displayReportPath` to the report that begins 'An index of the generated HTML coverage reports'.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building, and using, `stack` with the change.
