### PR TITLE
Fix #5968 New approach to overwriting existing Stack executable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,12 @@ Behavior changes:
 * Removed `--ghc-paths`, `--global-stack-root` and `--local-bin-path` flags for
   `stack path`, deprecated in Stack 1.1.0 in favour of `--programs`,
   `--stack-root` and `local-bin` respectively.
+* On Windows, `stack upgrade` always renames the file of the running Stack
+  executable (adding extension `.old`) before attempting to write to the
+  original file name.
+* On Windows, `stack upgrade` does not offer `sudo` command alternatives if
+  attempting to write to the original file name of the running Stack exectuable
+  results in a 'Permission' error.
 
 Other enhancements:
 

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -167,7 +167,7 @@ upgrade builtHash (UpgradeOpts mbo mso) =
       prettyWarnL
         [ flow "Exception occurred when trying to perform binary upgrade:"
         , fromString . show $ e
-        , line <> flow "Falling back to source upgrade"
+        , line <> flow "Falling back to source upgrade."
         ]
       source so
  where
@@ -205,7 +205,7 @@ binaryUpgrade (BinaryOpts mplatform force' mver morg mrepo) =
         Just downloadVersion -> do
           prettyInfoL
             [ flow "Current Stack version:"
-            , fromString (versionString stackVersion) <> ","
+            , fromString (versionString stackVersion) <> ";"
             , flow "available download version:"
             , fromString (versionString downloadVersion) <> "."
             ]


### PR DESCRIPTION
I have tested the following on Windows (see further below) but I am unable to test myself on non-Windows. Can any non-Windows/x86_64 users of Stack assist with testing?

I understand that, on Windows, you can rename the file of a running executable but you can't overwrite it. That was reflected in the existing code at `Stack.Setup.downloadStackExe` (extract):

~~~haskell
      case platform of
          Platform _ Cabal.Windows | FP.equalFilePath (toFilePath destFile) currExe -> do
              old <- parseAbsFile (toFilePath destFile ++ ".old")
              renameFile destFile old
              renameFile tmpFile destFile
          _ -> renameFile tmpFile destFile
~~~

I moved that same logic into a new helper function `relocateStackExeFile`:

~~~haskell
relocateStackExeFile ::
     HasTerm env
  => Path Abs File
     -- ^ Path to the currently running executable
  -> Path Abs File
     -- ^ Path to the executable file to be relocated
  -> Path Abs File
     -- ^ Path to the new location for the excutable file
  -> RIO env ()
relocateStackExeFile currExeFile newExeFile destExeFile = do
  when (osIsWindows && destExeFile == currExeFile) $ do
    -- Windows allows a running executable's file to be renamed, but not to be
    -- overwritten.
    old <- addExtension ".old" currExeFile
    prettyInfoL
      [ flow "Renaming existing:"
      , pretty currExeFile
      , "as:"
      , pretty old <> "."
      ]
    renameFile currExeFile old
  renameFile newExeFile destExeFile
~~~

I made use of `osIsWindows` rather than ` Platform _ Cabal.Windows` to determine what operating system Stack is running on. I moved it to the `RIO env` monad (from `IO`), because I wanted to add some pretty information about the renaming. So, now I have (extract):

~~~haskell
liftIO $ do
      setFileExecutable (toFilePath tmpFile)
      testExe tmpFile

relocateStackExeFile currExe tmpFile destFile
~~~

However, the same logic was not reflected in the existing code of `Stack.Setup.performPathChecking` (extract below), despite that function always looking to replace the file of the currently running Stack executable:

~~~haskell
    tmpFile <- parseAbsFile $ executablePath ++ ".tmp"
    eres <- tryIO $ do
      liftIO $ copyFile newFile tmpFile
      setFileExecutable (toFilePath tmpFile)
      liftIO $ renameFile tmpFile executablePath'
~~~

I could not see why this function would not do what `downloadStackExe` does. So, I changed that to:

~~~haskell
    tmpFile <- toFilePath <$> addExtension ".tmp" currExeFile
    eres <- tryIO $
      relocateStackExeFile currExeFile newExeFile currExeFile
~~~

I kept the `tmpFile` as it uses in the `sudo` command alternatives fallback (which is unchanged).

On Windows, offering the `sudo` command alternatives (if attempting to write to the original file name of the running Stack executable results in a 'Permission' error) did not seem to make much sense. I limited that to non-Windows (extract below), again making use of `isOsWindows`:

~~~haskell
    case eres of
      Right () -> prettyInfoS "Stack executable copied successfully!"
      Left e
        | isPermissionError e -> if osIsWindows
            then do
              prettyWarn $
                   flow "Permission error when trying to copy:"
                <> blankLine
                <> string (displayException e)
            else do
              prettyWarn $
                   flow "Permission error when trying to copy:"
                <> blankLine
                <> string (displayException e)
                <> blankLine
                <> fillSep
                     [ flow "Should I try to perform the file copy using"
                     , style Shell "sudo" <> "?"
                     , flow "This may fail."
                     ]
              toSudo <- promptBool "Try using sudo? (y/n) "

~~~

In the course of making these changes, I also made the related Stack messages prettier (but I did not revisit the content of the existing messages).

## Testing

In respect of testing, my currently running Stack is in my default `stack path --local-bin` (`C:\Users\mike\AppData\Roaming\local\bin`). So, I tried both:

~~~text
stack upgrade --force-download
~~~

and

~~~text
stack --local-bin-path C:\temp upgrade --force-download
~~~

Both worked as expected. The first test writes directly to the location of the currently running Stack executable (and works as it used to work). The second test writes to `C:\temp` and then also writes to the location of the currently running Stack executable (this now works, whereas it used to fail with Stack 2.9.3).

I am unable myself to test on non-Windows, because my other machine is macOS/AArch64 and Stack does not (yet) support binary download for AArch64 because GitHub does not (yet) offer a runner for macOS/AArch64.