### PR TITLE
pkg-config supplied in GitHub Hosted Runner for macOS

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,11 +39,6 @@ jobs:
           release-args: ""
           cache-bust: "23"
     steps:
-    - name: Setup macOS
-      if: startsWith(runner.os, 'macOS')
-      run: |
-        # pkg-config added because it is required by package digest-0.0.1.4.
-        brew install pkg-config
     - name: Clone project
       uses: actions/checkout@v3
     - name: Cache dependencies on Unix-like OS

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -52,11 +52,6 @@ jobs:
           extra-suffix: ""
           stack-args: ""
     steps:
-    - name: Setup macOS
-      if: startsWith(runner.os, 'macOS')
-      run: |
-        # pkg-config added because it is required by package digest-0.0.1.4.
-        brew install pkg-config
     - name: Clone project
       uses: actions/checkout@v3
     - name: Cache dependencies on Unix-like OS


### PR DESCRIPTION
`pkg-config` is now supplied in the GitHub Hosted Runner for macOS. See https://github.com/actions/runner-images/pull/7125.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI to test CI.
