### PR TITLE
import `Data.List` qualified as "-Wcompat-unqualified-imports" says

### DIFF
--- a/src/Path/Find.hs
+++ b/src/Path/Find.hs
@@ -12,7 +12,7 @@ module Path.Find
 
 import RIO
 import System.IO.Error (isPermissionError)
-import Data.List
+import qualified Data.List as L
 import Path
 import Path.IO hiding (findFiles)
 import System.PosixCompat.Files (getSymbolicLinkStatus, isSymbolicLink)
@@ -43,7 +43,7 @@ findPathUp :: (MonadIO m,MonadThrow m)
            -> m (Maybe (Path Abs t))           -- ^ Absolute path.
 findPathUp pathType dir p upperBound =
   do entries <- listDir dir
-     case find p (pathType entries) of
+     case L.find p (pathType entries) of
        Just path -> pure (Just path)
        Nothing | Just dir == upperBound -> pure Nothing
                | parent dir == dir -> pure Nothing

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -17,7 +17,7 @@ module Stack.Build.ConstructPlan
 import           Stack.Prelude hiding (Display (..), loadPackage)
 import           Control.Monad.RWS.Strict hiding ((<>))
 import           Control.Monad.State.Strict (execState)
-import           Data.List
+import qualified Data.List as L
 import qualified Data.Map.Strict as M
 import qualified Data.Map.Strict as Map
 import           Data.Monoid.Map (MonoidMap(..))
@@ -285,12 +285,12 @@ instance Show NotOnlyLocal where
     [ "Specified only-locals, but I need to build snapshot contents:\n"
     , if null packages then "" else concat
         [ "Packages: "
-        , intercalate ", " (map packageNameString packages)
+        , L.intercalate ", " (map packageNameString packages)
         , "\n"
         ]
     , if null exes then "" else concat
         [ "Executables: "
-        , intercalate ", " (map T.unpack exes)
+        , L.intercalate ", " (map T.unpack exes)
         , "\n"
         ]
     ]
@@ -1037,7 +1037,7 @@ pprintExceptions exceptions stackYaml stackRoot parentMap wanted' prunedGlobalDe
     mconcat $
       [ flow "While constructing the build plan, the following exceptions were encountered:"
       , line <> line
-      , mconcat (intersperse (line <> line) (mapMaybe pprintException exceptions'))
+      , mconcat (L.intersperse (line <> line) (mapMaybe pprintException exceptions'))
       , line <> line
       , flow "Some different approaches to resolving this:"
       , line <> line
@@ -1173,7 +1173,7 @@ pprintExceptions exceptions stackYaml stackRoot parentMap wanted' prunedGlobalDe
             align (flow "is a library dependency, but the package provides no library")
         BDDependencyCycleDetected names -> Just $
             style Error (fromString $ packageNameString name) <+>
-            align (flow $ "dependency cycle detected: " ++ intercalate ", " (map packageNameString names))
+            align (flow $ "dependency cycle detected: " ++ L.intercalate ", " (map packageNameString names))
       where
         goodRange = style Good (fromString (Cabal.display range))
         latestApplicable mversion =
@@ -1215,9 +1215,9 @@ getShortestDepsPath (MonoidMap parentsMap) wanted' name =
     findShortest fuel paths =
         case targets of
             [] -> findShortest (fuel - 1) $ M.fromListWith chooseBest $ concatMap extendPath recurses
-            _ -> let (DepsPath _ _ path) = minimum (map snd targets) in path
+            _ -> let (DepsPath _ _ path) = L.minimum (map snd targets) in path
       where
-        (targets, recurses) = partition (\(n, _) -> n `Set.member` wanted') (M.toList paths)
+        (targets, recurses) = L.partition (\(n, _) -> n `Set.member` wanted') (M.toList paths)
     chooseBest :: DepsPath -> DepsPath -> DepsPath
     chooseBest x y = max x y
     -- Extend a path to all its parents.

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -16,7 +16,6 @@ module Stack.Build.Installed
 import           Data.Conduit
 import qualified Data.Conduit.List as CL
 import qualified Data.Set as Set
-import           Data.List
 import qualified Data.Map.Strict as Map
 import           Path
 import           Stack.Build.Cache

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -23,7 +23,7 @@ import qualified    Pantry.SHA256 as SHA256
 import              Data.ByteString.Builder (toLazyByteString)
 import              Conduit (ZipSink (..), withSourceFile)
 import qualified    Distribution.PackageDescription as C
-import              Data.List
+import qualified    Data.List as L
 import qualified    Data.Map as Map
 import qualified    Data.Map.Strict as M
 import qualified    Data.Set as Set
@@ -363,7 +363,7 @@ loadLocalPackage pp = do
           pure $
             if not (Set.null allDirtyFiles)
                 then let tryStripPrefix y =
-                          fromMaybe y (stripPrefix (toFilePath $ ppRoot pp) y)
+                          fromMaybe y (L.stripPrefix (toFilePath $ ppRoot pp) y)
                       in Just $ Set.map tryStripPrefix allDirtyFiles
                 else Nothing
         newBuildCaches =

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -17,7 +17,7 @@ module Stack.GhcPkg
 import           Stack.Prelude
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy as BL
-import           Data.List
+import qualified Data.List as L
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import           Path (parent, (</>))
@@ -152,7 +152,7 @@ unregisterGhcPkgIds pkgexe pkgDb epgids = do
 -- | Get the value for GHC_PACKAGE_PATH
 mkGhcPackagePath :: Bool -> Path Abs Dir -> Path Abs Dir -> [Path Abs Dir] -> Path Abs Dir -> Text
 mkGhcPackagePath locals localdb deps extras globaldb =
-  T.pack $ intercalate [searchPathSeparator] $ concat
+  T.pack $ L.intercalate [searchPathSeparator] $ concat
     [ [toFilePathNoTrailingSep localdb | locals]
     , [toFilePathNoTrailingSep deps]
     , [toFilePathNoTrailingSep db | db <- reverse extras]

--- a/src/Stack/Ghci/Script.hs
+++ b/src/Stack/Ghci/Script.hs
@@ -15,7 +15,7 @@ module Stack.Ghci.Script
   ) where
 
 import           Data.ByteString.Builder (toLazyByteString)
-import           Data.List
+import qualified Data.List as L
 import qualified Data.Set as S
 import           Path
 import           Stack.Prelude
@@ -71,8 +71,8 @@ commandToBuilder (Add modules)
   | S.null modules = mempty
   | otherwise      =
        ":add "
-    <> mconcat (intersperse " " $
-         fmap (fromString . quoteFileName . either (mconcat . intersperse "." . components) toFilePath)
+    <> mconcat (L.intersperse " " $
+         fmap (fromString . quoteFileName . either (mconcat . L.intersperse "." . components) toFilePath)
               (S.toAscList modules))
     <> "\n"
 
@@ -83,8 +83,8 @@ commandToBuilder (Module modules)
   | S.null modules = ":module +\n"
   | otherwise      =
        ":module + "
-    <> mconcat (intersperse " "
-        $ fromString . quoteFileName . mconcat . intersperse "." . components <$> S.toAscList modules)
+    <> mconcat (L.intersperse " "
+        $ fromString . quoteFileName . mconcat . L.intersperse "." . components <$> S.toAscList modules)
     <> "\n"
 
 -- | Make sure that a filename with spaces in it gets the proper quotes.

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -23,7 +23,7 @@ import qualified Data.ByteString.Base64 as B64
 import           Data.ByteString.Builder (lazyByteString)
 import qualified Data.ByteString.Lazy as LB
 import           Data.Conduit
-import           Data.List
+import qualified Data.List as L
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -256,7 +256,7 @@ applyTemplate project template nonceParams dir templateText = do
     when (M.null files) $
          throwM (InvalidTemplate template "Template does not contain any files")
 
-    let isPkgSpec f = ".cabal" `isSuffixOf` f || f == "package.yaml"
+    let isPkgSpec f = ".cabal" `L.isSuffixOf` f || f == "package.yaml"
     unless (any isPkgSpec . M.keys $ files) $
          throwM (InvalidTemplate template
            "Template does not contain a .cabal or package.yaml file")
@@ -400,16 +400,16 @@ instance Show NewException where
     show (AlreadyExists path) =
         "Directory " <> toFilePath path <> " already exists. Aborting."
     show (MissingParameters name template missingKeys userConfigPath) =
-        intercalate
+        L.intercalate
             "\n"
             [ "The following parameters were needed by the template but not provided: " <>
-              intercalate ", " (S.toList missingKeys)
+              L.intercalate ", " (S.toList missingKeys)
             , "You can provide them in " <>
               toFilePath userConfigPath <>
               ", like this:"
             , "templates:"
             , "  params:"
-            , intercalate
+            , L.intercalate
                   "\n"
                   (map
                        (\key ->

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -25,7 +25,7 @@ import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy as L
 import           Data.Char (toLower)
 import           Data.Data (cast)
-import           Data.List
+import qualified Data.List as List
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -84,7 +84,7 @@ instance Exception CheckException
 instance Show CheckException where
   show (CheckException xs) =
     "Package check reported the following errors:\n" ++
-    (intercalate "\n" . fmap show . NE.toList $ xs)
+    (List.intercalate "\n" . fmap show . NE.toList $ xs)
 
 -- | Given the path to a local package, creates its source
 -- distribution tarball.
@@ -436,10 +436,10 @@ checkPackageInExtractedTarball pkgDir = do
           let criticalIssue (Check.PackageBuildImpossible _) = True
               criticalIssue (Check.PackageDistInexcusable _) = True
               criticalIssue _ = False
-          in partition criticalIssue checks
+          in List.partition criticalIssue checks
     unless (null warnings) $
         logWarn $ "Package check reported the following warnings:\n" <>
-                   mconcat (intersperse "\n" . fmap displayShow $ warnings)
+                   mconcat (List.intersperse "\n" . fmap displayShow $ warnings)
     case NE.nonEmpty errors of
         Nothing -> pure ()
         Just ne -> throwM $ CheckException ne

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -41,7 +41,6 @@ import              Data.Conduit.Lazy (lazyConsume)
 import qualified    Data.Conduit.List as CL
 import              Data.Conduit.Process.Typed (createSource)
 import              Data.Conduit.Zlib          (ungzip)
-import              Data.List hiding (concat, elem, maximumBy, any)
 import qualified    Data.Map as Map
 import qualified    Data.Set as Set
 import qualified    Data.Text as T

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -24,7 +24,7 @@ module Stack.Setup.Installed
 import           Stack.Prelude
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy as BL
-import           Data.List hiding (concat, elem, maximumBy)
+import qualified Data.List as L
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import           Distribution.System (Platform (..))
@@ -176,7 +176,7 @@ extraDirs tool = do
             logWarn $ "binDirs: unexpected OS/tool combo: " <> displayShow (x, toolName)
             pure mempty
   where
-    isGHC n = "ghc" == n || "ghc-" `isPrefixOf` n
+    isGHC n = "ghc" == n || "ghc-" `L.isPrefixOf` n
 
 installDir :: (MonadReader env m, MonadThrow m)
            => Path Abs Dir


### PR DESCRIPTION
Pretty simple import fixes.
Importing `Data.List` qualified wherever it's used  (and removing it when only `map` is used, because it's from `base`)