### PR TITLE
refactoring: bring package file gathering logic into dedicated module…

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -85,6 +85,7 @@ import           Stack.Types.Config
 import           Stack.Types.GhcPkgId
 import           Stack.Types.NamedComponent
 import           Stack.Types.Package
+import           Stack.Types.PackageFile
 import           Stack.Types.Version
 import qualified System.Directory as D
 import           System.Environment (getExecutablePath, lookupEnv)

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -36,6 +36,7 @@ import              Stack.Types.Build
 import              Stack.Types.Config
 import              Stack.Types.NamedComponent
 import              Stack.Types.Package
+import              Stack.Types.PackageFile
 import              Stack.Types.SourceMap
 import              System.FilePath (takeFileName)
 import              System.IO.Error (isDoesNotExistError)

--- a/src/Stack/ComponentFile.hs
+++ b/src/Stack/ComponentFile.hs
@@ -1,0 +1,522 @@
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+
+-- | A module which gathers all component level file gathering logic.
+-- It also includes many small utility functions for handling paths and directories.
+
+module Stack.ComponentFile
+  (resolveOrWarn
+  ,libraryFiles
+  ,executableFiles
+  ,testFiles
+  ,benchmarkFiles
+  ,componentOutputDir
+  ,componentBuildDir
+  ,packageAutogenDir
+  ,buildDir
+  ,componentAutogenDir
+  )
+  where
+
+import           Control.Exception (throw)
+import           Data.List (find, isPrefixOf)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+import           Distribution.ModuleName (ModuleName)
+import qualified Distribution.ModuleName as Cabal
+import           Distribution.Package hiding (Package, packageName, packageVersion, PackageIdentifier)
+import           Distribution.PackageDescription hiding (FlagName)
+import           Distribution.Text (display)
+import           Distribution.Utils.Path (getSymbolicPath)
+import           Distribution.Version (mkVersion)
+import qualified HiFileParser as Iface
+import           Path as FL hiding (replaceExtension)
+import           Path.Extra
+import           Path.IO hiding (findFiles)
+import           Stack.Constants
+import           Stack.Prelude hiding (Display (..))
+import           Stack.Types.Config
+import           Stack.Types.NamedComponent
+import           Stack.Types.Package
+import qualified System.Directory as D (doesFileExist)
+import qualified System.FilePath as FilePath
+import           RIO.PrettyPrint
+import qualified RIO.PrettyPrint as PP (Style (Module))
+import           Stack.Types.PackageFile (GetPackageFileContext(..), DotCabalDescriptor(..), DotCabalPath(..), PackageWarning(..))
+
+
+-- | Get all files referenced by the benchmark.
+benchmarkFiles
+    :: NamedComponent
+    -> Benchmark
+    -> RIO GetPackageFileContext (Map ModuleName (Path Abs File), [DotCabalPath], [PackageWarning])
+benchmarkFiles component bench = do
+    resolveComponentFiles component build names
+  where
+    names = bnames <> exposed
+    exposed =
+        case benchmarkInterface bench of
+            BenchmarkExeV10 _ fp -> [DotCabalMain fp]
+            BenchmarkUnsupported _ -> []
+    bnames = map DotCabalModule (otherModules build)
+    build = benchmarkBuildInfo bench
+
+-- | Get all files referenced by the test.
+testFiles
+    :: NamedComponent
+    -> TestSuite
+    -> RIO GetPackageFileContext (Map ModuleName (Path Abs File), [DotCabalPath], [PackageWarning])
+testFiles component test = do
+    resolveComponentFiles component build names
+  where
+    names = bnames <> exposed
+    exposed =
+        case testInterface test of
+            TestSuiteExeV10 _ fp -> [DotCabalMain fp]
+            TestSuiteLibV09 _ mn -> [DotCabalModule mn]
+            TestSuiteUnsupported _ -> []
+    bnames = map DotCabalModule (otherModules build)
+    build = testBuildInfo test
+
+-- | Get all files referenced by the executable.
+executableFiles
+    :: NamedComponent
+    -> Executable
+    -> RIO GetPackageFileContext (Map ModuleName (Path Abs File), [DotCabalPath], [PackageWarning])
+executableFiles component exe = do
+    resolveComponentFiles component build names
+  where
+    build = buildInfo exe
+    names =
+        map DotCabalModule (otherModules build) ++
+        [DotCabalMain (modulePath exe)]
+
+-- | Get all files referenced by the library.
+libraryFiles
+    :: NamedComponent
+    -> Library
+    -> RIO GetPackageFileContext (Map ModuleName (Path Abs File), [DotCabalPath], [PackageWarning])
+libraryFiles component lib = do
+    resolveComponentFiles component build names
+  where
+    build = libBuildInfo lib
+    names = bnames ++ exposed
+    exposed = map DotCabalModule (exposedModules lib)
+    bnames = map DotCabalModule (otherModules build)
+
+
+-- | Get all files referenced by the component.
+resolveComponentFiles
+    :: NamedComponent
+    -> BuildInfo
+    -> [DotCabalDescriptor]
+    -> RIO GetPackageFileContext (Map ModuleName (Path Abs File), [DotCabalPath], [PackageWarning])
+resolveComponentFiles component build names = do
+    dirs <- mapMaybeM (resolveDirOrWarn . getSymbolicPath) (hsSourceDirs build)
+    dir <- asks (parent . ctxFile)
+    agdirs <- autogenDirs
+    (modules,files,warnings) <-
+        resolveFilesAndDeps
+            component
+            ((if null dirs then [dir] else dirs) ++ agdirs)
+            names
+    cfiles <- buildOtherSources build
+    pure (modules, files <> cfiles, warnings)
+  where
+    autogenDirs = do
+      cabalVer <- asks ctxCabalVer
+      distDir <- asks ctxDistDir
+      let compDir = componentAutogenDir cabalVer component distDir
+          pkgDir = maybeToList $ packageAutogenDir cabalVer distDir
+      filterM doesDirExist $ compDir : pkgDir
+
+
+-- | Try to resolve the list of base names in the given directory by
+-- looking for unique instances of base names applied with the given
+-- extensions, plus find any of their module and TemplateHaskell
+-- dependencies.
+resolveFilesAndDeps
+    :: NamedComponent       -- ^ Package component name
+    -> [Path Abs Dir]       -- ^ Directories to look in.
+    -> [DotCabalDescriptor] -- ^ Base names.
+    -> RIO GetPackageFileContext (Map ModuleName (Path Abs File),[DotCabalPath],[PackageWarning])
+resolveFilesAndDeps component dirs names0 = do
+    (dotCabalPaths, foundModules, missingModules) <- loop names0 S.empty
+    warnings <- liftM2 (++) (warnUnlisted foundModules) (warnMissing missingModules)
+    pure (foundModules, dotCabalPaths, warnings)
+  where
+    loop [] _ = pure ([], M.empty, [])
+    loop names doneModules0 = do
+        resolved <- resolveFiles dirs names
+        let foundFiles = mapMaybe snd resolved
+            foundModules = mapMaybe toResolvedModule resolved
+            missingModules = mapMaybe toMissingModule resolved
+        pairs <- mapM (getDependencies component dirs) foundFiles
+        let doneModules =
+                S.union
+                    doneModules0
+                    (S.fromList (mapMaybe dotCabalModule names))
+            moduleDeps = S.unions (map fst pairs)
+            thDepFiles = concatMap snd pairs
+            modulesRemaining = S.difference moduleDeps doneModules
+        -- Ignore missing modules discovered as dependencies - they may
+        -- have been deleted.
+        (resolvedFiles, resolvedModules, _) <-
+            loop (map DotCabalModule (S.toList modulesRemaining)) doneModules
+        pure
+            ( nubOrd $ foundFiles <> map DotCabalFilePath thDepFiles <> resolvedFiles
+            , M.union
+                  (M.fromList foundModules)
+                  resolvedModules
+            , missingModules)
+    warnUnlisted foundModules = do
+        let unlistedModules =
+                foundModules `M.difference`
+                M.fromList (mapMaybe (fmap (, ()) . dotCabalModule) names0)
+        pure $
+            if M.null unlistedModules
+                then []
+                else [ UnlistedModulesWarning
+                           component
+                           (map fst (M.toList unlistedModules))]
+    warnMissing _missingModules = do
+        pure []
+        -- TODO: bring this back - see
+        -- https://github.com/commercialhaskell/stack/issues/2649
+        {-
+        cabalfp <- asks ctxFile
+        pure $
+            if null missingModules
+               then []
+               else [ MissingModulesWarning
+                           cabalfp
+                           component
+                           missingModules]
+        -}
+    -- TODO: In usages of toResolvedModule / toMissingModule, some sort
+    -- of map + partition would probably be better.
+    toResolvedModule
+        :: (DotCabalDescriptor, Maybe DotCabalPath)
+        -> Maybe (ModuleName, Path Abs File)
+    toResolvedModule (DotCabalModule mn, Just (DotCabalModulePath fp)) =
+        Just (mn, fp)
+    toResolvedModule _ =
+        Nothing
+    toMissingModule
+        :: (DotCabalDescriptor, Maybe DotCabalPath)
+        -> Maybe ModuleName
+    toMissingModule (DotCabalModule mn, Nothing) =
+        Just mn
+    toMissingModule _ =
+        Nothing
+
+
+-- | Get the dependencies of a Haskell module file.
+getDependencies
+    :: NamedComponent -> [Path Abs Dir] -> DotCabalPath -> RIO GetPackageFileContext (Set ModuleName, [Path Abs File])
+getDependencies component dirs dotCabalPath =
+    case dotCabalPath of
+        DotCabalModulePath resolvedFile -> readResolvedHi resolvedFile
+        DotCabalMainPath resolvedFile -> readResolvedHi resolvedFile
+        DotCabalFilePath{} -> pure (S.empty, [])
+        DotCabalCFilePath{} -> pure (S.empty, [])
+  where
+    readResolvedHi resolvedFile = do
+        dumpHIDir <- componentOutputDir component <$> asks ctxDistDir
+        dir <- asks (parent . ctxFile)
+        let sourceDir = fromMaybe dir $ find (`isProperPrefixOf` resolvedFile) dirs
+            stripSourceDir d = stripProperPrefix d resolvedFile
+        case stripSourceDir sourceDir of
+            Nothing -> pure (S.empty, [])
+            Just fileRel -> do
+                let hiPath =
+                        FilePath.replaceExtension
+                            (toFilePath (dumpHIDir </> fileRel))
+                            ".hi"
+                dumpHIExists <- liftIO $ D.doesFileExist hiPath
+                if dumpHIExists
+                    then parseHI hiPath
+                    else pure (S.empty, [])
+
+
+-- | Parse a .hi file into a set of modules and files.
+parseHI
+    :: FilePath -> RIO GetPackageFileContext (Set ModuleName, [Path Abs File])
+parseHI hiPath = do
+  dir <- asks (parent . ctxFile)
+  result <- liftIO $ Iface.fromFile hiPath `catchAnyDeep` \e -> pure (Left (show e))
+  case result of
+    Left msg -> do
+      prettyStackDevL
+        [ flow "Failed to decode module interface:"
+        , style File $ fromString hiPath
+        , flow "Decoding failure:"
+        , style Error $ fromString msg
+        ]
+      pure (S.empty, [])
+    Right iface -> do
+      let moduleNames = fmap (fromString . T.unpack . decodeUtf8Lenient . fst) .
+                        Iface.unList . Iface.dmods . Iface.deps
+          resolveFileDependency file = do
+            resolved <- liftIO (forgivingAbsence (resolveFile dir file)) >>= rejectMissingFile
+            when (isNothing resolved) $
+              prettyWarnL
+              [ flow "Dependent file listed in:"
+              , style File $ fromString hiPath
+              , flow "does not exist:"
+              , style File $ fromString file
+              ]
+            pure resolved
+          resolveUsages = traverse (resolveFileDependency . Iface.unUsage) . Iface.unList . Iface.usage
+      resolvedUsages <- catMaybes <$> resolveUsages iface
+      pure (S.fromList $ moduleNames iface, resolvedUsages)
+
+
+-- | The directory where generated files are put like .o or .hs (from .x files).
+componentOutputDir :: NamedComponent -> Path Abs Dir -> Path Abs Dir
+componentOutputDir namedComponent distDir =
+    case namedComponent of
+        CLib -> buildDir distDir
+        CInternalLib name -> makeTmp name
+        CExe name -> makeTmp name
+        CTest name -> makeTmp name
+        CBench name -> makeTmp name
+  where
+    makeTmp name =
+      buildDir distDir </> componentNameToDir (name <> "/" <> name <> "-tmp")
+
+-- | Try to resolve the list of base names in the given directory by
+-- looking for unique instances of base names applied with the given
+-- extensions.
+resolveFiles
+    :: [Path Abs Dir] -- ^ Directories to look in.
+    -> [DotCabalDescriptor] -- ^ Base names.
+    -> RIO GetPackageFileContext [(DotCabalDescriptor, Maybe DotCabalPath)]
+resolveFiles dirs names =
+    forM names (\name -> liftM (name, ) (findCandidate dirs name))
+
+-- | Find a candidate for the given module-or-filename from the list
+-- of directories and given extensions.
+findCandidate
+    :: [Path Abs Dir]
+    -> DotCabalDescriptor
+    -> RIO GetPackageFileContext (Maybe DotCabalPath)
+findCandidate dirs name = do
+    pkg <- asks ctxFile >>= parsePackageNameFromFilePath
+    customPreprocessorExts <- view $ configL . to configCustomPreprocessorExts
+    let haskellPreprocessorExts = haskellDefaultPreprocessorExts ++ customPreprocessorExts
+    candidates <- liftIO $ makeNameCandidates haskellPreprocessorExts
+    case candidates of
+        [candidate] -> pure (Just (cons candidate))
+        [] -> do
+            case name of
+                DotCabalModule mn
+                  | display mn /= paths_pkg pkg -> logPossibilities dirs mn
+                _ -> pure ()
+            pure Nothing
+        (candidate:rest) -> do
+            warnMultiple name candidate rest
+            pure (Just (cons candidate))
+  where
+    cons =
+        case name of
+            DotCabalModule{} -> DotCabalModulePath
+            DotCabalMain{} -> DotCabalMainPath
+            DotCabalFile{} -> DotCabalFilePath
+            DotCabalCFile{} -> DotCabalCFilePath
+    paths_pkg pkg = "Paths_" ++ packageNameString pkg
+    makeNameCandidates haskellPreprocessorExts =
+        liftM (nubOrd . concat) (mapM (makeDirCandidates haskellPreprocessorExts) dirs)
+    makeDirCandidates :: [Text]
+                      -> Path Abs Dir
+                      -> IO [Path Abs File]
+    makeDirCandidates haskellPreprocessorExts dir =
+        case name of
+            DotCabalMain fp -> resolveCandidate dir fp
+            DotCabalFile fp -> resolveCandidate dir fp
+            DotCabalCFile fp -> resolveCandidate dir fp
+            DotCabalModule mn -> do
+              let perExt ext =
+                     resolveCandidate dir (Cabal.toFilePath mn ++ "." ++ T.unpack ext)
+              withHaskellExts <- mapM perExt haskellFileExts
+              withPPExts <- mapM perExt haskellPreprocessorExts
+              pure $
+                case (concat withHaskellExts, concat withPPExts) of
+                  -- If we have exactly 1 Haskell extension and exactly
+                  -- 1 preprocessor extension, assume the former file is
+                  -- generated from the latter
+                  --
+                  -- See https://github.com/commercialhaskell/stack/issues/4076
+                  ([_], [y]) -> [y]
+
+                  -- Otherwise, return everything
+                  (xs, ys) -> xs ++ ys
+    resolveCandidate dir = fmap maybeToList . resolveDirFile dir
+
+-- | Log that we couldn't find a candidate, but there are
+-- possibilities for custom preprocessor extensions.
+--
+-- For example: .erb for a Ruby file might exist in one of the
+-- directories.
+logPossibilities
+    :: HasTerm env
+    => [Path Abs Dir] -> ModuleName -> RIO env ()
+logPossibilities dirs mn = do
+    possibilities <- liftM concat (makePossibilities mn)
+    unless (null possibilities) $ prettyWarnL
+        [ flow "Unable to find a known candidate for the Cabal entry"
+        , (style PP.Module . fromString $ display mn) <> ","
+        , flow "but did find:"
+        , line <> bulletedList (map pretty possibilities)
+        , flow "If you are using a custom preprocessor for this module"
+        , flow "with its own file extension, consider adding the extension"
+        , flow "to the 'custom-preprocessor-extensions' field in stack.yaml."
+        ]
+  where
+    makePossibilities name =
+        mapM
+            (\dir ->
+                  do (_,files) <- listDir dir
+                     pure
+                         (map
+                              filename
+                              (filter
+                                   (isPrefixOf (display name) .
+                                    toFilePath . filename)
+                                   files)))
+            dirs
+
+-- | Get all C sources and extra source files in a build.
+buildOtherSources :: BuildInfo -> RIO GetPackageFileContext [DotCabalPath]
+buildOtherSources build = do
+    cwd <- liftIO getCurrentDir
+    dir <- asks (parent . ctxFile)
+    file <- asks ctxFile
+    let resolveDirFiles files toCabalPath =
+            forMaybeM files $ \fp -> do
+                result <- resolveDirFile dir fp
+                case result of
+                    Nothing -> do
+                        warnMissingFile "File" cwd fp file
+                        pure Nothing
+                    Just p -> pure $ Just (toCabalPath p)
+    csources <- resolveDirFiles (cSources build) DotCabalCFilePath
+    jsources <- resolveDirFiles (targetJsSources build) DotCabalFilePath
+    pure (csources <> jsources)
+
+-- | Get the target's JS sources.
+targetJsSources :: BuildInfo -> [FilePath]
+targetJsSources = jsSources
+
+-- | Resolve file as a child of a specified directory, symlinks
+-- don't get followed.
+resolveDirFile
+    :: (MonadIO m, MonadThrow m)
+    => Path Abs Dir -> FilePath.FilePath -> m (Maybe (Path Abs File))
+resolveDirFile x y = do
+    -- The standard canonicalizePath does not work for this case
+    p <- parseCollapsedAbsFile (toFilePath x FilePath.</> y)
+    exists <- doesFileExist p
+    pure $ if exists then Just p else Nothing
+
+-- | Warn the user that multiple candidates are available for an
+-- entry, but that we picked one anyway and continued.
+warnMultiple
+    :: DotCabalDescriptor -> Path b t -> [Path b t] -> RIO GetPackageFileContext ()
+warnMultiple name candidate rest =
+    -- TODO: figure out how to style 'name' and the dispOne stuff
+    prettyWarnL
+        [ flow "There were multiple candidates for the Cabal entry"
+        , fromString . showName $ name
+        , line <> bulletedList (map dispOne (candidate:rest))
+        , line <> flow "picking:"
+        , dispOne candidate
+        ]
+  where showName (DotCabalModule name') = display name'
+        showName (DotCabalMain fp) = fp
+        showName (DotCabalFile fp) = fp
+        showName (DotCabalCFile fp) = fp
+        dispOne = fromString . toFilePath
+          -- TODO: figure out why dispOne can't be just `display`
+          --       (remove the .hlint.yaml exception if it can be)
+
+-- | Parse a package name from a file path.
+parsePackageNameFromFilePath :: MonadThrow m => Path a File -> m PackageName
+parsePackageNameFromFilePath fp = do
+    base <- clean $ toFilePath $ filename fp
+    case parsePackageName base of
+        Nothing -> throwM $ CabalFileNameInvalidPackageName $ toFilePath fp
+        Just x -> pure x
+  where clean = liftM reverse . strip . reverse
+        strip ('l':'a':'b':'a':'c':'.':xs) = pure xs
+        strip _ = throwM (CabalFileNameParseFail (toFilePath fp))
+
+-- | Resolve the directory, if it can't be resolved, warn for the user
+-- (purely to be helpful).
+resolveDirOrWarn :: FilePath.FilePath
+                 -> RIO GetPackageFileContext (Maybe (Path Abs Dir))
+resolveDirOrWarn = resolveOrWarn "Directory" f
+  where f p x = liftIO (forgivingAbsence (resolveDir p x)) >>= rejectMissingDir
+
+-- | Make the global autogen dir if Cabal version is new enough.
+packageAutogenDir :: Version -> Path Abs Dir -> Maybe (Path Abs Dir)
+packageAutogenDir cabalVer distDir
+    | cabalVer < mkVersion [2, 0] = Nothing
+    | otherwise = Just $ buildDir distDir </> relDirGlobalAutogen
+
+-- | Make the autogen dir.
+componentAutogenDir :: Version -> NamedComponent -> Path Abs Dir -> Path Abs Dir
+componentAutogenDir cabalVer component distDir =
+    componentBuildDir cabalVer component distDir </> relDirAutogen
+
+-- | Make the build dir. Note that Cabal >= 2.0 uses the
+-- 'componentBuildDir' above for some things.
+buildDir :: Path Abs Dir -> Path Abs Dir
+buildDir distDir = distDir </> relDirBuild
+
+-- NOTE: don't export this, only use it for valid paths based on
+-- component names.
+componentNameToDir :: Text -> Path Rel Dir
+componentNameToDir name =
+  fromMaybe (throw ComponentNotParsedBug) (parseRelDir (T.unpack name))
+
+-- | See 'Distribution.Simple.LocalBuildInfo.componentBuildDir'
+componentBuildDir :: Version -> NamedComponent -> Path Abs Dir -> Path Abs Dir
+componentBuildDir cabalVer component distDir
+    | cabalVer < mkVersion [2, 0] = buildDir distDir
+    | otherwise =
+        case component of
+            CLib -> buildDir distDir
+            CInternalLib name -> buildDir distDir </> componentNameToDir name
+            CExe name -> buildDir distDir </> componentNameToDir name
+            CTest name -> buildDir distDir </> componentNameToDir name
+            CBench name -> buildDir distDir </> componentNameToDir name
+
+-- Internal helper to define resolveFileOrWarn and resolveDirOrWarn
+resolveOrWarn :: Text
+              -> (Path Abs Dir -> String -> RIO GetPackageFileContext (Maybe a))
+              -> FilePath.FilePath
+              -> RIO GetPackageFileContext (Maybe a)
+resolveOrWarn subject resolver path =
+  do cwd <- liftIO getCurrentDir
+     file <- asks ctxFile
+     dir <- asks (parent . ctxFile)
+     result <- resolver dir path
+     when (isNothing result) $ warnMissingFile subject cwd path file
+     pure result
+
+warnMissingFile :: Text -> Path Abs Dir -> FilePath -> Path Abs File -> RIO GetPackageFileContext ()
+warnMissingFile subject cwd path fromFile =
+    prettyWarnL
+        [ fromString . T.unpack $ subject -- TODO: needs style?
+        , flow "listed in"
+        , maybe (pretty fromFile) pretty (stripProperPrefix cwd fromFile)
+        , flow "file does not exist:"
+        , style Dir . fromString $ path
+        ]

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -47,6 +47,7 @@ import           Stack.Types.Build
 import           Stack.Types.Config
 import           Stack.Types.NamedComponent
 import           Stack.Types.Package
+import           Stack.Types.PackageFile
 import           Stack.Types.SourceMap
 import           System.IO (putStrLn)
 import           System.IO.Temp (getCanonicalTemporaryDirectory)

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -4,10 +4,8 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
 
 -- | Dealing with Cabal.
 
@@ -17,7 +15,6 @@ module Stack.Package
   ,packageFromPackageDescription
   ,Package(..)
   ,PackageDescriptionPair(..)
-  ,GetPackageFiles(..)
   ,GetPackageOpts(..)
   ,PackageConfig(..)
   ,buildLogPath
@@ -27,21 +24,18 @@ module Stack.Package
   ,applyForceCustomBuild
   ) where
 
-import           Data.List (find, isPrefixOf, unzip)
+import           Data.List (unzip)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import           Distribution.CabalSpecVersion
 import           Distribution.Compiler
-import           Distribution.ModuleName (ModuleName)
-import qualified Distribution.ModuleName as Cabal
 import           Distribution.Package hiding (Package, packageName, packageVersion, PackageIdentifier)
 import           Distribution.PackageDescription hiding (FlagName)
 #if !MIN_VERSION_Cabal(3,8,1)
 import           Distribution.PackageDescription.Parsec
 #endif
 import           Distribution.Pretty (prettyShow)
-import           Distribution.Simple.Glob (matchDirFileGlob)
 #if MIN_VERSION_Cabal(3,8,1)
 import           Distribution.Simple.PackageDescription (readHookedBuildInfo)
 #endif
@@ -55,7 +49,6 @@ import qualified Distribution.Types.UnqualComponentName as Cabal
 import           Distribution.Utils.Path (getSymbolicPath)
 import           Distribution.Verbosity (silent)
 import           Distribution.Version (mkVersion, orLaterVersion, anyVersion)
-import qualified HiFileParser as Iface
 import           Path as FL hiding (replaceExtension)
 import           Path.Extra
 import           Path.IO hiding (findFiles)
@@ -69,40 +62,12 @@ import           Stack.Types.GhcPkgId
 import           Stack.Types.NamedComponent
 import           Stack.Types.Package
 import           Stack.Types.Version
-import qualified System.Directory as D (doesFileExist)
 import           System.FilePath (replaceExtension)
-import qualified System.FilePath as FilePath
-import           System.IO.Error
-import           RIO.Process
 import           RIO.PrettyPrint
-import qualified RIO.PrettyPrint as PP (Style (Module))
 import           Stack.Types.Dependency (DepValue(..), DepType (..))
-
-data Ctx = Ctx { ctxFile :: !(Path Abs File)
-               , ctxDistDir :: !(Path Abs Dir)
-               , ctxBuildConfig :: !BuildConfig
-               , ctxCabalVer :: !Version
-               }
-
-instance HasPlatform Ctx
-instance HasGHCVariant Ctx
-instance HasLogFunc Ctx where
-    logFuncL = configL.logFuncL
-instance HasRunner Ctx where
-    runnerL = configL.runnerL
-instance HasStylesUpdate Ctx where
-  stylesUpdateL = runnerL.stylesUpdateL
-instance HasTerm Ctx where
-  useColorL = runnerL.useColorL
-  termWidthL = runnerL.termWidthL
-instance HasConfig Ctx
-instance HasPantryConfig Ctx where
-    pantryConfigL = configL.pantryConfigL
-instance HasProcessContext Ctx where
-    processContextL = configL.processContextL
-instance HasBuildConfig Ctx where
-    buildConfigL = lens ctxBuildConfig (\x y -> x { ctxBuildConfig = y })
-
+import           Stack.Types.PackageFile (GetPackageFileContext(..), DotCabalPath, GetPackageFiles(..))
+import           Stack.PackageFile (packageDescModulesAndFiles)
+import           Stack.ComponentFile
 -- | Read @<package>.buildinfo@ ancillary files produced by some Setup.hs hooks.
 -- The file includes Cabal file syntax to be merged into the package description
 -- derived from the package's Cabal file.
@@ -222,7 +187,7 @@ packageFromPackageDescription packageConfig pkgFlags (PackageDescriptionPair pkg
              cabalVer <- view cabalVersionL
              (componentModules,componentFiles,dataFiles',warnings) <-
                  runRIO
-                     (Ctx cabalfp distDir bc cabalVer)
+                     (GetPackageFileContext cabalfp distDir bc cabalVer)
                      (packageDescModulesAndFiles pkg)
              setupFiles <-
                  if buildType pkg == Custom
@@ -470,53 +435,6 @@ makeObjectFilePathFromC cabalDir namedComponent distDir cFilePath = do
         parseRelFile (replaceExtension (toFilePath relCFilePath) "o")
     pure (componentOutputDir namedComponent distDir </> relOFilePath)
 
--- | Make the global autogen dir if Cabal version is new enough.
-packageAutogenDir :: Version -> Path Abs Dir -> Maybe (Path Abs Dir)
-packageAutogenDir cabalVer distDir
-    | cabalVer < mkVersion [2, 0] = Nothing
-    | otherwise = Just $ buildDir distDir </> relDirGlobalAutogen
-
--- | Make the autogen dir.
-componentAutogenDir :: Version -> NamedComponent -> Path Abs Dir -> Path Abs Dir
-componentAutogenDir cabalVer component distDir =
-    componentBuildDir cabalVer component distDir </> relDirAutogen
-
--- | See 'Distribution.Simple.LocalBuildInfo.componentBuildDir'
-componentBuildDir :: Version -> NamedComponent -> Path Abs Dir -> Path Abs Dir
-componentBuildDir cabalVer component distDir
-    | cabalVer < mkVersion [2, 0] = buildDir distDir
-    | otherwise =
-        case component of
-            CLib -> buildDir distDir
-            CInternalLib name -> buildDir distDir </> componentNameToDir name
-            CExe name -> buildDir distDir </> componentNameToDir name
-            CTest name -> buildDir distDir </> componentNameToDir name
-            CBench name -> buildDir distDir </> componentNameToDir name
-
--- | The directory where generated files are put like .o or .hs (from .x files).
-componentOutputDir :: NamedComponent -> Path Abs Dir -> Path Abs Dir
-componentOutputDir namedComponent distDir =
-    case namedComponent of
-        CLib -> buildDir distDir
-        CInternalLib name -> makeTmp name
-        CExe name -> makeTmp name
-        CTest name -> makeTmp name
-        CBench name -> makeTmp name
-  where
-    makeTmp name =
-      buildDir distDir </> componentNameToDir (name <> "/" <> name <> "-tmp")
-
--- | Make the build dir. Note that Cabal >= 2.0 uses the
--- 'componentBuildDir' above for some things.
-buildDir :: Path Abs Dir -> Path Abs Dir
-buildDir distDir = distDir </> relDirBuild
-
--- NOTE: don't export this, only use it for valid paths based on
--- component names.
-componentNameToDir :: Text -> Path Rel Dir
-componentNameToDir name =
-  fromMaybe (impureThrow ComponentNotParsedBug) (parseRelDir (T.unpack name))
-
 -- | Get all dependencies of the package (buildable targets only).
 --
 -- Note that for Cabal versions 1.22 and earlier, there is a bug where
@@ -639,199 +557,6 @@ allBuildInfo' pkg_descr = [ bi | lib <- allLibraries pkg_descr
                        ++ [ bi | tst <- benchmarks pkg_descr
                                , let bi = benchmarkBuildInfo tst
                                , buildable bi ]
-
--- | Get all files referenced by the package.
-packageDescModulesAndFiles
-    :: PackageDescription
-    -> RIO Ctx (Map NamedComponent (Map ModuleName (Path Abs File)), Map NamedComponent [DotCabalPath], Set (Path Abs File), [PackageWarning])
-packageDescModulesAndFiles pkg = do
-    (libraryMods,libDotCabalFiles,libWarnings) <-
-        maybe
-            (pure (M.empty, M.empty, []))
-            (asModuleAndFileMap libComponent libraryFiles)
-            (library pkg)
-    (subLibrariesMods,subLibDotCabalFiles,subLibWarnings) <-
-        liftM
-            foldTuples
-            (mapM
-                 (asModuleAndFileMap internalLibComponent libraryFiles)
-                 (subLibraries pkg))
-    (executableMods,exeDotCabalFiles,exeWarnings) <-
-        liftM
-            foldTuples
-            (mapM
-                 (asModuleAndFileMap exeComponent executableFiles)
-                 (executables pkg))
-    (testMods,testDotCabalFiles,testWarnings) <-
-        liftM
-            foldTuples
-            (mapM (asModuleAndFileMap testComponent testFiles) (testSuites pkg))
-    (benchModules,benchDotCabalPaths,benchWarnings) <-
-        liftM
-            foldTuples
-            (mapM
-                 (asModuleAndFileMap benchComponent benchmarkFiles)
-                 (benchmarks pkg))
-    dfiles <- resolveGlobFiles (specVersion pkg)
-                    (extraSrcFiles pkg
-                        ++ map (dataDir pkg FilePath.</>) (dataFiles pkg))
-    let modules = libraryMods <> subLibrariesMods <> executableMods <> testMods <> benchModules
-        files =
-            libDotCabalFiles <> subLibDotCabalFiles <> exeDotCabalFiles <> testDotCabalFiles <>
-            benchDotCabalPaths
-        warnings = libWarnings <> subLibWarnings <> exeWarnings <> testWarnings <> benchWarnings
-    pure (modules, files, dfiles, warnings)
-  where
-    libComponent = const CLib
-    internalLibComponent = CInternalLib . T.pack . maybe "" Cabal.unUnqualComponentName . libraryNameString . libName
-    exeComponent = CExe . T.pack . Cabal.unUnqualComponentName . exeName
-    testComponent = CTest . T.pack . Cabal.unUnqualComponentName . testName
-    benchComponent = CBench . T.pack . Cabal.unUnqualComponentName . benchmarkName
-    asModuleAndFileMap label f lib = do
-        (a,b,c) <- f (label lib) lib
-        pure (M.singleton (label lib) a, M.singleton (label lib) b, c)
-    foldTuples = foldl' (<>) (M.empty, M.empty, [])
-
--- | Resolve globbing of files (e.g. data files) to absolute paths.
-resolveGlobFiles
-  :: CabalSpecVersion -- ^ Cabal file version
-  -> [String]
-  -> RIO Ctx (Set (Path Abs File))
-resolveGlobFiles cabalFileVersion =
-    liftM (S.fromList . catMaybes . concat) .
-    mapM resolve
-  where
-    resolve name =
-        if '*' `elem` name
-            then explode name
-            else liftM pure (resolveFileOrWarn name)
-    explode name = do
-        dir <- asks (parent . ctxFile)
-        names <-
-            matchDirFileGlob'
-                (FL.toFilePath dir)
-                name
-        mapM resolveFileOrWarn names
-    matchDirFileGlob' dir glob =
-        catch
-            (liftIO (matchDirFileGlob minBound cabalFileVersion dir glob))
-            (\(e :: IOException) ->
-                  if isUserError e
-                      then do
-                          prettyWarnL
-                              [ flow "Wildcard does not match any files:"
-                              , style File $ fromString glob
-                              , line <> flow "in directory:"
-                              , style Dir $ fromString dir
-                              ]
-                          pure []
-                      else throwIO e)
-
--- | Get all files referenced by the benchmark.
-benchmarkFiles
-    :: NamedComponent
-    -> Benchmark
-    -> RIO Ctx (Map ModuleName (Path Abs File), [DotCabalPath], [PackageWarning])
-benchmarkFiles component bench = do
-    resolveComponentFiles component build names
-  where
-    names = bnames <> exposed
-    exposed =
-        case benchmarkInterface bench of
-            BenchmarkExeV10 _ fp -> [DotCabalMain fp]
-            BenchmarkUnsupported _ -> []
-    bnames = map DotCabalModule (otherModules build)
-    build = benchmarkBuildInfo bench
-
--- | Get all files referenced by the test.
-testFiles
-    :: NamedComponent
-    -> TestSuite
-    -> RIO Ctx (Map ModuleName (Path Abs File), [DotCabalPath], [PackageWarning])
-testFiles component test = do
-    resolveComponentFiles component build names
-  where
-    names = bnames <> exposed
-    exposed =
-        case testInterface test of
-            TestSuiteExeV10 _ fp -> [DotCabalMain fp]
-            TestSuiteLibV09 _ mn -> [DotCabalModule mn]
-            TestSuiteUnsupported _ -> []
-    bnames = map DotCabalModule (otherModules build)
-    build = testBuildInfo test
-
--- | Get all files referenced by the executable.
-executableFiles
-    :: NamedComponent
-    -> Executable
-    -> RIO Ctx (Map ModuleName (Path Abs File), [DotCabalPath], [PackageWarning])
-executableFiles component exe = do
-    resolveComponentFiles component build names
-  where
-    build = buildInfo exe
-    names =
-        map DotCabalModule (otherModules build) ++
-        [DotCabalMain (modulePath exe)]
-
--- | Get all files referenced by the library.
-libraryFiles
-    :: NamedComponent
-    -> Library
-    -> RIO Ctx (Map ModuleName (Path Abs File), [DotCabalPath], [PackageWarning])
-libraryFiles component lib = do
-    resolveComponentFiles component build names
-  where
-    build = libBuildInfo lib
-    names = bnames ++ exposed
-    exposed = map DotCabalModule (exposedModules lib)
-    bnames = map DotCabalModule (otherModules build)
-
--- | Get all files referenced by the component.
-resolveComponentFiles
-    :: NamedComponent
-    -> BuildInfo
-    -> [DotCabalDescriptor]
-    -> RIO Ctx (Map ModuleName (Path Abs File), [DotCabalPath], [PackageWarning])
-resolveComponentFiles component build names = do
-    dirs <- mapMaybeM (resolveDirOrWarn . getSymbolicPath) (hsSourceDirs build)
-    dir <- asks (parent . ctxFile)
-    agdirs <- autogenDirs
-    (modules,files,warnings) <-
-        resolveFilesAndDeps
-            component
-            ((if null dirs then [dir] else dirs) ++ agdirs)
-            names
-    cfiles <- buildOtherSources build
-    pure (modules, files <> cfiles, warnings)
-  where
-    autogenDirs = do
-      cabalVer <- asks ctxCabalVer
-      distDir <- asks ctxDistDir
-      let compDir = componentAutogenDir cabalVer component distDir
-          pkgDir = maybeToList $ packageAutogenDir cabalVer distDir
-      filterM doesDirExist $ compDir : pkgDir
-
--- | Get all C sources and extra source files in a build.
-buildOtherSources :: BuildInfo -> RIO Ctx [DotCabalPath]
-buildOtherSources build = do
-    cwd <- liftIO getCurrentDir
-    dir <- asks (parent . ctxFile)
-    file <- asks ctxFile
-    let resolveDirFiles files toCabalPath =
-            forMaybeM files $ \fp -> do
-                result <- resolveDirFile dir fp
-                case result of
-                    Nothing -> do
-                        warnMissingFile "File" cwd fp file
-                        pure Nothing
-                    Just p -> pure $ Just (toCabalPath p)
-    csources <- resolveDirFiles (cSources build) DotCabalCFilePath
-    jsources <- resolveDirFiles (targetJsSources build) DotCabalFilePath
-    pure (csources <> jsources)
-
--- | Get the target's JS sources.
-targetJsSources :: BuildInfo -> [FilePath]
-targetJsSources = jsSources
 
 -- | A pair of package descriptions: one which modified the buildable
 -- values of test suites and benchmarks depending on whether they are
@@ -994,288 +719,6 @@ resolveConditions rc addDeps (CondNode lib deps cs) = basic <> children
                         (GHC, ACGhc vghc) -> vghc `withinRange` range
                         _ -> False
 
--- | Try to resolve the list of base names in the given directory by
--- looking for unique instances of base names applied with the given
--- extensions, plus find any of their module and TemplateHaskell
--- dependencies.
-resolveFilesAndDeps
-    :: NamedComponent       -- ^ Package component name
-    -> [Path Abs Dir]       -- ^ Directories to look in.
-    -> [DotCabalDescriptor] -- ^ Base names.
-    -> RIO Ctx (Map ModuleName (Path Abs File),[DotCabalPath],[PackageWarning])
-resolveFilesAndDeps component dirs names0 = do
-    (dotCabalPaths, foundModules, missingModules) <- loop names0 S.empty
-    warnings <- liftM2 (++) (warnUnlisted foundModules) (warnMissing missingModules)
-    pure (foundModules, dotCabalPaths, warnings)
-  where
-    loop [] _ = pure ([], M.empty, [])
-    loop names doneModules0 = do
-        resolved <- resolveFiles dirs names
-        let foundFiles = mapMaybe snd resolved
-            foundModules = mapMaybe toResolvedModule resolved
-            missingModules = mapMaybe toMissingModule resolved
-        pairs <- mapM (getDependencies component dirs) foundFiles
-        let doneModules =
-                S.union
-                    doneModules0
-                    (S.fromList (mapMaybe dotCabalModule names))
-            moduleDeps = S.unions (map fst pairs)
-            thDepFiles = concatMap snd pairs
-            modulesRemaining = S.difference moduleDeps doneModules
-        -- Ignore missing modules discovered as dependencies - they may
-        -- have been deleted.
-        (resolvedFiles, resolvedModules, _) <-
-            loop (map DotCabalModule (S.toList modulesRemaining)) doneModules
-        pure
-            ( nubOrd $ foundFiles <> map DotCabalFilePath thDepFiles <> resolvedFiles
-            , M.union
-                  (M.fromList foundModules)
-                  resolvedModules
-            , missingModules)
-    warnUnlisted foundModules = do
-        let unlistedModules =
-                foundModules `M.difference`
-                M.fromList (mapMaybe (fmap (, ()) . dotCabalModule) names0)
-        pure $
-            if M.null unlistedModules
-                then []
-                else [ UnlistedModulesWarning
-                           component
-                           (map fst (M.toList unlistedModules))]
-    warnMissing _missingModules = do
-        pure []
-        -- TODO: bring this back - see
-        -- https://github.com/commercialhaskell/stack/issues/2649
-        {-
-        cabalfp <- asks ctxFile
-        pure $
-            if null missingModules
-               then []
-               else [ MissingModulesWarning
-                           cabalfp
-                           component
-                           missingModules]
-        -}
-    -- TODO: In usages of toResolvedModule / toMissingModule, some sort
-    -- of map + partition would probably be better.
-    toResolvedModule
-        :: (DotCabalDescriptor, Maybe DotCabalPath)
-        -> Maybe (ModuleName, Path Abs File)
-    toResolvedModule (DotCabalModule mn, Just (DotCabalModulePath fp)) =
-        Just (mn, fp)
-    toResolvedModule _ =
-        Nothing
-    toMissingModule
-        :: (DotCabalDescriptor, Maybe DotCabalPath)
-        -> Maybe ModuleName
-    toMissingModule (DotCabalModule mn, Nothing) =
-        Just mn
-    toMissingModule _ =
-        Nothing
-
--- | Get the dependencies of a Haskell module file.
-getDependencies
-    :: NamedComponent -> [Path Abs Dir] -> DotCabalPath -> RIO Ctx (Set ModuleName, [Path Abs File])
-getDependencies component dirs dotCabalPath =
-    case dotCabalPath of
-        DotCabalModulePath resolvedFile -> readResolvedHi resolvedFile
-        DotCabalMainPath resolvedFile -> readResolvedHi resolvedFile
-        DotCabalFilePath{} -> pure (S.empty, [])
-        DotCabalCFilePath{} -> pure (S.empty, [])
-  where
-    readResolvedHi resolvedFile = do
-        dumpHIDir <- componentOutputDir component <$> asks ctxDistDir
-        dir <- asks (parent . ctxFile)
-        let sourceDir = fromMaybe dir $ find (`isProperPrefixOf` resolvedFile) dirs
-            stripSourceDir d = stripProperPrefix d resolvedFile
-        case stripSourceDir sourceDir of
-            Nothing -> pure (S.empty, [])
-            Just fileRel -> do
-                let hiPath =
-                        FilePath.replaceExtension
-                            (toFilePath (dumpHIDir </> fileRel))
-                            ".hi"
-                dumpHIExists <- liftIO $ D.doesFileExist hiPath
-                if dumpHIExists
-                    then parseHI hiPath
-                    else pure (S.empty, [])
-
--- | Parse a .hi file into a set of modules and files.
-parseHI
-    :: FilePath -> RIO Ctx (Set ModuleName, [Path Abs File])
-parseHI hiPath = do
-  dir <- asks (parent . ctxFile)
-  result <- liftIO $ Iface.fromFile hiPath `catchAnyDeep` \e -> pure (Left (show e))
-  case result of
-    Left msg -> do
-      prettyStackDevL
-        [ flow "Failed to decode module interface:"
-        , style File $ fromString hiPath
-        , flow "Decoding failure:"
-        , style Error $ fromString msg
-        ]
-      pure (S.empty, [])
-    Right iface -> do
-      let moduleNames = fmap (fromString . T.unpack . decodeUtf8Lenient . fst) .
-                        Iface.unList . Iface.dmods . Iface.deps
-          resolveFileDependency file = do
-            resolved <- liftIO (forgivingAbsence (resolveFile dir file)) >>= rejectMissingFile
-            when (isNothing resolved) $
-              prettyWarnL
-              [ flow "Dependent file listed in:"
-              , style File $ fromString hiPath
-              , flow "does not exist:"
-              , style File $ fromString file
-              ]
-            pure resolved
-          resolveUsages = traverse (resolveFileDependency . Iface.unUsage) . Iface.unList . Iface.usage
-      resolvedUsages <- catMaybes <$> resolveUsages iface
-      pure (S.fromList $ moduleNames iface, resolvedUsages)
-
--- | Try to resolve the list of base names in the given directory by
--- looking for unique instances of base names applied with the given
--- extensions.
-resolveFiles
-    :: [Path Abs Dir] -- ^ Directories to look in.
-    -> [DotCabalDescriptor] -- ^ Base names.
-    -> RIO Ctx [(DotCabalDescriptor, Maybe DotCabalPath)]
-resolveFiles dirs names =
-    forM names (\name -> liftM (name, ) (findCandidate dirs name))
-
--- | Parse a package name from a file path.
-parsePackageNameFromFilePath :: MonadThrow m => Path a File -> m PackageName
-parsePackageNameFromFilePath fp = do
-    base <- clean $ toFilePath $ filename fp
-    case parsePackageName base of
-        Nothing -> throwM $ CabalFileNameInvalidPackageName $ toFilePath fp
-        Just x -> pure x
-  where clean = liftM reverse . strip . reverse
-        strip ('l':'a':'b':'a':'c':'.':xs) = pure xs
-        strip _ = throwM (CabalFileNameParseFail (toFilePath fp))
-
--- | Find a candidate for the given module-or-filename from the list
--- of directories and given extensions.
-findCandidate
-    :: [Path Abs Dir]
-    -> DotCabalDescriptor
-    -> RIO Ctx (Maybe DotCabalPath)
-findCandidate dirs name = do
-    pkg <- asks ctxFile >>= parsePackageNameFromFilePath
-    customPreprocessorExts <- view $ configL . to configCustomPreprocessorExts
-    let haskellPreprocessorExts = haskellDefaultPreprocessorExts ++ customPreprocessorExts
-    candidates <- liftIO $ makeNameCandidates haskellPreprocessorExts
-    case candidates of
-        [candidate] -> pure (Just (cons candidate))
-        [] -> do
-            case name of
-                DotCabalModule mn
-                  | display mn /= paths_pkg pkg -> logPossibilities dirs mn
-                _ -> pure ()
-            pure Nothing
-        (candidate:rest) -> do
-            warnMultiple name candidate rest
-            pure (Just (cons candidate))
-  where
-    cons =
-        case name of
-            DotCabalModule{} -> DotCabalModulePath
-            DotCabalMain{} -> DotCabalMainPath
-            DotCabalFile{} -> DotCabalFilePath
-            DotCabalCFile{} -> DotCabalCFilePath
-    paths_pkg pkg = "Paths_" ++ packageNameString pkg
-    makeNameCandidates haskellPreprocessorExts =
-        liftM (nubOrd . concat) (mapM (makeDirCandidates haskellPreprocessorExts) dirs)
-    makeDirCandidates :: [Text]
-                      -> Path Abs Dir
-                      -> IO [Path Abs File]
-    makeDirCandidates haskellPreprocessorExts dir =
-        case name of
-            DotCabalMain fp -> resolveCandidate dir fp
-            DotCabalFile fp -> resolveCandidate dir fp
-            DotCabalCFile fp -> resolveCandidate dir fp
-            DotCabalModule mn -> do
-              let perExt ext =
-                     resolveCandidate dir (Cabal.toFilePath mn ++ "." ++ T.unpack ext)
-              withHaskellExts <- mapM perExt haskellFileExts
-              withPPExts <- mapM perExt haskellPreprocessorExts
-              pure $
-                case (concat withHaskellExts, concat withPPExts) of
-                  -- If we have exactly 1 Haskell extension and exactly
-                  -- 1 preprocessor extension, assume the former file is
-                  -- generated from the latter
-                  --
-                  -- See https://github.com/commercialhaskell/stack/issues/4076
-                  ([_], [y]) -> [y]
-
-                  -- Otherwise, return everything
-                  (xs, ys) -> xs ++ ys
-    resolveCandidate dir = fmap maybeToList . resolveDirFile dir
-
--- | Resolve file as a child of a specified directory, symlinks
--- don't get followed.
-resolveDirFile
-    :: (MonadIO m, MonadThrow m)
-    => Path Abs Dir -> FilePath.FilePath -> m (Maybe (Path Abs File))
-resolveDirFile x y = do
-    -- The standard canonicalizePath does not work for this case
-    p <- parseCollapsedAbsFile (toFilePath x FilePath.</> y)
-    exists <- doesFileExist p
-    pure $ if exists then Just p else Nothing
-
--- | Warn the user that multiple candidates are available for an
--- entry, but that we picked one anyway and continued.
-warnMultiple
-    :: DotCabalDescriptor -> Path b t -> [Path b t] -> RIO Ctx ()
-warnMultiple name candidate rest =
-    -- TODO: figure out how to style 'name' and the dispOne stuff
-    prettyWarnL
-        [ flow "There were multiple candidates for the Cabal entry"
-        , fromString . showName $ name
-        , line <> bulletedList (map dispOne (candidate:rest))
-        , line <> flow "picking:"
-        , dispOne candidate
-        ]
-  where showName (DotCabalModule name') = display name'
-        showName (DotCabalMain fp) = fp
-        showName (DotCabalFile fp) = fp
-        showName (DotCabalCFile fp) = fp
-        dispOne = fromString . toFilePath
-          -- TODO: figure out why dispOne can't be just `display`
-          --       (remove the .hlint.yaml exception if it can be)
-
--- | Log that we couldn't find a candidate, but there are
--- possibilities for custom preprocessor extensions.
---
--- For example: .erb for a Ruby file might exist in one of the
--- directories.
-logPossibilities
-    :: HasTerm env
-    => [Path Abs Dir] -> ModuleName -> RIO env ()
-logPossibilities dirs mn = do
-    possibilities <- liftM concat (makePossibilities mn)
-    unless (null possibilities) $ prettyWarnL
-        [ flow "Unable to find a known candidate for the Cabal entry"
-        , (style PP.Module . fromString $ display mn) <> ","
-        , flow "but did find:"
-        , line <> bulletedList (map pretty possibilities)
-        , flow "If you are using a custom preprocessor for this module"
-        , flow "with its own file extension, consider adding the extension"
-        , flow "to the 'custom-preprocessor-extensions' field in stack.yaml."
-        ]
-  where
-    makePossibilities name =
-        mapM
-            (\dir ->
-                  do (_,files) <- listDir dir
-                     pure
-                         (map
-                              filename
-                              (filter
-                                   (isPrefixOf (display name) .
-                                    toFilePath . filename)
-                                   files)))
-            dirs
-
 -- | Path for the package's build log.
 buildLogPath :: (MonadReader env m, HasBuildConfig env, MonadThrow m)
              => Package -> Maybe String -> m (Path Abs File)
@@ -1286,43 +729,6 @@ buildLogPath package' msuffix = do
     packageIdentifierString (packageIdentifier package') :
     maybe id (\suffix -> ("-" :) . (suffix :)) msuffix [".log"]
   pure $ stack </> relDirLogs </> fp
-
--- Internal helper to define resolveFileOrWarn and resolveDirOrWarn
-resolveOrWarn :: Text
-              -> (Path Abs Dir -> String -> RIO Ctx (Maybe a))
-              -> FilePath.FilePath
-              -> RIO Ctx (Maybe a)
-resolveOrWarn subject resolver path =
-  do cwd <- liftIO getCurrentDir
-     file <- asks ctxFile
-     dir <- asks (parent . ctxFile)
-     result <- resolver dir path
-     when (isNothing result) $ warnMissingFile subject cwd path file
-     pure result
-
-warnMissingFile :: Text -> Path Abs Dir -> FilePath -> Path Abs File -> RIO Ctx ()
-warnMissingFile subject cwd path fromFile =
-    prettyWarnL
-        [ fromString . T.unpack $ subject -- TODO: needs style?
-        , flow "listed in"
-        , maybe (pretty fromFile) pretty (stripProperPrefix cwd fromFile)
-        , flow "file does not exist:"
-        , style Dir . fromString $ path
-        ]
-
--- | Resolve the file, if it can't be resolved, warn for the user
--- (purely to be helpful).
-resolveFileOrWarn :: FilePath.FilePath
-                  -> RIO Ctx (Maybe (Path Abs File))
-resolveFileOrWarn = resolveOrWarn "File" f
-  where f p x = liftIO (forgivingAbsence (resolveFile p x)) >>= rejectMissingFile
-
--- | Resolve the directory, if it can't be resolved, warn for the user
--- (purely to be helpful).
-resolveDirOrWarn :: FilePath.FilePath
-                 -> RIO Ctx (Maybe (Path Abs Dir))
-resolveDirOrWarn = resolveOrWarn "Directory" f
-  where f p x = liftIO (forgivingAbsence (resolveDir p x)) >>= rejectMissingDir
 
     {- FIXME
 -- | Create a 'ProjectPackage' from a directory containing a package.

--- a/src/Stack/PackageFile.hs
+++ b/src/Stack/PackageFile.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+
+-- | A module which gathers all package level file gathering logic.
+module Stack.PackageFile
+    (packageDescModulesAndFiles
+    )
+    where
+
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+import           Distribution.ModuleName (ModuleName)
+import qualified Distribution.Types.UnqualComponentName as Cabal
+import           Distribution.PackageDescription hiding (FlagName)
+import           Path as FL hiding (replaceExtension)
+import           Path.Extra
+import           Path.IO hiding (findFiles)
+import           Stack.Prelude hiding (Display (..))
+import           Stack.Types.NamedComponent
+import qualified System.FilePath as FilePath
+import           RIO.PrettyPrint
+import           Stack.Types.PackageFile (GetPackageFileContext(..), DotCabalPath(..), PackageWarning(..))
+import           Distribution.CabalSpecVersion (CabalSpecVersion)
+import           Distribution.Simple.Glob (matchDirFileGlob)
+import           System.IO.Error (isUserError)
+import           Stack.ComponentFile
+
+-- | Resolve the file, if it can't be resolved, warn for the user
+-- (purely to be helpful).
+resolveFileOrWarn :: FilePath.FilePath
+                  -> RIO GetPackageFileContext (Maybe (Path Abs File))
+resolveFileOrWarn = resolveOrWarn "File" f
+  where f p x = liftIO (forgivingAbsence (resolveFile p x)) >>= rejectMissingFile
+
+-- | Get all files referenced by the package.
+packageDescModulesAndFiles
+    :: PackageDescription
+    -> RIO GetPackageFileContext (Map NamedComponent (Map ModuleName (Path Abs File)), Map NamedComponent [DotCabalPath], Set (Path Abs File), [PackageWarning])
+packageDescModulesAndFiles pkg = do
+    (libraryMods,libDotCabalFiles,libWarnings) <-
+        maybe
+            (pure (M.empty, M.empty, []))
+            (asModuleAndFileMap libComponent libraryFiles)
+            (library pkg)
+    (subLibrariesMods,subLibDotCabalFiles,subLibWarnings) <-
+        liftM
+            foldTuples
+            (mapM
+                 (asModuleAndFileMap internalLibComponent libraryFiles)
+                 (subLibraries pkg))
+    (executableMods,exeDotCabalFiles,exeWarnings) <-
+        liftM
+            foldTuples
+            (mapM
+                 (asModuleAndFileMap exeComponent executableFiles)
+                 (executables pkg))
+    (testMods,testDotCabalFiles,testWarnings) <-
+        liftM
+            foldTuples
+            (mapM (asModuleAndFileMap testComponent testFiles) (testSuites pkg))
+    (benchModules,benchDotCabalPaths,benchWarnings) <-
+        liftM
+            foldTuples
+            (mapM
+                 (asModuleAndFileMap benchComponent benchmarkFiles)
+                 (benchmarks pkg))
+    dfiles <- resolveGlobFiles (specVersion pkg)
+                    (extraSrcFiles pkg
+                        ++ map (dataDir pkg FilePath.</>) (dataFiles pkg))
+    let modules = libraryMods <> subLibrariesMods <> executableMods <> testMods <> benchModules
+        files =
+            libDotCabalFiles <> subLibDotCabalFiles <> exeDotCabalFiles <> testDotCabalFiles <>
+            benchDotCabalPaths
+        warnings = libWarnings <> subLibWarnings <> exeWarnings <> testWarnings <> benchWarnings
+    pure (modules, files, dfiles, warnings)
+  where
+    libComponent = const CLib
+    internalLibComponent = CInternalLib . T.pack . maybe "" Cabal.unUnqualComponentName . libraryNameString . libName
+    exeComponent = CExe . T.pack . Cabal.unUnqualComponentName . exeName
+    testComponent = CTest . T.pack . Cabal.unUnqualComponentName . testName
+    benchComponent = CBench . T.pack . Cabal.unUnqualComponentName . benchmarkName
+    asModuleAndFileMap label f lib = do
+        (a,b,c) <- f (label lib) lib
+        pure (M.singleton (label lib) a, M.singleton (label lib) b, c)
+    foldTuples = foldl' (<>) (M.empty, M.empty, [])
+
+
+-- | Resolve globbing of files (e.g. data files) to absolute paths.
+resolveGlobFiles
+  :: CabalSpecVersion -- ^ Cabal file version
+  -> [String]
+  -> RIO GetPackageFileContext (Set (Path Abs File))
+resolveGlobFiles cabalFileVersion =
+    liftM (S.fromList . catMaybes . concat) .
+    mapM resolve
+  where
+    resolve name =
+        if '*' `elem` name
+            then explode name
+            else liftM pure (resolveFileOrWarn name)
+    explode name = do
+        dir <- asks (parent . ctxFile)
+        names <-
+            matchDirFileGlob'
+                (FL.toFilePath dir)
+                name
+        mapM resolveFileOrWarn names
+    matchDirFileGlob' dir glob =
+        catch
+            (liftIO (matchDirFileGlob minBound cabalFileVersion dir glob))
+            (\(e :: IOException) ->
+                  if isUserError e
+                      then do
+                          prettyWarnL
+                              [ flow "Wildcard does not match any files:"
+                              , style File $ fromString glob
+                              , line <> flow "in directory:"
+                              , style Dir $ fromString dir
+                              ]
+                          pure []
+                      else throwIO e)

--- a/src/Stack/Types/PackageFile.hs
+++ b/src/Stack/Types/PackageFile.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE NoImplicitPrelude          #-}
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE RankNTypes                 #-}
+
+-- | The facility for retrieving all files from the main stack "Stack.Types.Package" type.
+-- This was moved into its own module for allowing component-level file gathering without
+-- circular dependency at the Package level.
+module Stack.Types.PackageFile
+  (GetPackageFileContext(..)
+  ,DotCabalPath(..)
+  ,DotCabalDescriptor(..)
+  ,GetPackageFiles(..)
+  ,PackageWarning(..)
+  )
+  where
+
+import           Stack.Prelude
+import           Stack.Types.Config (BuildConfig, HasBuildConfig(..), HasConfig(..), HasGHCVariant, HasPlatform, HasRunner(..), HasEnvConfig)
+import           RIO.PrettyPrint (HasTerm(..), HasStylesUpdate(..))
+import           RIO.Process (HasProcessContext (processContextL))
+import           Distribution.ModuleName (ModuleName)
+import Stack.Types.NamedComponent (NamedComponent)
+
+data GetPackageFileContext = GetPackageFileContext { ctxFile :: !(Path Abs File)
+               , ctxDistDir :: !(Path Abs Dir)
+               , ctxBuildConfig :: !BuildConfig
+               , ctxCabalVer :: !Version
+               }
+
+instance HasPlatform GetPackageFileContext
+instance HasGHCVariant GetPackageFileContext
+instance HasLogFunc GetPackageFileContext where
+    logFuncL = configL.logFuncL
+instance HasRunner GetPackageFileContext where
+    runnerL = configL.runnerL
+instance HasStylesUpdate GetPackageFileContext where
+  stylesUpdateL = runnerL.stylesUpdateL
+instance HasTerm GetPackageFileContext where
+  useColorL = runnerL.useColorL
+  termWidthL = runnerL.termWidthL
+instance HasConfig GetPackageFileContext
+instance HasPantryConfig GetPackageFileContext where
+    pantryConfigL = configL.pantryConfigL
+instance HasProcessContext GetPackageFileContext where
+    processContextL = configL.processContextL
+instance HasBuildConfig GetPackageFileContext where
+    buildConfigL = lens ctxBuildConfig (\x y -> x { ctxBuildConfig = y })
+
+-- | A path resolved from the Cabal file, which is either main-is or
+-- an exposed/internal/referenced module.
+data DotCabalPath
+    = DotCabalModulePath !(Path Abs File)
+    | DotCabalMainPath !(Path Abs File)
+    | DotCabalFilePath !(Path Abs File)
+    | DotCabalCFilePath !(Path Abs File)
+    deriving (Eq,Ord,Show)
+
+
+-- | A descriptor from a Cabal file indicating one of the following:
+--
+-- exposed-modules: Foo
+-- other-modules: Foo
+-- or
+-- main-is: Foo.hs
+--
+data DotCabalDescriptor
+    = DotCabalModule !ModuleName
+    | DotCabalMain !FilePath
+    | DotCabalFile !FilePath
+    | DotCabalCFile !FilePath
+    deriving (Eq,Ord,Show)
+
+-- | Files that the package depends on, relative to package directory.
+-- Argument is the location of the Cabal file
+newtype GetPackageFiles = GetPackageFiles
+    { getPackageFiles :: forall env. HasEnvConfig env
+                      => Path Abs File
+                      -> RIO env
+                           (Map NamedComponent (Map ModuleName (Path Abs File))
+                           ,Map NamedComponent [DotCabalPath]
+                           ,Set (Path Abs File)
+                           ,[PackageWarning])
+    }
+instance Show GetPackageFiles where
+    show _ = "<GetPackageFiles>"
+
+-- | Warning generated when reading a package
+data PackageWarning
+    = UnlistedModulesWarning NamedComponent [ModuleName]
+      -- ^ Modules found that are not listed in Cabal file
+
+    -- TODO: bring this back - see
+    -- https://github.com/commercialhaskell/stack/issues/2649
+    {-
+    | MissingModulesWarning (Path Abs File) (Maybe String) [ModuleName]
+      -- ^ Modules not found in file system, which are listed in Cabal file
+    -}

--- a/stack.cabal
+++ b/stack.cabal
@@ -219,8 +219,11 @@ library
       Paths_stack
   other-modules:
       Path.Extended
+      Stack.ComponentFile
+      Stack.PackageFile
       Stack.Types.Cache
       Stack.Types.Dependency
+      Stack.Types.PackageFile
   autogen-modules:
       Paths_stack
   hs-source-dirs:


### PR DESCRIPTION
Ok so @mpilgrem, this is also a preparation work for #5920.

The idea is that, bringing a proper component design to the Package type will allow us to grab files by component instead of doing the current package level file gathering which consists of :

- When processing the raw Cabal 'PackageDescription' data, create a function which holds a reference to this type.
- When calling the function iterate on many cabal based info from the retained 'PackageDescription', these iterations are mostly at the component level.

This is at a very high level what the 'packageDescModulesAndFiles' is doing.

Now, I didn't want to do all this Module creation and code moving, but I faced very compelling reasons to do so while reviewing the code :

- Splitting file gathering by component (while keeping the overall existing architecture and logic) imposed the use of many utility functions wich were in the Package module. importing them in a (incoming) Component module or in a ComponentFile module created circular imports.
- The File gathering logic is not using any of the overall Package type design and values, so it's weird to keep this in the same place to begin with.
- The file gathering logic take a huge place in the Package module wihtout any hierarchy for functions rendering the overall Package module hard to navigate.

Overall I don't think the current design for file gathering logic is legitimate. Once I bring proper structured components data with BuildInfo and all, I expect that the packageFiles field of the Package type can be simplified to a simple function taking a Package (instead of a field). But this is a side note, and we'll go step by step.

Something like :
```hs
-- Assuming Package has all the cabal level info needed for gathering the files
getPackageFiles :: forall env. HasEnvConfig env
                      => Path Abs File
                      -> Package
                      -> RIO env
                           (Map NamedComponent (Map ModuleName (Path Abs File))
                           ,Map NamedComponent [DotCabalPath]
                           ,Set (Path Abs File)
                           ,[PackageWarning])
```


