### PR TITLE
Lint YAML especially `.hlint.yaml`.

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,8 +1,7 @@
 name: hlint
 
-on:
-  pull_request:
-  push:
+# yamllint disable-line rule:truthy
+on: [pull_request, push]
 
 jobs:
   style:

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,0 +1,27 @@
+name: hlint
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  style:
+    name: hlint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - uses: haskell/actions/hlint-setup@v2
+        name: Set up HLint
+        with:
+          version: "3.4"
+
+      - name: hlint
+        run: |
+          set -ex
+          hlint src/
+          hlint src/ --cpp-define=WINDOWS=1
+          hlint test/ --cpp-simple

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -10,9 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
+      - name: Clone project
+        uses: actions/checkout@v3
 
       - uses: haskell/actions/hlint-setup@v2
         name: Set up HLint

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,20 +10,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  style:
-    name: Style
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone project
-        uses: actions/checkout@v2
-      - name: hlint
-        run: |
-          set -ex
-          ./etc/scripts/get-hlint.sh
-          export PATH="$(pwd)"/hlint:$PATH
-          hlint src/
-          hlint src/ --cpp-define=WINDOWS=1
-          hlint test/ --cpp-simple
   pedantic:
     name: Pedantic
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache dependencies
         uses: actions/cache@v1
         with:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -9,3 +9,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
+        with:
+          format: github

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,10 @@
+---
+name: Yaml Lint
+on: [push]  # yamllint disable-line rule:truthy
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,6 +1,7 @@
 ---
-name: Yaml Lint
-on: [push]  # yamllint disable-line rule:truthy
+name: yamllint
+# yamllint disable-line rule:truthy
+on: [pull_request, push]
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,47 +1,6 @@
 # HLint configuration file
 # https://github.com/ndmitchell/hlint
 
-# Not considered useful hints
-- ignore: {name: "Redundant do"}
-- ignore: {name: "Use section"}
-- ignore: {name: "Use camelCase"}
-- ignore: {name: "Use list comprehension"}
-- ignore: {name: "Redundant if"}
-- ignore: {name: "Avoid lambda"}
-- ignore: {name: "Eta reduce"}
-- ignore: {name: "Use fmap"}  # specific for GHC 7.8 compat
-- ignore: {name: "Parse error"}  # we trust the compiler over HLint
-- ignore: {name: "Use =="}  # Creates infinite loops in `EQ` using expressions
-- ignore: {name: "Evaluate"}
-- ignore: {name: "Use &&&"}
-- ignore: {name: "Redundant compare"}
-- ignore: {name: "Use Just"}
-- ignore: {name: "Avoid lambda using `infix`"}
-
-# Added in hlint-2.0.10, ignoring for now
-- ignore: {name: "Unnecessary hiding"}
-- ignore: {name: "Use lambda-case"}
-
-- ignore: {name: "Use fewer imports", within: [
-  "System.Process.Read",  # Related to 'Hide post-AMP warnings' comment
-  "Stack.Exec"  # ifdef for System.Process.Read
-  ]
-}
-
-- ignore: {name: "Use fromMaybe", within: [
-    "Stack.Types.Config.explicitSetupDeps"  # Related to 'explicit pattern matching is clearer' comment
-  ]
-}
-
-# For clarity (related to do syntax)
-- ignore: {name: "Reduce duplication", within: [
-    "Network.HTTP.Download.VerifiedSpec",
-    "Stack.PackageDumpSpec",
-    "Stack.Types.StackT",
-    "Stack.Docker"
-  ]
-}
-
 - error: {lhs: "Network.HTTP.Client.MultipartFormData.formDataBody", rhs: "Network.HTTP.StackClient.formDataBody"}
 - error: {lhs: "Network.HTTP.Client.MultipartFormData.partBS", rhs: "Network.HTTP.StackClient.partBS"}
 - error: {lhs: "Network.HTTP.Client.MultipartFormData.partFileRequestBody", rhs: "Network.HTTP.StackClient.partFileRequestBody"}
@@ -83,8 +42,59 @@
 - error: {lhs: "Network.HTTP.Types.hContentLength", rhs: "Network.HTTP.StackClient.hContentLength"}
 - error: {lhs: "Network.HTTP.Types.hContentMD5", rhs: "Network.HTTP.StackClient.hContentMD5"}
 - error: {lhs: "Network.HTTP.Types.methodPut", rhs: "Network.HTTP.StackClient.methodPut"}
-- ignore: {name: "Use alternative", within: "Network.HTTP.StackClient"}
+
+# We define the above alternatives but then must ignore these with
+# ignore "Use alternative" within Network.HTTP.StackClient.
+- ignore:
+    name: "Use alternative"
+    within:
+      - Network.HTTP.StackClient
+
+# Not considered useful hints
+- ignore: {name: "Redundant do"}
+- ignore: {name: "Use section"}
+- ignore: {name: "Use camelCase"}
+- ignore: {name: "Use list comprehension"}
+- ignore: {name: "Redundant if"}
+- ignore: {name: "Avoid lambda"}
+- ignore: {name: "Eta reduce"}
+- ignore: {name: "Use fmap"}  # specific for GHC 7.8 compat
+- ignore: {name: "Parse error"}  # we trust the compiler over HLint
+- ignore: {name: "Use =="}  # Creates infinite loops in `EQ` using expressions
+- ignore: {name: "Evaluate"}
+- ignore: {name: "Use &&&"}
+- ignore: {name: "Redundant compare"}
+- ignore: {name: "Use Just"}
+- ignore: {name: "Avoid lambda using `infix`"}
+
+# Added in hlint-2.0.10, ignoring for now
+- ignore: {name: "Unnecessary hiding"}
+- ignore: {name: "Use lambda-case"}
+
+- ignore:
+    name: "Use fewer imports"
+    within:
+      - System.Process.Read  # Related to 'Hide post-AMP warnings' comment
+      - Stack.Exec  # ifdef for System.Process.Read
+
+# Related to 'explicit pattern matching is clearer' comment
+- ignore:
+    name: "Use fromMaybe"
+    within:
+      - Stack.Types.Config.explicitSetupDeps
+
+# For clarity (related to do syntax)
+- ignore:
+    name: "Reduce duplication"
+    within:
+      - Network.HTTP.Download.VerifiedSpec
+      - Stack.PackageDumpSpec
+      - Stack.Types.StackT
+      - Stack.Docker
 
 # Gives an incorrect hint that breaks type checking due to mismatched types
-- ignore: {name: "Too strict maybe", within: "Stack.Package" }
-- ignore: {name: "Too strict maybe", within: "Stack.Config" }
+- ignore:
+    name: "Too strict maybe"
+    within:
+      - Stack.Config
+      - Stack.Package

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,10 @@
+extends: default
+rules:
+  document-start: disable
+  line-length: disable
+ignore: |
+  .github/workflows/arm64-release.yml
+  .github/workflows/integration-tests.yml
+  .github/workflows/unit-tests.yml
+  doc
+  test

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,45 +8,45 @@ docs_dir: doc
 site_dir: _site
 theme: readthedocs
 extra_css:
-- css/extra.css
+  - css/extra.css
 extra_javascript:
-- js/searchhack.js
+  - js/searchhack.js
 
 pages:
-- Home: README.md
-- Changelog: ChangeLog.md
-- Tool documentation:
-  - Install/upgrade: install_and_upgrade.md
-  - User guide: GUIDE.md
-  - FAQ: faq.md
-  - Configuration (project and global): yaml_configuration.md
-  - stack.yaml vs cabal package files: stack_yaml_vs_cabal_package_file.md
-  - Build command: build_command.md
-  - Developing on Windows: developing_on_windows.md
-  - Dependency visualization: dependency_visualization.md
-  - Docker integration: docker_integration.md
-  - Nix integration: nix_integration.md
-  - Non-standard project initialization: nonstandard_project_init.md
-  - Shell auto-completion: shell_autocompletion.md
-  - Travis CI: travis_ci.md
-  - Azure CI: azure_ci.md
-  - Custom snapshots: custom_snapshot.md
-  - Code coverage: coverage.md
-  - GHCi: ghci.md
-  - Pantry: pantry.md
-  - Lock files: lock_files.md
-- Advanced documentation:
-  - Build overview: build_overview.md
-- Project documentation:
-  - Contributors guide: CONTRIBUTING.md
-  - Maintainer guide:
-    - Releases: maintainers/releases.md
-    - Maintainer team process: maintainers/team_process.md
-    - Add GHC version: maintainers/ghc.md
-    - Docker images: maintainers/docker.md
-    - Upgrading MSYS2: maintainers/msys.md
-  - Signing key: SIGNING_KEY.md
+  - Home: README.md
+  - Changelog: ChangeLog.md
+  - Tool documentation:
+      - Install/upgrade: install_and_upgrade.md
+      - User guide: GUIDE.md
+      - FAQ: faq.md
+      - Configuration (project and global): yaml_configuration.md
+      - stack.yaml vs cabal package files: stack_yaml_vs_cabal_package_file.md
+      - Build command: build_command.md
+      - Developing on Windows: developing_on_windows.md
+      - Dependency visualization: dependency_visualization.md
+      - Docker integration: docker_integration.md
+      - Nix integration: nix_integration.md
+      - Non-standard project initialization: nonstandard_project_init.md
+      - Shell auto-completion: shell_autocompletion.md
+      - Travis CI: travis_ci.md
+      - Azure CI: azure_ci.md
+      - Custom snapshots: custom_snapshot.md
+      - Code coverage: coverage.md
+      - GHCi: ghci.md
+      - Pantry: pantry.md
+      - Lock files: lock_files.md
+  - Advanced documentation:
+      - Build overview: build_overview.md
+  - Project documentation:
+      - Contributors guide: CONTRIBUTING.md
+      - Maintainer guide:
+          - Releases: maintainers/releases.md
+          - Maintainer team process: maintainers/team_process.md
+          - Add GHC version: maintainers/ghc.md
+          - Docker images: maintainers/docker.md
+          - Upgrading MSYS2: maintainers/msys.md
+      - Signing key: SIGNING_KEY.md
 
 markdown_extensions:
-- toc:
-    permalink: true
+  - toc:
+      permalink: true

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stack
-version: '2.7.6'
+version: "2.7.6"
 synopsis: The Haskell Tool Stack
 description: |
   Please see the documentation at <https://docs.haskellstack.org>
@@ -22,311 +22,311 @@ github: commercialhaskell/stack
 homepage: http://haskellstack.org
 custom-setup:
   dependencies:
-  - base >=4.13 && < 5
-  - Cabal
-  - filepath
+    - base >=4.13 && < 5
+    - Cabal
+    - filepath
 extra-source-files:
-# note: leaving out 'package.yaml' because it causes confusion with hackage metadata revisions
-- CONTRIBUTING.md
-- ChangeLog.md
-- README.md
-- stack.yaml
-- doc/*.md
-- src/setup-shim/StackSetupShim.hs
-- test/package-dump/ghc-7.10.txt
-- test/package-dump/ghc-7.8.4-osx.txt
-- test/package-dump/ghc-7.8.txt
-- test/package-dump/ghc-head.txt
-- src/test/Stack/Untar/test1.tar.gz
-- src/test/Stack/Untar/test2.tar.gz
+  # note: leaving out 'package.yaml' because it causes confusion with hackage metadata revisions
+  - CONTRIBUTING.md
+  - ChangeLog.md
+  - README.md
+  - stack.yaml
+  - doc/*.md
+  - src/setup-shim/StackSetupShim.hs
+  - test/package-dump/ghc-7.10.txt
+  - test/package-dump/ghc-7.8.4-osx.txt
+  - test/package-dump/ghc-7.8.txt
+  - test/package-dump/ghc-head.txt
+  - src/test/Stack/Untar/test1.tar.gz
+  - src/test/Stack/Untar/test2.tar.gz
 ghc-options:
-- -Wall
-- -fwarn-tabs
-- -fwarn-incomplete-uni-patterns
-- -fwarn-incomplete-record-updates
-- -optP-Wno-nonportable-include-path # workaround [Filename case on macOS · Issue #4739 · haskell/cabal](https://github.com/haskell/cabal/issues/4739)
+  - -Wall
+  - -fwarn-tabs
+  - -fwarn-incomplete-uni-patterns
+  - -fwarn-incomplete-record-updates
+  - -optP-Wno-nonportable-include-path  # workaround [Filename case on macOS · Issue #4739 · haskell/cabal](https://github.com/haskell/cabal/issues/4739)
 dependencies:
-- Cabal
-- aeson
-- annotated-wl-pprint
-- ansi-terminal
-- array
-- async
-- attoparsec
-- base >=4.10 && < 5
-- base64-bytestring
-- bytestring
-- colour
-- conduit
-- conduit-extra
-- containers
-- cryptonite
-- cryptonite-conduit
-- deepseq
-- directory
-- echo
-- exceptions
-- extra
-- file-embed
-- filelock
-- filepath
-- fsnotify
-- generic-deriving
-- hackage-security
-- hashable
-- hi-file-parser
-- hpack
-- hpc
-- http-client
-- http-client-tls
-- http-conduit
-- http-download
-- http-types
-- memory
-- microlens
-- mintty
-- mono-traversable
-- mtl
-- mustache
-- neat-interpolation
-- network-uri
-- open-browser
-- optparse-applicative >= 0.14.3.0
-- pantry >= 0.5.6
-- casa-client
-- casa-types
-- path
-- path-io
-# In order for Cabal (the tool) to build Stack, it needs to be told of the
-# upper bound on persistent. See
-# https://github.com/commercialhaskell/stack/pull/5677#issuecomment-1193318542 
-- persistent < 2.14
-- persistent-sqlite
-- persistent-template
-- pretty
-- primitive
-- process
-- project-template
-- retry
-- rio >= 0.1.21.0
-- rio-prettyprint >= 0.1.1.0
-- semigroups
-- split
-- stm
-- streaming-commons
-- tar
-- template-haskell
-- temporary
-- text
-- text-metrics
-- th-reify-many
-- time
-- tls
-- transformers
-- typed-process
-- unicode-transforms
-- unix-compat
-- unliftio
-- unordered-containers
-- vector
-- yaml
-- zip-archive
-- zlib
+  - Cabal
+  - aeson
+  - annotated-wl-pprint
+  - ansi-terminal
+  - array
+  - async
+  - attoparsec
+  - base >=4.10 && < 5
+  - base64-bytestring
+  - bytestring
+  - colour
+  - conduit
+  - conduit-extra
+  - containers
+  - cryptonite
+  - cryptonite-conduit
+  - deepseq
+  - directory
+  - echo
+  - exceptions
+  - extra
+  - file-embed
+  - filelock
+  - filepath
+  - fsnotify
+  - generic-deriving
+  - hackage-security
+  - hashable
+  - hi-file-parser
+  - hpack
+  - hpc
+  - http-client
+  - http-client-tls
+  - http-conduit
+  - http-download
+  - http-types
+  - memory
+  - microlens
+  - mintty
+  - mono-traversable
+  - mtl
+  - mustache
+  - neat-interpolation
+  - network-uri
+  - open-browser
+  - optparse-applicative >= 0.14.3.0
+  - pantry >= 0.5.6
+  - casa-client
+  - casa-types
+  - path
+  - path-io
+  # In order for Cabal (the tool) to build Stack, it needs to be told of the
+  # upper bound on persistent. See
+  # https://github.com/commercialhaskell/stack/pull/5677#issuecomment-1193318542
+  - persistent < 2.14
+  - persistent-sqlite
+  - persistent-template
+  - pretty
+  - primitive
+  - process
+  - project-template
+  - retry
+  - rio >= 0.1.21.0
+  - rio-prettyprint >= 0.1.1.0
+  - semigroups
+  - split
+  - stm
+  - streaming-commons
+  - tar
+  - template-haskell
+  - temporary
+  - text
+  - text-metrics
+  - th-reify-many
+  - time
+  - tls
+  - transformers
+  - typed-process
+  - unicode-transforms
+  - unix-compat
+  - unliftio
+  - unordered-containers
+  - vector
+  - yaml
+  - zip-archive
+  - zlib
 when:
-- condition: os(windows)
-  then:
-    cpp-options: -DWINDOWS
-    dependencies:
-    - Win32
-  else:
-    verbatim: |
-      build-tool-depends:
-          hsc2hs:hsc2hs
-    dependencies:
-    - unix
-- condition: flag(developer-mode)
-  then:
-    cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=True
-  else:
-    cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=False
+  - condition: os(windows)
+    then:
+      cpp-options: -DWINDOWS
+      dependencies:
+        - Win32
+    else:
+      verbatim: |
+        build-tool-depends:
+            hsc2hs:hsc2hs
+      dependencies:
+        - unix
+  - condition: flag(developer-mode)
+    then:
+      cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=True
+    else:
+      cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=False
 library:
   source-dirs: src/
   ghc-options:
-  - -fwarn-identities
+    - -fwarn-identities
   generated-exposed-modules:
-  - Paths_stack
+    - Paths_stack
   exposed-modules:
-  - Control.Concurrent.Execute
-  - Data.Attoparsec.Args
-  - Data.Attoparsec.Combinators
-  - Data.Attoparsec.Interpreter
-  - Data.Monoid.Map
-  - Network.HTTP.StackClient
-  - Options.Applicative.Args
-  - Options.Applicative.Builder.Extra
-  - Options.Applicative.Complicated
-  - Path.CheckInstall
-  - Path.Extra
-  - Path.Find
-  - Stack.Build
-  - Stack.Build.Cache
-  - Stack.Build.ConstructPlan
-  - Stack.Build.Execute
-  - Stack.Build.Haddock
-  - Stack.Build.Installed
-  - Stack.Build.Source
-  - Stack.Build.Target
-  - Stack.BuildPlan
-  - Stack.Clean
-  - Stack.Config
-  - Stack.Config.Build
-  - Stack.Config.Docker
-  - Stack.Config.Nix
-  - Stack.ConfigCmd
-  - Stack.Constants
-  - Stack.Constants.Config
-  - Stack.Coverage
-  - Stack.DefaultColorWhen
-  - Stack.Docker
-  - Stack.Dot
-  - Stack.FileWatch
-  - Stack.GhcPkg
-  - Stack.Ghci
-  - Stack.Ghci.Script
-  - Stack.Hoogle
-  - Stack.IDE
-  - Stack.Init
-  - Stack.List
-  - Stack.Ls
-  - Stack.Lock
-  - Stack.New
-  - Stack.Nix
-  - Stack.Options.BenchParser
-  - Stack.Options.BuildMonoidParser
-  - Stack.Options.BuildParser
-  - Stack.Options.CleanParser
-  - Stack.Options.ConfigParser
-  - Stack.Options.Completion
-  - Stack.Options.DockerParser
-  - Stack.Options.DotParser
-  - Stack.Options.ExecParser
-  - Stack.Options.GhcBuildParser
-  - Stack.Options.GhciParser
-  - Stack.Options.GhcVariantParser
-  - Stack.Options.GlobalParser
-  - Stack.Options.HaddockParser
-  - Stack.Options.HpcReportParser
-  - Stack.Options.LogLevelParser
-  - Stack.Options.NewParser
-  - Stack.Options.NixParser
-  - Stack.Options.PackageParser
-  - Stack.Options.ResolverParser
-  - Stack.Options.ScriptParser
-  - Stack.Options.SDistParser
-  - Stack.Options.TestParser
-  - Stack.Options.UploadParser
-  - Stack.Options.Utils
-  - Stack.Package
-  - Stack.PackageDump
-  - Stack.Path
-  - Stack.Prelude
-  - Stack.Runners
-  - Stack.Script
-  - Stack.SDist
-  - Stack.Setup
-  - Stack.Setup.Installed
-  - Stack.SetupCmd
-  - Stack.SourceMap
-  - Stack.Storage.Project
-  - Stack.Storage.User
-  - Stack.Storage.Util
-  - Stack.Types.Build
-  - Stack.Types.CompilerBuild
-  - Stack.Types.Compiler
-  - Stack.Types.Config
-  - Stack.Types.Config.Build
-  - Stack.Types.Docker
-  - Stack.Types.GhcPkgId
-  - Stack.Types.NamedComponent
-  - Stack.Types.Nix
-  - Stack.Types.Package
-  - Stack.Types.PackageName
-  - Stack.Types.Resolver
-  - Stack.Types.SourceMap
-  - Stack.Types.TemplateName
-  - Stack.Types.Version
-  - Stack.Unpack
-  - Stack.Upgrade
-  - Stack.Upload
-  - System.Info.ShortPathName
-  - System.Permissions
-  - System.Process.Pager
-  - System.Terminal
+    - Control.Concurrent.Execute
+    - Data.Attoparsec.Args
+    - Data.Attoparsec.Combinators
+    - Data.Attoparsec.Interpreter
+    - Data.Monoid.Map
+    - Network.HTTP.StackClient
+    - Options.Applicative.Args
+    - Options.Applicative.Builder.Extra
+    - Options.Applicative.Complicated
+    - Path.CheckInstall
+    - Path.Extra
+    - Path.Find
+    - Stack.Build
+    - Stack.Build.Cache
+    - Stack.Build.ConstructPlan
+    - Stack.Build.Execute
+    - Stack.Build.Haddock
+    - Stack.Build.Installed
+    - Stack.Build.Source
+    - Stack.Build.Target
+    - Stack.BuildPlan
+    - Stack.Clean
+    - Stack.Config
+    - Stack.Config.Build
+    - Stack.Config.Docker
+    - Stack.Config.Nix
+    - Stack.ConfigCmd
+    - Stack.Constants
+    - Stack.Constants.Config
+    - Stack.Coverage
+    - Stack.DefaultColorWhen
+    - Stack.Docker
+    - Stack.Dot
+    - Stack.FileWatch
+    - Stack.GhcPkg
+    - Stack.Ghci
+    - Stack.Ghci.Script
+    - Stack.Hoogle
+    - Stack.IDE
+    - Stack.Init
+    - Stack.List
+    - Stack.Ls
+    - Stack.Lock
+    - Stack.New
+    - Stack.Nix
+    - Stack.Options.BenchParser
+    - Stack.Options.BuildMonoidParser
+    - Stack.Options.BuildParser
+    - Stack.Options.CleanParser
+    - Stack.Options.ConfigParser
+    - Stack.Options.Completion
+    - Stack.Options.DockerParser
+    - Stack.Options.DotParser
+    - Stack.Options.ExecParser
+    - Stack.Options.GhcBuildParser
+    - Stack.Options.GhciParser
+    - Stack.Options.GhcVariantParser
+    - Stack.Options.GlobalParser
+    - Stack.Options.HaddockParser
+    - Stack.Options.HpcReportParser
+    - Stack.Options.LogLevelParser
+    - Stack.Options.NewParser
+    - Stack.Options.NixParser
+    - Stack.Options.PackageParser
+    - Stack.Options.ResolverParser
+    - Stack.Options.ScriptParser
+    - Stack.Options.SDistParser
+    - Stack.Options.TestParser
+    - Stack.Options.UploadParser
+    - Stack.Options.Utils
+    - Stack.Package
+    - Stack.PackageDump
+    - Stack.Path
+    - Stack.Prelude
+    - Stack.Runners
+    - Stack.Script
+    - Stack.SDist
+    - Stack.Setup
+    - Stack.Setup.Installed
+    - Stack.SetupCmd
+    - Stack.SourceMap
+    - Stack.Storage.Project
+    - Stack.Storage.User
+    - Stack.Storage.Util
+    - Stack.Types.Build
+    - Stack.Types.CompilerBuild
+    - Stack.Types.Compiler
+    - Stack.Types.Config
+    - Stack.Types.Config.Build
+    - Stack.Types.Docker
+    - Stack.Types.GhcPkgId
+    - Stack.Types.NamedComponent
+    - Stack.Types.Nix
+    - Stack.Types.Package
+    - Stack.Types.PackageName
+    - Stack.Types.Resolver
+    - Stack.Types.SourceMap
+    - Stack.Types.TemplateName
+    - Stack.Types.Version
+    - Stack.Unpack
+    - Stack.Upgrade
+    - Stack.Upload
+    - System.Info.ShortPathName
+    - System.Permissions
+    - System.Process.Pager
+    - System.Terminal
   when:
-  - condition: 'os(windows)'
-    then:
-      source-dirs: src/windows/
-    else:
-      source-dirs: src/unix/
-      c-sources: src/unix/cbits/uname.c
+    - condition: "os(windows)"
+      then:
+        source-dirs: src/windows/
+      else:
+        source-dirs: src/unix/
+        c-sources: src/unix/cbits/uname.c
 executables:
   stack:
     main: Main.hs
     source-dirs: src/main
     generated-other-modules:
-    - Build_stack
-    - Paths_stack
+      - Build_stack
+      - Paths_stack
     ghc-options:
-    - -threaded
-    - -rtsopts
+      - -threaded
+      - -rtsopts
     dependencies:
-    - stack
+      - stack
     when:
-    - condition: flag(static)
-      ld-options:
-      - -static
-      - -pthread
-    - condition: ! '!(flag(disable-git-info))'
-      cpp-options: -DUSE_GIT_INFO
-      dependencies:
-      - githash
-      - optparse-simple
-    - condition: flag(hide-dependency-versions)
-      cpp-options: -DHIDE_DEP_VERSIONS
-    - condition: flag(supported-build)
-      cpp-options: -DSUPPORTED_BUILD
+      - condition: flag(static)
+        ld-options:
+          - -static
+          - -pthread
+      - condition: ! "!(flag(disable-git-info))"
+        cpp-options: -DUSE_GIT_INFO
+        dependencies:
+          - githash
+          - optparse-simple
+      - condition: flag(hide-dependency-versions)
+        cpp-options: -DHIDE_DEP_VERSIONS
+      - condition: flag(supported-build)
+        cpp-options: -DSUPPORTED_BUILD
   stack-integration-test:
     main: IntegrationSpec.hs
     source-dirs:
-    - test/integration
-    - test/integration/lib
+      - test/integration
+      - test/integration/lib
     ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
     dependencies:
-    - filepath
-    - hspec
-    - optparse-generic
+      - filepath
+      - hspec
+      - optparse-generic
     when:
-    - condition: ! '!(flag(integration-tests))'
-      buildable: false
-    - condition: flag(static)
-      ld-options:
-      - -static
-      - -pthread
+      - condition: ! "!(flag(integration-tests))"
+        buildable: false
+      - condition: flag(static)
+        ld-options:
+          - -static
+          - -pthread
 tests:
   stack-test:
     main: Spec.hs
     source-dirs: src/test
     ghc-options:
-    - -threaded
+      - -threaded
     dependencies:
-    - QuickCheck
-    - hspec
-    - raw-strings-qq
-    - stack
-    - smallcheck
+      - QuickCheck
+      - hspec
+      - raw-strings-qq
+      - stack
+      - smallcheck
     verbatim: |
       build-tool-depends:
           hspec-discover:hspec-discover
@@ -340,7 +340,8 @@ flags:
     manual: true
     default: false
   hide-dependency-versions:
-    description: "Hides dependency versions from 'stack --version', used only by building
+    description:
+      "Hides dependency versions from 'stack --version', used only by building
       Stack and the default 'stack.yaml'.  Note to packagers/distributors:
       DO NOT OVERRIDE THIS FLAG IF YOU ARE BUILDING 'stack' ANY OTHER WAY
       (e.g. using cabal or from Hackage), as it makes debugging support

--- a/stack-ghc-902.yaml
+++ b/stack-ghc-902.yaml
@@ -2,7 +2,7 @@
 resolver: lts-19.16
 
 packages:
-- .
+  - .
 
 docker:
   enable: false
@@ -22,13 +22,13 @@ ghc-options:
   "$locals": -fhide-source-paths
 
 extra-deps:
-# mustache absent from lts-19.16
-- mustache-2.4.1@sha256:dc92ddbf90e3a64c3f2ec7785cf2937d6dcf6ffcebbc38ad9c8b33b6a70bb298,3180
-# lts-19.16 is limited to hpack-0.34.7
-- hpack-0.35.0@sha256:8cd6146fae269390f41dc7237ebd2c479074d4163806d349a41f5a7751d6cea5,4726
-# See https://github.com/commercialhaskell/pantry/pull/53
-- pantry-0.5.6@rev:0
+  # mustache absent from lts-19.16
+  - mustache-2.4.1@sha256:dc92ddbf90e3a64c3f2ec7785cf2937d6dcf6ffcebbc38ad9c8b33b6a70bb298,3180
+  # lts-19.16 is limited to hpack-0.34.7
+  - hpack-0.35.0@sha256:8cd6146fae269390f41dc7237ebd2c479074d4163806d349a41f5a7751d6cea5,4726
+  # See https://github.com/commercialhaskell/pantry/pull/53
+  - pantry-0.5.6@rev:0
 
 drop-packages:
-# See https://github.com/commercialhaskell/stack/pull/4712
-- cabal-install
+  # See https://github.com/commercialhaskell/stack/pull/4712
+  - cabal-install

--- a/stack-ghc-922.yaml
+++ b/stack-ghc-922.yaml
@@ -2,7 +2,7 @@
 resolver: nightly-2022-04-09
 
 packages:
-- .
+  - .
 
 docker:
   enable: false
@@ -19,11 +19,11 @@ flags:
     developer-mode: true
 
 ghc-options:
-   "$locals": -fhide-source-paths
+  "$locals": -fhide-source-paths
 
 extra-deps:
-- pantry-0.5.6@rev:0 # https://github.com/commercialhaskell/pantry/pull/53
+  - pantry-0.5.6@rev:0  # https://github.com/commercialhaskell/pantry/pull/53
 
 drop-packages:
-# See https://github.com/commercialhaskell/stack/pull/4712
-- cabal-install
+  # See https://github.com/commercialhaskell/stack/pull/4712
+  - cabal-install

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,17 +1,16 @@
 resolver: lts-17.15
 
 packages:
-- .
+  - .
 
 extra-deps:
-- hpack-0.35.0@rev:0
-- pantry-0.5.6@rev:0 # https://github.com/commercialhaskell/pantry/pull/53
-- rio-0.1.21.0@rev:0
-
+  - hpack-0.35.0@rev:0
+  - pantry-0.5.6@rev:0  # https://github.com/commercialhaskell/pantry/pull/53
+  - rio-0.1.21.0@rev:0
 
 docker:
   enable: false
-  #repo: fpco/alpine-haskell-stack:8.10.4
+  # repo: fpco/alpine-haskell-stack:8.10.4
   repo: fpco/alpine-haskell-stack@sha256:1024fe4b3b082a8df64d00e8563b3151220ed90af09604a8f7e1d44040500c30
 
 nix:
@@ -24,8 +23,8 @@ flags:
     developer-mode: true
 
 ghc-options:
-   "$locals": -fhide-source-paths
+  "$locals": -fhide-source-paths
 
 drop-packages:
-# See https://github.com/commercialhaskell/stack/pull/4712
-- cabal-install
+  # See https://github.com/commercialhaskell/stack/pull/4712
+  - cabal-install


### PR DESCRIPTION
The vscode editor showed problems with `.hlint.yaml`. I was able to reproduce these before fixing them by installing and configuring yamllint for which I added a GitHub action. In reviewing `.hlint.yaml` I saw that we should have been adding our errors before any ignores. Added a comment introducing why we have the "Use alternative" ignore. The ignore for "Too strict maybe" was repeated so I reduced this duplication collecting the within modules together. For YAML linting I'm ignoring most of `.gitub/workflows/`, `doc` and `test` folders.

I pulled the hlint action out of the unit-tests action and used `haskell/actions/setup-hlint` for the set up.
