### PR TITLE
Fix #5758 Warn only if GHC > 9.2 or > Cabal > 3.6

### DIFF
--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -475,9 +475,9 @@ warnUnsupportedCompiler ghcVersion = do
         logWarn "For more information, see: https://github.com/commercialhaskell/stack/issues/648"
         logWarn ""
         pure True
-    | ghcVersion >= mkVersion [9, 1] -> do
+    | ghcVersion >= mkVersion [9, 3] -> do
         logWarn $
-          "Stack has not been tested with GHC versions above 9.0, and using " <>
+          "Stack has not been tested with GHC versions above 9.2, and using " <>
           fromString (versionString ghcVersion) <>
           ", this may fail"
         pure True
@@ -502,9 +502,9 @@ warnUnsupportedCompilerCabal cp didWarn = do
         logWarn "This invocation will most likely fail."
         logWarn "To fix this, either use an older version of Stack or a newer resolver"
         logWarn "Acceptable resolvers: lts-3.0/nightly-2015-05-05 or later"
-    | cabalVersion >= mkVersion [3, 5] ->
+    | cabalVersion >= mkVersion [3, 7] ->
         logWarn $
-          "Stack has not been tested with Cabal versions above 3.4, but version " <>
+          "Stack has not been tested with Cabal versions above 3.6, but version " <>
           fromString (versionString cabalVersion) <>
           " was found, this may fail"
     | otherwise -> pure ()
@@ -610,7 +610,7 @@ ensureCompiler
 ensureCompiler sopts getSetupInfo' = do
     let wanted = soptsWantedCompiler sopts
     wc <- either throwIO (pure . whichCompiler) $ wantedToActual wanted
-    
+
     hook <- ghcInstallHook
     hookIsExecutable <- handleIO (\_ -> pure False) $ if osIsWindows
       then doesFileExist hook  -- can't really detect executable on windows, only file extension
@@ -645,7 +645,7 @@ ensureCompiler sopts getSetupInfo' = do
           -- if the hook fails, we fall through to stacks sandboxed installation
             hookGHC <- runGHCInstallHook sopts hook
             maybe (pure Nothing) checkCompiler hookGHC
-         | otherwise -> return Nothing           
+         | otherwise -> return Nothing
     case mcp of
       Nothing -> ensureSandboxedCompiler sopts getSetupInfo'
       Just cp -> do


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Taken from #5763 development and tested as part of the testing of that.
