### PR TITLE
Fix #6125 Restore building Stack with Cabal flag disable-git-info

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ on:
     - rc/**
   workflow_dispatch:
 
-# As of 5 May 2023, ubuntu-latest, windows-latest and macos-latest come
+# As of 22 May 2023, ubuntu-latest, windows-latest and macos-latest come
 # with Stack 2.9.3 and GHC 9.6.1.
 
 jobs:
@@ -28,9 +28,10 @@ jobs:
           ${{ runner.os }}-
     - name: Pedantic build
       run: |
-        # Stack 2.9.3 is required to build Stack
-        stack upgrade
         stack build --pedantic
+    - name: disable-git-info build
+      run: |
+        stack build --pedantic --flag stack:disable-git-info
   unit-tests:
     name: Unit tests
     runs-on: ${{ matrix.os }}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,9 @@ Other enhancements:
 
 Bug fixes:
 
+* Restore building of Stack with Cabal flag `disable-git-info` (broken with
+  Stack 2.11.1).
+
 ## v2.11.1 - 2023-05-18
 
 **Changes since v2.9.3:**

--- a/src/main/BuildInfo.hs
+++ b/src/main/BuildInfo.hs
@@ -16,21 +16,18 @@ module BuildInfo
 #ifndef HIDE_DEP_VERSIONS
 import qualified Build_stack
 #endif
-#ifdef USE_GIT_INFO
 import           Data.Version ( versionBranch )
-#else
-import           Data.Version ( showVersion, versionBranch )
-#endif
 import           Distribution.System ( buildArch )
 import qualified Distribution.Text as Cabal ( display )
 #ifdef USE_GIT_INFO
 import           GitHash ( giCommitCount, tGitInfoCwdTry )
-#endif
-#ifdef USE_GIT_INFO
 import           Options.Applicative.Simple ( simpleVersion )
 #endif
-import           Stack.Prelude
 import qualified Paths_stack as Meta
+import           Stack.Prelude
+#ifndef USE_GIT_INFO
+import           Stack.Types.Version ( showStackVersion )
+#endif
 
 versionString' :: String
 #ifdef USE_GIT_INFO


### PR DESCRIPTION
Also extend CI to include `stack build --flag stack:disable-git-info`.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally and also relying on extended CI.
