### PR TITLE
Re #5911 Tidy up exceptions in Stack.SDist, Stack.Hoogle and various other

### DIFF
--- a/doc/maintainers/stack_errors.md
+++ b/doc/maintainers/stack_errors.md
@@ -45,6 +45,12 @@ to take stock of the errors that Stack itself can raise, by reference to the
         | ExecutableToRunNotFound
         ~~~
 
+    -   `Options.Applicative.Builder.Extra.OptionsApplicativeExtraException`
+
+        ~~~haskell
+        = FlagNotFoundBug
+        ~~~
+
     -   `Stack.Build.QueryException`
 
         ~~~haskell
@@ -105,6 +111,12 @@ to take stock of the errors that Stack itself can raise, by reference to the
         = NoProjectConfigAvailable
         ~~~
 
+    -   `Stack.Constants.ConstantsException`
+
+        ~~~haskell
+        = WiredInPackagesNotParsedBug
+        ~~~
+
     -   `Stack.Coverage.CoverageException`
 
         ~~~haskell
@@ -129,6 +141,15 @@ to take stock of the errors that Stack itself can raise, by reference to the
         | Can'tSpecifyFilesAndTargets
         | Can'tSpecifyFilesAndMainIs
         | GhciTargetParseException [Text]
+        ~~~
+
+
+    -   `Stack.Hoogle.HoogleException`
+
+        ~~~haskell
+        = HoogleDatabaseNotFound
+        | HoogleNotFound String
+        | HoogleOnPathNotFound
         ~~~
 
     -   `Stack.Init.InitException`
@@ -195,10 +216,12 @@ to take stock of the errors that Stack itself can raise, by reference to the
         | DockerWithinNixInvalid
         ~~~
 
-    -   `Stack.SDist.CheckException`
+    -   `Stack.SDist.SDistException`
 
         ~~~haskell
         = CheckException (NonEmpty PackageCheck)
+        | CabalFilePathsInconsistentBug (Path Abs File) (Path Abs File)
+        | ToTarPathException
         ~~~
 
     -   `Stack.Script.ScriptException`
@@ -432,23 +455,6 @@ to take stock of the errors that Stack itself can raise, by reference to the
 
     \* The instance of `Show` is derived.
 
-    Stack also makes use of `UnlifIO.Exception.throwString`, which throws an
-    exception of type `UnliftIO.Exception.StringException`:
-
-    ~~~haskell
-    = StringException String CallStack
-    ~~~
-
-*   `Options.Applicative.Builder.Extra.enableDisableFlagsNoDefault`:
-
-    ~~~text
-    enableDisableFlagsNoDefault.last
-    ~~~
-
-    `StringException`
-
-    `impureThrow`
-
 *   `Stack.Build.Execute.singleBuild`: catches exceptions in `cabal ...`
 
     `throwM`
@@ -468,16 +474,12 @@ to take stock of the errors that Stack itself can raise, by reference to the
     <path>
     ~~~
 
-*   `Stack.Constants.wiredInPackages`:
-
-    ~~~text
-    Parse error in wiredInPackages
-    ~~~
-
-    `error`
-
 *   `Stack.Coverage.generateHpcReport`: catches exceptions from
     `findPackageFieldForBuiltPackage`
+
+    ~~~text
+    <exception>
+    ~~~
 
 *   `Stack.Coverage.generateHpcReportInternal`:
 
@@ -532,14 +534,6 @@ to take stock of the errors that Stack itself can raise, by reference to the
     Unable to create package database at <path>
     ~~~
 
-*   `Stack.Hoogle.hoogleCmd`:
-
-    ~~~text
-    No Hoogle database. Not building one due to --no-setup
-    ~~~
-
-    `exitWith (ExitFailure (-1))`
-
 *   `Stack.Lock.loadYamlThrow`:
 
     `Data.Yaml.AesonException`
@@ -574,30 +568,17 @@ to take stock of the errors that Stack itself can raise, by reference to the
     Ignoring SYLGlobalProject for script command
     ~~~
 
-*   `Stack.SDist.getCabalLbs`:
-
-    ~~~text
-    getCabalLbs: cabalfp /= cabalfp': (<cabalfp>, <cabalfp'>)
-    ~~~
-
-    `error`
-
 *   `Stack.SDist.getSDistTarball`:
 
     ~~~text
     Error building custom-setup dependencies: <exception>
     ~~~
 
-*   `Stack.SDist.getSDistTarball`: catches exception from
-    `Codec.Archive.Tar.Entry.toTarPath`
+*   `Stack.Setup.downloadStackExe`: catches exceptions from `performPathChecking`
 
     ~~~text
     <exception>
     ~~~
-
-    `throwString`
-
-*   `Stack.Setup.downloadStackExe`: catches exceptions from `performPathChecking`
 
 *   `Stack.Upload.uploadBytes`:
 

--- a/src/Options/Applicative/Builder/Extra.hs
+++ b/src/Options/Applicative/Builder/Extra.hs
@@ -46,6 +46,19 @@ import System.Directory (getCurrentDirectory, getDirectoryContents, doesDirector
 import System.Environment (withArgs)
 import System.FilePath (takeBaseName, (</>), splitFileName, isRelative, takeExtension)
 
+-- | Type representing exceptions thrown by functions exported by the
+-- "Options.Applicative.Builder.Extra" module.
+data OptionsApplicativeExtraException
+  = FlagNotFoundBug
+  deriving Typeable
+
+instance Show OptionsApplicativeExtraException where
+  show FlagNotFoundBug =
+    "Error: The impossible happened! No valid flags found in \
+    \enableDisableFlagsNoDefault."
+
+instance Exception OptionsApplicativeExtraException
+
 -- | Enable/disable flags for a 'Bool'.
 boolFlags :: Bool                 -- ^ Default value
           -> String               -- ^ Flag name
@@ -129,7 +142,7 @@ enableDisableFlagsNoDefault enabledValue disabledValue name helpSuffix mods =
   where
     last xs =
       case reverse xs of
-        [] -> impureThrow $ stringException "enableDisableFlagsNoDefault.last"
+        [] -> impureThrow FlagNotFoundBug
         x:_ -> x
 
 -- | Show an extra help option (e.g. @--docker-help@ shows help for all @--docker*@ args).

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -15,7 +15,6 @@ module Stack.Build.ConstructPlan
     ) where
 
 import           Stack.Prelude hiding (Display (..), loadPackage)
-import           Control.Exception (throw)
 import           Control.Monad.RWS.Strict hiding ((<>))
 import           Control.Monad.State.Strict (execState)
 import qualified Data.List as L
@@ -979,7 +978,7 @@ stripNonDeps deps plan = plan
         when (providesDep task) $ collectMissing mempty (taskProvides task)
 
     collectMissing dependents pid = do
-      when (pid `elem` dependents) $ throw $ TaskCycleBug pid
+      when (pid `elem` dependents) $ impureThrow $ TaskCycleBug pid
       modify'(<> Set.singleton pid)
       mapM_ (collectMissing (pid:dependents)) (fromMaybe mempty $ M.lookup pid missing)
 

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -22,7 +22,6 @@ module Stack.BuildPlan
     ) where
 
 import           Stack.Prelude hiding (Display (..))
-import           Control.Exception (throw)
 import qualified Data.Foldable as F
 import qualified Data.Set as Set
 import           Data.List (intercalate)
@@ -317,7 +316,7 @@ checkBundleBuildPlan platform compiler pool flags gpds =
         flags' f gpd = fromMaybe Map.empty (Map.lookup (gpdPackageName gpd) f)
         pool' = Map.union (gpdPackages gpds) pool
 
-        dupError _ _ = throw DuplicatePackagesBug
+        dupError _ _ = impureThrow DuplicatePackagesBug
 
 data BuildPlanCheck =
       BuildPlanCheckOk      (Map PackageName (Map FlagName Bool))

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -16,7 +16,6 @@ module Stack.Dot (dot
                  ,pruneGraph
                  ) where
 
-import           Control.Exception (throw)
 import           Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as LBC8
 import qualified Data.Foldable as F
@@ -435,7 +434,7 @@ createDepLoader sourceMap globalDumpMap globalIdMap loadPackageDeps pkgName = do
      where
       deps = map ghcIdToPackageName (dpDepends dump)
       ghcIdToPackageName depId =
-        maybe (throw $ DependencyNotFoundBug depId)
+        maybe (impureThrow $ DependencyNotFoundBug depId)
               Stack.Prelude.pkgName
               (Map.lookup depId globalIdMap)
 

--- a/src/Stack/Ls.hs
+++ b/src/Stack/Ls.hs
@@ -8,7 +8,6 @@ module Stack.Ls
   , lsParser
   ) where
 
-import Control.Exception (throw)
 import Data.Aeson
 import Data.Array.IArray ((//), elems)
 import Distribution.Package (mkPackageName)
@@ -189,7 +188,7 @@ toSnapshot [String sid, String stitle, String stime] =
     , snapTitle = stitle
     , snapTime = stime
     }
-toSnapshot val = throw $ ParseFailure val
+toSnapshot val = impureThrow $ ParseFailure val
 
 newtype LsException =
     ParseFailure [Value]

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -27,7 +27,6 @@ module Stack.Package
   ,applyForceCustomBuild
   ) where
 
-import           Control.Exception (throw)
 import           Data.List (find, isPrefixOf, unzip)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -515,7 +514,7 @@ buildDir distDir = distDir </> relDirBuild
 -- component names.
 componentNameToDir :: Text -> Path Rel Dir
 componentNameToDir name =
-  fromMaybe (throw ComponentNotParsedBug) (parseRelDir (T.unpack name))
+  fromMaybe (impureThrow ComponentNotParsedBug) (parseRelDir (T.unpack name))
 
 -- | Get all dependencies of the package (buildable targets only).
 --

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -45,8 +45,6 @@ module Stack.Types.Build
     )
     where
 
-import           Stack.Prelude
-import           Control.Exception               (throw)
 import           Data.Aeson                      (ToJSON, FromJSON)
 import qualified Data.ByteString                 as S
 import           Data.Char                       (isSpace)
@@ -65,6 +63,7 @@ import           Distribution.Version            (mkVersion)
 import           Path                            (parseRelDir, (</>), parent)
 import           Path.Extra                      (toFilePathNoTrailingSep)
 import           Stack.Constants
+import           Stack.Prelude
 import           Stack.Types.Compiler
 import           Stack.Types.CompilerBuild
 import           Stack.Types.Config
@@ -376,7 +375,7 @@ showBuildError isBuildingSetup exitCode mtaskProvides execName fullArgs logFiles
       logLocations = maybe "" (\fp -> "\n    Logs have been written to: " ++ toFilePath fp) logFiles
   in "\n--  While building " ++
      (case (isBuildingSetup, mtaskProvides) of
-       (False, Nothing) -> throw ShowBuildErrorBug
+       (False, Nothing) -> impureThrow ShowBuildErrorBug
        (False, Just taskProvides') -> "package " ++ dropQuotes (packageIdentifierString taskProvides')
        (True, Nothing) -> "simple Setup.hs"
        (True, Just taskProvides') -> "custom Setup.hs for package " ++ dropQuotes (packageIdentifierString taskProvides')

--- a/src/Stack/Types/TemplateName.hs
+++ b/src/Stack/Types/TemplateName.hs
@@ -17,7 +17,6 @@ module Stack.Types.TemplateName
   , defaultTemplateName
   ) where
 
-import           Control.Exception (throw)
 import           Data.Aeson (FromJSON (..), withText)
 import qualified Data.Text as T
 import           Network.HTTP.StackClient (parseRequest)
@@ -116,7 +115,7 @@ parseTemplateNameFromString fname =
 defaultTemplateName :: TemplateName
 defaultTemplateName =
   case parseTemplateNameFromString "new-template" of
-    Left s -> throw $ DefaultTemplateNameNotParsedBug s
+    Left s -> impureThrow $ DefaultTemplateNameNotParsedBug s
     Right x -> x
 
 -- | Get a text representation of the template name.


### PR DESCRIPTION
Also prefers `RIO`'s `impureThrow` to `Control.Exception`'s `throw`.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying mainly on CI.
