### PR TITLE
Bump pantry to 0.5.6 commercialhaskell/pantry#53

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,6 +37,8 @@ Bug fixes:
 * Fix an inconsistency in the pretty formatting of the output of
   `stack build --coverage`
 * Fix repeated warning about missing parameters when using `stack new`
+* Include `pantry-0.5.6`: Remove operational and mirror keys from bootstrap key
+  set [#53](https://github.com/commercialhaskell/pantry/pull/53)
 
 ## v2.7.5
 

--- a/package.yaml
+++ b/package.yaml
@@ -92,7 +92,7 @@ dependencies:
 - network-uri
 - open-browser
 - optparse-applicative >= 0.14.3.0
-- pantry >= 0.5.3
+- pantry >= 0.5.6
 - casa-client
 - casa-types
 - path

--- a/stack-ghc-902.yaml
+++ b/stack-ghc-902.yaml
@@ -26,6 +26,7 @@ extra-deps:
 - mustache-2.4.1@sha256:dc92ddbf90e3a64c3f2ec7785cf2937d6dcf6ffcebbc38ad9c8b33b6a70bb298,3180
 # lts-19.11 is limited to hpack-0.34.7
 - hpack-0.35.0@sha256:8cd6146fae269390f41dc7237ebd2c479074d4163806d349a41f5a7751d6cea5,4726
+- pantry-0.5.6@rev:0 # https://github.com/commercialhaskell/pantry/pull/53
 
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712

--- a/stack-ghc-922.yaml
+++ b/stack-ghc-922.yaml
@@ -21,7 +21,8 @@ flags:
 ghc-options:
    "$locals": -fhide-source-paths
 
-extra-deps: []
+extra-deps:
+- pantry-0.5.6@rev:0 # https://github.com/commercialhaskell/pantry/pull/53
 
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712

--- a/stack.cabal
+++ b/stack.cabal
@@ -271,7 +271,7 @@ library
     , network-uri
     , open-browser
     , optparse-applicative >=0.14.3.0
-    , pantry >=0.5.3
+    , pantry >=0.5.6
     , path
     , path-io
     , persistent
@@ -394,7 +394,7 @@ executable stack
     , network-uri
     , open-browser
     , optparse-applicative >=0.14.3.0
-    , pantry >=0.5.3
+    , pantry >=0.5.6
     , path
     , path-io
     , persistent
@@ -518,7 +518,7 @@ executable stack-integration-test
     , open-browser
     , optparse-applicative >=0.14.3.0
     , optparse-generic
-    , pantry >=0.5.3
+    , pantry >=0.5.6
     , path
     , path-io
     , persistent
@@ -647,7 +647,7 @@ test-suite stack-test
     , network-uri
     , open-browser
     , optparse-applicative >=0.14.3.0
-    , pantry >=0.5.3
+    , pantry >=0.5.6
     , path
     , path-io
     , persistent

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ packages:
 
 extra-deps:
 - hpack-0.35.0@rev:0
-- pantry-0.5.3@rev:0
+- pantry-0.5.6@rev:0 # https://github.com/commercialhaskell/pantry/pull/53
 - rio-0.1.21.0@rev:0
 
 


### PR DESCRIPTION
Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [X] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
