### PR TITLE
Fix CI hlint message

### DIFF
--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -1219,7 +1219,7 @@ getShortestDepsPath (MonoidMap parentsMap) wanted' name =
       where
         (targets, recurses) = partition (\(n, _) -> n `Set.member` wanted') (M.toList paths)
     chooseBest :: DepsPath -> DepsPath -> DepsPath
-    chooseBest x y = if x > y then x else y
+    chooseBest x y = max x y
     -- Extend a path to all its parents.
     extendPath :: (PackageName, DepsPath) -> [(PackageName, DepsPath)]
     extendPath (n, dp) =


### PR DESCRIPTION
Clears
~~~
src/Stack/Build/ConstructPlan.hs:1222:22-43: Warning: Use max
Found:
  if x > y then x else y
Perhaps:
  max x y
~~~

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
