### PR TITLE
Fix digest computation duplication

### DIFF
--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -24,6 +24,7 @@ import qualified Distribution.PackageDescription as C
 import qualified Pantry.SHA256 as SHA256
 import           Stack.Build.Cache ( tryGetBuildCache )
 import           Stack.Build.Haddock ( shouldHaddockDeps )
+import           Stack.FileDigestCache ( readFileDigest )
 import           Stack.Package ( resolvePackage )
 import           Stack.Prelude
 import           Stack.SourceMap
@@ -435,13 +436,13 @@ loadLocalPackage pp = do
 
 -- | Compare the current filesystem state to the cached information, and
 -- determine (1) if the files are dirty, and (2) the new cache values.
-checkBuildCache :: forall m. (MonadIO m)
+checkBuildCache :: HasEnvConfig env
                 => Map FilePath FileCacheInfo -- ^ old cache
                 -> [Path Abs File] -- ^ files in package
-                -> m (Set FilePath, Map FilePath FileCacheInfo)
+                -> RIO env (Set FilePath, Map FilePath FileCacheInfo)
 checkBuildCache oldCache files = do
   fileTimes <- fmap Map.fromList $ forM files $ \fp -> do
-    mdigest <- liftIO (getFileDigestMaybe (toFilePath fp))
+    mdigest <- getFileDigestMaybe (toFilePath fp)
     pure (toFilePath fp, mdigest)
   fmap (mconcat . Map.elems) $ sequence $
     Map.merge
@@ -454,7 +455,7 @@ checkBuildCache oldCache files = do
   go :: FilePath
      -> Maybe SHA256
      -> Maybe FileCacheInfo
-     -> m (Set FilePath, Map FilePath FileCacheInfo)
+     -> RIO env (Set FilePath, Map FilePath FileCacheInfo)
   -- Filter out the cabal_macros file to avoid spurious recompilations
   go fp _ _ | takeFileName fp == "cabal_macros.h" = pure (Set.empty, Map.empty)
   -- Common case where it's in the cache and on the filesystem.
@@ -518,17 +519,15 @@ getPackageFilesForTargets pkg cabalFP nonLibComponents = do
   pure (componentsFiles, warnings)
 
 -- | Get file digest, if it exists
-getFileDigestMaybe :: MonadIO m => FilePath -> m (Maybe SHA256)
-getFileDigestMaybe fp =
-  liftIO $
-    catch
-      (fmap Just getDigest)
-      (\e ->
-            if isDoesNotExistError e
-                then pure Nothing
-                else throwM e)
- where
-  getDigest = SHA256.hashFile fp
+getFileDigestMaybe :: HasEnvConfig env => FilePath -> RIO env (Maybe SHA256)
+getFileDigestMaybe fp = do
+  cache <- view $ envConfigL.to envConfigFileDigestCache
+  catch
+    (Just <$> readFileDigest cache fp)
+    (\e ->
+          if isDoesNotExistError e
+              then pure Nothing
+              else throwM e)
 
 -- | Get 'PackageConfig' for package given its name.
 getPackageConfig ::

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -14,7 +14,6 @@ module Stack.Build.Source
   , hashSourceMapData
   ) where
 
-import           Conduit ( ZipSink (..), withSourceFile )
 import           Data.ByteString.Builder ( toLazyByteString )
 import qualified Data.List as L
 import qualified Data.Map as Map
@@ -523,13 +522,13 @@ getFileDigestMaybe :: MonadIO m => FilePath -> m (Maybe SHA256)
 getFileDigestMaybe fp =
   liftIO $
     catch
-      (fmap Just . withSourceFile fp $ getDigest)
+      (fmap Just getDigest)
       (\e ->
             if isDoesNotExistError e
                 then pure Nothing
                 else throwM e)
  where
-  getDigest src = runConduit $ src .| getZipSink (ZipSink SHA256.sinkHash)
+  getDigest = SHA256.hashFile fp
 
 -- | Get 'PackageConfig' for package given its name.
 getPackageConfig ::

--- a/src/Stack/FileDigestCache.hs
+++ b/src/Stack/FileDigestCache.hs
@@ -1,0 +1,24 @@
+module Stack.FileDigestCache
+  ( FileDigestCache
+  , newFileDigestCache
+  , readFileDigest
+  ) where
+
+import           Stack.Prelude
+import qualified Data.Map.Strict as Map
+import qualified Pantry.SHA256 as SHA256
+
+type FileDigestCache = IORef (Map FilePath SHA256)
+
+newFileDigestCache :: MonadIO m => m FileDigestCache
+newFileDigestCache = newIORef Map.empty
+
+readFileDigest :: MonadIO m => FileDigestCache -> FilePath -> m SHA256
+readFileDigest cache filePath = do
+  digests <- readIORef cache
+  case Map.lookup filePath digests of
+    Just digest -> pure digest
+    Nothing -> do
+      sha256 <- SHA256.hashFile filePath
+      writeIORef cache $ Map.insert filePath sha256 digests
+      pure sha256

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -104,6 +104,7 @@ import           Stack.Constants
                    , relFileStackDotTmpDotExe, stackProgName, usrLibDirs
                    )
 import           Stack.Constants.Config ( distRelativeDir )
+import           Stack.FileDigestCache ( newFileDigestCache )
 import           Stack.GhcPkg
                    ( createDatabase, getGlobalDB, ghcPkgPathEnvVar
                    , mkGhcPackagePath )
@@ -666,9 +667,12 @@ setupEnv needTargets boptsCLI mResolveMissingGHC = do
     sourceMapHash <- hashSourceMapData boptsCLI sourceMap
     pure (sourceMap, sourceMapHash)
 
+  fileDigestCache <- newFileDigestCache
+
   let envConfig0 = EnvConfig
         { envConfigBuildConfig = bc
         , envConfigBuildOptsCLI = boptsCLI
+        , envConfigFileDigestCache = fileDigestCache
         , envConfigSourceMap = sourceMap
         , envConfigSourceMapHash = sourceMapHash
         , envConfigCompilerPaths = compilerPaths
@@ -780,6 +784,7 @@ setupEnv needTargets boptsCLI mResolveMissingGHC = do
             }
         }
     , envConfigBuildOptsCLI = boptsCLI
+    , envConfigFileDigestCache = fileDigestCache
     , envConfigSourceMap = sourceMap
     , envConfigSourceMapHash = sourceMapHash
     , envConfigCompilerPaths = compilerPaths

--- a/src/Stack/Types/EnvConfig.hs
+++ b/src/Stack/Types/EnvConfig.hs
@@ -42,6 +42,7 @@ import           Stack.Constants
                    , relDirHoogle, relDirHpc, relDirInstall, relDirPkgdb
                    , relDirSnapshots, relFileDatabaseHoo
                    )
+import           Stack.FileDigestCache (FileDigestCache)
 import           Stack.Prelude
 import           Stack.Types.BuildConfig
                     ( BuildConfig (..), HasBuildConfig (..), getProjectWorkDir )
@@ -63,6 +64,7 @@ import           Stack.Types.SourceMap
 data EnvConfig = EnvConfig
   { envConfigBuildConfig :: !BuildConfig
   , envConfigBuildOptsCLI :: !BuildOptsCLI
+  , envConfigFileDigestCache :: !FileDigestCache
   , envConfigSourceMap :: !SourceMap
   , envConfigSourceMapHash :: !SourceMapHash
   , envConfigCompilerPaths :: !CompilerPaths

--- a/stack.cabal
+++ b/stack.cabal
@@ -322,6 +322,7 @@ library
       Paths_stack
   other-modules:
       Stack.Config.ConfigureScript
+      Stack.FileDigestCache
   autogen-modules:
       Build_stack
       Paths_stack


### PR DESCRIPTION
On a project with many local packages I had "suprising" pauses in logged activity when running `stack build --verbose` and these always "nagged" me. Tonight I went in and found thta these pauses contribute to 2-3s of "dead time" before a `--file-watch` triggererd build would start working on my `.hs` file changes.

So I started to add strategic `bracketDebug` till I localized the dead "time" in `checkBuildCache`. And found the work there to be duplicate between the various packages. Lots of `.so` files my packages share (mostly boot libs, that can be quite big) would get hashed many times over.

So I implemented the simplest possible cache that has the lifetime of a build triggered by `--file-watch` to deduplicate these hash attempts. It shaved 2-3 seconds from my build and this is a lot as these 2-3 seconds would get "payed" every time before my code change would even start building. Now they are entirely gone.

On the stack code base as it only has one local source module this change does not make a difference, but on projects with many local source modules if they depend on shared "GHC stuff" its quite noticable.

When testing: Watch out for the `checkCacheResults` debug I added, and try without the last commit in this series to verify.

This is still an RFC, so not fully ready for merge.

TODO:

* [x] Verify with maintainers that this approach is actually correct, and not breaking invariants I did not anticipate.
* [ ] Add changelog entry.
* [x] Remove extra debug bracket added to show the speed difference.

Note the hashing is still not optimal with this change. Other areas of improvement I may do in followups.

* We can likely use pooled concurrency to spread out the work cross multiple cores.
* We can change to not read the entire file into memory to hash it than, but chunk this. This should reduce allocations.
