### PR TITLE
Fix #5833 Add `int-native` GHC variant

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,6 +38,7 @@ Other enhancements:
   [#5585](https://github.com/commercialhaskell/stack/pull/5585)
 * `tools` subcommand added to `stack ls`, to list stack's installed tools.
 * `stack uninstall` shows how to uninstall Stack.
+* `--ghc-variant` accepts `int-native` as a variant.
 
 Bug fixes:
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -666,7 +666,7 @@ compiler's binary directory - will take precedence over those specified here
 Specify a specialized architecture bindist to use.  Normally this is
 determined automatically, but you can override the autodetected value here.
 Possible arguments include `standard`, `gmp4`, `nopie`, `tinfo6`,
-`tinfo6-nopie`, `ncurses6`, and `integersimple`.
+`tinfo6-nopie`, `ncurses6`, `int-native` and `integersimple`.
 
 ### ghc-options
 
@@ -710,6 +710,10 @@ Default: `standard`
 Specify a variant binary distribution of GHC to use. Known values:
 
 * `standard`: Use the standard GHC binary distribution
+* `int-native`: From GHC 9.4.1, use a GHC bindist that uses the Haskell-native
+   big-integer
+  [backend](https://downloads.haskell.org/~ghc/9.0.2/docs/html/users_guide/9.0.1-notes.html#highlights).
+  For further information, see this [article](https://iohk.io/en/blog/posts/2020/07/28/improving-haskells-big-numbers-support/).
 * `integersimple`: Use a GHC bindist that uses
   [integer-simple instead of GMP](https://ghc.haskell.org/trac/ghc/wiki/ReplacingGMPNotes)
 * any other value: Use a custom GHC bindist. You should specify

--- a/src/Stack/Options/GhcBuildParser.hs
+++ b/src/Stack/Options/GhcBuildParser.hs
@@ -14,7 +14,14 @@ ghcBuildParser hide =
     option
         readGHCBuild
         (long "ghc-build" <> metavar "BUILD" <>
-         completeWith ["standard", "gmp4", "nopie", "tinfo6", "tinfo6-nopie", "ncurses6", "integersimple"] <>
+         completeWith [ "standard"
+                      , "gmp4"
+                      , "nopie"
+                      , "tinfo6"
+                      , "tinfo6-nopie"
+                      , "ncurses6"
+                      , "int-native"
+                      , "integersimple"] <>
          help
              "Specialized GHC build, e.g. 'gmp4' or 'standard' (usually auto-detected)" <>
          hideMods hide

--- a/src/Stack/Options/GhcVariantParser.hs
+++ b/src/Stack/Options/GhcVariantParser.hs
@@ -10,17 +10,16 @@ import           Stack.Types.Config
 
 -- | GHC variant parser
 ghcVariantParser :: Bool -> Parser GHCVariant
-ghcVariantParser hide =
-    option
-        readGHCVariant
-        (long "ghc-variant" <> metavar "VARIANT" <>
-         help
-             "Specialized GHC variant, e.g. integersimple (incompatible with --system-ghc)" <>
-         hideMods hide
-        )
-  where
-    readGHCVariant = do
-        s <- readerAsk
-        case parseGHCVariant s of
-            Left e -> readerError (show e)
-            Right v -> return v
+ghcVariantParser hide = option readGHCVariant
+   ( long "ghc-variant"
+  <> metavar "VARIANT"
+  <> help "Specialized GHC variant, e.g. int-native or integersimple \
+          \(incompatible with --system-ghc)"
+  <> hideMods hide
+   )
+ where
+  readGHCVariant = do
+    s <- readerAsk
+    case parseGHCVariant s of
+      Left e -> readerError (show e)
+      Right v -> return v

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -1617,9 +1617,14 @@ platformVariantSuffix (PlatformVariant v) = "-" ++ v
 
 -- | Specialized bariant of GHC (e.g. libgmp4 or integer-simple)
 data GHCVariant
-    = GHCStandard -- ^ Standard bindist
-    | GHCIntegerSimple -- ^ Bindist that uses integer-simple
-    | GHCCustom String -- ^ Other bindists
+    = GHCStandard
+    -- ^ Standard bindist
+    | GHCIntegerSimple
+    -- ^ Bindist that uses integer-simple
+    | GHCNativeBignum
+    -- ^ Bindist that uses the Haskell-native big-integer backend
+    | GHCCustom String
+    -- ^ Other bindists
     deriving (Show)
 
 instance FromJSON GHCVariant where
@@ -1633,6 +1638,7 @@ instance FromJSON GHCVariant where
 ghcVariantName :: GHCVariant -> String
 ghcVariantName GHCStandard = "standard"
 ghcVariantName GHCIntegerSimple = "integersimple"
+ghcVariantName GHCNativeBignum = "int-native"
 ghcVariantName (GHCCustom name) = "custom-" ++ name
 
 -- | Render a GHC variant to a String suffix.
@@ -1649,6 +1655,7 @@ parseGHCVariant s =
           | s == "" -> return GHCStandard
           | s == "standard" -> return GHCStandard
           | s == "integersimple" -> return GHCIntegerSimple
+          | s == "int-native" -> return GHCNativeBignum
           | otherwise -> return (GHCCustom s)
 
 -- | Build of the compiler distribution (e.g. standard, gmp4, tinfo6)


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Tested by building and using Stack with the `--ghc-variant=int-native` option and GHC 9.4.2, using:

~~~yaml
resolver: ghc-9.4.2
packages:
- .

ghc-variant: int-native

setup-info:
  ghc:
    windows64-int-native:
      9.4.2:
        url: https://downloads.haskell.org/~ghc/9.4.2/ghc-9.4.2-x86_64-unknown-mingw32-int_native.tar.xz
        content-length: 282584664
        sha1: 6469af0cc463ee15826cda353784cfea6c81f439
        sha256: e5267e340da903be81a55f12d63637ed5c493b6d5232bb87149ae4bf420ae0dd
~~~
