### PR TITLE
doc: `stack new` links directly to `template_command.md`

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -83,7 +83,7 @@ We'll call our project `helloworld`, and we'll use the `new-template` project
 template. This template is used by default, but in our example we will refer to
 it expressly. Other templates are available. For further information about
 templates, see the `stack templates` command
-[documentation](GUIDE_advanced.md#the-stack-templates-command).
+[documentation](templates_command.md).
 
 From the root directory for all our Haskell projects, we command:
 


### PR DESCRIPTION
The current link points to a non-existing anchor on the `GUIDE_advanced.md` page.  It seems reasonable to link directly to the `template` command page, when the text says `see the stack templates command documentation`.

Note: Fixes for the online documentation of the current Stack release (https://docs.haskellstack.org/en/stable/) should target the 'stable' branch, not the 'master' branch.

Please include the following checklist in your pull request:

* [X] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [X] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
