### PR TITLE
Fix #5870 Add `stack config set package-index download-prefix` command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,8 @@ Behavior changes:
   key or the `package-indices` item can be omitted, and the Hackage Security
   configuration for the item will default to that for the official Hackage
   server. See [#5870](https://github.com/commercialhaskell/stack/issues/5870).
+* Add the `stack config set package-index download-prefix` command to set the
+  location of Stack's package index in YAML configuration files.
 
 Other enhancements:
 

--- a/doc/GUIDE_advanced.md
+++ b/doc/GUIDE_advanced.md
@@ -108,6 +108,16 @@ YAML configuration file, accordingly. By default, the project-level
 configuration file (`stack.yaml`) is altered. The `--global` flag specifies the
 user-specific global configuration file (`config.yaml`).
 
+## The `stack config set package-index download-prefix` command
+
+:octicons-tag-24: Unreleased
+
+`stack config set package-index download-prefix <url>` sets the
+`download-prefix` key of the `package-index` key in a YAML configuration file,
+accordingly. By default, the project-level configuration file (`stack.yaml`) is
+altered. The `--global` flag specifies the user-specific global configuration
+file (`config.yaml`).
+
 ## The `stack config set resolver` command
 
 `stack config set resolver <snapshot>` sets the `resolver` key in the


### PR DESCRIPTION
This approach to `set` for a sequence of keys (here `package-index`, `download-prefix` - the first non-top-level key for `set`) chimes (deliberately) with the existing approach to `query` (eg `stack query locals stack version`).

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building and using Stack on Windows 11.