### PR TITLE
Fix #5973 `stack ghci` makes use of Cabal file `default-language` keys

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,10 @@ Major changes:
 
 Behavior changes:
 
+* `stack ghci` and `stack repl` now take into account the values of
+  `default-language` keys in Cabal files, like they take into account the values
+  of `default-extensions` keys.
+
 Other enhancements:
 
 Bug fixes:

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -362,7 +362,9 @@ generateBuildInfoOpts BioInput {..} =
         | Dependency name _ _ <- targetBuildDepends biBuildInfo -- TODO: cabal 3 introduced multiple public libraries in a single dependency
         , name `notElem` biOmitPackages]
     PerCompilerFlavor ghcOpts _ = options biBuildInfo
-    extOpts = map (("-X" ++) . display) (usedExtensions biBuildInfo)
+    extOpts =
+         map (("-X" ++) . display) (allLanguages biBuildInfo)
+      <> map (("-X" ++) . display) (usedExtensions biBuildInfo)
     srcOpts =
         map (("-i" <>) . toFilePathNoTrailingSep)
             (concat


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building and using Stack on Windows.
