### PR TITLE
Revert to Stack's Stack 2.9.3 in arm64.Dockerfile

### DIFF
--- a/etc/dockerfiles/arm64.Dockerfile
+++ b/etc/dockerfiles/arm64.Dockerfile
@@ -14,8 +14,10 @@ RUN cd /tmp && \
     tar xfv /tmp/llvm.tar --strip-components 1 -C /usr && \
     rm /tmp/llvm.tar
 
-RUN curl -L https://downloads.haskell.org/ghcup/unofficial-bindists/stack/2.9.1/stack-2.9.1-linux-aarch64.tar.gz --output /tmp/stack.tar.gz && \
-    tar xfv /tmp/stack.tar.gz -C /usr/local/bin && \
+# Stack's *.tar archive contains a directory that contains the 'stack'
+# executable, hence the use of tar's '--strip-components 1' option.
+RUN curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.3/stack-2.9.3-linux-aarch64.tar.gz --output /tmp/stack.tar.gz && \
+    tar xfv /tmp/stack.tar.gz -C /usr/local/bin --strip-components 1 && \
     rm /tmp/stack.tar.gz
 
 # RUN curl -sSL https://github.com/commercialhaskell/stack/releases/download/v2.7.1/stack-2.7.1-linux-aarch64.bin > /usr/local/bin/stack && \


### PR DESCRIPTION
Stack had used GHCup's Stack 2.9.1 because of problems with Stack's Stack 2.9.1.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
