### PR TITLE
Fix #6003 Remove deprecated `stack path` flags

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,9 @@ Behavior changes:
 * `stack ghci` and `stack repl` now take into account the values of
   `default-language` keys in Cabal files, like they take into account the values
   of `default-extensions` keys.
+* Removed `--ghc-paths`, `--global-stack-root` and `--local-bin-path` flags for
+  `stack path`, deprecated in Stack 1.1.0 in favour of `--programs`,
+  `--stack-root` and `local-bin` respectively.
 
 Other enhancements:
 

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -1265,9 +1265,6 @@ the output of the command:
 --local-hoogle-root      Local project documentation root
 --dist-dir               Dist work directory, relative to package directory
 --local-hpc-root         Where HPC reports and tix files are stored
---local-bin-path         DEPRECATED: Use '--local-bin' instead
---ghc-paths              DEPRECATED: Use '--programs' instead
---global-stack-root      DEPRECATED: Use '--stack-root' instead
 ~~~
 
 In addition, `stack path` accepts the flags above on the command line to state

--- a/doc/path_command.md
+++ b/doc/path_command.md
@@ -10,7 +10,6 @@ stack path [--stack-root] [--global-config] [--project-root] [--config-location]
            [--global-pkg-db] [--ghc-package-path] [--snapshot-install-root]
            [--local-install-root] [--snapshot-doc-root] [--local-doc-root]
            [--local-hoogle-root] [--dist-dir] [--local-hpc-root]
-           [--local-bin-path] [--ghc-paths] [--global-stack-root]
 ~~~
 
 `stack path` provides information about files and locations used by Stack.
@@ -28,12 +27,9 @@ Pass the following flags for information about specific files or locations:
 |--extra-include-dirs   |Extra include directories.                            |
 |--extra-library-dirs   |Extra library directories.                            |
 |--ghc-package-path     |The `GHC_PACKAGE_PATH` environment variable.          |
-|--ghc-paths            |Deprecated.                                           |
 |--global-config        |Stack's user-specific global YAML configuration file (`config.yaml`).|
 |--global-pkg-db        |The global package database.                          |
-|--global-stack-root    |Deprecated.                                           |
 |--local-bin            |The directory in which Stack installs executables.    |
-|--local-bin-path       |Deprecated.                                           |
 |--local-doc-root       |The root directory for local project documentation.   |
 |--local-hoogle-root    |The root directory for local project documentation.   |
 |--local-hpc-root       |The root directory for .tix files and HPC reports.    |

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -17,7 +17,6 @@ module Stack.Constants
   , stackRootOptionName
   , stackGlobalConfigOptionName
   , pantryRootEnvVar
-  , deprecatedStackRootOptionName
   , inContainerEnvVar
   , inNixShellEnvVar
   , stackProgNameUpper
@@ -190,15 +189,6 @@ stackGlobalConfigOptionName = "global-config"
 -- | Environment variable used to override the location of the Pantry store
 pantryRootEnvVar :: String
 pantryRootEnvVar = "PANTRY_ROOT"
-
--- | Deprecated option name for the global Stack root.
---
--- Deprecated since stack-1.1.0.
---
--- TODO: Remove occurrences of this variable and use 'stackRootOptionName' only
--- after an appropriate deprecation period.
-deprecatedStackRootOptionName :: String
-deprecatedStackRootOptionName = "global-stack-root"
 
 -- | Environment variable used to indicate Stack is running in container.
 inContainerEnvVar :: String

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -17,8 +17,8 @@ import           Path ( (</>), parent )
 import           Path.Extra ( toFilePathNoTrailingSep )
 import           RIO.Process ( HasProcessContext (..), exeSearchPathL )
 import           Stack.Constants
-                   ( deprecatedStackRootOptionName, docDirSuffix
-                   , stackGlobalConfigOptionName, stackRootOptionName
+                   ( docDirSuffix, stackGlobalConfigOptionName
+                   , stackRootOptionName
                    )
 import           Stack.Constants.Config ( distRelativeDir )
 import           Stack.GhcPkg as GhcPkg
@@ -43,24 +43,10 @@ import qualified System.FilePath as FP
 -- support others later).
 path :: [Text] -> RIO Runner ()
 path keys = do
-  let deprecated = filter ((`elem` keys) . fst) deprecatedPathKeys
-  forM_ deprecated $ \(oldOption, newOption) ->
-    logWarn $
-         "\n"
-      <> "'--"
-      <> display oldOption
-      <> "' will be removed in a future release.\n"
-      <> "Please use '--"
-      <> display newOption
-      <> "' instead.\n"
-      <> "\n"
-  let -- filter the chosen paths in flags (keys),
-      -- or show all of them if no specific paths chosen.
+  let -- filter the chosen paths in flags (keys), or show all of them if no
+      -- specific paths chosen.
       goodPaths = filter
-        ( \(_, key, _) ->
-               (null keys && key /= T.pack deprecatedStackRootOptionName)
-            || elem key keys
-        )
+        ( \(_, key, _) -> null keys || elem key keys )
         paths
       singlePath = length goodPaths == 1
       toEither (_, k, UseHaddocks p) = Left (k, p)
@@ -269,22 +255,4 @@ paths =
   , ( "Where HPC reports and tix files are stored"
     , "local-hpc-root"
     , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . piHpcDir )
-  , ( "DEPRECATED: Use '--local-bin' instead"
-    , "local-bin-path"
-    , WithoutHaddocks $
-        T.pack . toFilePathNoTrailingSep . configLocalBin . view configL )
-  , ( "DEPRECATED: Use '--programs' instead"
-    , "ghc-paths"
-    , WithoutHaddocks $
-        T.pack . toFilePathNoTrailingSep . configLocalPrograms . view configL )
-  , ( "DEPRECATED: Use '--" <> stackRootOptionName <> "' instead"
-    , T.pack deprecatedStackRootOptionName
-    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . view stackRootL )
-  ]
-
-deprecatedPathKeys :: [(Text, Text)]
-deprecatedPathKeys =
-  [ (T.pack deprecatedStackRootOptionName, T.pack stackRootOptionName)
-  , ("ghc-paths", "programs")
-  , ("local-bin-path", "local-bin")
   ]


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested by building and using Stack on Windows.
