### PR TITLE
Stack upgrade binary linux fix

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,20 @@
+cradle:
+  multi:
+    - path: "./.stack-work"
+      config: { cradle: { none } }
+    - path: "./Setup.hs"
+      config: { cradle: { none } }
+    - path: "./etc"
+      config: { cradle: { none } }
+    - path: "./"
+      config:
+        cradle:
+          stack:
+            - path: "./src"
+              component: "stack:lib"
+            - path: "./src/test"
+              component: "stack:test:stack-test"
+            - path: "./src/main"
+              component: "stack:exe:stack"
+            - path: "./test/integration"
+              component: "stack:exe:stack-integration-test"


### PR DESCRIPTION
Check for relative paths in `Location` headers of redirect responses when trying to get a new `stack` binary when using `stack upgrade` and re-add the domain when it begins with a `/`.

Can't really test this, but it's an easy/obvious enough fix, methinks.