### PR TITLE
Check if target might be a project-level configuration file, not a missing directory

### DIFF
--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -188,7 +188,7 @@ parseRawTargetDirs root locals ri =
   projectTypo :: Int -> Int -> String -> StyleDoc
   projectTypo padLength dropLength option =
     vsep
-      [ style Dir ((fromString $ replicate padLength ' ') <> (fromString $ T.unpack t))
+      [ style Dir (fromString (replicate padLength ' ') <> fromString (T.unpack t))
         <> " is not a directory."
       , style Highlight (fromString $ "--" <> option)
         <> style Dir (fromString . drop dropLength $ T.unpack t)


### PR DESCRIPTION
A rough fix for #6032. If it merits more work, I'll be happy to tidy it up, add a change log and some tests. What do you think?

The new behaviour:

```
$ stack build stack-yaml ghc-9.2.4.cabal2stack.yaml --dry-run

Error: [S-8506]
       Stack failed to parse the target(s).
       
       While parsing, Stack encountered the error:
       
           Directory not found: ghc-9.2.4.cabal2stack.yaml. Is this a typo? Can I suggest: --stack-yaml ghc-9.2.4.cabal2stack.yaml
       
       Stack expects a target to be a package name (e.g. my-package), a package identifier (e.g. my-package-0.1.2.3), a package component
       (e.g. my-package:test:my-test-suite), or, failing that, a relative path to a directory that is a local package directory or a parent
       directory of one or more local package directories.
```

```
$ stack build stack-yaml=ghc-9.2.4.cabal2stack.yaml --dry-run

Error: [S-8506]
       Stack failed to parse the target(s).
       
       While parsing, Stack encountered the error:
       
           Directory not found: stack-yaml=ghc-9.2.4.cabal2stack.yaml. Is this a typo? Can I suggest:
           --stack-yaml=ghc-9.2.4.cabal2stack.yaml
       
       Stack expects a target to be a package name (e.g. my-package), a package identifier (e.g. my-package-0.1.2.3), a package component
       (e.g. my-package:test:my-test-suite), or, failing that, a relative path to a directory that is a local package directory or a parent
       directory of one or more local package directories.
```
