### PR TITLE
distRelativeDir: use ghc version instead of Cabal version 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,10 @@ Major changes:
 
 Behavior changes:
 
+* The path dist directory path '.stack-work/dist/<platform>/Cabal-*/'
+  changes to '.stack-work/dist/<platform>/ghc-*/' so that build artifacts are
+  clearly distinguished by ghc version.
+
 Other enhancements:
 
 * Avoid the duplicate resolving of usage files when parsing `*.hi` files into a

--- a/src/Stack/Constants/Config.hs
+++ b/src/Stack/Constants/Config.hs
@@ -24,11 +24,11 @@ module Stack.Constants.Config
   ) where
 
 import           Path ( (</>), mkRelDir, mkRelFile, parseRelDir )
-import           Stack.Constants
-                   ( cabalPackageName, relDirDist, relDirGhci, relDirHpc )
+import           Stack.Constants ( relDirDist, relDirGhci, relDirHpc )
 import           Stack.Prelude
 import           Stack.Types.BuildConfig ( HasBuildConfig, projectRootL )
-import           Stack.Types.CompilerPaths ( cabalVersionL )
+import           Stack.Types.Compiler ( compilerVersionString )
+import           Stack.Types.CompilerPaths ( compilerVersionL )
 import           Stack.Types.Config ( Config, HasConfig, stackRootL, workDirL )
 import           Stack.Types.EnvConfig
                    ( HasEnvConfig, platformGhcRelDir, useShaPathOnWindows )
@@ -162,13 +162,11 @@ templatesDir config = view stackRootL config </> $(mkRelDir "templates")
 distRelativeDir :: (MonadThrow m, MonadReader env m, HasEnvConfig env)
                 => m (Path Rel Dir)
 distRelativeDir = do
-    cabalPkgVer <- view cabalVersionL
+    compilerVer <- view compilerVersionL
     platform <- platformGhcRelDir
     -- Cabal version
     envDir <-
-        parseRelDir $
-        packageIdentifierString $
-        PackageIdentifier cabalPackageName cabalPkgVer
+        parseRelDir $ compilerVersionString compilerVer
     platformAndCabal <- useShaPathOnWindows (platform </> envDir)
     allDist <- rootDistRelativeDir
     pure $ allDist </> platformAndCabal

--- a/src/Stack/Types/CompilerPaths.hs
+++ b/src/Stack/Types/CompilerPaths.hs
@@ -5,6 +5,7 @@ module Stack.Types.CompilerPaths
   , GhcPkgExe (..)
   , HasCompiler (..)
   , cabalVersionL
+  , compilerVersionL
   , cpWhich
   , getCompilerPath
   , getGhcPkgExe
@@ -61,6 +62,9 @@ newtype GhcPkgExe
 
 cabalVersionL :: HasCompiler env => SimpleGetter env Version
 cabalVersionL = compilerPathsL.to cpCabalVersion
+
+compilerVersionL :: HasCompiler env => SimpleGetter env ActualCompiler
+compilerVersionL = compilerPathsL.to cpCompilerVersion
 
 cpWhich :: (MonadReader env m, HasCompiler env) => m WhichCompiler
 cpWhich = view $ compilerPathsL.to (whichCompiler.cpCompilerVersion)


### PR DESCRIPTION
This makes the dist build paths more consistent: clearly differentiated by ghc minor versions.

Please include the following checklist in your pull request:
- [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.

I tested by building stack with a stack including this change.

There is a bit more rationale in the commit message.
