### PR TITLE
Fix #5312 Better help for `stack ls snapshots local`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -55,6 +55,8 @@ Bug fixes:
 * Fixed logic in `get_isa()` in `get-stack.sh` to exclude systems that don't
   have x86 in their `uname -m` output. See
   [5792](https://github.com/commercialhaskell/stack/issues/5792).
+* Fixed output of `stack ls snapshots local` on Windows, to behave like that on
+  Unix-like operating systems.
 
 ## v2.7.5
 


### PR DESCRIPTION
Explains that local snapshots are identified by hash codes.

Also explains that, on a terminal, the `stack ls snapshots` command uses a pager if one is available (and how).

Also removes the redundant `Stack.Ls.listDependenciesCmd`.

Also corrects the incorrect output of `stack ls snapshots local` on Windows.

* [X] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [X] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building and using Stack (on Windows).

There are other improvements that could be made to `stack ls snapshots` (for example: `local` is of little use - `remote` would be the better default; the `lts` and `nightly` filters make no sense for `local`), which would change the existing behviour (rather than correct it). This pull request does not address those other improvements.