### PR TITLE
Remove redundant `HasLogFunc env` constraints

### DIFF
--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -207,7 +207,7 @@ checkCabalVersion = do
 
 -- | See https://github.com/commercialhaskell/stack/issues/1198.
 warnIfExecutablesWithSameNameCouldBeOverwritten ::
-     (HasLogFunc env, HasTerm env)
+     HasTerm env
   => [LocalPackage]
   -> Plan
   -> RIO env ()
@@ -289,10 +289,7 @@ warnIfExecutablesWithSameNameCouldBeOverwritten locals plan = do
   collect :: Ord k => [(k,v)] -> Map k (NonEmpty v)
   collect = Map.map NE.fromList . Map.fromDistinctAscList . groupSort
 
-warnAboutSplitObjs ::
-     (HasLogFunc env, HasTerm env)
-  => BuildOpts
-  -> RIO env ()
+warnAboutSplitObjs :: HasTerm env => BuildOpts -> RIO env ()
 warnAboutSplitObjs bopts | boptsSplitObjs bopts =
   prettyWarnL
     [ flow "Building with"
@@ -426,13 +423,11 @@ checkComponentsBuildable lps =
     ]
 
 -- | Find if sublibrary dependency exist in each project
-checkSubLibraryDependencies ::
-     (HasLogFunc env, HasTerm env)
-  => [ProjectPackage]
-  -> RIO env ()
+checkSubLibraryDependencies :: HasTerm env => [ProjectPackage] -> RIO env ()
 checkSubLibraryDependencies proj =
   forM_ proj $ \p -> do
-    C.GenericPackageDescription _ _ _ lib subLibs foreignLibs exes tests benches <- liftIO $ cpGPD . ppCommon $ p
+    C.GenericPackageDescription _ _ _ lib subLibs foreignLibs exes tests benches <-
+      liftIO $ cpGPD . ppCommon $ p
 
     let dependencies = concatMap getDeps subLibs <>
                        concatMap getDeps foreignLibs <>

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -798,12 +798,7 @@ executePlan' installedMap0 targets plan ee@ExecuteEnv {..} = do
                 $ planUnregisterLocal plan
 
 unregisterPackages ::
-     ( HasCompiler env
-     , HasLogFunc env
-     , HasPlatform env
-     , HasProcessContext env
-     , HasTerm env
-     )
+     (HasCompiler env, HasPlatform env, HasProcessContext env, HasTerm env)
   => ActualCompiler
   -> Path Abs Dir
   -> NonEmpty (GhcPkgId, (PackageIdentifier, Text))
@@ -2686,7 +2681,7 @@ expectBenchmarkFailure pname =
   maybe False (Set.member pname . curatorExpectBenchmarkFailure)
 
 fulfillCuratorBuildExpectations ::
-     (HasCallStack, HasLogFunc env, HasTerm env)
+     (HasCallStack, HasTerm env)
   => PackageName
   -> Maybe Curator
   -> Bool

--- a/src/Stack/ComponentFile.hs
+++ b/src/Stack/ComponentFile.hs
@@ -395,11 +395,7 @@ findCandidate dirs name = do
 --
 -- For example: .erb for a Ruby file might exist in one of the
 -- directories.
-logPossibilities ::
-     HasTerm env
-  => [Path Abs Dir]
-  -> ModuleName
-  -> RIO env ()
+logPossibilities :: HasTerm env => [Path Abs Dir] -> ModuleName -> RIO env ()
 logPossibilities dirs mn = do
   possibilities <- fmap concat (makePossibilities mn)
   unless (null possibilities) $ prettyWarnL

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -581,8 +581,7 @@ findPackageFieldForBuiltPackage pkgDir pkgId internalLibs field = do
             <> T.pack (toFilePath inplaceDir)
             <> ". Maybe try 'stack clean' on this package?"
 
-displayReportPath :: (HasTerm env)
-                  => StyleDoc -> Text -> StyleDoc -> RIO env ()
+displayReportPath :: HasTerm env => StyleDoc -> Text -> StyleDoc -> RIO env ()
 displayReportPath prefix report reportPath =
   prettyInfo $
         prefix

--- a/src/Stack/FileWatch.hs
+++ b/src/Stack/FileWatch.hs
@@ -21,13 +21,13 @@ import           System.FSNotify
 import           System.IO ( getLine )
 
 fileWatch ::
-     (HasLogFunc env, HasTerm env)
+     HasTerm env
   => ((Set (Path Abs File) -> IO ()) -> RIO env ())
   -> RIO env ()
 fileWatch = fileWatchConf defaultConfig
 
 fileWatchPoll ::
-     (HasLogFunc env, HasTerm env)
+     HasTerm env
   => ((Set (Path Abs File) -> IO ()) -> RIO env ())
   -> RIO env ()
 fileWatchPoll =
@@ -38,7 +38,7 @@ fileWatchPoll =
 -- The action provided takes a callback that is used to set the files to be
 -- watched. When any of those files are changed, we rerun the action again.
 fileWatchConf ::
-     (HasLogFunc env, HasTerm env)
+     HasTerm env
   => WatchConfig
   -> ((Set (Path Abs File) -> IO ()) -> RIO env ())
   -> RIO env ()

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -32,7 +32,7 @@ import           System.FilePath ( searchPathSeparator )
 
 -- | Get the global package database
 getGlobalDB ::
-     (HasLogFunc env, HasProcessContext env, HasTerm env)
+     (HasProcessContext env, HasTerm env)
   => GhcPkgExe
   -> RIO env (Path Abs Dir)
 getGlobalDB pkgexe = do
@@ -51,7 +51,7 @@ getGlobalDB pkgexe = do
 
 -- | Run the ghc-pkg executable
 ghcPkg ::
-     (HasLogFunc env, HasProcessContext env, HasTerm env)
+     (HasProcessContext env, HasTerm env)
   => GhcPkgExe
   -> [Path Abs Dir]
   -> [String]
@@ -70,7 +70,7 @@ ghcPkg pkgexe@(GhcPkgExe pkgPath) pkgDbs args = do
 
 -- | Create a package database in the given directory, if it doesn't exist.
 createDatabase ::
-     (HasLogFunc env, HasProcessContext env, HasTerm env)
+     (HasProcessContext env, HasTerm env)
   => GhcPkgExe
   -> Path Abs Dir
   -> RIO env ()
@@ -116,7 +116,7 @@ packageDbFlags pkgDbs =
 
 -- | Get the value of a field of the package.
 findGhcPkgField ::
-     (HasLogFunc env, HasProcessContext env, HasTerm env)
+     (HasProcessContext env, HasTerm env)
   => GhcPkgExe
   -> [Path Abs Dir] -- ^ package databases
   -> String -- ^ package identifier, or GhcPkgId
@@ -138,7 +138,7 @@ findGhcPkgField pkgexe pkgDbs name field = do
 -- see https://github.com/commercialhaskell/stack/issues/2662#issuecomment-460342402
 -- using GHC package id where available (from GHC 7.9)
 unregisterGhcPkgIds ::
-     ( HasLogFunc env, HasProcessContext env, HasTerm env)
+     (HasProcessContext env, HasTerm env)
   => GhcPkgExe
   -> Path Abs Dir -- ^ package database
   -> NonEmpty (Either PackageIdentifier GhcPkgId)

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -861,10 +861,7 @@ wantedPackageComponents bopts (TargetAll PTProject) pkg = S.fromList $
     (if boptsBenchmarks bopts then map CBench (S.toList (packageBenchmarks pkg)) else [])
 wantedPackageComponents _ _ _ = S.empty
 
-checkForIssues ::
-     (HasLogFunc env, HasTerm env)
-  => [GhciPkgInfo]
-  -> RIO env ()
+checkForIssues :: HasTerm env => [GhciPkgInfo] -> RIO env ()
 checkForIssues pkgs =
   when (length pkgs > 1) $ do
     -- Cabal flag issues could arise only when there are at least 2 packages

--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -58,7 +58,7 @@ instance Exception PackageDumpException where
 -- | Call ghc-pkg dump with appropriate flags and stream to the given @Sink@,
 -- for a single database
 ghcPkgDump ::
-     (HasLogFunc env, HasProcessContext env, HasTerm env)
+     (HasProcessContext env, HasTerm env)
   => GhcPkgExe
   -> [Path Abs Dir] -- ^ if empty, use global
   -> ConduitM Text Void (RIO env) a
@@ -68,7 +68,7 @@ ghcPkgDump pkgexe = ghcPkgCmdArgs pkgexe ["dump"]
 -- | Call ghc-pkg describe with appropriate flags and stream to the given
 -- @Sink@, for a single database
 ghcPkgDescribe ::
-     (HasCompiler env, HasLogFunc env, HasProcessContext env, HasTerm env)
+     (HasCompiler env, HasProcessContext env, HasTerm env)
   => GhcPkgExe
   -> PackageName
   -> [Path Abs Dir] -- ^ if empty, use global
@@ -79,7 +79,7 @@ ghcPkgDescribe pkgexe pkgName' = ghcPkgCmdArgs
 
 -- | Call ghc-pkg and stream to the given @Sink@, for a single database
 ghcPkgCmdArgs ::
-     (HasLogFunc env, HasProcessContext env, HasTerm env)
+     (HasProcessContext env, HasTerm env)
   => GhcPkgExe
   -> [String]
   -> [Path Abs Dir] -- ^ if empty, use global

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -796,10 +796,7 @@ ensureCompilerAndMsys sopts = do
   pure (cp, paths)
 
 -- | See <https://github.com/commercialhaskell/stack/issues/4246>
-warnUnsupportedCompiler ::
-     (HasLogFunc env, HasTerm env)
-  => Version
-  -> RIO env Bool
+warnUnsupportedCompiler :: HasTerm env => Version -> RIO env Bool
 warnUnsupportedCompiler ghcVersion =
   if
     | ghcVersion < mkVersion [7, 8] -> do
@@ -827,7 +824,7 @@ warnUnsupportedCompiler ghcVersion =
 
 -- | See <https://github.com/commercialhaskell/stack/issues/4246>
 warnUnsupportedCompilerCabal ::
-     (HasLogFunc env, HasTerm env)
+     HasTerm env
   => CompilerPaths
   -> Bool -- ^ already warned about GHC?
   -> RIO env ()
@@ -1555,7 +1552,7 @@ mungeRelease = intercalate "-" . prefixMaj . splitOn "."
   prefixMaj = prefixFst "maj" prefixMin
   prefixMin = prefixFst "min" (map ('r':))
 
-sysRelease :: (HasLogFunc env, HasTerm env) => RIO env String
+sysRelease :: HasTerm env => RIO env String
 sysRelease =
   handleIO
     ( \e -> do
@@ -2245,7 +2242,7 @@ removeHaskellEnvVars =
 
 -- | Get map of environment variables to set to change the GHC's encoding to UTF-8
 getUtf8EnvVars ::
-     (HasLogFunc env, HasPlatform env, HasProcessContext env, HasTerm env)
+     (HasPlatform env, HasProcessContext env, HasTerm env)
   => ActualCompiler
   -> RIO env (Map Text Text)
 getUtf8EnvVars compilerVer =

--- a/src/Stack/SourceMap.hs
+++ b/src/Stack/SourceMap.hs
@@ -138,7 +138,7 @@ getPLIVersion (PLIArchive _ pm) = pkgVersion $ pmIdent pm
 getPLIVersion (PLIRepo _ pm) = pkgVersion $ pmIdent pm
 
 globalsFromDump ::
-     (HasLogFunc env, HasProcessContext env, HasTerm env)
+     (HasProcessContext env, HasTerm env)
   => GhcPkgExe
   -> RIO env (Map PackageName DumpedGlobalPackage)
 globalsFromDump pkgexe = do


### PR DESCRIPTION
`HasTerm env` implies `HasLogFunc env`.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
