### PR TITLE
Fix #5902 Change behaviour of `stack --no-install-ghc setup`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,10 @@ Behavior changes:
   for the item will default to that for the official Hackage server.
   See [#5870](https://github.com/commercialhaskell/stack/issues/5870).
 
+* `stack setup` with the `--no-install-ghc` flag warns that the flag and the
+  command are inconsistent and now takes no action. Previously the flag was
+  silently ignored.
+
 Other enhancements:
 
 * Help documentation for `stack upgrade` warns that if GHCup is used to install

--- a/doc/GUIDE_advanced.md
+++ b/doc/GUIDE_advanced.md
@@ -390,7 +390,8 @@ downloaded and installed. This option requires the use of the `--ghc-variant`
 option specifying a custom GHC variant.
 
 If Stack is configured not to install GHC (`install-ghc: false` or passing the
-`--no-install-ghc` flag) then `stack setup` will silently ignore the flag.
+`--no-install-ghc` flag) then `stack setup` will warn that the flag and the
+command are inconsistent and take no action.
 
 ## The `stack templates` command
 

--- a/test/integration/tests/internal-libraries/Main.hs
+++ b/test/integration/tests/internal-libraries/Main.hs
@@ -2,5 +2,8 @@ import StackTest
 
 main :: IO ()
 main = do
-  stack ["setup"] -- See stack.yaml; using GHC 8.10.7
+  -- The '--install-ghc' flag is passed here, because etc/scripts/release.hs
+  -- passes `--no-install-ghc` when `--alpine` is passed to its 'check'
+  -- command.
+  stack ["--install-ghc", "setup"] -- See stack.yaml; using GHC 8.10.7
   stack ["build"]


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building and using Stack on Windows 11.
