### PR TITLE
Fix #5412 sanityCheck passes GHC flag -hide-all-packages

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,9 @@ Bug fixes:
 
 * Restore building of Stack with Cabal flag `disable-git-info` (broken with
   Stack 2.11.1).
+* Stack's sanity check on a selected GHC now passes GHC flag
+  `-hide-all-packages`, stopping GHC from looking for a package environment in
+  default locations.
 
 ## v2.11.1 - 2023-05-18
 

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -2336,6 +2336,12 @@ sanityCheck ghc = withSystemTempDir "stack-sanity-check" $ \dir -> do
   eres <- withWorkingDir (toFilePath dir) $ proc (toFilePath ghc)
     [ fp
     , "-no-user-package-db"
+    -- Required to stop GHC looking for a package environment in default
+    -- locations.
+    , "-hide-all-packages"
+    -- Required because GHC flag -hide-all-packages is passed.
+    , "-package base"
+    , "-package Cabal" -- required for "import Distribution.Simple"
     ] $ try . readProcess_
   case eres of
     Left e -> prettyThrowIO $ GHCSanityCheckCompileFailed e ghc


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested that it does not break `stack setup` on Windows. Not tested that it solves the reported issue. Relying on CI for other operating systems.
