### PR TITLE
 Expand Nix integration docs with more context and NixOS section

### DIFF
--- a/doc/nix_integration.md
+++ b/doc/nix_integration.md
@@ -272,7 +272,7 @@ Nix derivations ("packages"), for instance to change some build options of the
 libraries you use, or to set additional environment variables. See the
 [Nix manual][nix-manual-exprs] for more. The `buildStackProject` utility
 function is documented in the [Nixpkgs manual][nixpkgs-manual-haskell].  In such
-case, stack expect this file to define a function of exactly one argument that
+case, stack expects this file to define a function of exactly one argument that
 should be called `ghc` (as arguments within a set are non-positional), which you
 should give to `buildStackProject`. This is a GHC Nix package in the version as
 defined in the resolver you set in the `stack.yaml` file.

--- a/doc/nix_integration.md
+++ b/doc/nix_integration.md
@@ -19,7 +19,7 @@ using `nix-shell`, similar to building inside an isolated
 There are two options to create such a build environment:
 
 - provide a list of [Nix packages][nix-search-packages]
-- provide a custom `shell.nix` file that gives you more control 
+- provide a `shell.nix` file that gives you more control 
   of what libraries and tools are available inside the shell. 
 
 The second requires writing code in 

--- a/doc/nix_integration.md
+++ b/doc/nix_integration.md
@@ -23,7 +23,7 @@ There are two options to create such a build environment:
   of what libraries and tools are available inside the shell. 
 
 The second requires writing code in 
-[Nix's custom language](https://nixos.wiki/wiki/Nix_Expression_Language). 
+[Nix's custom language][nix-language]. 
 So use this option only if you already know Nix and have special requirements,
 such as using custom Nix packages that override the standard ones or
 using system libraries with special requirements.
@@ -232,13 +232,12 @@ nix:
 
 ## Option 2: External C libraries through a custom shell.nix file
 
-Nix is also a programming language, and as specified
-[here](#nix-integration) if you know it you can provide to the shell
-a fully customized derivation as an environment to use. Here is the
-equivalent of the configuration used in
-[this section](#additions-to-your-stackyaml), but with an explicit
-`shell.nix` file (make sure you're using a nixpkgs version later than
-2015-03-05):
+There's also the [Nix programming language][nix-language]
+to provide a fully customized derivation as an environment to use. 
+Here's the equivalent of the configuration used in the 
+[previous example](#option-1-external-c-libraries-through-a-list-of-nix-packages), 
+but with an explicit `shell.nix` file 
+(make sure you're using a nixpkgs version later than 2015-03-05):
 
 ```nix
 {ghc}:
@@ -275,4 +274,6 @@ error. (Comment one out before adding the other.)
 
 [nix-manual-exprs]: http://nixos.org/nix/manual/#chap-writing-nix-expressions
 [nixpkgs-manual-haskell]: https://nixos.org/nixpkgs/manual/#users-guide-to-the-haskell-infrastructure
-[nix-search-packages](https://nixos.org/nixos/packages.html)
+[nix-search-packages]: https://nixos.org/nixos/packages.html
+[nix-language]: https://nixos.wiki/wiki/Nix_Expression_Language
+

--- a/doc/nix_integration.md
+++ b/doc/nix_integration.md
@@ -4,16 +4,18 @@
 
 (since 0.1.10.0)
 
-When using the Nix integration, Haskell dependencies are handled as usual: They
-are downloaded from Stackage and built locally by Stack. Nix is used by Stack to
-provide the _non-Haskell_ dependencies needed by these Haskell packages.
-
-`stack` can automatically create a build environment (the equivalent
-of a "container" in Docker parlance) using `nix-shell`, provided Nix
-is already installed on your system. To do so, please visit the
+When using the Nix integration, Stack handles Haskell dependencies as usual
+while Nix handles _non-Haskell_ dependencies needed by these Haskell packages.
+That is, Stack downloads Haskell packages from [Stackage](https://www.stackage.org/lts)
+and builds them locally but uses Nix to download 
+[Nix packages](https://search.nixos.org/packages) that provide the GHC compiler and 
+external C libraries like zlib that you would normally install manually.
+You can install Nix with all the necessary commandline tools from the 
 [Nix download page](http://nixos.org/nix/download.html).
 
-There are two ways to create a build environment:
+`stack` can automatically create a build environment similar to building
+inside an isolated [Docker](https://www.docker.com/) container using `nix-shell`. 
+There are two ways to create such a build environment:
 
 - providing a list of packages (by "attribute name") from
   [Nixpkgs](http://nixos.org/nixos/packages.html), or

--- a/stack.cabal
+++ b/stack.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -462,8 +462,6 @@ executable stack-integration-test
   other-modules:
       StackTest
       Paths_stack
-  autogen-modules:
-      Paths_stack
   hs-source-dirs:
       test/integration
       test/integration/lib
@@ -591,8 +589,6 @@ test-suite stack-test
       Stack.PackageDumpSpec
       Stack.Types.TemplateNameSpec
       Stack.UploadSpec
-      Paths_stack
-  autogen-modules:
       Paths_stack
   hs-source-dirs:
       src/test

--- a/stack.cabal
+++ b/stack.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
@@ -462,6 +462,8 @@ executable stack-integration-test
   other-modules:
       StackTest
       Paths_stack
+  autogen-modules:
+      Paths_stack
   hs-source-dirs:
       test/integration
       test/integration/lib
@@ -589,6 +591,8 @@ test-suite stack-test
       Stack.PackageDumpSpec
       Stack.Types.TemplateNameSpec
       Stack.UploadSpec
+      Paths_stack
+  autogen-modules:
       Paths_stack
   hs-source-dirs:
       src/test


### PR DESCRIPTION
Rewritten some paragraphs in an active voice, added more background info of Nix in some places to make it easier for Nix beginners to use it with Stack, and added a section on how to use Stack with NixOS and Nix flakes.

It answers my question in https://github.com/commercialhaskell/stack/issues/5773.

Feel free to edit as you wish, maintainers.