### PR TITLE
Fix #5866 Replace duff `forgivingAbsence $ resolveFile ...`

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -76,11 +76,14 @@ import           Path
                    , stripProperPrefix
                    )
 import           Path.CheckInstall ( warnInstallSearchPathIssues )
-import           Path.Extra ( toFilePathNoTrailingSep, rejectMissingFile )
+import           Path.Extra
+                   ( forgivingResolveFile, rejectMissingFile
+                   , toFilePathNoTrailingSep
+                   )
 import           Path.IO
                    ( copyFile, doesDirExist, doesFileExist, ensureDir
-                   , forgivingAbsence, ignoringAbsence, removeDirRecur
-                   , removeFile, renameDir, renameFile, resolveFile
+                   , ignoringAbsence, removeDirRecur, removeFile, renameDir
+                   , renameFile
                    )
 import           RIO.Process
                    ( HasProcessContext, byteStringInput, doesExecutableExist
@@ -660,7 +663,7 @@ copyExecutables exes = do
             case loc of
                 Snap -> snapBin
                 Local -> localBin
-    mfp <- liftIO $ forgivingAbsence (resolveFile bindir $ T.unpack name ++ ext)
+    mfp <- liftIO $ forgivingResolveFile bindir (T.unpack name ++ ext)
       >>= rejectMissingFile
     case mfp of
       Nothing -> do
@@ -2541,7 +2544,7 @@ mungeBuildOutput excludeTHLoading makeAbsolute pkgDir compilerVer = void $
       if isValidSuffix y
         then liftIO $
           fmap (fmap ((T.takeWhile isSpace x <>) . T.pack . toFilePath)) $
-            forgivingAbsence (resolveFile pkgDir (T.unpack $ T.dropWhile isSpace x)) `catch`
+            forgivingResolveFile pkgDir (T.unpack $ T.dropWhile isSpace x) `catch`
               \(_ :: PathException) -> pure Nothing
         else pure Nothing
     case mabs of

--- a/src/Stack/ComponentFile.hs
+++ b/src/Stack/ComponentFile.hs
@@ -43,11 +43,12 @@ import           Path
                    , stripProperPrefix
                    )
 import           Path.Extra
-                   ( parseCollapsedAbsFile, rejectMissingDir, rejectMissingFile
+                   ( forgivingResolveFile, parseCollapsedAbsFile
+                   , rejectMissingDir, rejectMissingFile
                    )
 import           Path.IO
                    ( doesDirExist, doesFileExist, forgivingAbsence
-                   , getCurrentDir, listDir, resolveDir, resolveFile
+                   , getCurrentDir, listDir, resolveDir
                    )
 import           Stack.Constants
                    ( haskellDefaultPreprocessorExts, haskellFileExts
@@ -294,7 +295,7 @@ parseHI hiPath = do
                         Iface.unList . Iface.dmods . Iface.deps
           resolveFileDependency file = do
             resolved <-
-              liftIO (forgivingAbsence (resolveFile dir file)) >>=
+              liftIO (forgivingResolveFile dir file) >>=
                 rejectMissingFile
             when (isNothing resolved) $
               prettyWarnL

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -30,7 +30,7 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
 import qualified Distribution.PackageDescription as C
 import           Path
-import           Path.Extra ( toFilePathNoTrailingSep )
+import           Path.Extra ( forgivingResolveFile', toFilePathNoTrailingSep )
 import           Path.IO hiding ( withSystemTempDir )
 import           RIO.Process
                    ( HasProcessContext, exec, proc, readProcess_
@@ -239,7 +239,7 @@ preprocessTargets buildOptsCLI sma rawTargets = do
         then do
             fileTargets <- forM fileTargetsRaw $ \fp0 -> do
                 let fp = T.unpack fp0
-                mpath <- liftIO $ forgivingAbsence (resolveFile' fp)
+                mpath <- liftIO $ forgivingResolveFile' fp
                 case mpath of
                     Nothing -> throwM (MissingFileTarget fp)
                     Just path -> pure path

--- a/src/Stack/PackageFile.hs
+++ b/src/Stack/PackageFile.hs
@@ -16,8 +16,7 @@ import           Distribution.PackageDescription hiding ( FlagName )
 import           Distribution.Simple.Glob ( matchDirFileGlob )
 import qualified Distribution.Types.UnqualComponentName as Cabal
 import           Path ( parent )
-import           Path.Extra ( rejectMissingFile )
-import           Path.IO ( forgivingAbsence, resolveFile )
+import           Path.Extra ( forgivingResolveFile, rejectMissingFile )
 import           Stack.ComponentFile
                    ( benchmarkFiles, executableFiles, libraryFiles
                    , resolveOrWarn, testFiles
@@ -37,7 +36,7 @@ resolveFileOrWarn :: FilePath.FilePath
                   -> RIO GetPackageFileContext (Maybe (Path Abs File))
 resolveFileOrWarn = resolveOrWarn "File" f
  where
-  f p x = liftIO (forgivingAbsence (resolveFile p x)) >>= rejectMissingFile
+  f p x = liftIO (forgivingResolveFile p x) >>= rejectMissingFile
 
 -- | Get all files referenced by the package.
 packageDescModulesAndFiles ::


### PR DESCRIPTION
As discussed in the corresponding issue, `resolveFile` can throw an error that `forgivingAbsence` does not 'forgive', if the path is to a file that does not exist and it contains elements that `parseAbsFile` will reject as not being a valid absolute path to a file.

This pull request replaces that with a new helper function `forgivingResolveFile` that handles the actual error that `resolveFile` might throw: `InvalidAbsFile`.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
