### PR TITLE
Simple refactoring

### DIFF
--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -52,6 +52,7 @@ import           System.Environment (lookupEnv)
 import           System.IO (putStrLn)
 import           RIO.PrettyPrint
 import           RIO.Process (findExecutable, HasProcessContext (..))
+import Stack.Types.Dependency (DepValue(DepValue), DepType (AsLibrary))
 
 data PackageInfo
     =

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -52,7 +52,7 @@ import           System.Environment (lookupEnv)
 import           System.IO (putStrLn)
 import           RIO.PrettyPrint
 import           RIO.Process (findExecutable, HasProcessContext (..))
-import Stack.Types.Dependency (DepValue(DepValue), DepType (AsLibrary))
+import           Stack.Types.Dependency (DepValue(DepValue), DepType (AsLibrary))
 
 data PackageInfo
     =

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 
 -- | Generate haddocks
@@ -107,7 +107,7 @@ generateLocalHaddockIndex
 generateLocalHaddockIndex bco localDumpPkgs locals = do
     let dumpPackages =
             mapMaybe
-                (\LocalPackage{lpPackage = Package{..}} ->
+                (\LocalPackage{lpPackage = Package{packageName, packageVersion}} ->
                     F.find
                         (\dp -> dpPackageIdent dp == PackageIdentifier packageName packageVersion)
                         localDumpPkgs)
@@ -139,7 +139,7 @@ generateDepsHaddockIndex bco globalDumpPkgs snapshotDumpPkgs localDumpPkgs local
         depDocDir
   where
     getGhcPkgId :: LocalPackage -> Maybe GhcPkgId
-    getGhcPkgId LocalPackage{lpPackage = Package{..}} =
+    getGhcPkgId LocalPackage{lpPackage = Package{packageName, packageVersion}} =
         let pkgId = PackageIdentifier packageName packageVersion
             mdpPkg = F.find (\dp -> dpPackageIdent dp == pkgId) localDumpPkgs
         in fmap dpGhcPkgId mdpPkg
@@ -219,7 +219,7 @@ generateHaddockIndex descr bco dumpPackages docRelFP destDir = do
                 fromString (toFilePath destIndexFile)
   where
     toInterfaceOpt :: DumpPackage -> IO (Maybe ([String], UTCTime, Path Abs File, Path Abs File))
-    toInterfaceOpt DumpPackage {..} =
+    toInterfaceOpt DumpPackage {dpHaddockInterfaces, dpPackageIdent, dpHaddockHtml} =
         case dpHaddockInterfaces of
             [] -> pure Nothing
             srcInterfaceFP:_ -> do

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -315,24 +315,12 @@ loadLocalPackage pp = do
             { packageConfigEnableTests = not $ Set.null tests
             , packageConfigEnableBenchmarks = not $ Set.null benches
             }
-        testconfig = config
-            { packageConfigEnableTests = True
-            , packageConfigEnableBenchmarks = False
-            }
-        benchconfig = config
-            { packageConfigEnableTests = False
-            , packageConfigEnableBenchmarks = True
-            }
 
-        -- We resolve the package in 4 different configurations:
+        -- We resolve the package in 2 different configurations:
         --
         -- - pkg doesn't have tests or benchmarks enabled.
         --
         -- - btpkg has them enabled if they are present.
-        --
-        -- - testpkg has tests enabled, but not benchmarks.
-        --
-        -- - benchpkg has benchmarks enabled, but not tests.
         --
         -- The latter two configurations are used to compute the deps
         -- when --enable-benchmarks or --enable-tests are configured.
@@ -343,8 +331,6 @@ loadLocalPackage pp = do
         btpkg
             | Set.null tests && Set.null benches = Nothing
             | otherwise = Just (resolvePackage btconfig gpkg)
-        testpkg = resolvePackage testconfig gpkg
-        benchpkg = resolvePackage benchconfig gpkg
 
     componentFiles <- memoizeRefWith $ fst <$> getPackageFilesForTargets pkg (ppCabalFP pp) nonLibComponents
 
@@ -372,8 +358,6 @@ loadLocalPackage pp = do
 
     pure LocalPackage
         { lpPackage = pkg
-        , lpTestDeps = dvVersionRange <$> packageDeps testpkg
-        , lpBenchDeps = dvVersionRange <$> packageDeps benchpkg
         , lpTestBench = btpkg
         , lpComponentFiles = componentFiles
         , lpBuildHaddocks = cpHaddocks (ppCommon pp)

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -77,7 +77,7 @@ import           System.IO.Error
 import           RIO.Process
 import           RIO.PrettyPrint
 import qualified RIO.PrettyPrint as PP (Style (Module))
-import Stack.Types.Dependency (DepValue(..), DepType (..))
+import           Stack.Types.Dependency (DepValue(..), DepType (..))
 
 data Ctx = Ctx { ctxFile :: !(Path Abs File)
                , ctxDistDir :: !(Path Abs Dir)

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -143,7 +143,7 @@ packageFromPackageDescription packageConfig pkgFlags (PackageDescriptionPair pkg
     , packageFlags = packageConfigFlags packageConfig
     , packageDefaultFlags = M.fromList
       [(flagName flag, flagDefault flag) | flag <- pkgFlags]
-    , packageAllDeps = S.fromList (M.keys deps)
+    , packageAllDeps = M.keysSet deps
     , packageLibraries =
         let mlib = do
               lib <- library pkg

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -77,6 +77,7 @@ import           System.IO.Error
 import           RIO.Process
 import           RIO.PrettyPrint
 import qualified RIO.PrettyPrint as PP (Style (Module))
+import Stack.Types.Dependency (DepValue(..), DepType (..))
 
 data Ctx = Ctx { ctxFile :: !(Path Abs File)
                , ctxDistDir :: !(Path Abs Dir)

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -322,8 +322,6 @@ readLocalPackage pkgDir = do
         , lpCabalFile = cabalfp
         -- NOTE: these aren't the 'correct values, but aren't used in
         -- the usage of this function in this module.
-        , lpTestDeps = Map.empty
-        , lpBenchDeps = Map.empty
         , lpTestBench = Nothing
         , lpBuildHaddocks = False
         , lpForceDirty = False

--- a/src/Stack/Types/Dependency.hs
+++ b/src/Stack/Types/Dependency.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Stack.Types.Dependency where
 

--- a/src/Stack/Types/Dependency.hs
+++ b/src/Stack/Types/Dependency.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
-module Stack.Types.Dependency where
+module Stack.Types.Dependency
+  (DepValue(..)
+  ,DepType(..)
+  )
+  where
 
 import Stack.Prelude
 import Distribution.Types.VersionRange (VersionRange)
@@ -14,7 +18,7 @@ data DepValue = DepValue
   { dvVersionRange :: !VersionRange
   , dvType :: !DepType
   }
-  deriving (Show,Typeable)
+  deriving (Show, Typeable)
 instance Semigroup DepValue where
   DepValue a x <> DepValue b y = DepValue (intersectVersionRanges a b) (x <> y)
 

--- a/src/Stack/Types/Dependency.hs
+++ b/src/Stack/Types/Dependency.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Stack.Types.Dependency where
+
+import Stack.Prelude
+import Distribution.Types.VersionRange (VersionRange)
+import Stack.Types.Version (intersectVersionRanges)
+
+
+-- | The value for a map from dependency name. This contains both the
+-- version range and the type of dependency, and provides a semigroup
+-- instance.
+data DepValue = DepValue
+  { dvVersionRange :: !VersionRange
+  , dvType :: !DepType
+  }
+  deriving (Show,Typeable)
+instance Semigroup DepValue where
+  DepValue a x <> DepValue b y = DepValue (intersectVersionRanges a b) (x <> y)
+
+-- | Is this package being used as a library, or just as a build tool?
+-- If the former, we need to ensure that a library actually
+-- exists. See
+-- <https://github.com/commercialhaskell/stack/issues/2195>
+data DepType = AsLibrary | AsBuildTool
+  deriving (Show, Eq)
+instance Semigroup DepType where
+  AsLibrary <> _ = AsLibrary
+  AsBuildTool <> x = x

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -29,6 +29,7 @@ import           Stack.Types.GhcPkgId
 import           Stack.Types.NamedComponent
 import           Stack.Types.SourceMap
 import           Stack.Types.Version
+import qualified Data.Map as Map
 
 -- | Type representing exceptions thrown by functions exported by the
 -- "Stack.Package" module.
@@ -278,11 +279,6 @@ data LocalPackage = LocalPackage
     -- "buildable: false".
     , lpWanted        :: !Bool -- FIXME Should completely drop this "wanted" terminology, it's unclear
     -- ^ Whether this package is wanted as a target.
-    , lpTestDeps      :: !(Map PackageName VersionRange)
-    -- ^ Used for determining if we can use --enable-tests in a normal build.
-    , lpBenchDeps     :: !(Map PackageName VersionRange)
-    -- ^ Used for determining if we can use --enable-benchmarks in a normal
-    -- build.
     , lpTestBench     :: !(Maybe Package)
     -- ^ This stores the 'Package' with tests and benchmarks enabled, if
     -- either is asked for by the user.

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -29,7 +29,7 @@ import           Stack.Types.GhcPkgId
 import           Stack.Types.NamedComponent
 import           Stack.Types.SourceMap
 import           Stack.Types.Version
-import qualified Data.Map as Map
+import Stack.Types.Dependency (DepValue)
 
 -- | Type representing exceptions thrown by functions exported by the
 -- "Stack.Package" module.
@@ -139,27 +139,6 @@ data Package =
 
 packageIdent :: Package -> PackageIdentifier
 packageIdent p = PackageIdentifier (packageName p) (packageVersion p)
-
--- | The value for a map from dependency name. This contains both the
--- version range and the type of dependency, and provides a semigroup
--- instance.
-data DepValue = DepValue
-  { dvVersionRange :: !VersionRange
-  , dvType :: !DepType
-  }
-  deriving (Show,Typeable)
-instance Semigroup DepValue where
-  DepValue a x <> DepValue b y = DepValue (intersectVersionRanges a b) (x <> y)
-
--- | Is this package being used as a library, or just as a build tool?
--- If the former, we need to ensure that a library actually
--- exists. See
--- <https://github.com/commercialhaskell/stack/issues/2195>
-data DepType = AsLibrary | AsBuildTool
-  deriving (Show, Eq)
-instance Semigroup DepType where
-  AsLibrary <> _ = AsLibrary
-  AsBuildTool <> x = x
 
 packageIdentifier :: Package -> PackageIdentifier
 packageIdentifier pkg =

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -197,11 +197,6 @@ data BuildInfoOpts = BuildInfoOpts
     , bioCabalMacros :: Path Abs File
     } deriving Show
 
--- | Files to get for a cabal package.
-data CabalFileType
-    = AllFiles
-    | Modules
-
 -- | Files that the package depends on, relative to package directory.
 -- Argument is the location of the Cabal file
 newtype GetPackageFiles = GetPackageFiles

--- a/stack.cabal
+++ b/stack.cabal
@@ -200,7 +200,6 @@ library
       Stack.Types.Config
       Stack.Types.Config.Build
       Stack.Types.Docker
-      Stack.Types.Dependency
       Stack.Types.GhcPkgId
       Stack.Types.NamedComponent
       Stack.Types.Nix
@@ -221,6 +220,7 @@ library
   other-modules:
       Path.Extended
       Stack.Types.Cache
+      Stack.Types.Dependency
   autogen-modules:
       Paths_stack
   hs-source-dirs:

--- a/stack.cabal
+++ b/stack.cabal
@@ -200,6 +200,7 @@ library
       Stack.Types.Config
       Stack.Types.Config.Build
       Stack.Types.Docker
+      Stack.Types.Dependency
       Stack.Types.GhcPkgId
       Stack.Types.NamedComponent
       Stack.Types.Nix


### PR DESCRIPTION
This is a preparation work for #5920. It really is a simple review of unused fields and I had to move all the Dependency related types to a dedicated module because having them in Package made circular imports when moving dependencies to Components. 

@mpilgrem
