### PR TITLE
Fix #6050 Drop Cabal versions before 1.22.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@ Major changes:
 
 Behavior changes:
 
+* Drop support for `Cabal` versions before 1.22 and, consequently, GHC versions
+  before 7.10.
 * `stack ghci` and `stack repl` now take into account the values of
   `default-language` keys in Cabal files, like they take into account the values
   of `default-extensions` keys.

--- a/doc/maintainers/stack_errors.md
+++ b/doc/maintainers/stack_errors.md
@@ -5,7 +5,7 @@
 In connection with considering Stack's support of the
 [Haskell Error Index](https://errors.haskell.org/) initiative, this page seeks
 to take stock of the errors that Stack itself can raise, by reference to the
-`master` branch of the Stack repository. Last updated: 2023-01-21.
+`master` branch of the Stack repository. Last updated: 2023-02-02.
 
 *   `Main.main`: catches exceptions from action `commandLineHandler`.
 
@@ -60,11 +60,10 @@ to take stock of the errors that Stack itself can raise, by reference to the
         [S-1711] | CannotApplySelector Value [Text]
         ~~~
 
-    -   `Stack.Build.CabalVersionException`
+    -   `Stack.Build.CabalVersionPrettyException`
 
         ~~~haskell
-        [S-8503] = AllowNewerNotSupported Version
-        [S-5973] | CabalVersionNotSupported Version
+        [S-5973] = CabalVersionNotSupported Version
         ~~~
 
     -   `Stack.Build.ConstructPlan.NotOnlyLocal`


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
