### PR TITLE
Add XDG support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ updates with your pull request.
 ## Backwards Compatability
 
 The Stack executable does not need to, and does not, strive for the same broad
-compatability with versions of GHC that a library package (such as `pantry`)
+compatibility with versions of GHC that a library package (such as `pantry`)
 would seek. Instead, Stack aims to define a well-known combination of
 dependencies on which its executable relies. That applies in particular to the
 `Cabal` package, where Stack aims to support one, and only one, version of

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,8 @@ Other enhancements:
   likely overwrite on upgrade.
 * Add `stack ls dependencies cabal` command, which lists dependencies in the
   format of exact Cabal constraints.
+* Add `STACK_XDG` environment variable to use the XDG directory specification
+  for the Stack root.
 
 Bug fixes:
 

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1764,6 +1764,16 @@ stack path --stack-root
 The location of the Stack root can be configured by setting the `STACK_ROOT`
 environment variable or using Stack's `--stack-root` option on the command line.
 
+Alternatively, Stack can follow the XDG specification by setting the `STACK_XDG`
+environment variable to anything non-empty:
+
+~~~bash
+export STACK_XDG=1
+~~~
+
+The global `config.yaml` will then go in `$XDG_CONFIG_HOME/stack` and the Stack
+root will be located in `$XDG_DATA_HOME/stack`.
+
 On Windows, the length of filepaths may be limited (to
 [MAX_PATH](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd)),
 and things can break when this limit is exceeded. Setting a Stack root with a

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -760,16 +760,17 @@ determineStackRootAndOwnership clArgs = liftIO $ do
                 mstackRoot <- lookupEnv stackRootEnvVar
                 case mstackRoot of
                     Nothing -> do
-                      oldStyleRoot <- getAppUserDataDir stackProgName
-                      oldExists <- doesDirExist oldStyleRoot
-                      if oldExists
-                        then pure (oldStyleRoot, oldStyleRoot)
-                        else do
+                      wantXdg <- fromMaybe "" <$> lookupEnv stackXdgEnvVar
+                      if not (null wantXdg)
+                        then do
                           -- TODO: should `InvalidRelDir` be handled?
                           xdgRelDir <- parseRelDir stackProgName
                           (,)
                             <$> getXdgDir XdgConfig (Just xdgRelDir)
                             <*> getXdgDir XdgData (Just xdgRelDir)
+                        else do
+                          oldStyleRoot <- getAppUserDataDir stackProgName
+                          pure (oldStyleRoot, oldStyleRoot)
                     Just x -> case parseAbsDir x of
                         Nothing ->
                             throwIO $ ParseAbsolutePathException stackRootEnvVar x

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -486,7 +486,7 @@ loadConfig inner = do
     mproject <- loadProjectConfig mstackYaml
     mresolver <- view $ globalOptsL.to globalResolver
     configArgs <- view $ globalOptsL.to globalConfigMonoid
-    (stackRoot, userOwnsStackRoot) <- determineStackRootAndOwnership configArgs
+    (configRoot, stackRoot, userOwnsStackRoot) <- determineStackRootAndOwnership configArgs
 
     let (mproject', addConfigMonoid) =
           case mproject of
@@ -494,7 +494,7 @@ loadConfig inner = do
             PCGlobalProject -> (PCGlobalProject, id)
             PCNoProject deps -> (PCNoProject deps, id)
 
-    userConfigPath <- getDefaultUserConfigPath stackRoot
+    userConfigPath <- getDefaultUserConfigPath configRoot
     extraConfigs0 <- getExtraConfigs userConfigPath >>=
         mapM (\file -> loadConfigYaml (parseConfigMonoid (parent file)) file)
     let extraConfigs =
@@ -751,19 +751,29 @@ determineStackRootAndOwnership
     :: (MonadIO m)
     => ConfigMonoid
     -- ^ Parsed command-line arguments
-    -> m (Path Abs Dir, Bool)
+    -> m (Path Abs Dir, Path Abs Dir, Bool)
 determineStackRootAndOwnership clArgs = liftIO $ do
-    stackRoot <- do
+    (configRoot, stackRoot) <- do
         case getFirst (configMonoidStackRoot clArgs) of
-            Just x -> pure x
+            Just x -> pure (x, x)
             Nothing -> do
                 mstackRoot <- lookupEnv stackRootEnvVar
                 case mstackRoot of
-                    Nothing -> getAppUserDataDir stackProgName
+                    Nothing -> do
+                      oldStyleRoot <- getAppUserDataDir stackProgName
+                      oldExists <- doesDirExist oldStyleRoot
+                      if oldExists
+                        then pure (oldStyleRoot, oldStyleRoot)
+                        else do
+                          -- TODO: should `InvalidRelDir` be handled?
+                          xdgRelDir <- parseRelDir stackProgName
+                          (,)
+                            <$> getXdgDir XdgConfig (Just xdgRelDir)
+                            <*> getXdgDir XdgData (Just xdgRelDir)
                     Just x -> case parseAbsDir x of
                         Nothing ->
                             throwIO $ ParseAbsolutePathException stackRootEnvVar x
-                        Just parsed -> pure parsed
+                        Just parsed -> pure (parsed, parsed)
 
     (existingStackRootOrParentDir, userOwnsIt) <- do
         mdirAndOwnership <- findInParents getDirAndOwnership stackRoot
@@ -779,8 +789,9 @@ determineStackRootAndOwnership clArgs = liftIO $ do
                     stackRoot
                     existingStackRootOrParentDir
 
+    configRoot' <- canonicalizePath configRoot
     stackRoot' <- canonicalizePath stackRoot
-    pure (stackRoot', userOwnsIt)
+    pure (configRoot', stackRoot', userOwnsIt)
 
 -- | @'checkOwnership' dir@ throws 'UserDoesn'tOwnDirectory' if @dir@
 -- isn't owned by the current user.

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -763,7 +763,6 @@ determineStackRootAndOwnership clArgs = liftIO $ do
                       wantXdg <- fromMaybe "" <$> lookupEnv stackXdgEnvVar
                       if not (null wantXdg)
                         then do
-                          -- TODO: should `InvalidRelDir` be handled?
                           xdgRelDir <- parseRelDir stackProgName
                           (,)
                             <$> getXdgDir XdgConfig (Just xdgRelDir)

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -13,6 +13,7 @@ module Stack.Constants
     ,stackDotYaml
     ,stackWorkEnvVar
     ,stackRootEnvVar
+    ,stackXdgEnvVar
     ,stackRootOptionName
     ,stackGlobalConfigOptionName
     ,pantryRootEnvVar
@@ -163,6 +164,10 @@ stackWorkEnvVar = "STACK_WORK"
 -- | Environment variable used to override the '~/.stack' location.
 stackRootEnvVar :: String
 stackRootEnvVar = "STACK_ROOT"
+
+-- | Environment variable used to indicate XDG directories should be used.
+stackXdgEnvVar :: String
+stackXdgEnvVar = "STACK_XDG"
 
 -- | Option name for the global Stack root.
 stackRootOptionName :: String

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -14,6 +14,7 @@ module Stack.Constants
     ,stackWorkEnvVar
     ,stackRootEnvVar
     ,stackRootOptionName
+    ,stackGlobalConfigOptionName
     ,pantryRootEnvVar
     ,deprecatedStackRootOptionName
     ,inContainerEnvVar
@@ -166,6 +167,10 @@ stackRootEnvVar = "STACK_ROOT"
 -- | Option name for the global Stack root.
 stackRootOptionName :: String
 stackRootOptionName = "stack-root"
+
+-- | Option name for the global Stack configuration file.
+stackGlobalConfigOptionName :: String
+stackGlobalConfigOptionName = "global-config"
 
 -- | Environment variable used to override the location of the Pantry store
 pantryRootEnvVar :: String

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -152,6 +152,9 @@ paths =
     [ ( "Global Stack root directory"
       , T.pack stackRootOptionName
       , WithoutHaddocks $ view (stackRootL.to toFilePathNoTrailingSep.to T.pack))
+    , ( "Global Stack configuration file"
+      , T.pack stackGlobalConfigOptionName
+      , WithoutHaddocks $ view (stackGlobalConfigL.to toFilePath.to T.pack))
     , ( "Project root (derived from stack.yaml file)"
       , "project-root"
       , WithoutHaddocks $ view (projectRootL.to toFilePathNoTrailingSep.to T.pack))

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -169,6 +169,7 @@ module Stack.Types.Config
   ,buildOptsHaddockL
   ,globalOptsBuildOptsMonoidL
   ,stackRootL
+  ,stackGlobalConfigL
   ,cabalVersionL
   ,whichCompilerL
   ,envOverrideSettingsL
@@ -2037,6 +2038,9 @@ instance HasTerm EnvConfig where
 
 stackRootL :: HasConfig s => Lens' s (Path Abs Dir)
 stackRootL = configL.lens configStackRoot (\x y -> x { configStackRoot = y })
+
+stackGlobalConfigL :: HasConfig s => Lens' s (Path Abs File)
+stackGlobalConfigL = configL.lens configUserConfigPath (\x y -> x { configUserConfigPath = y })
 
 -- | The compiler specified by the @SnapshotDef@. This may be
 -- different from the actual compiler used!


### PR DESCRIPTION
* [ ] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [ ] The documentation has been updated, if necessary

This patch implements basic XDG support, as requested in #4243, with the
following logic:

- Environment variable override takes precedence as before.
- If the old-style `~/.stack` directory exists, use it.
- Otherwise, put the global `config.yaml` in a subdirectory of
  `XDG_CONFIG_HOME`, and the rest in a subdirectory of `XDG_DATA_HOME`.

I tested this in a clean VM with no prior `stack` installed, with the following commands:

```bash
vagrant@bullseye:~$ tree -a
.
├── .bash_logout
├── .bashrc
├── .profile
└── .ssh
    └── authorized_keys

1 directory, 4 files
vagrant@bullseye:~$ /vagrant/build/stack new test
[...]
vagrant@bullseye:~$ tree -a
.
├── .bash_logout
├── .bashrc
├── .config
│   └── stack
│       └── config.yaml
├── .local
│   └── share
│       └── stack
│           ├── pantry
│           │   ├── global-hints-cache.yaml
│           │   ├── pantry.sqlite3
│           │   └── pantry.sqlite3.pantry-write-lock
│           ├── stack.sqlite3
│           ├── stack.sqlite3.pantry-write-lock
│           └── templates
│               └── new-template.hsfiles
├── .profile
├── .ssh
│   └── authorized_keys
└── test
    ├── app
    │   └── Main.hs
    ├── CHANGELOG.md
    ├── .gitignore
    ├── LICENSE
    ├── package.yaml
    ├── README.md
    ├── Setup.hs
    ├── src
    │   └── Lib.hs
    ├── stack.yaml
    ├── test
    │   └── Spec.hs
    └── test.cabal

12 directories, 22 files
```

Backwards-compatibility test:

```bash
vagrant@bullseye:~$ tree -a
.
├── .bash_logout
├── .bashrc
├── .profile
├── .ssh
│   └── authorized_keys
└── .stack
    ├── config.yaml
    ├── pantry
    │   ├── global-hints-cache.yaml
    │   ├── pantry.sqlite3
    │   └── pantry.sqlite3.pantry-write-lock
    ├── stack.sqlite3
    ├── stack.sqlite3.pantry-write-lock
    └── templates
        └── new-template.hsfiles

4 directories, 11 files
vagrant@bullseye:~$ /vagrant/build/stack new test
[...]
vagrant@bullseye:~$ tree -a
.
├── .bash_logout
├── .bashrc
├── .profile
├── .ssh
│   └── authorized_keys
├── .stack
│   ├── config.yaml
│   ├── pantry
│   │   ├── global-hints-cache.yaml
│   │   ├── pantry.sqlite3
│   │   └── pantry.sqlite3.pantry-write-lock
│   ├── stack.sqlite3
│   ├── stack.sqlite3.pantry-write-lock
│   └── templates
│       └── new-template.hsfiles
└── test
    ├── app
    │   └── Main.hs
    ├── CHANGELOG.md
    ├── .gitignore
    ├── LICENSE
    ├── package.yaml
    ├── README.md
    ├── Setup.hs
    ├── src
    │   └── Lib.hs
    ├── stack.yaml
    ├── test
    │   └── Spec.hs
    └── test.cabal

8 directories, 22 files
```

Although this is not much, I think it's indicative enough that `stack` is
reading/writing files in the correct locations. If the maintainers think written
tests need to be added, I am open to suggestions.

Some typo fixed while reading `CONTRIBUTING.md` too! :o)

A `TODO` comment asks if some `Path.IO` exception should be handled because I
don't know what is the general expected behavior of `stack` here.

There are several other problems and questions that I'm unable to answer alone:

- IMO this should be the default behavior, but I can't speak for the
  maintainers. For instance, it seems Travis caching will be broken by this
  change. I don't know your policy about this kind of questions.
- The documentation question depends on the above too, since the default
  behavior should be documented and, if XDG becomes default, I personally don't
  think legacy behavior should be cluttering the documentation.
- I have not tested this on Windows, nor do I know how to do it since I am
  unfamiliar with this OS. If you have a standard way, I'm open to suggestions.
