### PR TITLE
Fix #5677 Add upper bound for `persistent` in `package.yaml`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -97,7 +97,10 @@ dependencies:
 - casa-types
 - path
 - path-io
-- persistent
+# In order for Cabal (the tool) to build Stack, it needs to be told of the
+# upper bound on persistent. See
+# https://github.com/commercialhaskell/stack/pull/5677#issuecomment-1193318542 
+- persistent < 2.14
 - persistent-sqlite
 - persistent-template
 - pretty

--- a/stack.cabal
+++ b/stack.cabal
@@ -274,7 +274,7 @@ library
     , pantry >=0.5.6
     , path
     , path-io
-    , persistent
+    , persistent <2.14
     , persistent-sqlite
     , persistent-template
     , pretty
@@ -397,7 +397,7 @@ executable stack
     , pantry >=0.5.6
     , path
     , path-io
-    , persistent
+    , persistent <2.14
     , persistent-sqlite
     , persistent-template
     , pretty
@@ -521,7 +521,7 @@ executable stack-integration-test
     , pantry >=0.5.6
     , path
     , path-io
-    , persistent
+    , persistent <2.14
     , persistent-sqlite
     , persistent-template
     , pretty
@@ -650,7 +650,7 @@ test-suite stack-test
     , pantry >=0.5.6
     , path
     , path-io
-    , persistent
+    , persistent <2.14
     , persistent-sqlite
     , persistent-template
     , pretty


### PR DESCRIPTION
Stack advises that it should be built with Stack, but some users wish to use Cabal (the tool) to build Stack. This is possible if the upper bound on `persistent` is specified.
* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.