### PR TITLE
Fix #2868 Add --PROG-option to stack build

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,13 @@ Behavior changes:
 
 Other enhancements:
 
+* Add options of the form `--PROG-option=<argument>` to `stack build`, where
+  `PROG` is a program recognised by the Cabal library and one of `alex`, `ar`,
+  `c2hs`, `cpphs`, `gcc`, `greencard`, `happy`, `hsc2hs`, `hscolour`, `ld`,
+  `pkg-config`, `strip` and `tar`. If Cabal uses the program during the
+  configuration step, the argument is passed to it.
+* By default all `--PROG-option` options are applied to all local packages. This
+  behaviour can be changed with new configuration option `apply-prog-options`.
 * Add flag `--[no-]use-root` to `stack script` (default disabled). Used with
   `--compile` or `--optimize`, when enabled all compilation outputs (including
   the executable) are written to a script-specific location in the `scripts`

--- a/doc/build_command.md
+++ b/doc/build_command.md
@@ -406,6 +406,35 @@ symbols.
 Pass the flag to enable profiling in libraries, executables, etc. for all
 expressions, and generate a backtrace on exception.
 
+## Flags affecting other tools' behaviour
+
+### `--PROG-option` options
+
+:octicons-tag-24: UNRELEASED
+
+`PROG` is a program recognised by Cabal (the library) and one of `alex`, `ar`,
+`c2hs`, `cpphs`, `gcc`, `greencard`, `happy`, `hsc2hs`, `hscolour`, `ld`,
+`pkg-config`, `strip` and `tar`.
+
+`stack build --PROG-option <PROG_argument>` passes the specified command line
+argument to `PROG`, if it used by Cabal during the configuration step. This
+option can be specified multiple times. For example, if the program `happy` is
+used by Cabal during the configuration step, you could command
+`stack build --happy-option=--ghc` or `stack build --happy-option --ghc` to pass
+to `happy` its `--ghc` flag.
+
+By default, all and any `--PROG-option` options on Stack's command line are
+applied to all local packages (targets or otherwise). This behaviour can be
+changed. See the
+[`apply-prog-options`](yaml_configuration.md#apply-prog-options) configuration
+option.
+
+Stack can also be configured to pass Cabal's `--PROG-option`, `--PROG-options`
+or other options to Cabal during the configuration step. For further
+information, see the documentation for the
+[configure-options](yaml_configuration.md#configure-options) configuration
+option.
+
 ## Flags relating to build outputs
 
 ### `--[no]-cabal-verbose` flag

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -412,6 +412,24 @@ or otherwise), `locals` (all local packages, targets or otherwise), and
 
     Before Stack 0.1.6.0, the default value was `targets`.
 
+### apply-prog-options
+
+:octicons-tag-24: UNRELEASED
+
+Default: `locals`
+
+Related command line:
+[`stack build --PROG-option`](build_command.md#-prog-option-options) options
+
+Determines to which packages all and any `--PROG-option` command line options
+specified on the command line are applied. Possible values are: `everything`
+(all packages, local or otherwise), `locals` (all local packages, targets or
+otherwise), and `targets` (all local packages that are targets).
+
+!!! note
+
+    The use of `everything` can break invariants about your snapshot database.
+
 ### arch
 
 Default: The machine architecture on which Stack is running.
@@ -628,16 +646,23 @@ concurrent-tests: false
 
 [:octicons-tag-24: 2.1.1](https://github.com/commercialhaskell/stack/releases/tag/v2.1.1)
 
-Options which are passed to the configure step of the Cabal build process.
-These can either be set by package name, or using the `$everything`,
-`$targets`, and `$locals` special keys. These special keys have the same
-meaning as in `ghc-options`.
+Related command line (takes precedence):
+[`stack build --PROG-option`](build_command.md#prog-option-options) options
+
+`configure-options` can specify Cabal (the library) options (including
+`--PROG-option` or `--PROG-options` options) for the configure step of the Cabal
+build process for a named package, all local packages that are targets (using
+the `$targets` key), all local packages (targets or otherwise) (using the
+`$locals` key), or all packages (local or otherwise) (using the `$everything`
+key).
 
 ~~~yaml
 configure-options:
   $everything:
   - --with-gcc
   - /some/path
+  $locals:
+  - --happy-option=--ghc
   my-package:
   - --another-flag
 ~~~

--- a/package.yaml
+++ b/package.yaml
@@ -263,6 +263,7 @@ library:
   - Stack.Types.AddCommand
   - Stack.Types.AllowNewerDeps
   - Stack.Types.ApplyGhcOptions
+  - Stack.Types.ApplyProgOptions
   - Stack.Types.Build
   - Stack.Types.BuildConfig
   - Stack.Types.BuildOpts

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -99,6 +99,7 @@ import           Stack.Storage.User ( initUserStorage )
 import           Stack.Storage.Util ( handleMigrationException )
 import           Stack.Types.AllowNewerDeps ( AllowNewerDeps (..) )
 import           Stack.Types.ApplyGhcOptions ( ApplyGhcOptions (..) )
+import           Stack.Types.ApplyProgOptions ( ApplyProgOptions (..) )
 import           Stack.Types.Build ( BuildException (..), FlagSource (..) )
 import           Stack.Types.BuildConfig ( BuildConfig (..) )
 import           Stack.Types.BuildOpts ( BuildOpts (..) )
@@ -410,6 +411,7 @@ configFromConfigMonoid
         configModifyCodePage = fromFirstTrue configMonoidModifyCodePage
         configRebuildGhcOptions = fromFirstFalse configMonoidRebuildGhcOptions
         configApplyGhcOptions = fromFirst AGOLocals configMonoidApplyGhcOptions
+        configApplyProgOptions = fromFirst APOLocals configMonoidApplyProgOptions
         configAllowNewer = fromFirst False configMonoidAllowNewer
         configAllowNewerDeps = coerce configMonoidAllowNewerDeps
         configDefaultTemplate = getFirst configMonoidDefaultTemplate

--- a/src/Stack/Types/ApplyProgOptions.hs
+++ b/src/Stack/Types/ApplyProgOptions.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Stack.Types.ApplyProgOptions
+  ( ApplyProgOptions (..)
+  ) where
+
+import           Pantry.Internal.AesonExtended ( FromJSON (..), withText )
+import           Stack.Prelude
+
+-- | Which packages do all and any --PROG-option options on the command line
+-- apply to?
+data ApplyProgOptions
+  = APOTargets -- ^ All local packages that are targets.
+  | APOLocals -- ^ All local packages (targets or otherwise).
+  | APOEverything -- ^ All packages (local or otherwise).
+  deriving (Bounded, Enum, Eq, Ord, Read, Show)
+
+instance FromJSON ApplyProgOptions where
+  parseJSON = withText "ApplyProgOptions" $ \t ->
+    case t of
+      "targets" -> pure APOTargets
+      "locals" -> pure APOLocals
+      "everything" -> pure APOEverything
+      _ -> fail $ "Invalid ApplyProgOptions: " ++ show t

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -1171,12 +1171,13 @@ configureOptsDirs bco isMutable package = concat
     )
 
 -- | Same as 'configureOpts', but does not include directory path options
-configureOptsNoDir :: EnvConfig
-                   -> BaseConfigOpts
-                   -> Map PackageIdentifier GhcPkgId -- ^ dependencies
-                   -> Bool -- ^ is this a local, non-extra-dep?
-                   -> Package
-                   -> [String]
+configureOptsNoDir ::
+     EnvConfig
+  -> BaseConfigOpts
+  -> Map PackageIdentifier GhcPkgId -- ^ Dependencies.
+  -> Bool -- ^ Is this a local, non-extra-dep?
+  -> Package
+  -> [String]
 configureOptsNoDir econfig bco deps isLocal package = concat
   [ depOptions
   , [ "--enable-library-profiling"

--- a/src/Stack/Types/BuildOpts.hs
+++ b/src/Stack/Types/BuildOpts.hs
@@ -11,6 +11,7 @@ module Stack.Types.BuildOpts
   , defaultBuildOpts
   , defaultBuildOptsCLI
   , BuildOptsCLI (..)
+  , boptsCLIAllProgOptions
   , BuildOptsMonoid (..)
   , buildOptsMonoidBenchmarksL
   , buildOptsMonoidHaddockL
@@ -140,6 +141,7 @@ defaultBuildOptsCLI = BuildOptsCLI
   , boptsCLIDryrun = False
   , boptsCLIFlags = Map.empty
   , boptsCLIGhcOptions = []
+  , boptsCLIProgsOptions = []
   , boptsCLIBuildSubset = BSAll
   , boptsCLIFileWatch = NoFileWatch
   , boptsCLIWatchAll = False
@@ -173,6 +175,7 @@ data BuildOptsCLI = BuildOptsCLI
   { boptsCLITargets :: ![Text]
   , boptsCLIDryrun :: !Bool
   , boptsCLIGhcOptions :: ![Text]
+  , boptsCLIProgsOptions :: ![(Text, [Text])]
   , boptsCLIFlags :: !(Map ApplyCLIFlag (Map FlagName Bool))
   , boptsCLIBuildSubset :: !BuildSubset
   , boptsCLIFileWatch :: !FileWatchOpts
@@ -183,6 +186,25 @@ data BuildOptsCLI = BuildOptsCLI
   , boptsCLIInitialBuildSteps :: !Bool
   }
   deriving Show
+
+-- | Generate a list of --PROG-option="<argument>" arguments for all PROGs.
+boptsCLIAllProgOptions :: BuildOptsCLI -> [Text]
+boptsCLIAllProgOptions boptsCLI =
+  concatMap progOptionArgs (boptsCLIProgsOptions boptsCLI)
+ where
+  -- Generate a list of --PROG-option="<argument>" arguments for a PROG.
+  progOptionArgs :: (Text, [Text]) -> [Text]
+  progOptionArgs (prog, opts) = map progOptionArg opts
+   where
+    -- Generate a --PROG-option="<argument>" argument for a PROG and option.
+    progOptionArg :: Text -> Text
+    progOptionArg opt = T.concat
+      [ "--"
+      , prog
+      , "-option=\""
+      , opt
+      , "\""
+      ]
 
 -- | Command sum type for conditional arguments.
 data BuildCommand

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -32,6 +32,7 @@ import           Path ( (</>), parent, reldir, relfile )
 import           RIO.Process ( HasProcessContext (..), ProcessContext )
 import           Stack.Prelude
 import           Stack.Types.ApplyGhcOptions ( ApplyGhcOptions (..) )
+import           Stack.Types.ApplyProgOptions ( ApplyProgOptions (..) )
 import           Stack.Types.BuildOpts ( BuildOpts )
 import           Stack.Types.CabalConfigKey ( CabalConfigKey )
 import           Stack.Types.Compiler ( CompilerRepository )
@@ -139,7 +140,10 @@ data Config = Config
   , configRebuildGhcOptions   :: !Bool
     -- ^ Rebuild on GHC options changes
   , configApplyGhcOptions     :: !ApplyGhcOptions
-    -- ^ Which packages to ghc-options on the command line apply to?
+    -- ^ Which packages do --ghc-options on the command line apply to?
+  , configApplyProgOptions     :: !ApplyProgOptions
+    -- ^ Which packages do all and any --PROG-option options on the command line
+    -- apply to?
   , configAllowNewer          :: !Bool
     -- ^ Ignore version ranges in .cabal files. Funny naming chosen to
     -- match cabal.

--- a/src/Stack/Types/ConfigMonoid.hs
+++ b/src/Stack/Types/ConfigMonoid.hs
@@ -30,6 +30,7 @@ import           Pantry.Internal.AesonExtended
 import           Stack.Prelude
 import           Stack.Types.AllowNewerDeps ( AllowNewerDeps )
 import           Stack.Types.ApplyGhcOptions ( ApplyGhcOptions (..) )
+import           Stack.Types.ApplyProgOptions ( ApplyProgOptions (..) )
 import           Stack.Types.BuildOpts ( BuildOptsMonoid )
 import           Stack.Types.CabalConfigKey ( CabalConfigKey )
 import           Stack.Types.ColorWhen ( ColorWhen )
@@ -140,6 +141,8 @@ data ConfigMonoid = ConfigMonoid
     -- ^ See 'configMonoidRebuildGhcOptions'
   , configMonoidApplyGhcOptions     :: !(First ApplyGhcOptions)
     -- ^ See 'configApplyGhcOptions'
+  , configMonoidApplyProgOptions     :: !(First ApplyProgOptions)
+    -- ^ See 'configApplyProgOptions'
   , configMonoidAllowNewer          :: !(First Bool)
     -- ^ See 'configMonoidAllowNewer'
   , configMonoidAllowNewerDeps      :: !(Maybe AllowNewerDeps)
@@ -283,7 +286,8 @@ parseConfigMonoidObject rootDir obj = do
       configMonoidGhcOptionsByName = coerce $ Map.fromList
           [(name, opts) | (GOKPackage name, opts) <- Map.toList options]
 
-  configMonoidCabalConfigOpts' <- obj ..:? "configure-options" ..!= mempty
+  configMonoidCabalConfigOpts' <-
+    obj ..:? configMonoidConfigureOptionsName ..!= mempty
   let configMonoidCabalConfigOpts =
         coerce (configMonoidCabalConfigOpts' :: Map CabalConfigKey [Text])
 
@@ -301,6 +305,8 @@ parseConfigMonoidObject rootDir obj = do
     FirstFalse <$> obj ..:? configMonoidRebuildGhcOptionsName
   configMonoidApplyGhcOptions <-
     First <$> obj ..:? configMonoidApplyGhcOptionsName
+  configMonoidApplyProgOptions <-
+    First <$> obj ..:? configMonoidApplyProgOptionsName
   configMonoidAllowNewer <- First <$> obj ..:? configMonoidAllowNewerName
   configMonoidAllowNewerDeps <- obj ..:? configMonoidAllowNewerDepsName
   configMonoidDefaultTemplate <-
@@ -351,6 +357,9 @@ configMonoidDockerOptsName = "docker"
 
 configMonoidNixOptsName :: Text
 configMonoidNixOptsName = "nix"
+
+configMonoidConfigureOptionsName :: Text
+configMonoidConfigureOptionsName = "configure-options"
 
 configMonoidConnectionCountName :: Text
 configMonoidConnectionCountName = "connection-count"
@@ -457,6 +466,9 @@ configMonoidRebuildGhcOptionsName = "rebuild-ghc-options"
 
 configMonoidApplyGhcOptionsName :: Text
 configMonoidApplyGhcOptionsName = "apply-ghc-options"
+
+configMonoidApplyProgOptionsName :: Text
+configMonoidApplyProgOptionsName = "apply-prog-options"
 
 configMonoidAllowNewerName :: Text
 configMonoidAllowNewerName = "allow-newer"

--- a/stack.cabal
+++ b/stack.cabal
@@ -243,6 +243,7 @@ library
       Stack.Types.AddCommand
       Stack.Types.AllowNewerDeps
       Stack.Types.ApplyGhcOptions
+      Stack.Types.ApplyProgOptions
       Stack.Types.Build
       Stack.Types.BuildConfig
       Stack.Types.BuildOpts


### PR DESCRIPTION
Also adds apply-prog-options configuration option.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested in a similar way to #6083, but also checked that flags are considered to have changed if options changed. 
