### PR TITLE
Stack.Setup: bump version warnings to ghc-9.8 and Cabal-3.12

### DIFF
--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -923,7 +923,7 @@ warnUnsupportedCompiler ghcVersion =
         pure True
     | ghcVersion >= mkVersion [9, 7] -> do
         prettyWarnL
-          [ flow "Stack has not been tested with GHC versions above 9.8, and \
+          [ flow "Stack has not been tested with GHC versions 9.8 and above, and \
                  \using"
           , fromString (versionString ghcVersion) <> ","
           , flow "this may fail."
@@ -957,7 +957,7 @@ warnUnsupportedCompilerCabal cp didWarn = do
           ]
     | cabalVersion >= mkVersion [3, 11] ->
         prettyWarnL
-          [ flow "Stack has not been tested with Cabal versions above 3.12, \
+          [ flow "Stack has not been tested with Cabal versions 3.12 and above, \
                  \but version"
           , fromString (versionString cabalVersion)
           , flow "was found, this may fail."

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -921,9 +921,9 @@ warnUnsupportedCompiler ghcVersion =
           , style Url "https://github.com/commercialhaskell/stack/issues/648" <> "."
           ]
         pure True
-    | ghcVersion >= mkVersion [9, 5] -> do
+    | ghcVersion >= mkVersion [9, 7] -> do
         prettyWarnL
-          [ flow "Stack has not been tested with GHC versions above 9.6, and \
+          [ flow "Stack has not been tested with GHC versions above 9.8, and \
                  \using"
           , fromString (versionString ghcVersion) <> ","
           , flow "this may fail."
@@ -955,9 +955,9 @@ warnUnsupportedCompilerCabal cp didWarn = do
                  \resolver. Acceptable resolvers: lts-3.0/nightly-2015-05-05 \
                  \or later."
           ]
-    | cabalVersion >= mkVersion [3, 9] ->
+    | cabalVersion >= mkVersion [3, 11] ->
         prettyWarnL
-          [ flow "Stack has not been tested with Cabal versions above 3.10, \
+          [ flow "Stack has not been tested with Cabal versions above 3.12, \
                  \but version"
           , fromString (versionString cabalVersion)
           , flow "was found, this may fail."


### PR DESCRIPTION
Current stack seems to work fine with ghc-9.6 and Cabal-3.10 afaict.

TBH I don't find these warnings very helpful and they always lag into the stablized ghc minor versions.
ie we are already at ghc-9.6.2 but stack is still saying it is untested:

```
Warning: Stack has not been tested with GHC versions above 9.6, and using 9.6.2,
         this may fail.

Warning: Stack has not been tested with Cabal versions above 3.10, but version
         3.10.1.0 was found, this may fail.
```

I feel like it would be better even to either bump the warning by another major version
(9.8 is just around the corner) or just drop them entirely?  I don't feel they are
providing that much value: if stack really breaks it should be fairly obvious anyway.