### PR TITLE
Add sub-library dependencies to Package type

### DIFF
--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -164,6 +164,8 @@ data Package = Package
     -- the hard-coded lookup.
   , packageAllDeps :: !(Set PackageName)
     -- ^ Original dependencies (not sieved).
+  , packageSubLibDeps :: !(Map MungedPackageName DepValue)
+    -- ^ Original sub-library dependencies (not sieved).
   , packageGhcOptions :: ![Text]
     -- ^ Ghc options used on package.
   , packageCabalConfigOpts :: ![Text]


### PR DESCRIPTION
Also, extends `Stack.Types.Build.configureOptsNoDir` (`toDepOption`, for Cabal's `--dependency` option) to recognise when a package identifier's name refers to a sub-library dependency.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI,
