### PR TITLE
move relevant sentence closer to the example

### DIFF
--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -100,14 +100,13 @@ The `packages` field is _optional_. If omitted, it is treated as:
 packages:
 - .
 ```
+Meaning that your project has exactly one package, and it is located
+in the current directory.
 
 Each package directory specified must have a valid cabal file or hpack
 `package.yaml` file present. Note that the subdirectories of the
 directory are not searched for cabal files. Subdirectories will have
 to be specified as independent items in the list of packages.
-
-Meaning that your project has exactly one package, and it is located
-in the current directory.
 
 Project packages are different from snapshot dependencies (via
 `resolver`) and extra dependencies (via `extra-deps`) in multiple


### PR DESCRIPTION
Yesterday, I didn't get that this dot is **not** a placeholder for `no-matter-what`, but one for the current directory, and spent long hours trying to generate a valid hie.yaml for a multi-package project :(

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
