### PR TITLE
Remove back tick from documentation

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -335,7 +335,7 @@ The following assumes that you already have installed a version of Stack and the
 1.  Clone the `stack` repository from GitHub with the command:
 
     ~~~text
-    git clone https://github.com/commercialhaskell/stack.git`
+    git clone https://github.com/commercialhaskell/stack.git
     ~~~
 
 2.  Change the current working directory to the cloned `stack` directory with the


### PR DESCRIPTION
This back tick causes the command to be incorrect

Note: Fixes for the online documentation of the current Stack release (https://docs.haskellstack.org/en/stable/) should target the 'stable' branch, not the 'master' branch.

Please include the following checklist in your pull request:

* [ ] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
