### PR TITLE
Fix #6180 Take a different approach to building GHC from source

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,10 @@ Behavior changes:
   be distinguished by GHC version.
 * By default, the `stack build` progress bar is capped to a length equal to the
   terminal width.
+* When building GHC from source, Stack no longer uses Hadrian's deprecated
+  `--configure`\\`-c` flag and, instead, seeks to run GHC's Python `boot` and
+  sh `configure` scripts, and ensure that the `happy` and `alex` executables are
+  on the PATH.
 
 Other enhancements:
 

--- a/doc/maintainers/stack_errors.md
+++ b/doc/maintainers/stack_errors.md
@@ -286,6 +286,7 @@ to take stock of the errors that Stack itself can raise, by reference to the
         [S-5219] | GHCInfoMissingTargetPlatform
         [S-8299] | GHCInfoTargetPlatformInvalid String
         [S-2574] | CabalNotFound (Path Abs File)
+        [S-8488] | GhcBootScriptNotFound
         [S-1128] | HadrianScriptNotFound
         [S-1906] | URLInvalid String
         [S-1648] | UnknownArchiveExtension String

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -543,12 +543,13 @@ compiler-check: match-exact
 
 [:octicons-tag-24: 2.1.1](https://github.com/commercialhaskell/stack/releases/tag/v2.1.1)
 
-Stack supports building the GHC compiler from source. The version to build and
-to use is defined by a a Git commit ID and an Hadrian "flavour" (Hadrian is the
-build system of GHC) with the following syntax:
+Stack supports building the GHC compiler from source, using
+[Hadrian](https://gitlab.haskell.org/ghc/ghc/blob/master/hadrian/README.md) (the
+build system for GHC). The GHC version to build and to use is defined by a a Git
+commit ID and a Hadrian "flavour", with the following syntax:
 
 ~~~yaml
-compiler: ghc-git-COMMIT-FLAVOUR
+compiler: ghc-git-<commit_id>-<Hadrian_flavour>
 ~~~
 
 In the following example the commit ID is "5be7ad..." and the flavour is
@@ -558,8 +559,8 @@ In the following example the commit ID is "5be7ad..." and the flavour is
 compiler: ghc-git-5be7ad7861c8d39f60b7101fd8d8e816ff50353a-quick
 ~~~
 
-By default the code is retrieved from the main GHC repository. If you want to
-select another repository, set the "compiler-repository" option:
+By default, the code is retrieved from the main GHC repository. If you want to
+select another repository, use the `compiler-repository` option:
 
 ~~~yaml
 compiler-repository: git://my/ghc/repository
@@ -567,12 +568,100 @@ compiler-repository: git://my/ghc/repository
 # compiler-repository: https://gitlab.haskell.org/ghc/ghc.git
 ~~~
 
-Note that Stack doesn't check the compiler version when it uses a compiler built
-from source. Moreover it is assumed that the built compiler is recent enough as
-Stack doesn't enable any known workaround to make older compilers work.
+Stack does not check the compiler version when it uses a compiler built from
+source. It is assumed that the built compiler is recent enough as Stack doesn't
+enable any known workaround to make older compilers work.
 
-Building the compiler can take a very long time (more than one hour). Hint: for
-faster build times, use Hadrian flavours that disable documentation generation.
+Building the compiler can take a very long time (more than one hour). For faster
+build times, use Hadrian flavours that disable documentation generation.
+
+#### Bootstrap compiler
+
+Building GHC from source requires a working GHC (known as the bootstrap
+compiler). As we use a Stack based version of Hadrian (`hadrian/build-stack` in
+GHC sources), the bootstrap compiler is configured into `hadrian/stack.yaml` and
+fully managed by Stack.
+
+!!! note
+
+    For some commit IDs, the resolver specified in `hadrian/stack.yaml`
+    specifies a version of GHC that cannot be used to build GHC. This results in
+    GHC's `configure` script reporting messages similar to the following before
+    aborting:
+
+    ~~~text
+    checking version of ghc... 9.0.2
+    configure: error: GHC version 9.2 or later is required to compile GHC.
+    ~~~
+
+    The resolution is: (1) to specify an alternative resolver (one that
+    specifies a sufficiently recent version of GHC) on the command line, using
+    Stack's option `--resolver <resolver>`. Stack will use that resolver when
+    running GHC's `configure` script; and (2) to set the contents of the `STACK`
+    environment variable to be `stack --resolver <resolver>`. Hadrian's
+    `build-stack` script wil refer to that environment variable for the Stack
+    command it uses.
+
+#### Hadrian prerequisites
+
+The Hadrian build system has certain
+[prerequisites](https://gitlab.haskell.org/ghc/ghc/-/wikis/building/preparation).
+It requires certain versions of the `happy` and `alex` executables on the PATH.
+Stack will build and install `happy` and `alex`, if not already on the PATH.
+
+=== "macOS"
+
+    Hadrian requires, or case use, certain tools or Python packages that do not
+    come with macOS by default and that need to be installed using `brew` or
+    `pip3` (Python). Hadrian's LaTeX documentation also requires the
+    [DejaVu fonts](https://dejavu-fonts.github.io/) to be installed.
+
+    ~~~zsh
+    brew install python@3.11
+    # GHC uses a Python script named `boot`.
+    brew install automake
+    # Tool for generating GNU Standards-compliant Makefiles.
+    brew install texinfo
+    # Official documentation format of the GNU project.
+    pip3 install -U sphinx
+    # Sphinx is the Python documentation generator.
+    brew install --cask mactex
+    # MacTeX: Full TeX Live distribution with GUI applications
+    ~~~
+
+=== "Windows"
+
+    Hadrian requires, or can use, certain MSYS2 or Python packages that do not
+    come with the Stack-supplied MSYS2 by default and need to be installed
+    using `pacman` (MSYS2) or `pip` (Python). Hadrian's LaTeX documentation also
+    requires the [DejaVu fonts](https://dejavu-fonts.github.io/) to be
+    installed.
+
+    ~~~pwsh
+    stack exec -- pacman --sync --refresh
+    # Synchronize MSYS2 package databases
+    stack exec -- pacman --sync mingw-w64-x86_64-python-pip
+    # The PyPA recommended tool (pip) for installing Python packages. Also
+    # installs Python as a dependency. GHC uses a Python script named `boot`.
+    # The package must be the one from the `mingw64` MSYS2 repository, as Python
+    # from the `msys` repository cannot interpret Windows file paths correctly.
+    stack exec -- pacman --sync mingw-w64-x86_64-autotools
+    # The GNU autotools build system, including `autoreconf`, `aclocal`
+    # and `make`. GHC uses a sh script named `configure` which is itself created
+    # from a file named `configure.ac`.
+    stack exec -- pacman --sync patch
+    # A utility to apply patch files to original sources.
+    stack exec -- pacman --sync texinfo
+    # Utilities to work with and produce manuals, ASCII text, and on-line
+    # documentation from a single source file, including `makeinfo`.
+    stack exec -- pacman --sync mingw-w64-x86_64-ca-certificates
+    # Common CA (certificate authority) certificates.
+    stack exec -- pip install -U sphinx
+    # Sphinx is the Python documentation generator.
+    ~~~
+
+    Hadrian may require certain LaTeX packages and may prompt for these to be
+    installed duing the build process.
 
 #### Global packages
 
@@ -604,13 +693,6 @@ extra-deps:
     - libraries/Cabal/Cabal
     - libraries/...
 ~~~
-
-#### Bootstrapping compiler
-
-Building GHC from source requires a working GHC (known as the bootstrap
-compiler). As we use a Stack based version of Hadrian (`hadrian/build-stack` in
-GHC sources), the bootstrap compiler is configured into `hadrian/stack.yaml` and
-fully managed by Stack.
 
 ### compiler-check
 

--- a/src/Stack/Config/ConfigureScript.hs
+++ b/src/Stack/Config/ConfigureScript.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Stack.Config.ConfigureScript
+  ( ensureConfigureScript
+  ) where
+
+import           Path ( (</>) )
+import           Path.IO ( doesFileExist )
+import           Stack.Constants ( osIsWindows, relFileConfigure )
+import           Stack.DefaultColorWhen ( defaultColorWhen )
+import           Stack.Prelude
+import           RIO.Process ( HasProcessContext, withWorkingDir )
+
+ensureConfigureScript ::
+     (HasProcessContext env, HasTerm env)
+  => Path b Dir
+  -> RIO env ()
+ensureConfigureScript dir = do
+  let fp = dir </> relFileConfigure
+  exists <- doesFileExist fp
+  unless exists $ do
+    prettyInfoL
+      [ flow "Trying to generate"
+      , style Shell "configure"
+      , "with"
+      , style Shell "autoreconf"
+      , "in"
+      , pretty dir <> "."
+      ]
+    let autoreconf = if osIsWindows
+                       then readProcessNull "sh" ["autoreconf", "-i"]
+                       else readProcessNull "autoreconf" ["-i"]
+        -- On Windows 10, an upstream issue with the `sh autoreconf -i`
+        -- command means that command clears, but does not then restore, the
+        -- ENABLE_VIRTUAL_TERMINAL_PROCESSING flag for native terminals. The
+        -- following hack re-enables the lost ANSI-capability.
+        fixupOnWindows = when osIsWindows (void $ liftIO defaultColorWhen)
+    withWorkingDir (toFilePath dir) $ autoreconf `catchAny` \ex -> do
+      fixupOnWindows
+      prettyWarn $
+           fillSep
+             [ flow "Stack failed to run"
+             , style Shell "autoreconf" <> "."
+             ]
+        <> blankLine
+        <> flow "Stack encountered the following error:"
+        <> blankLine
+        <> string (displayException ex)
+      when osIsWindows $ do
+        prettyInfo $
+             fillSep
+               [ flow "Check that executable"
+               , style File "perl"
+               , flow "is on the path in Stack's MSYS2"
+               , style Dir "\\usr\\bin"
+               , flow "folder, and working, and that script files"
+               , style File "autoreconf"
+               , "and"
+               , style File "aclocal"
+               , flow "are on the path in that location. To check that"
+               , style File "perl" <> ","
+               , style File "autoreconf"
+               , "or"
+               , style File "aclocal"
+               , flow "are on the path in the required location, run commands:"
+               ]
+          <> blankLine
+          <> indent 4 (style Shell $ flow "stack exec where.exe -- perl")
+          <> line
+          <> indent 4 (style Shell $ flow "stack exec where.exe -- autoreconf")
+          <> line
+          <> indent 4 (style Shell $ flow "stack exec where.exe -- aclocal")
+          <> blankLine
+          <> fillSep
+               [ "If"
+               , style File "perl" <> ","
+               , style File "autoreconf"
+               , "or"
+               , style File "aclocal"
+               , flow "is not on the path in the required location, add them \
+                      \with command (note that the relevant package name is"
+               , style File "autotools"
+               , "not"
+               , style File "autoreconf" <> "):"
+               ]
+          <> blankLine
+          <> indent 4
+               (style Shell $ flow "stack exec pacman -- --sync --refresh mingw-w64-x86_64-autotools")
+          <> blankLine
+          <> fillSep
+               [ flow "Some versions of"
+               , style File "perl"
+               , flow "from MSYS2 are broken. See"
+               , style Url "https://github.com/msys2/MSYS2-packages/issues/1611"
+               , "and"
+               , style Url "https://github.com/commercialhaskell/stack/pull/4781" <> "."
+               , "To test if"
+               , style File "perl"
+               , flow "in the required location is working, try command:"
+               ]
+          <> blankLine
+          <> indent 4 (style Shell $ flow "stack exec perl -- --version")
+          <> blankLine
+    fixupOnWindows

--- a/src/unix/System/Permissions.hs
+++ b/src/unix/System/Permissions.hs
@@ -3,17 +3,26 @@
 -- | The module of this name differs as between Windows and non-Windows builds.
 -- This is the non-Windows version.
 module System.Permissions
-  ( setScriptPerms
+  ( osIsMacOS
   , osIsWindows
   , setFileExecutable
+  , setScriptPerms
   ) where
 
 import           RIO
 import qualified System.Posix.Files as Posix
+import           System.Info ( os )
 
--- | True if using Windows OS.
+-- | True if using macOS.
+osIsMacOS :: Bool
+osIsMacOS = os == "darwin"
+
+-- | False if not using Windows.
 osIsWindows :: Bool
 osIsWindows = False
+
+setFileExecutable :: MonadIO m => FilePath -> m ()
+setFileExecutable fp = liftIO $ Posix.setFileMode fp 0o755
 
 setScriptPerms :: MonadIO m => FilePath -> m ()
 setScriptPerms fp =
@@ -22,6 +31,3 @@ setScriptPerms fp =
     Posix.ownerWriteMode `Posix.unionFileModes`
     Posix.groupReadMode `Posix.unionFileModes`
     Posix.otherReadMode
-
-setFileExecutable :: MonadIO m => FilePath -> m ()
-setFileExecutable fp = liftIO $ Posix.setFileMode fp 0o755

--- a/src/windows/System/Permissions.hs
+++ b/src/windows/System/Permissions.hs
@@ -1,17 +1,22 @@
 -- | The module of this name differs as between Windows and non-Windows builds.
 -- This is the Windows version.
 module System.Permissions
-  ( setScriptPerms
+  ( osIsMacOS
   , osIsWindows
   , setFileExecutable
+  , setScriptPerms
   ) where
 
--- | True if using Windows OS.
+-- | False if using Windows.
+osIsMacOS :: Bool
+osIsMacOS = False
+
+-- | True if using Windows.
 osIsWindows :: Bool
 osIsWindows = True
 
-setScriptPerms :: Monad m => FilePath -> m ()
-setScriptPerms _ = pure ()
-
 setFileExecutable :: Monad m => FilePath -> m ()
 setFileExecutable _ = pure ()
+
+setScriptPerms :: Monad m => FilePath -> m ()
+setScriptPerms _ = pure ()

--- a/stack.cabal
+++ b/stack.cabal
@@ -320,6 +320,8 @@ library
       System.Terminal
       Build_stack
       Paths_stack
+  other-modules:
+      Stack.Config.ConfigureScript
   autogen-modules:
       Build_stack
       Paths_stack


### PR DESCRIPTION
`Stack.Setup.buildGhcFromSource` no longer uses the `-c` flag of `hadrian` but seeks to run the GHC repository's `boot` python script and `configure` sh script.

`Stack.Setup.buildGhcFromSource` requires MSYS2 tools, so - borrowing the pattern of `WithGHC env` - defined `newtype WithMSYS env` and `runWithMSYS`.

The GHC repository does not provide its `configure` file, so it has to be created by applying `autoreconf`. It also requires `aclocal`. Moved `ensureConfigureScript` out of `Stack.Build.Execute.ensureConfig` to new module `Stack.Config.ConfigureScript` and extended the help on Windows to refer to `aclocal` and the MSYS2 package `autotools`.

GHC's configure script requires ghc, happy and alex on the PATH. So, (1) it is run in Stack's environment, making use of the `stack.yaml` at `hadrian`; and (2) happy and alex are installed using Stack, if not on the PATH.

It appears that GHC's configure script requires a more recent version of GHC than is specified in the `stack.yaml`. So, the `stack.yaml` is overwritten with contents that specify a more recent GHC (LTS Haskell 20.26 (GHC 9.2.8)).

It also appears that `hadrian` has some other pre-requisites that are not included in the Stack-supplied MSYS2 out of the box and have to be installed if absent. They include `python` and the python package `sphinx`. They are not dealt with here, but the online documentation is extended.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally on Windows 11.
