### PR TITLE
stack script --use-root

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ Release notes:
 
 New features:
 
-* `stack script` learned a new option `--hide-built-files` (used with `--compile` or `--optimize`) which will make it write build artifacts like `Main.hi`, `Main.o`, and the executable itself `Main` to `~/.stack` so that those files don't clutter up your project directory.
+* `stack script` learned a new option `--hide-built-files` (used with `--compile` or `--optimize`) which will make it write build artifacts like `Main.hi`, `Main.o`, and the executable itself `Main` to the Stack root so that those files don't clutter up your project directory.
 
 **Changes since v2.9.3:**
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ Release notes:
 
 New features:
 
-* `stack script` learned a new option `--hide-built-files` (used with
+* `stack script` learned a new option `--use-root` (used with
   `--compile` or `--optimize`) which will make it write build artifacts like
   `Main.hi`, `Main.o`, and the executable itself `Main` to the Stack root so
   that those files don't clutter up your project directory.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 Release notes:
 
+New features:
+
+* `stack script` learned a new option `--hide-built-files` (used with `--compile` or `--optimize`) which will make it write build artifacts like `Main.hi`, `Main.o`, and the executable itself `Main` to `~/.stack` so that those files don't clutter up your project directory.
+
 **Changes since v2.9.3:**
 
 Major changes:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,10 @@ Release notes:
 
 New features:
 
-* `stack script` learned a new option `--hide-built-files` (used with `--compile` or `--optimize`) which will make it write build artifacts like `Main.hi`, `Main.o`, and the executable itself `Main` to the Stack root so that those files don't clutter up your project directory.
+* `stack script` learned a new option `--hide-built-files` (used with
+  `--compile` or `--optimize`) which will make it write build artifacts like
+  `Main.hi`, `Main.o`, and the executable itself `Main` to the Stack root so
+  that those files don't clutter up your project directory.
 
 **Changes since v2.9.3:**
 

--- a/doc/script_command.md
+++ b/doc/script_command.md
@@ -51,9 +51,9 @@ file is compiled, passing the `--no-run` flag will mean the compiled code is not
 run.
 
 The build artifacts like `Main.hi`, `Main.o`, and the executable itself `Main`
-can be hidden away under the Stack root so they don't clutter your project
-directory by passing the `--hide-built-files` flag. Here's what the directory
-structure looks like:
+can be written under the Stack root so they don't clutter your project directory
+by passing the `--use-root` flag. Here's what the directory structure looks
+like:
 
 ```
 ~/.stack/scripts/

--- a/doc/script_command.md
+++ b/doc/script_command.md
@@ -48,7 +48,9 @@ version of GHC specified by the snapshot is always available.
 The source file can be compiled by passing either the `--compile` flag (no
 optimization) or the `--optimize` flag (compilation with optimization). If the
 file is compiled, passing the `--no-run` flag will mean the compiled code is not
-run.
+run. The build artifacts like `Main.hi`, `Main.o`, and the executable itself
+`Main` can be hidden away under `~/.stack` so they don't clutter your project
+directory by passing the `--hide-built-files` flag.
 
 Additional options can be passed to GHC using the `--ghc-options` option.
 

--- a/doc/script_command.md
+++ b/doc/script_command.md
@@ -48,9 +48,23 @@ version of GHC specified by the snapshot is always available.
 The source file can be compiled by passing either the `--compile` flag (no
 optimization) or the `--optimize` flag (compilation with optimization). If the
 file is compiled, passing the `--no-run` flag will mean the compiled code is not
-run. The build artifacts like `Main.hi`, `Main.o`, and the executable itself
-`Main` can be hidden away under the Stack root so they don't clutter your
-project directory by passing the `--hide-built-files` flag.
+run.
+
+The build artifacts like `Main.hi`, `Main.o`, and the executable itself `Main`
+can be hidden away under the Stack root so they don't clutter your project
+directory by passing the `--hide-built-files` flag. Here's what the directory
+structure looks like:
+
+```
+~/.stack/scripts/
+├── %2FUsers%2Fjohn%2FMain.hs/
+│   ├── Main
+│   ├── Main.dyn_hi
+│   ├── Main.hi
+│   └── Main.o
+├── %2FUsers%2Fjohn%2FMain2.hs//
+└── %2FUsers%2Fjohn%2Fother%2FMain.hs//
+```
 
 Additional options can be passed to GHC using the `--ghc-options` option.
 

--- a/doc/script_command.md
+++ b/doc/script_command.md
@@ -49,8 +49,8 @@ The source file can be compiled by passing either the `--compile` flag (no
 optimization) or the `--optimize` flag (compilation with optimization). If the
 file is compiled, passing the `--no-run` flag will mean the compiled code is not
 run. The build artifacts like `Main.hi`, `Main.o`, and the executable itself
-`Main` can be hidden away under `~/.stack` so they don't clutter your project
-directory by passing the `--hide-built-files` flag.
+`Main` can be hidden away under the Stack root so they don't clutter your
+project directory by passing the `--hide-built-files` flag.
 
 Additional options can be passed to GHC using the `--ghc-options` option.
 

--- a/doc/script_command.md
+++ b/doc/script_command.md
@@ -62,8 +62,8 @@ like:
 │   ├── Main.dyn_hi
 │   ├── Main.hi
 │   └── Main.o
-├── %2FUsers%2Fjohn%2FMain2.hs//
-└── %2FUsers%2Fjohn%2Fother%2FMain.hs//
+├── %2FUsers%2Fjohn%2FMain2.hs/
+└── %2FUsers%2Fjohn%2Fother%2FMain.hs/
 ```
 
 Additional options can be passed to GHC using the `--ghc-options` option.

--- a/src/Stack/Options/ScriptParser.hs
+++ b/src/Stack/Options/ScriptParser.hs
@@ -9,7 +9,7 @@ module Stack.Options.ScriptParser
 
 import           Options.Applicative
                    ( Parser, completer, eitherReader, flag', help, long
-                   , metavar, option, strArgument, strOption
+                   , metavar, option, strArgument, strOption, switch
                    )
 import           Options.Applicative.Builder.Extra ( fileExtCompleter )
 import           Stack.Options.Completion ( ghcOptsCompleter )
@@ -23,6 +23,7 @@ data ScriptOpts = ScriptOpts
   , soGhcOptions :: ![String]
   , soScriptExtraDeps :: ![PackageIdentifierRevision]
   , soShouldRun :: !ShouldRun
+  , soHideBuiltFiles :: !Bool
   }
   deriving Show
 
@@ -79,6 +80,11 @@ scriptOptsParser = ScriptOpts
             <> help "Don't run, just compile."
             )
       <|> pure YesRun
+      )
+  <*> (switch
+        (  long "hide-built-files"
+        <> help "Write artifacts of compilation (.hi, .o, executable, etc.) to the Stack root scripts directory (usually ~/.stack/scripts) instead of the current directory."
+        )
       )
  where
   extraDepRead = eitherReader $

--- a/src/Stack/Options/ScriptParser.hs
+++ b/src/Stack/Options/ScriptParser.hs
@@ -81,11 +81,10 @@ scriptOptsParser = ScriptOpts
             )
       <|> pure YesRun
       )
-  <*> (switch
+  <*> switch
         (  long "hide-built-files"
         <> help "Write artifacts of compilation (.hi, .o, executable, etc.) to the Stack root scripts directory (usually ~/.stack/scripts) instead of the current directory."
         )
-      )
  where
   extraDepRead = eitherReader $
                    mapLeft show . parsePackageIdentifierRevision . fromString

--- a/src/Stack/Options/ScriptParser.hs
+++ b/src/Stack/Options/ScriptParser.hs
@@ -83,7 +83,7 @@ scriptOptsParser = ScriptOpts
       )
   <*> switch
         (  long "hide-built-files"
-        <> help "Write artifacts of compilation (.hi, .o, executable, etc.) to the Stack root scripts directory (usually ~/.stack/scripts) instead of the current directory."
+        <> help "Write artifacts of compilation (.hi, .o, executable, etc.) to the Stack root's scripts/ directory instead of the current directory."
         )
  where
   extraDepRead = eitherReader $

--- a/src/Stack/Options/ScriptParser.hs
+++ b/src/Stack/Options/ScriptParser.hs
@@ -23,7 +23,7 @@ data ScriptOpts = ScriptOpts
   , soGhcOptions :: ![String]
   , soScriptExtraDeps :: ![PackageIdentifierRevision]
   , soShouldRun :: !ShouldRun
-  , soHideBuiltFiles :: !Bool
+  , soUseRoot :: !Bool
   }
   deriving Show
 
@@ -82,7 +82,7 @@ scriptOptsParser = ScriptOpts
       <|> pure YesRun
       )
   <*> switch
-        (  long "hide-built-files"
+        (  long "use-root"
         <> help "Write artifacts of compilation (.hi, .o, executable, etc.) to the Stack root's scripts/ directory instead of the current directory."
         )
  where

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -422,7 +422,7 @@ parseImports =
             $ S8.takeWhile (\c -> c /= ' ' && c /= '(') bs3
         )
 
-data FailedToParseUrlEncodedPath
+newtype FailedToParseUrlEncodedPath
   = FailedToParseUrlEncodedPath (Path Abs File)
 
 instance Show FailedToParseUrlEncodedPath where

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -52,6 +52,7 @@ import           System.FilePath
                    ( dropExtension, replaceExtension, (</>), takeBaseName
                    , takeDirectory
                    )
+import           Network.HTTP.Types ( urlEncode )
 
 -- | Type representing exceptions thrown by functions exported by the
 -- "Stack.Script" module.
@@ -116,12 +117,9 @@ scriptCmd opts = do
 
   root <- withConfig NoReexec $ view stackRootL
 
-  let sanitizeChar '/' = "#"
-      sanitizeChar '#' = "##"
-      sanitizeChar c = [c]
-      sanitize = concatMap sanitizeChar
+  let escape = S8.unpack . urlEncode False . S8.pack
       outputDir = if soHideBuiltFiles opts
-        then toFilePath root </> "scripts" </> sanitize (toFilePath file)
+        then toFilePath root </> "scripts" </> escape (toFilePath file)
         else toFilePath scriptDir
       exe = if osIsWindows
         then replaceExtension (outputDir </> takeBaseName (toFilePath file)) "exe"

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -118,7 +118,7 @@ scriptCmd opts = do
   root <- withConfig NoReexec $ view stackRootL
 
   let escape = S8.unpack . urlEncode False . S8.pack
-      outputDir = if soHideBuiltFiles opts
+      outputDir = if soUseRoot opts
         then toFilePath root </> "scripts" </> escape (toFilePath file)
         else toFilePath scriptDir
       exe = if osIsWindows
@@ -210,7 +210,7 @@ scriptCmd opts = do
                   SECompile -> []
                   SEOptimize -> ["-O2"]
               , soGhcOptions opts
-              , if soHideBuiltFiles opts
+              , if soUseRoot opts
                   then
                     [ "-outputdir=" ++ takeDirectory exe
                     , "-o", exe

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -117,7 +117,7 @@ scriptCmd opts = do
 
   root <- withConfig NoReexec $ view stackRootL
   let escape path = case parseRelDir $ S8.unpack $ urlEncode True $ S8.pack $ toFilePath path of
-        Nothing -> throwIO $ FailedToParseUrlEncodedDir file
+        Nothing -> throwIO $ FailedToParseUrlEncodedPath file
         Just escaped -> return escaped
   outputDir <- if soUseRoot opts
     then do
@@ -422,13 +422,13 @@ parseImports =
             $ S8.takeWhile (\c -> c /= ' ' && c /= '(') bs3
         )
 
-data FailedToParseUrlEncodedDir
-  = FailedToParseUrlEncodedDir (Path Abs File)
+data FailedToParseUrlEncodedPath
+  = FailedToParseUrlEncodedPath (Path Abs File)
 
-instance Show FailedToParseUrlEncodedDir where
-  show (FailedToParseUrlEncodedDir fp) = unlines
-    [ "Failed to parse URL-encoded directory: " ++ fromAbsFile fp
+instance Show FailedToParseUrlEncodedPath where
+  show (FailedToParseUrlEncodedPath fp) = unlines
+    [ "Failed to parse URL-encoded file: " ++ fromAbsFile fp
     , "This should never happen because URL-encoded strings are valid filenames."
     ]
 
-instance Exception FailedToParseUrlEncodedDir
+instance Exception FailedToParseUrlEncodedPath

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -149,7 +149,7 @@ scriptCmd opts = do
       SEOptimize -> shortCut shouldRun shouldCompile file exe
 
  where
-  runCompiled shouldRun (exe :: Path Abs File) = do
+  runCompiled shouldRun exe = do
     case shouldRun of
       YesRun -> exec (fromAbsFile exe) (soArgs opts)
       NoRun -> prettyInfoL
@@ -157,7 +157,7 @@ scriptCmd opts = do
         , style File (fromString (fromAbsFile exe)) <> "."
         ]
 
-  shortCut shouldRun shouldCompile file (exe :: Path Abs File) =
+  shortCut shouldRun shouldCompile file exe =
     handleIO (const $ longWay shouldRun shouldCompile file exe) $ do
       srcMod <- getModificationTime file
       exeMod <- Dir.getModificationTime (fromAbsFile exe)
@@ -165,7 +165,7 @@ scriptCmd opts = do
         then runCompiled shouldRun exe
         else longWay shouldRun shouldCompile file exe
 
-  longWay shouldRun shouldCompile file (exe :: Path Abs File) =
+  longWay shouldRun shouldCompile file exe =
     withConfig YesReexec $
     withDefaultEnvConfig $ do
       config <- view configL

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -119,7 +119,7 @@ scriptCmd opts = do
   let sanitizeChar '/' = "#"
       sanitizeChar '#' = "##"
       sanitizeChar c = [c]
-      sanitize path = concatMap sanitizeChar path
+      sanitize = concatMap sanitizeChar
       outputDir = if soHideBuiltFiles opts
         then toFilePath root </> "scripts" </> sanitize (toFilePath file)
         else toFilePath scriptDir

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -116,7 +116,7 @@ scriptCmd opts = do
         else (soShouldRun opts, soCompile opts)
 
   root <- withConfig NoReexec $ view stackRootL
-  let escape path = case parseRelDir $ S8.unpack $ urlEncode False $ S8.pack $ toFilePath path of
+  let escape path = case parseRelDir $ S8.unpack $ urlEncode True $ S8.pack $ toFilePath path of
         Nothing -> throwIO $ FailedToParseUrlEncodedDir file
         Just escaped -> return escaped
   outputDir <- if soUseRoot opts


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

This adds a new option `stack script --use-root` which will write the intermediate files like `Main.hi` and `Main.o` and the executable itself `Main` to a unique subdirectory under the new `~/.stack/scripts` directory (to avoid conflicts) so that the intermediate files don't clutter up your project directory.

New `~/.stack/scripts` directory structure:

```
~/.stack/scripts/
├── %2FUsers%2Fjohn%2FMain.hs/
│   ├── Main
│   ├── Main.dyn_hi
│   ├── Main.hi
│   └── Main.o
├── %2FUsers%2Fjohn%2FMain2.hs/
└── %2FUsers%2Fjohn%2Fother%2FMain.hs/
```

Paths are escaped via URL encoding.

Resolves https://github.com/commercialhaskell/stack/issues/6079
