### PR TITLE
Add ide target component types

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ Other enhancements:
 * Avoid the duplicate resolving of usage files when parsing `*.hi` files into a
   set of modules and a collection of resolved usage files. See
   [#6123](https://github.com/commercialhaskell/stack/pull/6123).
+* Add component type flags to the `ide targets` command.
 
 Bug fixes:
 

--- a/doc/build_command.md
+++ b/doc/build_command.md
@@ -144,8 +144,14 @@ supported syntaxes for targets are:
 
 `stack build` with no targets specified will build all local packages.
 
-Command `stack ide targets` to get a list of the available targets in your
-project.
+## Listing targets
+
+`stack ide targets` lists every available target in your project.
+
+With one or more component type flags this listing can be restricted.
+
+`stack ide targets --exes` lists only exe targets.
+`stack ide targets --tests --benchmarks` lists test and benchmark targets.
 
 ## Controlling what gets built
 

--- a/src/Stack/IDE.hs
+++ b/src/Stack/IDE.hs
@@ -5,7 +5,6 @@
 module Stack.IDE
   ( OutputStream (..)
   , ListPackagesCmd (..)
-  , CompTypeCmd (..)
   , idePackagesCmd
   , ideTargetsCmd
   , listPackages
@@ -42,11 +41,6 @@ data ListPackagesCmd
     -- ^ Package names.
   | ListPackageCabalFiles
     -- ^ Paths to Cabal files.
-
--- Type representing output choices for the @stack ide packages@ command.
-data CompTypeCmd
-  = CompTypeTest
-  | CompTypeBench
 
 -- | Function underlying the @stack ide packages@ command. List packages in the
 -- project.

--- a/src/Stack/IDE.hs
+++ b/src/Stack/IDE.hs
@@ -26,6 +26,7 @@ import           Stack.Types.Runner ( Runner )
 import           Stack.Types.SourceMap
                    ( ProjectPackage (..), SMWanted (..), ppComponentsMaybe )
 import           System.IO ( putStrLn )
+import Data.Tuple (swap)
 
 -- Type representing output channel choices for the @stack ide packages@ and
 -- @stack ide targets@ commands.
@@ -65,8 +66,8 @@ compTypes (False, True, True) = \x -> isCTest x || isCBench x
 
 -- | Function underlying the @stack ide targets@ command. List targets in the
 -- project.
-ideTargetsCmd :: (OutputStream, (Bool, Bool, Bool))  -> RIO Runner ()
-ideTargetsCmd = withConfig NoReexec . withBuildConfig . uncurry listTargets . fmap compTypes
+ideTargetsCmd :: ((Bool, Bool, Bool), OutputStream)  -> RIO Runner ()
+ideTargetsCmd = withConfig NoReexec . withBuildConfig . uncurry listTargets . fmap compTypes . swap
 
 outputFunc :: HasTerm env => OutputStream -> String -> RIO env ()
 outputFunc OutputLogInfo = prettyInfo . fromString

--- a/src/Stack/IDE.hs
+++ b/src/Stack/IDE.hs
@@ -50,13 +50,7 @@ idePackagesCmd =
 
 compTypes :: (Bool, Bool, Bool) -> NamedComponent -> Bool
 compTypes (False, False, False) = const True
-compTypes (True, False, False) = isCExe
-compTypes (False, True, False) = isCTest
-compTypes (False, False, True) = isCBench
-compTypes (True, True, False) = \x -> isCExe x || isCTest x
-compTypes (True, False, True) = \x -> isCExe x || isCBench x
-compTypes (True, True, True) = \x -> isCExe x || isCTest x || isCBench x
-compTypes (False, True, True) = \x -> isCTest x || isCBench x
+compTypes (exe, test, bench) = \x -> (exe && isCExe x) || (test && isCTest x) || (bench && isCBench x)
 
 -- | Function underlying the @stack ide targets@ command. List targets in the
 -- project.

--- a/src/main/Stack/CLI.hs
+++ b/src/main/Stack/CLI.hs
@@ -320,15 +320,15 @@ commandLineHandler currentDir progName isInterpreter =
             )
           exeFlag = switch
             (  long "exes"
-            <> help "Restriction includes exes."
+            <> help "Include exes."
             )
           testFlag = switch
             (  long "tests"
-            <> help "Restriction includes tests."
+            <> help "Include tests."
             )
           benchFlag = switch
             (  long "benchmarks"
-            <> help "Restriction includes benchmarks."
+            <> help "Include benchmarks."
             )
        in  do
              addCommand'
@@ -338,7 +338,7 @@ commandLineHandler currentDir progName isInterpreter =
                ((,) <$> outputFlag <*> cabalFileFlag)
              addCommand'
                "targets"
-               "List every target. Restrict to runnable targets with component type flags."
+               "List targets, all of them (by default) or only some component types."
                ideTargetsCmd
                ((,) <$> ((,,) <$> exeFlag <*> testFlag <*> benchFlag) <*> outputFlag)
     )

--- a/src/main/Stack/CLI.hs
+++ b/src/main/Stack/CLI.hs
@@ -320,18 +320,15 @@ commandLineHandler currentDir progName isInterpreter =
             )
           exeFlag = switch
             (  long "exes"
-            <> help "List exes (list with --tests and --benchmarks). \
-                    \The default is to list every target but you can use \
-                    \--exes with --tests and --benchmarks to limit the \
-                    \output to 1, 2 or 3 of these component types."
+            <> help "Restriction includes exes."
             )
           testFlag = switch
             (  long "tests"
-            <> help "List tests (list with --exes and --benchmarks)."
+            <> help "Restriction includes tests."
             )
           benchFlag = switch
             (  long "benchmarks"
-            <> help "List benchmarks (list with --exes and --tests)."
+            <> help "Restriction includes benchmarks."
             )
        in  do
              addCommand'
@@ -341,7 +338,7 @@ commandLineHandler currentDir progName isInterpreter =
                ((,) <$> outputFlag <*> cabalFileFlag)
              addCommand'
                "targets"
-               "List all available Stack targets."
+               "List every target. Restrict to runnable targets with component type flags."
                ideTargetsCmd
                ((,) <$> ((,,) <$> exeFlag <*> testFlag <*> benchFlag) <*> outputFlag)
     )

--- a/src/main/Stack/CLI.hs
+++ b/src/main/Stack/CLI.hs
@@ -9,7 +9,7 @@ import           Data.Attoparsec.Interpreter ( getInterpreterArgs )
 import           Data.Char ( toLower )
 import qualified Data.List as L
 import           Options.Applicative
-                   ( Parser, ParserFailure, ParserHelp, ParserResult (..), flag
+                   ( Parser, ParserFailure, ParserHelp, ParserResult (..), flag, switch
                    , handleParseResult, help, helpError, idm, long, metavar
                    , overFailure, renderFailure, strArgument, switch )
 import           Options.Applicative.Help ( errorHelp, stringChunk, vcatChunks )
@@ -318,6 +318,18 @@ commandLineHandler currentDir progName isInterpreter =
             <> help "Print paths to package Cabal files instead of package \
                     \names."
             )
+          exeFlag = switch
+            (  long "exes"
+            <> help "Include executables."
+            )
+          testFlag = switch
+            (  long "tests"
+            <> help "Include test suites."
+            )
+          benchFlag = switch
+            (  long "benchmarks"
+            <> help "Include benchmarks."
+            )
        in  do
              addCommand'
                "packages"
@@ -328,7 +340,7 @@ commandLineHandler currentDir progName isInterpreter =
                "targets"
                "List all available Stack targets."
                ideTargetsCmd
-               outputFlag
+               ((,) <$> outputFlag <*> ((,,) <$> exeFlag <*> testFlag <*> benchFlag))
     )
 
   init = addCommand'

--- a/src/main/Stack/CLI.hs
+++ b/src/main/Stack/CLI.hs
@@ -338,7 +338,7 @@ commandLineHandler currentDir progName isInterpreter =
                ((,) <$> outputFlag <*> cabalFileFlag)
              addCommand'
                "targets"
-               "List targets, all of them (by default) or only some component types."
+               "List all targets or pick component types to list."
                ideTargetsCmd
                ((,) <$> ((,,) <$> exeFlag <*> testFlag <*> benchFlag) <*> outputFlag)
     )

--- a/src/main/Stack/CLI.hs
+++ b/src/main/Stack/CLI.hs
@@ -320,15 +320,18 @@ commandLineHandler currentDir progName isInterpreter =
             )
           exeFlag = switch
             (  long "exes"
-            <> help "Include executables."
+            <> help "List exes (list with --tests and --benchmarks). \
+                    \The default is to list every target but you can use \
+                    \--exes with --tests and --benchmarks to limit the \
+                    \output to 1, 2 or 3 of these component types."
             )
           testFlag = switch
             (  long "tests"
-            <> help "Include test suites."
+            <> help "List tests (list with --exes and --benchmarks)."
             )
           benchFlag = switch
             (  long "benchmarks"
-            <> help "Include benchmarks."
+            <> help "List benchmarks (list with --exes and --tests)."
             )
        in  do
              addCommand'
@@ -340,7 +343,7 @@ commandLineHandler currentDir progName isInterpreter =
                "targets"
                "List all available Stack targets."
                ideTargetsCmd
-               ((,) <$> outputFlag <*> ((,,) <$> exeFlag <*> testFlag <*> benchFlag))
+               ((,) <$> ((,,) <$> exeFlag <*> testFlag <*> benchFlag) <*> outputFlag)
     )
 
   init = addCommand'


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

In a project (`stack.yaml`) with hundreds of packages I want a quick way to list test suites only.

```
$ ~/.local/bin/stack ide targets --help
Usage: stack ide targets [--exes] [--tests] [--benchmarks] [--stdout] 
                         [--setup-info-yaml URL] [--snapshot-location-base URL] 
                         [--help]

  List all available Stack targets.

Available options:
  --exes                   List exes (list with --tests and --benchmarks). The
                           default is to list every target but you can use
                           --exes with --tests and --benchmarks to limit the
                           output to 1, 2 or 3 of these component types.
  --tests                  List tests (list with --exes and --benchmarks).
  --benchmarks             List benchmarks (list with --exes and --tests).
  --stdout                 Send output to the standard output stream instead of
                           the default, the standard error stream.
  --setup-info-yaml URL    Alternate URL or path (relative or absolute) for
                           Stack dependencies.
  --snapshot-location-base URL
                           The base location of LTS/Nightly snapshots.
  --help                   Show this help text.

Command 'stack --help' for global options that apply to all subcommands.
```

I used cabal for this demo because it has way more components (but not yet hundreds):

```
$ ~/.local/bin/stack ide targets
Cabal:lib
Cabal-QuickCheck:lib
Cabal-described:lib
Cabal-syntax:lib
Cabal-tests:test:check-tests
Cabal-tests:test:custom-setup-tests
Cabal-tests:test:hackage-tests
Cabal-tests:test:no-thunks-test
Cabal-tests:test:parser-tests
Cabal-tests:test:rpmvercmp
Cabal-tests:test:unit-tests
Cabal-tree-diff:lib
cabal-benchmarks:test:cabal-benchmarks
cabal-install:lib
cabal-install:exe:cabal
cabal-install:test:integration-tests2
cabal-install:test:long-tests
cabal-install:test:mem-use-tests
cabal-install:test:unit-tests
cabal-install-solver:lib
cabal-install-solver:test:unit-tests
cabal-testsuite:lib
cabal-testsuite:exe:cabal-tests
cabal-testsuite:exe:setup
solver-benchmarks:lib
solver-benchmarks:exe:hackage-benchmark
solver-benchmarks:test:unit-tests

$ ~/.local/bin/stack ide targets --exes
cabal-install:exe:cabal
cabal-testsuite:exe:cabal-tests
cabal-testsuite:exe:setup
solver-benchmarks:exe:hackage-benchmark

$ ~/.local/bin/stack ide targets --benchmarks

$ ~/.local/bin/stack ide targets --tests
Cabal-tests:test:check-tests
Cabal-tests:test:custom-setup-tests
Cabal-tests:test:hackage-tests
Cabal-tests:test:no-thunks-test
Cabal-tests:test:parser-tests
Cabal-tests:test:rpmvercmp
Cabal-tests:test:unit-tests
cabal-benchmarks:test:cabal-benchmarks
cabal-install:test:integration-tests2
cabal-install:test:long-tests
cabal-install:test:mem-use-tests
cabal-install:test:unit-tests
cabal-install-solver:test:unit-tests
solver-benchmarks:test:unit-tests

$ ~/.local/bin/stack ide targets --tests --exes
Cabal-tests:test:check-tests
Cabal-tests:test:custom-setup-tests
Cabal-tests:test:hackage-tests
Cabal-tests:test:no-thunks-test
Cabal-tests:test:parser-tests
Cabal-tests:test:rpmvercmp
Cabal-tests:test:unit-tests
cabal-benchmarks:test:cabal-benchmarks
cabal-install:exe:cabal
cabal-install:test:integration-tests2
cabal-install:test:long-tests
cabal-install:test:mem-use-tests
cabal-install:test:unit-tests
cabal-install-solver:test:unit-tests
cabal-testsuite:exe:cabal-tests
cabal-testsuite:exe:setup
solver-benchmarks:exe:hackage-benchmark
solver-benchmarks:test:unit-tests
```
