### PR TITLE
Ignore dist-newstyle folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ tags
 .hspec-failures
 better-cache/
 stack*.yaml.lock
+dist-newstyle/


### PR DESCRIPTION
I like to be able to build projects with either stack or cabal. I saw #5677 and tried it, noticing that the cabal build products aren't ignored by git. This change ignores those in `dist-newstyle/`.
