### PR TITLE
Update documentation for shell completion scripts (Bash, zsh, fish)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,6 +42,7 @@ Other enhancements:
 * `tools` subcommand added to `stack ls`, to list stack's installed tools.
 * `stack uninstall` shows how to uninstall Stack.
 * `--ghc-variant` accepts `int-native` as a variant.
+* Update documentaion for shell auto-completion with Bash and zsh. Added fish.
 
 Bug fixes:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,7 +42,7 @@ Other enhancements:
 * `tools` subcommand added to `stack ls`, to list stack's installed tools.
 * `stack uninstall` shows how to uninstall Stack.
 * `--ghc-variant` accepts `int-native` as a variant.
-* Update documentaion for shell auto-completion with Bash and zsh. Added fish.
+* Update documentation for shell auto-completion with Bash and zsh. Added fish.
 
 Bug fixes:
 

--- a/doc/shell_autocompletion.md
+++ b/doc/shell_autocompletion.md
@@ -2,10 +2,10 @@
 
 # Shell auto-completion
 
-The following adds support for the tab completion of standard Stack arguments in
-the Bash shell or the Z shell (Zsh). Completion of file names and executables
-within Stack is still lacking. For further information, see issue
-[#823](https://github.com/commercialhaskell/stack/issues/832).
+The following adds support for the tab completion of standard Stack arguments to
+some of the more popular shell programs: Bash, zsh, and fish. Completion of file
+names and executables within Stack is still lacking. For further information,
+see issue [#823](https://github.com/commercialhaskell/stack/issues/832).
 
 === "Bash"
 
@@ -68,3 +68,12 @@ within Stack is still lacking. For further information, see issue
 
         If you already have quite a large `.zshrc` file, or if you use
         `oh-my-zsh`, `compinit` will probably already be loaded.
+
+=== "Fish"
+
+    Add the output of the following command to your preferred completions file
+    (e.g. `~/.config/fish/completions/stack.fish`).
+
+    ~~~fish
+    stack --fish-completion-script stack
+    ~~~

--- a/doc/shell_autocompletion.md
+++ b/doc/shell_autocompletion.md
@@ -9,9 +9,6 @@ see issue [#823](https://github.com/commercialhaskell/stack/issues/832).
 
 !!! info
 
-    Stack's hidden option `--bash-completion-script <stack_executable_name>`
-    outputs a command that can be evaluated by Bash. For example:
-
     Stack's completion library provides
     [hidden options](https://github.com/pcapriotti/optparse-applicative#bash-zsh-and-fish-completions)
     for Bash, zsh, and fish which output commands used for shell

--- a/doc/shell_autocompletion.md
+++ b/doc/shell_autocompletion.md
@@ -49,36 +49,19 @@ see issue [#823](https://github.com/commercialhaskell/stack/issues/832).
 
 === "Zsh"
 
-    The Zsh
-    [manual](https://zsh.sourceforge.io/Doc/Release/Completion-System.html#Completion-System)
-    explains:
-
-    > The function `bashcompinit` provides compatibility with bash’s
-    programmable completion system. When run it will define the functions,
-    `compgen` and `complete` which correspond to the bash builtins with the same
-    names. It will then be possible to use completion specifications and
-    functions written for bash.
-
-    Consequently, you must:
-
-    1.  launch `compinint`
-    2.  launch `bashcompinit`
-    3.  eval Stack's Bash completion script
-
-    Issue the following commands or that them to your `~/.zshrc` file:
+    Add the output of the following command to your preferred completions file
+    (e.g. `~/.config/zsh/completions/_stack`).
 
     ~~~zsh
-    autoload -U +X compinit
-    compinit
-    autoload -U +X bashcompinit
-    bashcompinit
-    eval "$(stack --bash-completion-script stack)"
+    stack --zsh-completion-script $(which stack)
     ~~~
 
-    !!! info
+    You won't need to `source` these, but do update your `fpath`:
 
-        If you already have quite a large `.zshrc` file, or if you use
-        `oh-my-zsh`, `compinit` will probably already be loaded.
+    ~~~zsh
+    fpath=($HOME/.config/zsh/completions $fpath)
+    autoload -U compinit && compinit
+    ~~~
 
 === "Fish"
 

--- a/doc/shell_autocompletion.md
+++ b/doc/shell_autocompletion.md
@@ -75,5 +75,5 @@ see issue [#823](https://github.com/commercialhaskell/stack/issues/832).
     (e.g. `~/.config/fish/completions/stack.fish`).
 
     ~~~fish
-    stack --fish-completion-script stack
+    stack --fish-completion-script $(which stack)
     ~~~

--- a/doc/shell_autocompletion.md
+++ b/doc/shell_autocompletion.md
@@ -7,34 +7,45 @@ some of the more popular shell programs: Bash, zsh, and fish. Completion of file
 names and executables within Stack is still lacking. For further information,
 see issue [#823](https://github.com/commercialhaskell/stack/issues/832).
 
-=== "Bash"
+!!! info
 
-    Issue the following command or add it to your `~/.bashrc` file:
+    Stack's hidden option `--bash-completion-script <stack_executable_name>`
+    outputs a command that can be evaluated by Bash. For example:
+
+    Stack's completion library provides
+    [hidden options](https://github.com/pcapriotti/optparse-applicative#bash-zsh-and-fish-completions)
+    for Bash, zsh, and fish which output commands used for shell
+    auto-completion. For example:
 
     ~~~bash
-    eval "$(stack --bash-completion-script stack)"
+    $ stack --bash-completion-script stack
+    _stack()
+    {
+        local CMDLINE
+        local IFS=$'\n'
+        CMDLINE=(--bash-completion-index $COMP_CWORD)
+    
+        for arg in ${COMP_WORDS[@]}; do
+            CMDLINE=(${CMDLINE[@]} --bash-completion-word $arg)
+        done
+    
+        COMPREPLY=( $(stack "${CMDLINE[@]}") )
+    }
+    
+    complete -o filenames -F _stack stack
     ~~~
 
-    !!! info
 
-        Stack's hidden option `--bash-completion-script <stack_executable_name>`
-        outputs a command that can be evaluated by Bash. For example:
+=== "Bash"
 
-        ~~~text
-        stack --bash-completion-script stack
-        _stack.exe()
-        {
-            local CMDLINE
-            local IFS=$'\n'
-            CMDLINE=(--bash-completion-index $COMP_CWORD)
+    Add the output of the following command to your preferred completions file
+    (e.g. `~/.config/bash_completions.d/stack`).
 
-            for arg in ${COMP_WORDS[@]}; do
-                CMDLINE=(${CMDLINE[@]} --bash-completion-word $arg)
-            done
+    ~~~bash
+    stack --bash-completion-script $(which stack)
+    ~~~
 
-            COMPREPLY=( $(stack "${CMDLINE[@]}") )
-        }
-        ~~~
+    You may need to `source` this.
 
 === "Zsh"
 


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [X] The documentation has been updated, if necessary
* [ ] test rendering of documentation

Mostly looking for feedback on if this is necessary to include.

I'd be happy to extend the scope of this to clean up zsh and bash as well, since I see no reason similar approaches can't be used for all three shells as per the [optparse-applicative documentation](https://github.com/pcapriotti/optparse-applicative#bash-zsh-and-fish-completions).
