### PR TITLE
Help text allows multiple use for --package.

### DIFF
--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -964,7 +964,7 @@ packagesParser :: Parser [String]
 packagesParser = many (strOption
                    (long "package" <>
                      metavar "PACKAGE(S)" <>
-                     help "Additional package(s) that must be installed"))
+                     help "Each --package adds (installs) one package"))
 
 defaultConfigYaml :: (IsString s, Semigroup s) => s
 defaultConfigYaml =

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -54,7 +54,8 @@ import qualified Distribution.Text
 import           Distribution.Version (simplifyVersionRange, mkVersion')
 import           GHC.Conc (getNumProcessors)
 import           Network.HTTP.StackClient (httpJSON, parseUrlThrow, getResponseBody)
-import           Options.Applicative (Parser, help, long, metavar, strOption)
+import           Options.Applicative (Parser, help, long, metavar, strOption, style)
+import           Options.Applicative.Help.Pretty (brackets)
 import           Path
 import           Path.Extra (toFilePathNoTrailingSep)
 import           Path.Find (findInParents)
@@ -963,8 +964,9 @@ getDefaultUserConfigPath stackRoot = do
 packagesParser :: Parser [String]
 packagesParser = many (strOption
                    (long "package" <>
-                     metavar "PACKAGE(S)" <>
-                     help "Each --package adds (installs) one package"))
+                     metavar "PACKAGE" <>
+                     help "Add a package" <>
+                     style brackets))
 
 defaultConfigYaml :: (IsString s, Semigroup s) => s
 defaultConfigYaml =

--- a/src/Stack/Options/ExecParser.hs
+++ b/src/Stack/Options/ExecParser.hs
@@ -5,6 +5,7 @@ module Stack.Options.ExecParser where
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
 import           Options.Applicative.Args
+import           Options.Applicative.Help.Pretty (brackets)
 import           Stack.Options.Completion
 import           Stack.Prelude
 import           Stack.Types.Config
@@ -62,8 +63,9 @@ execOptsExtraParser = ExecOptsExtra
     eoPackagesParser :: Parser [String]
     eoPackagesParser = many
                        (strOption (long "package"
-                                  <> help "Each --package adds (installs) one package"
-                                  <> metavar "PACKAGE(S)"))
+                                  <> metavar "PACKAGE"
+                                  <> help "Add a package"
+                                  <> style brackets))
 
     eoRtsOptionsParser :: Parser [String]
     eoRtsOptionsParser = concat <$> many (argsOption

--- a/src/Stack/Options/ExecParser.hs
+++ b/src/Stack/Options/ExecParser.hs
@@ -62,7 +62,7 @@ execOptsExtraParser = ExecOptsExtra
     eoPackagesParser :: Parser [String]
     eoPackagesParser = many
                        (strOption (long "package"
-                                  <> help "Additional package(s) that must be installed"
+                                  <> help "Each --package adds (installs) one package"
                                   <> metavar "PACKAGE(S)"))
 
     eoRtsOptionsParser :: Parser [String]

--- a/src/Stack/Options/ScriptParser.hs
+++ b/src/Stack/Options/ScriptParser.hs
@@ -32,7 +32,7 @@ scriptOptsParser = ScriptOpts
     <$> many (strOption
           (long "package" <>
             metavar "PACKAGE(S)" <>
-            help "Additional package(s) that must be installed"))
+            help "Each --package adds (installs) one package"))
     <*> strArgument (metavar "FILE" <> completer (fileExtCompleter [".hs", ".lhs"]))
     <*> many (strArgument (metavar "-- ARGUMENT(S) (e.g. stack script X.hs -- argument(s) to program)"))
     <*> (flag' SECompile

--- a/src/Stack/Options/ScriptParser.hs
+++ b/src/Stack/Options/ScriptParser.hs
@@ -4,6 +4,7 @@ module Stack.Options.ScriptParser where
 
 import           Options.Applicative
 import           Options.Applicative.Builder.Extra
+import           Options.Applicative.Help.Pretty (brackets)
 import           Stack.Options.Completion
 import           Stack.Prelude
 
@@ -31,8 +32,9 @@ scriptOptsParser :: Parser ScriptOpts
 scriptOptsParser = ScriptOpts
     <$> many (strOption
           (long "package" <>
-            metavar "PACKAGE(S)" <>
-            help "Each --package adds (installs) one package"))
+            metavar "PACKAGE" <>
+            help "Add a package" <>
+            style brackets))
     <*> strArgument (metavar "FILE" <> completer (fileExtCompleter [".hs", ".lhs"]))
     <*> many (strArgument (metavar "-- ARGUMENT(S) (e.g. stack script X.hs -- argument(s) to program)"))
     <*> (flag' SECompile


### PR DESCRIPTION
Changes the help text for `--package`, see #5455.

Tested with:

```
> stack run stack -- repl --help
Usage: stack repl [TARGET/FILE] [--pedantic] [--ghci-options OPTIONS]
                  [--ghc-options OPTIONS] [--flag PACKAGE:[-]FLAG]
                  [--with-ghc GHC] [--[no-]load] [--package PACKAGE(S)]
                  [--main-is TARGET] [--load-local-deps] [--[no-]package-hiding]
                  [--only-main] [--trace] [--profile] [--no-strip] [--[no-]test]
                  [--[no-]bench] [--setup-info-yaml URL]
                  [--snapshot-location-base URL] [--help]
  Run ghci in the context of package(s) (experimental) (alias for 'ghci')

Available options:
  TARGET/FILE              If none specified, use all local packages. See
                           https://docs.haskellstack.org/en/stable/build_command/#target-syntax
                           for details. If a path to a .hs or .lhs file is
                           specified, it will be loaded.
  --pedantic               Turn on -Wall and -Werror
  --ghci-options OPTIONS   Additional options passed to GHCi
  --ghc-options OPTIONS    Additional options passed to both GHC and GHCi
  --flag PACKAGE:[-]FLAG   Override flags set in stack.yaml (applies to local
                           packages and extra-deps)
  --with-ghc GHC           Use this GHC to run GHCi
  --[no-]load              Enable/disable load modules on start-up (default:
                           enabled)
  --package PACKAGE(S)     Each --package adds (installs) one package
  --main-is TARGET         Specify which target should contain the main module
                           to load, such as for an executable for test suite or
                           benchmark.
  --load-local-deps        Load all local dependencies of your targets
  --[no-]package-hiding    Enable/disable package hiding
  --only-main              Only load and import the main module. If no main
                           module, no modules will be loaded.
  --trace                  Enable profiling in libraries, executables, etc. for
                           all expressions and generate a backtrace on exception
  --profile                profiling in libraries, executables, etc. for all
                           expressions and generate a profiling report in tests
                           or benchmarks
  --no-strip               Disable DWARF debugging symbol stripping in
                           libraries, executables, etc. for all expressions,
                           producing larger executables but allowing the use of
                           standard debuggers/profiling tools/other utilities
                           that use debugging symbols.
  --[no-]test              Enable/disable testing the package(s) in this
                           directory/configuration (default: disabled)
  --[no-]bench             Enable/disable benchmarking the package(s) in this
                           directory/configuration (default: disabled)
  --setup-info-yaml URL    Alternate URL or relative / absolute path for stack
                           dependencies
  --snapshot-location-base URL
                           The base location of LTS/Nightly snapshots
  --help                   Show this help text

Run 'stack --help' for global options that apply to all subcommands.
```
