### PR TITLE
Integration tests in forks

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -151,6 +151,8 @@ jobs:
 
   github-release:
     name: Create GitHub release
+    permissions:
+      contents: write
     needs:
     - integration-tests
     - linux-arm64

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -199,11 +199,11 @@ jobs:
         echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
     - name: Create GitHub release (final)
       if: "!startsWith(github.ref, 'refs/tags/rc/')"
-      uses: actions/create-release@v1
+      uses: ncipollo/release-action@v1.10.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
+        tag: ${{ github.ref }}
         body: |
           See https://haskellstack.org/ for installation and upgrade instructions.
 
@@ -218,11 +218,11 @@ jobs:
         prerelease: false
     - name: Create GitHub release (release candidate)
       if: "startsWith(github.ref, 'refs/tags/rc/')"
-      uses: actions/create-release@v1
+      uses: ncipollo/release-action@v1.10.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
+        tag: ${{ github.ref }}
         body: |
           **Changes since v[INSERT PREVIOUS VERSION]:**
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -98,8 +98,11 @@ jobs:
   configuration:
     name: Check for self-hosted runners
     runs-on: ubuntu-latest
+    env:
+      CAN_SIGN: ${{ secrets.RELEASE_SIGNING_KEY != '' }}
     outputs:
       arm64: ${{ fromJSON(steps.runners.outputs.arm64) }}
+      can-sign: ${{ env.CAN_SIGN }}
     steps:
     - name: Check for hosted runners
       id: runners
@@ -176,6 +179,7 @@ jobs:
         name: Linux-ARM64
         path: _release
     - name: Hash and sign assets
+      if: needs.configuration.outputs.can-sign
       shell: bash
       env:
         RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -112,7 +112,7 @@ jobs:
       run: |
         echo "::set-output name=runners::$SELF_HOSTED_RUNNERS"
         if echo "$SELF_HOSTED_RUNNERS" | grep -q 'arm64'; then
-          echo "::set-output name=arm64::[self-hosted, linux, ARM64]"
+          echo "::set-output name=arm64::['self-hosted', 'linux', 'ARM64']"
         else
           echo '::set-output name=arm64::"ubuntu-latest"'
         fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -101,7 +101,7 @@ jobs:
     env:
       CAN_SIGN: ${{ secrets.RELEASE_SIGNING_KEY != '' }}
     outputs:
-      arm64: ${{ fromJSON(steps.runners.outputs.arm64) }}
+      arm64: ${{ steps.runners.outputs.arm64 }}
       can-sign: ${{ env.CAN_SIGN }}
     steps:
     - name: Check for hosted runners

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -112,7 +112,7 @@ jobs:
       run: |
         echo "::set-output name=runners::$SELF_HOSTED_RUNNERS"
         if echo "$SELF_HOSTED_RUNNERS" | grep -q 'arm64'; then
-          echo '::set-output name=arm64::"[self-hosted, linux, ARM64]"'
+          echo "::set-output name=arm64::[self-hosted, linux, ARM64]"
         else
           echo '::set-output name=arm64::"ubuntu-latest"'
         fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -112,7 +112,7 @@ jobs:
       run: |
         echo "::set-output name=runners::$SELF_HOSTED_RUNNERS"
         if echo "$SELF_HOSTED_RUNNERS" | grep -q 'arm64'; then
-          echo '::set-output name=arm64::"[\"self-hosted\", \"linux\", \"ARM64\"]"'
+          echo '::set-output name=arm64::"[self-hosted, linux, ARM64]"'
         else
           echo '::set-output name=arm64::"ubuntu-latest"'
         fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -119,7 +119,7 @@ jobs:
 
   linux-arm64:
     name: Linux ARM64
-    runs-on: ${{ needs.configuration.outputs.arm64 }}
+    runs-on: ${{ fromJSON(needs.configuration.outputs.arm64) }}
     needs: configuration
     steps:
     - name: Skipping ARM64

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -95,14 +95,42 @@ jobs:
         name: ${{ runner.os }}
         path: _release/stack-*
 
+  configuration:
+    name: Check for self-hosted runners
+    runs-on: ubuntu-latest
+    outputs:
+      arm64: ${{ fromJSON(steps.runners.outputs.arm64) }}
+    steps:
+    - name: Check for hosted runners
+      id: runners
+      shell: bash
+      env:
+        SELF_HOSTED_RUNNERS: ${{ secrets.SELF_HOSTED_RUNNERS || (github.repository_owner == 'commercialhaskell' && 'arm64') }}
+      run: |
+        echo "::set-output name=runners::$SELF_HOSTED_RUNNERS"
+        if echo "$SELF_HOSTED_RUNNERS" | grep -q 'arm64'; then
+          echo '::set-output name=arm64::"[\"self-hosted\", \"linux\", \"ARM64\"]"'
+        else
+          echo '::set-output name=arm64::"ubuntu-latest"'
+        fi
+
   linux-arm64:
     name: Linux ARM64
-    runs-on: [self-hosted, linux, ARM64]
+    runs-on: ${{ needs.configuration.outputs.arm64 }}
+    needs: configuration
     steps:
+    - name: Skipping ARM64
+      if: needs.configuration.outputs.arm64 == 'ubuntu-latest'
+      shell: bash
+      run: |
+        echo '::notice title=ARM64 skipped::To build ARM64, a self-hosted runner needs to be configured and the SELF_HOSTED_RUNNERS secret must contain arm64'
+
     - name: Clone project
+      if: needs.configuration.outputs.arm64 != 'ubuntu-latest'
       uses: actions/checkout@v3
 
     - name: Build bindist
+      if: needs.configuration.outputs.arm64 != 'ubuntu-latest'
       shell: bash
       run: |
         set -ex
@@ -112,6 +140,7 @@ jobs:
         docker run --rm -v $(pwd):/src -w /src stack bash -c "/home/stack/release build"
 
     - name: Upload bindist
+      if: needs.configuration.outputs.arm64 != 'ubuntu-latest'
       uses: actions/upload-artifact@v3
       with:
         name: Linux-ARM64
@@ -141,6 +170,7 @@ jobs:
         name: Windows
         path: _release
     - name: Download Linux-ARM64 artifact
+      if: contains(needs.configuration.outputs.runners, 'arm64')
       uses: actions/download-artifact@v3
       with:
         name: Linux-ARM64


### PR DESCRIPTION
Note: Fixes for the online documentation of the current Stack release (https://docs.haskellstack.org/en/stable/) should target the 'stable' branch, not the 'master' branch.

Please include the following checklist in your pull request:

* [ ] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [ ] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!

Without these changes, the following things can go wrong in forks:
1. when one pulls in an update to `master`, the the workflow will run, and then get stuck waiting for a self-hosted-runner
2. if one _had_ a self-hosted-runner, signing would fail unless one also had a signing secret
3. if one had both of the above and had an organization that restricts permissions, then the workflow could fail because it doesn't ask for write permissions

Beyond that, the [GitHub's `actions/create-release`](https://github.com/actions/create-release) is unsupported, so this PR switches to a maintained action (one that actually documents the permission required required to create a release...).

Note: you should not merge this to this repository without creating a secret named `SELF_HOSTED_RUNNERS` that has a value like `arm64` (well, you can, but it'd result in arm64 builds being skipped until the secret is added).

Here's a run **with** the secret set (that would have passed if I had such a runner):
https://github.com/check-spelling/stack/actions/runs/3012421271

Here's a run **without** the secret set that passes:
https://github.com/check-spelling/stack/actions/runs/3012476622

<img width="400" alt="image" src="https://user-images.githubusercontent.com/2119212/189034845-7ea01365-4425-4708-a9df-6d608d53770f.png">
