### PR TITLE
Fix #809 Use `showHelpOnEmpty`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,9 @@ Other enhancements:
   comment in `Script.hs` on the command line. That may help test that scripts
   compile in CI (continuous integration). See
   [#5755](https://github.com/commercialhaskell/stack/issues/5755)
+* Fuller help is provided at the command line if a subcommand is missing (for
+  example, `stack ls` now yields the equivalent of `stack ls --help`). See
+  [#809](https://github.com/commercialhaskell/stack/issues/809)
 
 Bug fixes:
 

--- a/src/Options/Applicative/Complicated.hs
+++ b/src/Options/Applicative/Complicated.hs
@@ -48,8 +48,8 @@ complicatedOptions
   -> IO (a,b)
 complicatedOptions numericVersion stringVersion numericHpackVersion h pd footerStr commonParser mOnFailure commandParser =
   do args <- getArgs
-     (a,(b,c)) <- case execParserPure (prefs noBacktrack) parser args of
-       Failure _ | null args -> withArgs ["--help"] (execParser parser)
+     (a,(b,c)) <- let parserPrefs = prefs $ noBacktrack <> showHelpOnEmpty
+                  in  case execParserPure parserPrefs parser args of
        -- call onFailure handler if it's present and parsing options failed
        Failure f | Just onFailure <- mOnFailure -> onFailure f args
        parseResult -> handleParseResult parseResult


### PR DESCRIPTION
For example, before the change, `stack ls` yields only:

~~~
Missing: COMMAND

Usage: stack.exe ls COMMAND [--setup-info-yaml URL]
                    [--snapshot-location-base URL] [--help]
  List command. (Supports snapshots, dependencies and stack's styles)
~~~

After the change, `stack ls` yields the more informative:

~~~
Usage: stack.exe ls COMMAND [--setup-info-yaml URL]
                    [--snapshot-location-base URL] [--help]
  List command. (Supports snapshots, dependencies and stack's styles)

Available options:
  --setup-info-yaml URL    Alternate URL or relative / absolute path for stack
                           dependencies
  --snapshot-location-base URL
                           The base location of LTS/Nightly snapshots
  --help                   Show this help text

Available commands:
  snapshots                View local snapshot (default option)
  dependencies             View the dependencies
  stack-colors             View stack's output styles
  stack-colours            View stack's output styles (alias for 'stack-colors')

Run 'stack --help' for global options that apply to all subcommands.
~~~

Also deletes the case:

~~~haskell
Failure _ | null args -> withArgs ["--help"] (execParser parser)
~~~

as `stack` (without more) is now handled without it.

Also updates `ChangeLog.md`.

Tested by building and using Stack, including using Stack with scripts and `stack script`.

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.