### PR TITLE
Fix #5780 Accumulate missing keys before logging

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -36,6 +36,7 @@ Bug fixes:
   [#5714](https://github.com/commercialhaskell/stack/issues/5714)
 * Fix an inconsistency in the pretty formatting of the output of
   `stack build --coverage`
+* Fix repeated warning about missing parameters when using `stack new`
 
 ## v2.7.5
 


### PR DESCRIPTION
The problem was caused by `applyMustache` (in `Stack.New.applyTemplate`) containing the relevant `logInfo` action, and being applied repeatedly by `mapM`.

This solution moves the `logInfo` action outside the `mapM`, modifies `applyMustache` to yield also the missing keys, and accumulates the missing keys (`mapAccumLM`) as each of the `files` is processed.

`ChangeLog.md` is also updated. Tested by building and using Stack.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.