### PR TITLE
Be able to run TUI applications with "stack test"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,10 @@ Behavior changes:
   command are inconsistent and now takes no action. Previously the flag was
   silently ignored.
 
+* `stack test` will check if the process is running in a terminal. If so, it
+  will start the test suite in a way that it can use the terminal. This is
+  intended to support interactive terminal UI based testing.
+
 Other enhancements:
 
 * Help documentation for `stack upgrade` warns that if GHCup is used to install

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1989,18 +1989,7 @@ singleTest topts testsToRun ac ee task installedMap = do
                             liftIO $ hFlush stderr
                           _ -> pure ()
 
-                        let output =
-                                case outputType of
-                                    OTConsolePrefix (Just prefix) -> fmap
-                                      (\src -> Just $ runConduit $ src .|
-                                               CT.decodeUtf8Lenient .|
-                                               CT.lines .|
-                                               CL.map stripCR .|
-                                               CL.mapM_ (\t -> logInfo $ prefix <> RIO.display t))
-                                      createSource
-                                    OTLogFile _ h -> Nothing <$ useHandleOpen h
-                                    _ -> Nothing <$ inherit
-                            optionalTimeout action
+                        let optionalTimeout action
                                 | Just maxSecs <- toMaximumTimeSeconds topts, maxSecs > 0 = do
                                     timeout (maxSecs * 1000000) action
                                 | otherwise = Just <$> action
@@ -2019,6 +2008,16 @@ singleTest topts testsToRun ac ee task installedMap = do
                                          $ encodeUtf8 $ fromString $
                                          show (logPath, mkUnqualComponentName (T.unpack testName))
                                   else pure mempty
+                              let output = case outputType of
+                                    OTConsolePrefix (Just prefix) -> fmap
+                                      (\src -> Just $ runConduit $ src .|
+                                               CT.decodeUtf8Lenient .|
+                                               CT.lines .|
+                                               CL.map stripCR .|
+                                               CL.mapM_ (\t -> logInfo $ prefix <> RIO.display t))
+                                      createSource
+                                    OTLogFile _ h -> Nothing <$ useHandleOpen h
+                                    _ -> Nothing <$ inherit
                               let pc = setStdin (byteStringInput stdinBS)
                                      $ setStdout output
                                      $ setStderr output

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1297,13 +1297,15 @@ withSingleContext ActionContext {..} ee@ExecuteEnv {..} task@Task {..} allDeps m
                           void $ sinkProcessStderrStdout (toFilePath exeName) fullArgs
                               (sinkWithTimestamps prefixWithTimestamps h)
                               (sinkWithTimestamps prefixWithTimestamps h)
-                        OTConsoleTTY ->
-                          readProcessNull (toFilePath exeName) fullArgs
-                        OTConsolePrefix mprefix ->
-                          let prefix = fold mprefix in
-                            void $ sinkProcessStderrStdout (toFilePath exeName) fullArgs
-                                (outputSink KeepTHLoading LevelWarn compilerVer prefix)
-                                (outputSink stripTHLoading LevelInfo compilerVer prefix)
+                        OTConsoleTTY -> runWithPrefix compilerVer ""
+                        OTConsolePrefix mprefix -> runWithPrefix compilerVer (fold mprefix)
+
+                    runWithPrefix :: ActualCompiler -> Utf8Builder -> RIO env ()
+                    runWithPrefix compilerVer prefix =
+                        void $ sinkProcessStderrStdout (toFilePath exeName) fullArgs
+                            (outputSink KeepTHLoading LevelWarn compilerVer prefix)
+                            (outputSink stripTHLoading LevelInfo compilerVer prefix)
+
                     outputSink
                         :: HasCallStack
                         => ExcludeTHLoading

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1116,9 +1116,9 @@ withSingleContext ActionContext {..} ee@ExecuteEnv {..} task@Task {..} allDeps m
         -- to the console with no prefix.
         | console = do
             isTerminal <- hIsTerminalDeviceOrMinTTY stdout
-            case isTerminal of
-              True -> inner OTConsoleTTY
-              False -> inner $ OTConsolePrefix Nothing
+            if isTerminal
+              then inner OTConsoleTTY
+              else inner $ OTConsolePrefix Nothing
 
         -- If the user requested interleaved output, dump to the console with a
         -- prefix.

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -2032,6 +2032,7 @@ singleTest topts testsToRun ac ee task installedMap = do
                         -- output didn't finish with a newline.
                         case outputType of
                           OTConsolePrefix Nothing -> logInfo ""
+                          OTConsoleTTY -> logInfo ""
                           _ -> pure ()
                         -- Move the .tix file out of the package
                         -- directory into the hpc work dir, for

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1983,6 +1983,10 @@ singleTest topts testsToRun ac ee task installedMap = do
                         -- Clear "Progress: ..." message before
                         -- redirecting output.
                         case outputType of
+                          OTConsoleTTY -> do
+                            logStickyDone ""
+                            liftIO $ hFlush stdout
+                            liftIO $ hFlush stderr
                           OTConsolePrefix _ -> do
                             logStickyDone ""
                             liftIO $ hFlush stdout


### PR DESCRIPTION
Hi @mpilgrem -- I have something I'm starting to feel good about for #5897!

This PR shows my latest and best approach. There is no longer a command-line flag; instead we just test whether `stack test` is being run inside a terminal using the existing `hIsTerminalDeviceOrMinTTY` function. If so, then we launch the test process using a simple `proc` function rather than the traditional ways which captures stdout/stderr; see [here](https://github.com/commercialhaskell/stack/compare/master...codedownio:stack:test-tty-proc?expand=1#diff-13a25822d05cc83cb8a97c229c5b1474c20fd02f23b532ff4cd0884924946bd7R2009).

* [X] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [ ] The documentation has been updated, if necessary

I've tested this by installing it on my machine and running (in the [sandwich](https://github.com/codedownio/sandwich) repo):

```bash
stack test demo-stack-test --test-arguments --tui
```