### PR TITLE
Fix #6069 Avoid unix-compat's System.PosixCompat.User

### DIFF
--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -129,7 +129,7 @@ import           System.Console.ANSI
 import           System.Environment ( getEnvironment, lookupEnv )
 import           System.Info.ShortPathName ( getShortPathName )
 import           System.PosixCompat.Files ( fileOwner, getFileStatus )
-import           System.PosixCompat.User ( getEffectiveUserID )
+import           System.Posix.User ( getEffectiveUserID )
 
 -- | If deprecated path exists, use it and print a warning. Otherwise, return
 -- the new path.

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -75,7 +75,7 @@ import           System.Environment
 import qualified System.FilePath as FP
 import           System.IO.Error ( isDoesNotExistError )
 import           System.IO.Unsafe ( unsafePerformIO )
-import qualified System.PosixCompat.User as User
+import qualified System.Posix.User as User
 import qualified System.PosixCompat.Files as Files
 import           System.Terminal ( hIsTerminalDeviceOrMinTTY )
 import           Text.ParserCombinators.ReadP ( readP_to_S )

--- a/src/windows/System/Posix/User.hs
+++ b/src/windows/System/Posix/User.hs
@@ -1,0 +1,49 @@
+-- | The module of this name differs as between Windows and non-Windows builds.
+-- This is the Windows version. Non-Windows builds rely on the unix package,
+-- which exposes a module of the same name.
+
+module System.Posix.User
+  ( getEffectiveUserID
+  , getEffectiveGroupID
+  , getGroups
+  , getUserEntryForName
+  , homeDirectory
+  , setGroupID
+  , setUserID
+  ) where
+
+import           System.IO.Error ( illegalOperationErrorType, mkIOError )
+import           System.PosixCompat.Types ( GroupID, UserID )
+
+unsupported :: String -> IO a
+unsupported f = ioError $ mkIOError illegalOperationErrorType x Nothing Nothing
+ where
+  x = "System.Posix.User." ++ f ++ ": not supported on Windows."
+
+getEffectiveUserID :: IO UserID
+getEffectiveUserID = unsupported "getEffectiveUserID"
+
+getEffectiveGroupID :: IO GroupID
+getEffectiveGroupID = unsupported "getEffectiveGroupID"
+
+getGroups :: IO [GroupID]
+getGroups = return []
+
+getUserEntryForName :: String -> IO UserEntry
+getUserEntryForName _ = unsupported "getUserEntryForName"
+
+setGroupID :: GroupID -> IO ()
+setGroupID _ = return ()
+
+setUserID :: UserID -> IO ()
+setUserID _ = return ()
+
+data UserEntry = UserEntry
+    { userName      :: String
+    , userPassword  :: String
+    , userID        :: UserID
+    , userGroupID   :: GroupID
+    , userGecos     :: String
+    , homeDirectory :: String
+    , userShell     :: String
+    } deriving (Eq, Read, Show)

--- a/stack.cabal
+++ b/stack.cabal
@@ -367,6 +367,7 @@ library
     other-modules:
         Stack.Constants.UsrLibDirs
         Stack.Docker.Handlers
+        System.Posix.User
         System.Uname
     hs-source-dirs:
         src/windows/


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
