### PR TITLE
Fix #5713 Don't assume unified coverage report redundant if only one *.tix file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,11 @@ Major changes:
 
 Behavior changes:
 
+* `stack build --coverage` will generate a unified coverage report, even if
+  there is only one `*.tix` file, in case a package has tested the library of
+  another package that has not tested its own library. See
+  [#5713](https://github.com/commercialhaskell/stack/issues/5713)
+
 Other enhancements:
 
 Bug fixes:

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -288,10 +288,25 @@ generateHpcUnifiedReport = do
     extraTixFiles <- findExtraTixFiles
     let tixFiles = tixFiles0  ++ extraTixFiles
         reportDir = outputDir </> relDirCombined </> relDirAll
-    if length tixFiles < 2
-        then logInfo $
-            (if null tixFiles then "No tix files" else "Only one tix file") <>
-            " found in " <>
+-- Previously, the test below was:
+--
+--  if length tixFiles < 2
+--      then logInfo $
+--          (if null tixFiles then "No tix files" else "Only one tix file") <>
+--          " found in " <>
+--          fromString (toFilePath outputDir) <>
+--          ", so not generating a unified coverage report."
+--      else ...
+--
+-- However, a single *.tix file does not necessarily mean that a unified
+-- coverage report is redundant. For example, one package may test the library
+-- of another package that does not test its own library. See
+-- https://github.com/commercialhaskell/stack/issues/5713
+--
+-- As an interim solution, a unified coverage report will always be produced
+-- even if may be redundant in some circumstances.
+    if null tixFiles
+        then logInfo $ "No tix files found in " <>
             fromString (toFilePath outputDir) <>
             ", so not generating a unified coverage report."
         else do


### PR DESCRIPTION
Currently, `Stack.Coverage.generateHpcUnifiedReport` assumes that a unified coverage report will be redundant if there is only one `*.tix` file. However, that is not necessarily the case. For example, one package may test the library of another package that does not test its own library.

As an interim solution, this proposed pull request suggests that a unified report should always be produced if there is one or more `*.tix` files, even if it may be redundant in some circumstances.

A more complex solution would be to have a more complex test that determines whether a unified report would be truely redundant if there is only one `*.tix` file.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building, and using, `stack`.
