### PR TITLE
Allow stack to build with GHC 9.2.3 (nightly-2022-07-29)

### DIFF
--- a/stack-ghc-923.yaml
+++ b/stack-ghc-923.yaml
@@ -1,5 +1,5 @@
-# GHC 9.2.2
-resolver: nightly-2022-04-09
+# GHC 9.2.3
+resolver: nightly-2022-07-29
 
 packages:
 - .
@@ -22,7 +22,8 @@ ghc-options:
    "$locals": -fhide-source-paths
 
 extra-deps:
-- pantry-0.5.6@rev:0 # https://github.com/commercialhaskell/pantry/pull/53
+# See https://github.com/commercialhaskell/pantry/pull/53
+- pantry-0.5.6@rev:0
 
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712


### PR DESCRIPTION
GHC 9.2.3 comes with `Cabal-3.6.3.0`. From `Cabal-3.6.0.0` the type of `Distribution.Types.BuildInfo.hsSourceDirs` changed from:

~~~
BuildInfo -> [FilePath]
~~~

to:

~~~
BuildInfo -> [SymbolicPath PackageDir SourceDir]
~~~

where type `SymbolicPath from to` represents relative paths.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested as part of #5763. Stack built with GHC 9.2.3 reveals upstream bugs on macOS - see #5763.
