### PR TITLE
Add forgivingResolveDir

### DIFF
--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -68,8 +68,8 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import           Path ( isProperPrefixOf )
-import           Path.Extra ( rejectMissingDir )
-import           Path.IO ( forgivingAbsence, getCurrentDir, resolveDir )
+import           Path.Extra ( forgivingResolveDir, rejectMissingDir )
+import           Path.IO ( getCurrentDir )
 import           RIO.Process ( HasProcessContext )
 import           Stack.SourceMap ( additionalDepPackage )
 import           Stack.Prelude
@@ -150,8 +150,7 @@ parseRawTargetDirs root locals ri =
   case parseRawTarget t of
     Just rt -> pure $ Right [(ri, rt)]
     Nothing -> do
-      mdir <- liftIO $ forgivingAbsence (resolveDir root (T.unpack t))
-        >>= rejectMissingDir
+      mdir <- forgivingResolveDir root (T.unpack t) >>= rejectMissingDir
       case mdir of
         Nothing -> pure $ Left $
           fillSep

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -235,7 +235,7 @@ preprocessTargets buildOptsCLI sma rawTargets = do
         then do
             fileTargets <- forM fileTargetsRaw $ \fp0 -> do
                 let fp = T.unpack fp0
-                mpath <- liftIO $ forgivingResolveFile' fp
+                mpath <- forgivingResolveFile' fp
                 case mpath of
                     Nothing -> throwM (MissingFileTarget fp)
                     Just path -> pure path

--- a/src/Stack/PackageFile.hs
+++ b/src/Stack/PackageFile.hs
@@ -35,7 +35,7 @@ resolveFileOrWarn :: FilePath.FilePath
                   -> RIO GetPackageFileContext (Maybe (Path Abs File))
 resolveFileOrWarn = resolveOrWarn "File" f
  where
-  f p x = liftIO (forgivingResolveFile p x) >>= rejectMissingFile
+  f p x = forgivingResolveFile p x >>= rejectMissingFile
 
 -- | Get all files referenced by the package.
 packageDescModulesAndFiles ::


### PR DESCRIPTION
`forgivingResolveDir` corresponds to `forgivingResolveFile`, but for directories. See https://github.com/commercialhaskell/stack/pull/6028.

Fixes `InvalidAbsDir`, thrown by `Stack.Build.Target.parseRawTargetDirs`.

Also removes some redundant `liftIO` where `forgivingResolveFile` or `forgivingResolveFile'` was used.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
