### PR TITLE
Fix #5870 Provide default for `hackage-security` key

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,11 @@ Major changes:
 
 Behavior changes:
 
+* In YAML configuration files, the `hackage-security` key of the
+  `package-indices` item can be omitted, and the Hackage Security configuration
+  for the item will default to that for the official Hackage server.
+  See [#5870](https://github.com/commercialhaskell/stack/issues/5870).
+
 Other enhancements:
 
 * Help documentation for `stack upgrade` warns that if GHCup is used to install

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -962,7 +962,6 @@ package-indices:
     - aa315286e6ad281ad61182235533c41e806e5a787e0b6d1e7eef3f09d137d2e9
     - fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0
     key-threshold: 3
-
     ignore-expiry: true
 ~~~
 
@@ -996,6 +995,9 @@ In the case of Hackage, the keys of its root key holders are contained in the
 package index is signed. A signature is valid when three key holders have
 signed. The Hackage timestamp is also signed. A signature is valid when one key
 holder has signed.
+
+If the `hackage-security` key is absent, the Hackage Security configuration will
+default to that for the official Hackage server.
 
 `key-threshold` specifies the minimum number of keyholders that must have signed
 the package index for it to be considered valid.

--- a/package.yaml
+++ b/package.yaml
@@ -97,7 +97,7 @@ dependencies:
 - network-uri
 - open-browser
 - optparse-applicative >= 0.17.0.0
-- pantry >= 0.5.6 && < 0.6
+- pantry >= 0.6.0
 - path
 - path-io
 # In order for Cabal (the tool) to build Stack, it needs to be told of the

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -366,10 +366,10 @@ configFromConfigMonoid
                & useColorL .~ useColor''
          go = runnerGlobalOpts configRunner'
 
-     hsc <-
+     pic <-
        case getFirst configMonoidPackageIndices of
-         Nothing -> pure defaultHackageSecurityConfig
-         Just [hsc] -> pure hsc
+         Nothing -> pure defaultPackageIndexConfig
+         Just [pic] -> pure pic
          Just x -> error $ "When overriding the default package index, you must provide exactly one value, received: " ++ show x
      mpantryRoot <- liftIO $ lookupEnv "PANTRY_ROOT"
      pantryRoot <-
@@ -405,7 +405,7 @@ configFromConfigMonoid
        let configRunner = configRunner'' & logFuncL .~ logFunc
        withLocalLogFunc logFunc $ withPantryConfig
          pantryRoot
-         hsc
+         pic
          (maybe HpackBundled HpackCommand $ getFirst configMonoidOverrideHpack)
          clConnectionCount
          (fromFirst defaultCasaRepoPrefix configMonoidCasaRepoPrefix)

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -788,7 +788,7 @@ data ConfigMonoid =
     -- ^ See: 'configPrefixTimestamps'
     , configMonoidLatestSnapshot     :: !(First Text)
     -- ^ See: 'configLatestSnapshot'
-    , configMonoidPackageIndices     :: !(First [HackageSecurityConfig])
+    , configMonoidPackageIndices     :: !(First [PackageIndexConfig])
     -- ^ See: @picIndices@
     , configMonoidSystemGHC          :: !(First Bool)
     -- ^ See: 'configSystemGHC'

--- a/stack-macos.yaml
+++ b/stack-macos.yaml
@@ -20,6 +20,7 @@ extra-deps:
 # Although Cabal-3.6.3.0 is a global package, it depends on process and so has
 # to be expressly added as an extra-dep
 - Cabal-3.6.3.0@sha256:ff97c442b0c679c1c9876acd15f73ac4f602b973c45bde42b43ec28265ee48f4,12459
+- pantry-0.6.0@sha256:c87056df8151441911bece5c09d11738110284dc1eacb292686aa33c4308c8c2,4099
 
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712

--- a/stack-macos.yaml.lock
+++ b/stack-macos.yaml.lock
@@ -18,6 +18,13 @@ packages:
       size: 19757
   original:
     hackage: Cabal-3.6.3.0@sha256:ff97c442b0c679c1c9876acd15f73ac4f602b973c45bde42b43ec28265ee48f4,12459
+- completed:
+    hackage: pantry-0.6.0@sha256:c87056df8151441911bece5c09d11738110284dc1eacb292686aa33c4308c8c2,4099
+    pantry-tree:
+      sha256: a6ed2ac03d6ef3c156bf01390e70751c13cdfbdb2a24f626f5a3024d552f302d
+      size: 2524
+  original:
+    hackage: pantry-0.6.0@sha256:c87056df8151441911bece5c09d11738110284dc1eacb292686aa33c4308c8c2,4099
 snapshots:
 - completed:
     sha256: 1c049df0b264500e22262aa42a6f0a81cddd639cfd04f55c4acb0359f282dab2

--- a/stack.cabal
+++ b/stack.cabal
@@ -274,7 +274,7 @@ library
     , network-uri
     , open-browser
     , optparse-applicative >=0.17.0.0
-    , pantry >=0.5.6 && <0.6
+    , pantry >=0.6.0
     , path
     , path-io
     , persistent >=2.13.3.5 && <2.14
@@ -398,7 +398,7 @@ executable stack
     , network-uri
     , open-browser
     , optparse-applicative >=0.17.0.0
-    , pantry >=0.5.6 && <0.6
+    , pantry >=0.6.0
     , path
     , path-io
     , persistent >=2.13.3.5 && <2.14
@@ -523,7 +523,7 @@ executable stack-integration-test
     , open-browser
     , optparse-applicative >=0.17.0.0
     , optparse-generic
-    , pantry >=0.5.6 && <0.6
+    , pantry >=0.6.0
     , path
     , path-io
     , persistent >=2.13.3.5 && <2.14
@@ -653,7 +653,7 @@ test-suite stack-test
     , network-uri
     , open-browser
     , optparse-applicative >=0.17.0.0
-    , pantry >=0.5.6 && <0.6
+    , pantry >=0.6.0
     , path
     , path-io
     , persistent >=2.13.3.5 && <2.14

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,9 @@ resolver: nightly-2022-09-05
 packages:
 - .
 
+extra-deps:
+- pantry-0.6.0@sha256:c87056df8151441911bece5c09d11738110284dc1eacb292686aa33c4308c8c2,4099
+
 drop-packages:
 # See https://github.com/commercialhaskell/stack/pull/4712
 - cabal-install

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: pantry-0.6.0@sha256:c87056df8151441911bece5c09d11738110284dc1eacb292686aa33c4308c8c2,4099
+    pantry-tree:
+      sha256: a6ed2ac03d6ef3c156bf01390e70751c13cdfbdb2a24f626f5a3024d552f302d
+      size: 2524
+  original:
+    hackage: pantry-0.6.0@sha256:c87056df8151441911bece5c09d11738110284dc1eacb292686aa33c4308c8c2,4099
 snapshots:
 - completed:
     sha256: 1c049df0b264500e22262aa42a6f0a81cddd639cfd04f55c4acb0359f282dab2


### PR DESCRIPTION
See also the related Pantry pull request: https://github.com/commercialhaskell/pantry/pull/61.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building and using Stack on Windows 11.

This pull request is draft until the corresponding Pantry pull request is accepted.