### PR TITLE
Add unpacking of extra deps

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@ Release notes:
   matching cargo behavior and preventing logSticky spam on narrow 
   terminals and lots of dependencies building simultaneously
 
+* Add unpacking of source repository packages (`extra-deps`).
+
 **Changes since v2.11.1:**
 
 Major changes:

--- a/doc/unpack_command.md
+++ b/doc/unpack_command.md
@@ -17,3 +17,6 @@ By default:
 *   the package is unpacked into a directory named after the package and its
     version. Pass the option `--to <directory>` to specify the destination
     directory.
+
+If PACKAGE is the name of a source repository package or a suffix of its URL
+then the unpacking is direct, not via a package index.

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -18,6 +18,7 @@
 module Stack.Config
   ( loadConfig
   , loadConfigYaml
+  , loadProjectConfig
   , packagesParser
   , getImplicitGlobalProjectDir
   , getSnapshots

--- a/src/Stack/Unpack.hs
+++ b/src/Stack/Unpack.hs
@@ -248,7 +248,7 @@ longestUnique ::
      [(PackageName, RawPackageLocationImmutable)]
   -> [(PackageName, RawPackageLocationImmutable)]
 longestUnique xs =
-  L.concat $ L.groupBy (\(_, p1) (_, p2) -> p1 == p2) (L.take 1 $ L.sortBy (flip (comparing fst)) xs)
+  L.concat $ L.groupBy (\(_, p1) (_, p2) -> p1 == p2) (L.take 1 $ L.sortOn (Down . fst) xs)
 
 unpackMessage :: Display a => a -> Path Abs Dir -> [StyleDoc]
 unpackMessage loc dest =


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

I haven't added any tests. I tested by adding to `extra-deps` in the stack project itself and then running:

```
$ stack repl
ghci> :main unpack PACKAGE
```

I have a tool that I'd like to distribute as a package (rather than as a git submodule) and this would allow me to do that as the tool needs to be located in its own folder in the root of a project.
