### PR TITLE
Support sub-library dependencies (rebased).

### DIFF
--- a/test/integration/tests/cabal-sublibrary-dependency/Main.hs
+++ b/test/integration/tests/cabal-sublibrary-dependency/Main.hs
@@ -1,5 +1,3 @@
-import Control.Monad (unless)
-import Data.List (isInfixOf)
 import StackTest
 
 -- This tests building two local packages, one of which depends on the other
@@ -10,8 +8,4 @@ main :: IO ()
 -- The '--install-ghc' flag is passed here, because etc/scripts/release.hs
 -- passes `--no-install-ghc` when `--alpine` is passed to its 'check' command.
 -- (See stack.yaml; using GHC 9.4.4.)
-main = stackErrStderr ["build", "--install-ghc"] $ \str ->
-  let msg = "SubLibrary dependency is not supported, this will almost \
-            \certainly fail."
-  in  unless (msg `isInfixOf` str) $
-        error $ "Expected a warning: \n" ++ show msg
+main = stack ["build", "--install-ghc"]

--- a/test/integration/tests/cabal-sublibrary-dependency/files/cabal.project
+++ b/test/integration/tests/cabal-sublibrary-dependency/files/cabal.project
@@ -1,0 +1,3 @@
+packages:
+    ./
+  , subproject/


### PR DESCRIPTION
I brushed the dust off #5659, rebased it and tested it with [plugins-for-blobs](https://github.com/BlockScope/plugins-for-blobs). Seems to work.

```
> ~/.local/bin/stack clean

> ~/.local/bin/stack build --stack-yaml=stack.blobs.yaml
ghc-tcplugins-trace-0.1.0.0: unregistering
simple-smt-0.9.7: unregistering (local file changes: CHANGES SimpleSMT.hs simple-smt.cabal)
Building all executables for `build-plugins-for-blobs' once.
  After a successful build of all of them, only specified executables will be rebuilt.
build-plugins-for-blobs> configure (exe)
build-plugins-for-blobs> Configuring build-plugins-for-blobs-0.1.0...
build-plugins-for-blobs> build (exe)
ghc-tcplugins-trace    > configure (lib)
build-plugins-for-blobs> Preprocessing executable 'build-plugins-for-blobs'
build-plugins-for-blobs> Building executable 'build-plugins-for-blobs'
build-plugins-for-blobs> [1 of 2] Compiling Main
build-plugins-for-blobs> [2 of 2] Compiling Paths_build_plugins_for_blobs
ghc-tcplugins-trace    > Configuring ghc-tcplugins-trace-0.1.0.0...
ghc-tcplugins-trace    > build (lib)
build-plugins-for-blobs> Linking ...
ghc-tcplugins-trace    > Preprocessing library for ghc-tcplugins-trace-0.1.0.0..
ghc-tcplugins-trace    > Building library for ghc-tcplugins-trace-0.1.0.0..
simple-smt             > configure (lib)
ghc-tcplugins-trace    > [1 of 3] Compiling Plugins.Print.Constraints
simple-smt             > Configuring simple-smt-0.9.7...
ghc-tcplugins-trace    > [2 of 3] Compiling Plugins.Print.Flags
build-plugins-for-blobs> copy/register
simple-smt             > build (lib)
ghc-tcplugins-trace    > [3 of 3] Compiling Plugins.Print
simple-smt             > Preprocessing library for simple-smt-0.9.7..
simple-smt             > Building library for simple-smt-0.9.7..
build-plugins-for-blobs> Installing executable build-plugins-for-blobs in /.../bin
simple-smt             > [1 of 1] Compiling SimpleSMT
ghc-tcplugins-trace    > copy/register       
ghc-tcplugins-trace    > Installing library in /.../ghc-tcplugins-trace-0.1.0.0-93mkViScQTnCEFLPvUPNaq
ghc-tcplugins-trace    > Registering library for ghc-tcplugins-trace-0.1.0.0..
simple-smt             > copy/register       
simple-smt             > Installing library in /.../simple-smt-0.9.7-8DwBBLgHf4hIU6gyB8LxP1
simple-smt             > Registering library for simple-smt-0.9.7..
plugins-for-blobs      > build (internal-lib)
plugins-for-blobs      > Preprocessing library 'uom-quantity' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Building library 'uom-quantity' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Preprocessing library 'uom-th' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Building library 'uom-th' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Preprocessing library 'uom-plugin' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Building library 'uom-plugin' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Preprocessing library 'uom-plugin-defs' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Building library 'uom-plugin-defs' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Preprocessing library 'thoralf-theory' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Building library 'thoralf-theory' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Preprocessing library 'thoralf-encode' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Building library 'thoralf-encode' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Preprocessing library 'thoralf-plugin' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Building library 'thoralf-plugin' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Preprocessing library 'thoralf-plugin-rows' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Building library 'thoralf-plugin-rows' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Preprocessing library 'thoralf-plugin-uom' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Building library 'thoralf-plugin-uom' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Preprocessing library 'thoralf-plugin-defs' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > Building library 'thoralf-plugin-defs' for plugins-for-blobs-0.1.0..
plugins-for-blobs      > copy/register
plugins-for-blobs      > Installing internal library uom-quantity in /.../...-GwyR1RVr6FMD7RWaiQvBGo-uom-quantity
plugins-for-blobs      > Installing internal library uom-th in /.../...-Koubdi1gMCXDu2C87CZ3Z4-uom-th
plugins-for-blobs      > Installing internal library uom-plugin in /.../...-77EKG0oSYdm48UYcIgwxR3-uom-plugin
plugins-for-blobs      > Installing internal library uom-plugin-defs in /.../...-GPTrBk2wMfqJXQhmvZNGkj-uom-plugin-defs
plugins-for-blobs      > Installing internal library thoralf-theory in /.../...-6ntTdFkroSXAZMAxhqUQTe-thoralf-theory
plugins-for-blobs      > Installing internal library thoralf-encode in /.../...-K7QPeh1ogHA1982GJ0Y16Q-thoralf-encode
plugins-for-blobs      > Installing internal library thoralf-plugin in /.../...-HCgwvrdNNoAI0RArVjfoj7-thoralf-plugin
plugins-for-blobs      > Installing internal library thoralf-plugin-rows in /.../...-FfDbHar9QY8KemgkTi62J2-thoralf-plugin-rows
plugins-for-blobs      > Installing internal library thoralf-plugin-uom in /.../...-H0W6bQI6P5c3VAUT5bu8Sh-thoralf-plugin-uom
plugins-for-blobs      > Installing internal library thoralf-plugin-defs in /.../...-KUKBMGJE6LMAGMELEdh8Bx-thoralf-plugin-defs
Completed 4 action(s).
```
