### PR TITLE
stack script: recognize more extra-dep kinds

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@
 
 Release notes:
 
+Behavior changes:
+
+* `stack script --extra-dep=<...>` now recognizes all the kinds of extra-deps
+  that Stack can use (local packages, git repos, etc.), not just package names.
+
 **Changes since v2.9.3:**
 
 Major changes:

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -263,7 +263,7 @@ configFromConfigMonoid
           case configProject of
             PCProject _ -> True
             PCGlobalProject -> True
-            PCNoProject _ -> False
+            PCNoProject _ -> True
     configWorkDir0 <-
       let parseStackWorkEnv x =
             catch
@@ -681,7 +681,7 @@ withBuildConfig inner = do
  where
   getEmptyProject ::
        Maybe RawSnapshotLocation
-    -> [PackageIdentifierRevision]
+    -> [RawPackageLocation]
     -> RIO Config Project
   getEmptyProject mresolver extraDeps = do
     r <- case mresolver of
@@ -695,8 +695,7 @@ withBuildConfig inner = do
     pure Project
       { projectUserMsg = Nothing
       , projectPackages = []
-      , projectDependencies =
-          map (RPLImmutable . flip RPLIHackage Nothing) extraDeps
+      , projectDependencies = extraDeps
       , projectFlags = mempty
       , projectResolver = r
       , projectCompiler = Nothing

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -830,7 +830,7 @@ data StackYamlLoc
     -- ^ Use the standard parent-directory-checking logic
   | SYLOverride !(Path Abs File)
     -- ^ Use a specific stack.yaml file provided
-  | SYLNoProject ![PackageIdentifierRevision]
+  | SYLNoProject ![RawPackageLocation]
     -- ^ Do not load up a project, just user configuration. Include
     -- the given extra dependencies with the resolver.
   | SYLGlobalProject
@@ -882,7 +882,7 @@ data ProjectConfig a
   | PCGlobalProject
     -- ^ No project was found when using 'SYLDefault'. Instead, use
     -- the implicit global.
-  | PCNoProject ![PackageIdentifierRevision]
+  | PCNoProject ![RawPackageLocation]
     -- ^ Use a no project run. This comes from 'SYLNoProject'.
 
 -- | Parsed global command-line options monoid.


### PR DESCRIPTION
🚧 This is a WIP (it doesn't quite work yet, not sure why) 🚧

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

When you're working on a Stack script, sometimes you encounter a bug in a dependency and want to use a local patched version. Prior to this PR you couldn't because it only recognized package names. After this PR it will recognize the same kinds of [`extra-deps`](https://docs.haskellstack.org/en/stable/yaml_configuration/#extra-deps) as a proper Stack project, including local paths.

For convenience and backcompat, the argument is first parsed as a literal string, and if that fails then it is parsed as JSON.