### PR TITLE
Fix code block formatting

### DIFF
--- a/doc/maintainers/msys.md
+++ b/doc/maintainers/msys.md
@@ -64,9 +64,7 @@ the steps required to upgrade the MSYS2 version used by Stack.
       name of the `msys2-YYYYMMDD.installed` file in the `stack path --programs` directory; and
 
     * executing the command:
-
-
-          > stack setup --setup-info-yaml <path to local copy of stack-setup-2.yaml>
+      `stack setup --setup-info-yaml <path to local copy of stack-setup-2.yaml>`
 
     If all is well, the command should proceed to download the updated version
     of MSYS2 that has been specified.


### PR DESCRIPTION
MkDocs is limited in respect of the formatting of code blocks outside of the document root. See https://www.mkdocs.org/user-guide/writing-your-docs/ and https://python-markdown.github.io/extensions/fenced_code_blocks/.

This (hopefully) fixes the residual rendering problems introduced by my recent changes to `msys.md`.