### PR TITLE
Add config get and dump commands.

### DIFF
--- a/doc/GUIDE_advanced.md
+++ b/doc/GUIDE_advanced.md
@@ -81,17 +81,48 @@ the command, see the [build command](build_command.md) documentation.
 The `stack config` commands provide assistance with accessing or modifying
 Stack's configuration. See `stack config` for the available commands.
 
+## The `stack config dump-*` commands
+
+These commands dump YAML but can dump JSON with an added `--json` flag.
+
+## The `stack config dump-project` command
+
+The `stack config dump-project` command dumps project-only configuration. Any
+non-project configuration in the project is removed.
+
+## The `stack config dump-stack` command
+
+The `stack config dump-stack` command dumps configuration related to the
+operation of stack itself. This is non-project configuration. With `--lens` we
+can look at the configuration coming from the global settings, from stack
+settings within the project or the effective combination from those two
+locations.
+
+## The `stack config get` commands
+
+The `stack config get` commands gets values of keys in YAML configuration
+files but only those that can also be set.
+
+## The `stack config get resolver` command
+
+Gets the effective resolver.
+
+## The `stack config get *-ghc` commands
+
+The `--global` option will get these settings' global value.
+
+## The `stack config get system-ghc` commands
+
+Gets whether stack should use the system GHC installation.
+
+## The `stack config get install-ghc` command
+
+Gets whether stack should install GHC by itself.
+
 ## The `stack config set` commands
 
 The `stack config set` commands allow the values of keys in YAML configuration
 files to be set. See `stack config set` for the available keys.
-
-## The `stack config set install-ghc` command
-
-`stack config set install-ghc true` or `false` sets the `install-ghc` key in a
-YAML configuration file, accordingly. By default, the project-level
-configuration file (`stack.yaml`) is altered. The `--global` flag specifies the
-user-specific global configuration file (`config.yaml`).
 
 ## The `stack config set resolver` command
 
@@ -109,6 +140,13 @@ Known bug:
 ## The `stack config set system-ghc` command
 
 `stack config set system-ghc true` or `false` sets the `system-ghc` key in a
+YAML configuration file, accordingly. By default, the project-level
+configuration file (`stack.yaml`) is altered. The `--global` flag specifies the
+user-specific global configuration file (`config.yaml`).
+
+## The `stack config set install-ghc` command
+
+`stack config set install-ghc true` or `false` sets the `install-ghc` key in a
 YAML configuration file, accordingly. By default, the project-level
 configuration file (`stack.yaml`) is altered. The `--global` flag specifies the
 user-specific global configuration file (`config.yaml`).

--- a/doc/GUIDE_advanced.md
+++ b/doc/GUIDE_advanced.md
@@ -78,23 +78,8 @@ the command, see the [build command](build_command.md) documentation.
 
 ## The `stack config` commands
 
-The `stack config` commands provide assistence with accessing or modifying
+The `stack config` commands provide assistance with accessing or modifying
 Stack's configuration. See `stack config` for the available commands.
-
-## The `stack config env` command
-
-`stack config env` outputs a script that sets or unsets environment variables
-for a Stack environment. Flags modify the script that is output:
-
-* `--[no-]locals` (enabled by default) include/exclude local package information
-* `--[no-]ghc-package-path` (enabled by default) set `GHC_PACKAGE_PATH`
-  environment variable or not
-* `--[no-]stack-exe` (enabled by default) set `STACK_EXE` environment variable
-  or not
-* `--[no-]locale-utf8` (disabled by default) set the `GHC_CHARENC`
-  environment variable to `UTF-8` or not
-* `--[no-]keep-ghc-rts` (disabled by default) keep/discard any `GHCRTS`
-  environment variable
 
 ## The `stack config set` commands
 
@@ -127,6 +112,21 @@ Known bug:
 YAML configuration file, accordingly. By default, the project-level
 configuration file (`stack.yaml`) is altered. The `--global` flag specifies the
 user-specific global configuration file (`config.yaml`).
+
+## The `stack config env` command
+
+`stack config env` outputs a script that sets or unsets environment variables
+for a Stack environment. Flags modify the script that is output:
+
+* `--[no-]locals` (enabled by default) include/exclude local package information
+* `--[no-]ghc-package-path` (enabled by default) set `GHC_PACKAGE_PATH`
+  environment variable or not
+* `--[no-]stack-exe` (enabled by default) set `STACK_EXE` environment variable
+  or not
+* `--[no-]locale-utf8` (disabled by default) set the `GHC_CHARENC`
+  environment variable to `UTF-8` or not
+* `--[no-]keep-ghc-rts` (disabled by default) keep/discard any `GHCRTS`
+  environment variable
 
 ## The `stack dot` command
 

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,7 @@ dependencies:
 - base >= 4.16.3.0 && < 5
 - Cabal >= 3.6.3.0
 - aeson >= 2.0.3.0
+- aeson-pretty
 - annotated-wl-pprint
 - ansi-terminal
 - array

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -129,12 +129,17 @@ configCmdSetScope (ConfigCmdSetSystemGhc scope _) = scope
 configCmdSetScope (ConfigCmdSetInstallGhc scope _) = scope
 
 encodeDumpProject :: RawYaml -> ConfigDumpFormat -> Project -> ByteString
-encodeDumpProject rawConfig ConfigDumpYaml p = let e = Yaml.encode p in
-    Yaml.decodeEither' e & either (const e) (\(d :: KeyMap Yaml.Value) ->
+encodeDumpProject rawConfig format p
+    | ConfigDumpYaml <- format = dumpProject (\e d ->
         either (const e) encodeUtf8 (cfgRedress rawConfig d ""))
-encodeDumpProject rawConfig ConfigDumpJson p = let e = Yaml.encode p in
-    Yaml.decodeEither' e & either (const e) (\(d :: KeyMap Yaml.Value) ->
-        toStrictBytes $ encodePretty' (Aeson.defConfig{confCompare = cfgKeyCompare rawConfig d ""}) d)
+    | ConfigDumpJson <- format = dumpProject (\_ d ->
+        let cmp = cfgKeyCompare rawConfig d ""
+        in toStrictBytes $ encodePretty' (Aeson.defConfig{confCompare = cmp}) d)
+    where
+        -- REVIEW: Is there a way to encode straight to keymap?
+        -- encode project to bytestring then decode to keymap.
+        dumpProject f = let e = Yaml.encode p in Yaml.decodeEither' e &
+            either (const e) (\(d :: KeyMap Yaml.Value) -> f e d)
 
 cfgKeyCompare :: RawYaml -> KeyMap Yaml.Value -> Text -> (Text -> Text -> Ordering)
 cfgKeyCompare (yamlLines -> configLines) (fmap Key.toText . KeyMap.keys -> keys) cmdKey =

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -48,10 +48,10 @@ import           Stack.Prelude
 import           Data.Coerce (coerce)
 import           Pantry.Internal.AesonExtended
                  (ToJSON(..), FromJSON, (.=), WithJSONWarnings (WithJSONWarnings), object)
-import Data.Aeson.Encode.Pretty (encodePretty, encodePretty', confCompare)
+import           Data.Aeson.Encode.Pretty (encodePretty, encodePretty', confCompare)
 import qualified Data.Aeson.Encode.Pretty as Aeson (defConfig)
 import qualified Data.Aeson.Key as Key
-import Data.Aeson.KeyMap (KeyMap)
+import           Data.Aeson.KeyMap (KeyMap)
 import qualified Data.Aeson.KeyMap as KeyMap
 import           Data.ByteString.Builder (byteString)
 import qualified Data.Map.Merge.Strict as Map

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -48,7 +48,7 @@ import           Stack.Prelude
 import           Data.Coerce (coerce)
 import           Pantry.Internal.AesonExtended
                  (ToJSON(..), FromJSON, (.=), WithJSONWarnings (WithJSONWarnings), object)
-import qualified Data.Aeson as Aeson
+import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.Aeson.Key as Key
 import Data.Aeson.KeyMap (KeyMap)
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -128,18 +128,18 @@ configCmdSetScope (ConfigCmdSetSystemGhc scope _) = scope
 configCmdSetScope (ConfigCmdSetInstallGhc scope _) = scope
 
 encodeDumpProject :: RawYaml -> ConfigDumpFormat -> Project -> ByteString
-encodeDumpProject _ ConfigDumpJson = toStrictBytes . Aeson.encode
+encodeDumpProject _ ConfigDumpJson = toStrictBytes . encodePretty
 encodeDumpProject rawConfig ConfigDumpYaml = \p -> let e = Yaml.encode p in
     Yaml.decodeEither' e & either (const e) (\(d :: KeyMap Yaml.Value) ->
         either (const e) encodeUtf8 (cfgRedress rawConfig d ""))
 
 encodeDumpStackBy :: ToJSON a => (Config -> a) -> ConfigCmdDumpStack -> (Config -> ByteString)
 encodeDumpStackBy f (ConfigCmdDumpStack _ ConfigDumpYaml) = Yaml.encode . f
-encodeDumpStackBy f (ConfigCmdDumpStack _ ConfigDumpJson) = toStrictBytes . Aeson.encode . f
+encodeDumpStackBy f (ConfigCmdDumpStack _ ConfigDumpJson) = toStrictBytes . encodePretty . f
 
 encodeDumpStack :: ConfigDumpFormat -> (DumpStack -> ByteString)
 encodeDumpStack ConfigDumpYaml = Yaml.encode
-encodeDumpStack ConfigDumpJson = toStrictBytes . Aeson.encode
+encodeDumpStack ConfigDumpJson = toStrictBytes . encodePretty
 
 cfgReadProject :: (HasConfig env, HasLogFunc env) => CommandScope -> RIO env (Maybe Project)
 cfgReadProject scope = do

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -159,12 +159,9 @@ cfgReadProject scope = do
     (configFilePath, yamlConfig) <- cfgRead scope
     let parser = parseProjectAndConfigMonoid (parent configFilePath)
     case Yaml.parseEither parser yamlConfig of
-        Left err -> do
-            logError . display $ T.pack err
-            return Nothing
-        Right (WithJSONWarnings res _warnings) -> do
-            ProjectAndConfigMonoid project _ <- liftIO res
-            return $ Just project
+        Left err -> logError (display $ T.pack err) >> return Nothing
+        Right (WithJSONWarnings res _warnings) -> liftIO res >>=
+            \(ProjectAndConfigMonoid project _) -> return $ Just project
 
 cfgCmdDumpProject :: (HasConfig env, HasLogFunc env) => ConfigCmdDumpProject -> RIO env ()
 cfgCmdDumpProject (ConfigCmdDumpProject dumpFormat) = do

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -186,10 +186,10 @@ instance ToJSON DumpStack where
         ]
 
 cfgCmdDumpStack :: (HasConfig env, HasLogFunc env) => ConfigCmdDumpStack -> RIO env ()
-cfgCmdDumpStack (ConfigCmdDumpStack scope dumpFormat)
-    | DumpStackScopeEffective <- scope = cfgCmdDumpStackEffective dumpFormat
-    | DumpStackScopeProject <- scope = cfgDumpStack CommandScopeProject dumpFormat
-    | DumpStackScopeGlobal <- scope = cfgDumpStack CommandScopeGlobal dumpFormat
+cfgCmdDumpStack (ConfigCmdDumpStack scope dumpFormat) = dumpFormat & case scope of
+    DumpStackScopeEffective -> cfgCmdDumpStackEffective
+    DumpStackScopeProject -> cfgDumpStack CommandScopeProject
+    DumpStackScopeGlobal -> cfgDumpStack CommandScopeGlobal
 
 cfgDumpStack
     :: (HasConfig env, HasLogFunc env)

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -133,13 +133,14 @@ encodeDumpProject rawConfig format p
     | ConfigDumpYaml <- format = dumpProject (\e d ->
         either (const e) encodeUtf8 (cfgRedress rawConfig d ""))
     | ConfigDumpJson <- format = dumpProject (\_ d ->
-        let cmp = cfgKeyCompare rawConfig d ""
-        in toStrictBytes $ encodePretty' (Aeson.defConfig{confCompare = cmp}) d)
+        toStrictBytes $ encodePretty' (cfgPretty d) d)
     where
         -- REVIEW: Is there a way to encode straight to keymap?
         -- encode project to bytestring then decode to keymap.
         dumpProject f = let e = Yaml.encode p in Yaml.decodeEither' e &
             either (const e) (\(d :: KeyMap Yaml.Value) -> f e d)
+
+        cfgPretty d = Aeson.defConfig{confCompare = cfgKeyCompare rawConfig d ""}
 
 cfgKeyCompare :: RawYaml -> KeyMap Yaml.Value -> Text -> (Text -> Text -> Ordering)
 cfgKeyCompare (yamlLines -> configLines) (fmap Key.toText . KeyMap.keys -> keys) cmdKey =

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -173,6 +173,7 @@ cfgCmdDumpProject (ConfigCmdDumpProject dumpFormat) = do
         & decodeUtf8'
         & either throwM (logInfo . display))
 
+-- | The subset of stack's configuration that we dump.
 data DumpStack =
     DumpStack
         { dsInstallGHC :: !(Maybe Bool)

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -396,8 +396,20 @@ commandLineHandler currentDir progName isInterpreter = complicatedOptions
             ConfigCmd.cfgCmdName
             "Subcommands for accessing and modifying configuration values"
             (do
+               addCommand' ConfigCmd.cfgCmdDumpProjectName
+                          "Dump project related configuration"
+                          (withConfig NoReexec . cfgCmdDumpProject)
+                          configCmdDumpProjectParser
+               addCommand' ConfigCmd.cfgCmdDumpStackName
+                          "Dump stack operation related configuration"
+                          (withConfig NoReexec . cfgCmdDumpStack)
+                          configCmdDumpStackParser
+               addCommand' ConfigCmd.cfgCmdGetName
+                          "Get the current value of a settable field of configuration"
+                          (withConfig NoReexec . cfgCmdGet)
+                          configCmdGetParser
                addCommand' ConfigCmd.cfgCmdSetName
-                          "Sets a key in YAML configuration file to value"
+                          "A very restricted subset of configuration can be set with this command"
                           (withConfig NoReexec . cfgCmdSet)
                           configCmdSetParser
                addCommand' ConfigCmd.cfgCmdEnvName

--- a/stack.cabal
+++ b/stack.cabal
@@ -229,6 +229,7 @@ library
   build-depends:
       Cabal >=3.6.3.0
     , aeson >=2.0.3.0
+    , aeson-pretty
     , annotated-wl-pprint
     , ansi-terminal
     , array
@@ -353,6 +354,7 @@ executable stack
   build-depends:
       Cabal >=3.6.3.0
     , aeson >=2.0.3.0
+    , aeson-pretty
     , annotated-wl-pprint
     , ansi-terminal
     , array
@@ -476,6 +478,7 @@ executable stack-integration-test
   build-depends:
       Cabal >=3.6.3.0
     , aeson >=2.0.3.0
+    , aeson-pretty
     , annotated-wl-pprint
     , ansi-terminal
     , array
@@ -607,6 +610,7 @@ test-suite stack-test
       Cabal >=3.6.3.0
     , QuickCheck
     , aeson >=2.0.3.0
+    , aeson-pretty
     , annotated-wl-pprint
     , ansi-terminal
     , array


### PR DESCRIPTION
See #5600.

* [ ] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please don't merge yet as I would like to preserve the order of the fields when dumping the project as YAML.

```
> cabal run stack -- config dump-project
Up to date
drop-packages:
- cabal-install
extra-deps:
- hackage: hi-file-parser-0.1.3.0@sha256:b868e1bcb73fffe5963de6879f0a0a4c5ced97e08fc09c2c9428af884cdcaa74,2488
flags:
  stack:
    developer-mode: true
packages:
- .
resolver: nightly-2022-08-02
user-message: |
  If building Stack on macOS, you are advised to use stack-macos.yaml as the
  project-level configuration file, and command:

  stack --stack-yaml stack-macos.yaml build

  See that configuration file for further information.
```

```
> cat stack.yaml
# GHC 9.2.4
resolver: nightly-2022-08-02

packages:
- .

extra-deps:
# nightly-2022-08-02 provides hi-file-parser-0.1.2.0, which does not accomodate
# GHC 9.4.1
- hi-file-parser-0.1.3.0@sha256:b868e1bcb73fffe5963de6879f0a0a4c5ced97e08fc09c2c9428af884cdcaa74,2488

drop-packages:
# See https://github.com/commercialhaskell/stack/pull/4712
- cabal-install

docker:
  enable: false
  repo: psibi/alpine-haskell-stack:9.2.4

nix:
  # --nix on the command-line to enable.
  packages:
  - zlib
  - unzip

flags:
  stack:
    developer-mode: true

ghc-options:
  "$locals": -fhide-source-paths

user-message: |
  If building Stack on macOS, you are advised to use stack-macos.yaml as the
  project-level configuration file, and command:

  stack --stack-yaml stack-macos.yaml build

  See that configuration file for further information.
```