### PR TITLE
WIP: Use standard compiler builds on FreeBSD.

### DIFF
--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -993,13 +993,6 @@ getGhcBuilds = do
                         [] -> CompilerBuildStandard
                         _ -> CompilerBuildSpecialized (intercalate "-" c))
                     libComponents
-            Platform _ Cabal.FreeBSD -> do
-                let getMajorVer = readMaybe <=< headMaybe . (splitOn ".")
-                majorVer <- getMajorVer <$> sysRelease
-                if majorVer >= Just (12 :: Int) then
-                  useBuilds [CompilerBuildSpecialized "ino64"]
-                else
-                  useBuilds [CompilerBuildStandard]
             Platform _ Cabal.OpenBSD -> do
                 releaseStr <- mungeRelease <$> sysRelease
                 useBuilds [CompilerBuildSpecialized releaseStr]


### PR DESCRIPTION
Previosly, Stack had to discern between FreeBSD 11- and FreeBSD 12+ and select
a compiler based on this version check. Compiler builds for 12+ were named "-ino64".
Now that FreeBSD 11 reached EoL, there is no need to have two compiler build
versions, so just use standard name for those builds that were previosly named "ino64".
