### PR TITLE
Adds a cabal.project file.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+-- With cabal projects, import is available with cabal-install >= 3.8.
+import: https://www.stackage.org/nightly-2022-09-05/cabal.config
+packages: .


### PR DESCRIPTION
People (like me) that might like to use cabal to work on stack shouldn't need to first resolve dependencies. We can help with that. Before this fix:

```
> cabal build all --enable-tests --enable-benchmarks
Resolving dependencies...
Error: cabal: Could not resolve dependencies:
[__0] trying: stack-2.10.0 (user goal)
[__1] trying: template-haskell-2.19.0.0/installed-2.19.0.0 (dependency of
stack)
[__2] next goal: persistent (dependency of stack)
[__2] rejecting: persistent-2.14.2.0 (conflict: stack => persistent>=2.13.3.5
&& <2.14)
[__2] skipping: persistent-2.14.1.0, persistent-2.14.0.3, persistent-2.14.0.2,
persistent-2.14.0.1 (has the same characteristics that caused the previous
version to fail: excluded by constraint '>=2.13.3.5 && <2.14' from 'stack')
[__2] rejecting: persistent-2.13.3.5 (conflict:
template-haskell==2.19.0.0/installed-2.19.0.0, persistent =>
template-haskell>=2.13 && <2.19)
[__2] skipping: persistent-2.13.3.4, persistent-2.13.3.3, persistent-2.13.3.1,
persistent-2.13.3.0, persistent-2.13.2.2, persistent-2.13.2.1,
persistent-2.13.1.2, persistent-2.13.1.1, persistent-2.13.1.0,
persistent-2.13.0.4, persistent-2.13.0.3, persistent-2.13.0.2,
persistent-2.13.0.1, persistent-2.13.0.0, persistent-2.12.1.2,
persistent-2.12.1.1, persistent-2.12.1.0, persistent-2.12.0.2 (has the same
characteristics that caused the previous version to fail: excludes
'template-haskell' version 2.19.0.0)
[__2] rejecting: persistent-2.11.0.4 (conflict: stack => persistent>=2.13.3.5
&& <2.14)
[__2] skipping: persistent-2.11.0.2, persistent-2.11.0.1, persistent-2.11.0.0,
persistent-2.10.5.4, persistent-2.10.5.3, persistent-2.10.5.2,
persistent-2.10.5.1, persistent-2.10.5, persistent-2.10.4, persistent-2.10.3,
persistent-2.10.2, persistent-2.10.1, persistent-2.10.0, persistent-2.9.2,
persistent-2.9.1, persistent-2.9.0, persistent-2.8.2, persistent-2.8.1,
persistent-2.8.0, persistent-2.7.3.1, persistent-2.7.3, persistent-2.7.1,
persistent-2.7.0, persistent-2.6.1, persistent-2.6, persistent-2.5,
persistent-2.2.4.1, persistent-2.2.4, persistent-2.2.3, persistent-2.2.2.1,
persistent-2.2.2, persistent-2.2.1, persistent-2.2, persistent-2.1.6,
persistent-2.1.5, persistent-2.1.4, persistent-2.1.3, persistent-2.1.2,
persistent-2.1.1.7, persistent-2.1.1.6, persistent-2.1.1.5,
persistent-2.1.1.4, persistent-2.1.1.3, persistent-2.1.1.2,
persistent-2.1.1.1, persistent-2.1.1, persistent-2.1.0.2, persistent-2.1.0.1,
persistent-2.1, persistent-1.3.3, persistent-1.3.2, persistent-1.3.1.1,
persistent-1.3.1, persistent-1.3.0.6, persistent-1.3.0.5, persistent-1.3.0.4,
persistent-1.3.0.3, persistent-1.3.0.2, persistent-1.3.0, persistent-1.2.3.3,
persistent-1.2.3.2, persistent-1.2.3.0, persistent-1.2.2.0,
persistent-1.2.1.2, persistent-1.2.1.1, persistent-1.2.1, persistent-1.2.0.2,
persistent-1.2.0.1, persistent-1.2.0, persistent-1.1.5.1, persistent-1.1.5,
persistent-1.1.4, persistent-1.1.3.2, persistent-1.1.3.1, persistent-1.1.3,
persistent-1.1.2, persistent-1.1.0.1, persistent-1.1.0, persistent-1.0.2.2,
persistent-1.0.2.1, persistent-1.0.2, persistent-1.0.1.3, persistent-1.0.1.2,
persistent-1.0.1.1, persistent-1.0.1, persistent-1.0.0, persistent-0.9.0.4,
persistent-0.9.0.3, persistent-0.9.0.2, persistent-0.9.0.1, persistent-0.9.0,
persistent-0.8.0.2, persistent-0.8.0.1, persistent-0.8.0, persistent-0.7.0.1,
persistent-0.7.0, persistent-0.6.4.4, persistent-0.6.4.3, persistent-0.6.4.2,
persistent-0.6.4.1, persistent-0.6.4, persistent-0.6.3, persistent-0.6.2,
persistent-0.6.1, persistent-0.5.1, persistent-0.5.0, persistent-0.4.2,
persistent-0.4.1, persistent-0.4.0.1, persistent-0.4.0, persistent-0.3.1.3,
persistent-0.3.1.2, persistent-0.3.1.1, persistent-0.3.1, persistent-0.3.0.1,
persistent-0.3.0, persistent-0.2.4.1, persistent-0.2.4, persistent-0.2.3,
persistent-0.2.2.2, persistent-0.2.2.1, persistent-0.2.2, persistent-0.2.1,
persistent-0.2.0.2, persistent-0.2.0.1, persistent-0.2.0, persistent-0.1.0,
persistent-0.0.0.1, persistent-0.0.0, persistent-2.14.0.0,
persistent-2.13.3.2, persistent-2.12.0.1, persistent-2.12.0.0,
persistent-2.11.0.3, persistent-2.7.2, persistent-2.0.8, persistent-2.0.7.1,
persistent-2.0.7, persistent-2.0.5.1, persistent-2.0.5, persistent-2.0.4,
persistent-2.0.3.1, persistent-2.0.3, persistent-2.0.2, persistent-2.0.1.1,
persistent-2.0.1, persistent-2.0.0.1, persistent-2.0.0, persistent-1.2.3.1
(has the same characteristics that caused the previous version to fail:
excluded by constraint '>=2.13.3.5 && <2.14' from 'stack')
[__2] fail (backjumping, conflict set: persistent, stack, template-haskell)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: stack, persistent, template-haskell
```

After this fix:

```
> cabal build all --enable-tests --enable-benchmarks
Up to date
> cabal test all --test-show-details=always
...
> cabal run stack -- --help
...
> cabal repl lib:stack
...
```