### PR TITLE
Fix #5871 For AArch64, use Debian 10 rather than Ubuntu 20.04

### DIFF
--- a/etc/dockerfiles/arm64.Dockerfile
+++ b/etc/dockerfiles/arm64.Dockerfile
@@ -1,8 +1,12 @@
-FROM ubuntu:20.04
+# Stack is built with GHC 9.2.4. GHC 9.2.4 for Linux/AArch64 says it was made on
+# a Debian 10 system and requires GMP 6.1. Debian 10 is codename 'buster' and
+# includes libc6 (2.28-10+deb10u1).
+FROM debian:buster
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
-    curl build-essential curl libffi-dev libffi7 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 libnuma-dev xz-utils \
-    g++ gcc libc6-dev libffi-dev libgmp-dev make zlib1g-dev git gnupg netbase
+    curl build-essential curl libffi-dev libffi6 libgmp-dev libgmp10 \
+    libncurses-dev libncurses5 libtinfo5 libnuma-dev xz-utils g++ gcc \
+    libc6-dev libffi-dev libgmp-dev make zlib1g-dev git gnupg netbase
 
 RUN cd /tmp && \
     curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-9.0.1/clang+llvm-9.0.1-aarch64-linux-gnu.tar.xz --output /tmp/llvm.tar.xz && \
@@ -10,8 +14,12 @@ RUN cd /tmp && \
     tar xfv /tmp/llvm.tar --strip-components 1 -C /usr && \
     rm /tmp/llvm.tar
 
-RUN curl -sSL https://github.com/commercialhaskell/stack/releases/download/v2.7.1/stack-2.7.1-linux-aarch64.bin > /usr/local/bin/stack && \
-    chmod +x /usr/local/bin/stack
+RUN curl -L https://downloads.haskell.org/ghcup/unofficial-bindists/stack/2.7.5/stack-2.7.5-linux-aarch64.tar.gz --output /tmp/stack.tar.gz && \
+    tar xfv /tmp/stack.tar.gz -C /usr/local/bin && \
+    rm /tmp/stack.tar.gz
+
+# RUN curl -sSL https://github.com/commercialhaskell/stack/releases/download/v2.7.1/stack-2.7.1-linux-aarch64.bin > /usr/local/bin/stack && \
+RUN chmod +x /usr/local/bin/stack
 
 ARG USERID
 ARG GROUPID


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on the CI to test.
