### PR TITLE
Fix #5755 Add --script-no-run-compile flag

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,14 @@ Other enhancements:
 * Bump to `hpack-0.35.0`.
 * On Windows, the installer now sets `DisplayVersion` in the registry, enabling
   tools like `winget` to properly read the version number.
+* Adds flag `--script-no-run-compile` (disabled by default) that uses the
+  `--no-run` option with `stack script` (and forces the `--compile` option).
+  This enables a command like `stack --script-no-run-compile Script.hs` to
+  behave like `stack script <arguments> --no-run --compile -- Script.hs` but
+  without having to list all the `<arguments>` in the stack interpreter options
+  comment in `Script.hs` on the command line. That may help test that scripts
+  compile in CI (continuous integration). See
+  [#5755](https://github.com/commercialhaskell/stack/issues/5755)
 
 Bug fixes:
 

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1278,7 +1278,6 @@ arguments, or by providing a comma or space separated list. For example:
   --package http-client,http-conduit
 -}
 ```
-
 ### Stack configuration for scripts
 
 With the `script` command, all Stack configuration files are ignored to provide
@@ -1314,6 +1313,33 @@ a multi line block comment with ghc options:
   +RTS -s -RTS
 -}
 ```
+
+### Testing scripts
+
+You can use the flag `--script-no-run-compile` on the command line to enable (it
+is disabled by default) the use of the `--no-run` option with `stack script`
+(and forcing the `--compile` option). The flag may help test that scripts
+compile in CI (continuous integration).
+
+For example, consider the following simple script, in a file named `Script.hs`,
+which makes use of the joke package
+[`acme-missiles`](https://hackage.haskell.org/package/acme-missiles):
+```
+{- stack script
+   --resolver lts-19.9
+   --package acme-missiles
+-}
+import Acme.Missiles (launchMissiles)
+
+main :: IO ()
+main = launchMissiles
+```
+The command `stack --script-no-run-compile Script.hs` then behaves as if the
+command
+`stack script --resolver lts-19.9 --package acme-missiles --no-run --compile -- Script.hs`
+had been given (see further below about the `stack script` command). `Script.hs`
+is compiled (without optimisation) and the resulting executable is not run: no
+missiles are launched in the process!
 
 ### Writing independent and reliable scripts
 

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -342,6 +342,7 @@ configFromConfigMonoid
          configHackageBaseUrl = fromFirst "https://hackage.haskell.org/" configMonoidHackageBaseUrl
          configHideSourcePaths = fromFirstTrue configMonoidHideSourcePaths
          configRecommendUpgrade = fromFirstTrue configMonoidRecommendUpgrade
+         configNoRunCompile = fromFirstFalse configMonoidNoRunCompile
 
      configAllowDifferentUser <-
         case getFirst configMonoidAllowDifferentUser of

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -23,7 +23,7 @@ configOptsParser currentDir hide0 =
     (\stackRoot workDir buildOpts dockerOpts nixOpts systemGHC installGHC arch
         ghcVariant ghcBuild jobs includes libs preprocs overrideGccPath overrideHpack
         skipGHCCheck skipMsys localBin setupInfoLocations modifyCodePage
-        allowDifferentUser dumpLogs colorWhen snapLoc -> mempty
+        allowDifferentUser dumpLogs colorWhen snapLoc noRunCompile -> mempty
             { configMonoidStackRoot = stackRoot
             , configMonoidWorkDir = workDir
             , configMonoidBuildOpts = buildOpts
@@ -49,6 +49,7 @@ configOptsParser currentDir hide0 =
             , configMonoidDumpLogs = dumpLogs
             , configMonoidColorWhen = colorWhen
             , configMonoidSnapshotLocation = snapLoc
+            , configMonoidNoRunCompile = noRunCompile
             })
     <$> optionalFirst (absDirOption
             ( long stackRootOptionName
@@ -175,6 +176,10 @@ configOptsParser currentDir hide0 =
            <> help "The base location of LTS/Nightly snapshots"
            <> metavar "URL"
             ))
+    <*> firstBoolFlagsFalse
+            "script-no-run-compile"
+            "the use of options `--no-run --compile` with `stack script`"
+            hide
   where
     hide = hideMods (hide0 /= OuterGlobalOpts)
     toDumpLogs (First (Just True)) = First (Just DumpAllLogs)

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -381,6 +381,8 @@ data Config =
          -- ^ Enable GHC hiding source paths?
          ,configRecommendUpgrade    :: !Bool
          -- ^ Recommend a Stack upgrade?
+         ,configNoRunCompile   :: !Bool
+         -- ^ Use --no-run and --compile options when using `stack script`
          ,configStackDeveloperMode  :: !Bool
          -- ^ Turn on Stack developer mode for additional messages?
          }
@@ -867,6 +869,8 @@ data ConfigMonoid =
     , configMonoidCasaRepoPrefix     :: !(First CasaRepoPrefix)
     , configMonoidSnapshotLocation :: !(First Text)
     -- ^ Custom location of LTS/Nightly snapshots
+    , configMonoidNoRunCompile  :: !FirstFalse
+    -- ^ See: 'configNoRunCompile'
     , configMonoidStackDeveloperMode :: !(First Bool)
     -- ^ See 'configStackDeveloperMode'
     }
@@ -991,6 +995,7 @@ parseConfigMonoidObject rootDir obj = do
 
     configMonoidCasaRepoPrefix <- First <$> obj ..:? configMonoidCasaRepoPrefixName
     configMonoidSnapshotLocation <- First <$> obj ..:? configMonoidSnapshotLocationName
+    configMonoidNoRunCompile <- FirstFalse <$> obj ..:? configMonoidNoRunCompileName
 
     configMonoidStackDeveloperMode <- First <$> obj ..:? configMonoidStackDeveloperModeName
 
@@ -1151,6 +1156,9 @@ configMonoidCasaRepoPrefixName = "casa-repo-prefix"
 
 configMonoidSnapshotLocationName :: Text
 configMonoidSnapshotLocationName = "snapshot-location-base"
+
+configMonoidNoRunCompileName :: Text
+configMonoidNoRunCompileName = "script-no-run-compile"
 
 configMonoidStackDeveloperModeName :: Text
 configMonoidStackDeveloperModeName = "stack-developer-mode"


### PR DESCRIPTION
This proposed pull request adds a `--force-script-no-run-compile` flag (disabled by default) that forces the `--no-run` and `--compile` options with `stack script`.

This enables a command like `stack --force-script-no-run-compile Script.hs` to behave like `stack script ... --no-run --compile -- Script.hs` but without having to list all the other arguments in the stack interpreter options comment (represented by `...`) on the command line.

Also adds an explanation to the online documentation.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building and using `stack`.
