### PR TITLE
Bump the cabal project to match lts-20.0 in stack.yaml.

### DIFF
--- a/cabal.config
+++ b/cabal.config
@@ -1,11 +1,10 @@
 constraints:
-  , Cabal ==3.6.3.0
-  , Cabal-syntax ==3.6.0.0
+  , Cabal ==3.8.1.0
+  , Cabal-syntax ==3.8.1.0
   , Glob ==0.10.2
   , OneTuple ==0.3.1
   , QuickCheck ==2.14.2
   , StateVar ==1.2.2
-  , Win32 ==2.12.0.1
   , aeson ==2.0.3.0
   , annotated-wl-pprint ==0.7.0
   , ansi-terminal ==0.11.3
@@ -77,6 +76,7 @@ constraints:
   , hackage-security ==0.6.2.2
   , hashable ==1.4.1.0
   , hi-file-parser ==0.1.3.0
+  , hinotify ==0.4.1
   , hourglass ==0.2.12
   , hpack ==0.35.1
   , hpc ==0.6.1.0

--- a/cabal.project
+++ b/cabal.project
@@ -13,6 +13,11 @@
 --
 -- > stack ls dependencies cabal > cabal.config
 --
+-- From the resolver in `stack.yaml` be sure to set `with-compiler: ghc-x.y.z`.
+-- This can be checked in the cabal.config from stackage that matches the
+-- resolver, such as:
+--   https://www.stackage.org/lts-20.0/cabal.config
+--
 -- However, be aware that, in respect of the `unix` package or the `Win32`
 -- package (that may come with GHC, depending on the operating system):
 --
@@ -26,5 +31,6 @@
 -- the other. A comprehensive `cabal.config` will need to be created by editing
 -- the command's output.
 
+with-compiler: ghc-9.2.5
 import: cabal.config
 packages: .


### PR DESCRIPTION
A small maintenance bump in the cabal project to match the stack project. Added a note about using `with-compiler`.
