### PR TITLE
Add stan gh-action and ignore triggered checks

### DIFF
--- a/.github/workflows/stan.yml
+++ b/.github/workflows/stan.yml
@@ -1,0 +1,44 @@
+name: stan
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: ghc ${{ matrix.ghc }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cabal: ["3.6"]
+        ghc:
+          - "8.10.7"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - uses: haskell/actions/setup@v1
+        name: Setup GHC and cabal-install
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+
+      - uses: actions/cache@v2
+        name: cache ~/.cabal/store
+        with:
+          path: ~/.cabal/store
+          key: ${{ runner.os }}-${{ matrix.ghc }}-cabal
+
+      - name: update
+        run: cabal update
+
+      - name: install stan
+        run: cabal install stan --installdir=.bin --install-method=copy --overwrite-policy=always
+
+      - name: generate .hie for analysis
+        run: cabal build stack:lib:stack
+
+      - name: stan
+        run: .bin/stan report

--- a/.github/workflows/stan.yml
+++ b/.github/workflows/stan.yml
@@ -12,33 +12,33 @@ jobs:
       matrix:
         cabal: ["3.6"]
         ghc:
-          - "8.10.7"
+        - "8.10.7"
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
 
-      - uses: haskell/actions/setup@v1
-        name: Setup GHC and cabal-install
-        with:
-          ghc-version: ${{ matrix.ghc }}
-          cabal-version: ${{ matrix.cabal }}
+    - uses: haskell/actions/setup@v1
+      name: Setup GHC and cabal-install
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
 
-      - uses: actions/cache@v2
-        name: cache ~/.cabal/store
-        with:
-          path: ~/.cabal/store
-          key: ${{ runner.os }}-${{ matrix.ghc }}-cabal
+    - uses: actions/cache@v2
+      name: cache ~/.cabal/store
+      with:
+        path: ~/.cabal/store
+        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal
 
-      - name: update
-        run: cabal update
+    - name: update
+      run: cabal update
 
-      - name: install stan
-        run: cabal install stan --installdir=.bin --install-method=copy --overwrite-policy=always
+    - name: install stan
+      run: cabal install stan --installdir=.bin --install-method=copy --overwrite-policy=always
 
-      - name: generate .hie for analysis
-        run: cabal build stack:lib:stack
+    - name: generate .hie for analysis
+      run: cabal build stack:lib:stack
 
-      - name: stan
-        run: .bin/stan report
+    - name: stan
+      run: .bin/stan report

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ tags
 better-cache/
 stack*.yaml.lock
 dist-newstyle/
+.hie
+stan.html

--- a/.stan.toml
+++ b/.stan.toml
@@ -1,0 +1,89 @@
+# Partial: base/!!
+[[check]]
+  id = "STAN-0005"
+  scope = "all"
+  type = "Exclude"
+
+# Partial: base/minimum
+[[check]]
+  id = "STAN-0014"
+  scope = "all"
+  type = "Exclude"
+
+# Partial: base/minimumBy
+[[check]]
+  id = "STAN-0016"
+  scope = "all"
+  type = "Exclude"
+
+# Partial: base/fromList
+[[check]]
+  id = "STAN-0020"
+  scope = "all"
+  type = "Exclude"
+
+# Infinite: base/reverse
+[[check]]
+  id = "STAN-0101"
+  scope = "all"
+  type = "Exclude"
+
+# Infinite: base/isSuffixOf
+[[check]]
+  id = "STAN-0102"
+  scope = "all"
+  type = "Exclude"
+
+# Infinite: base/length
+[[check]]
+  id = "STAN-0103"
+  scope = "all"
+  type = "Exclude"
+
+# Anti-pattern: foldl
+[[check]]
+  id = "STAN-0202"
+  scope = "all"
+  type = "Exclude"
+
+# Anti-pattern: Data.ByteString.Char8.pack
+[[check]]
+  id = "STAN-0203"
+  scope = "all"
+  type = "Exclude"
+
+# Data types with non-strict fields
+[[check]]
+  id = "STAN-0206"
+  scope = "all"
+  type = "Exclude"
+
+# Anti-pattern: Foldable methods on possibly error-prone structures
+[[check]]
+  id = "STAN-0207"
+  scope = "all"
+  type = "Exclude"
+
+# Anti-pattern: Slow 'length' for Text
+[[check]]
+  id = "STAN-0208"
+  scope = "all"
+  type = "Exclude"
+
+# Anti-pattern: unsafe functions
+[[check]]
+  id = "STAN-0212"
+  scope = "all"
+  type = "Exclude"
+
+# Anti-pattern: Pattern matching on '_'
+[[check]]
+  id = "STAN-0213"
+  scope = "all"
+  type = "Exclude"
+
+# Using tuples of big size (>= 4) can decrease code readability
+[[check]]
+  id = "STAN-0302"
+  scope = "all"
+  type = "Exclude"

--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,8 @@ extra-source-files:
 - src/test/Stack/Untar/test1.tar.gz
 - src/test/Stack/Untar/test2.tar.gz
 ghc-options:
+- -fwrite-ide-info
+- -hiedir=.hie
 - -Wall
 - -fwarn-tabs
 - -fwarn-incomplete-uni-patterns

--- a/stack.cabal
+++ b/stack.cabal
@@ -223,7 +223,7 @@ library
       Paths_stack
   hs-source-dirs:
       src/
-  ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -optP-Wno-nonportable-include-path -fwarn-identities
+  ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -optP-Wno-nonportable-include-path -fwarn-identities
   build-depends:
       Cabal
     , aeson
@@ -346,7 +346,7 @@ executable stack
       Paths_stack
   hs-source-dirs:
       src/main
-  ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -optP-Wno-nonportable-include-path -threaded -rtsopts
+  ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -optP-Wno-nonportable-include-path -threaded -rtsopts
   build-depends:
       Cabal
     , aeson
@@ -468,7 +468,7 @@ executable stack-integration-test
   hs-source-dirs:
       test/integration
       test/integration/lib
-  ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Cabal
     , aeson
@@ -597,7 +597,7 @@ test-suite stack-test
       Paths_stack
   hs-source-dirs:
       src/test
-  ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -optP-Wno-nonportable-include-path -threaded
+  ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -optP-Wno-nonportable-include-path -threaded
   build-depends:
       Cabal
     , QuickCheck


### PR DESCRIPTION
Adds a gh-action for [stan](https://kowainik.github.io/projects/stan). Both the project and stan need to be built with the same GHC version. All of the triggered checks are excluded. We can chip away at the hints once this action is set up.
