### PR TITLE
Ellipsize build progress output line

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ Release notes:
 
 * Further to the release notes for Stack 2.3.1, the `-static` suffix has been
   removed from the statically linked Linux/x86_64 binaries.
+* The build progress line gets ellipsized in order to fit one terminal line
+  matching cargo behavior and preventing logSticky spam on narrow 
+  terminals and lots of dependencies building simultaneously
 
 **Changes since v2.11.1:**
 


### PR DESCRIPTION
This PR introduces truncating long build progress lines which are spamming narrow terminal window. Like this:

![image](https://github.com/commercialhaskell/stack/assets/89889/6b14cd99-cc27-401e-bb83-ac39905a33e6)
Before this PR _(repro: `stack --stack-root=/home/adziahel/.cache/stacktmp/root --terminal-width=20 build --fast`)_

The issue here is multifold and unclear — it's either the terminal processes `^A^K` before each `logSticky` poorly (because of incorrect terminfo), or it's bug in GNOME VTE, or is it `logSticky` ignores actual terminal width — could be all of these, if we're unlucky enough.

This PR replaces the tail of progress line with ellipsis (see screenshot below), preventing spamming terminal with repeating progress lines.

![image](https://github.com/commercialhaskell/stack/assets/89889/d6aa9bb2-7a38-45bc-b9bf-b1cfc577e192)
After this PR _(repro: `stack exec stack -- --stack-root=/home/adziahel/.cache/stacktmp/root --work-dir=.stackworktmp build --fast`)_

Please include the following checklist in your pull request:

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary
