### PR TITLE
Fix #6202 Restore `stack sdist --pvp-bounds lower`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -46,6 +46,7 @@ Other enhancements:
 
 Bug fixes:
 
+* Restore `stack sdist --pvp-bounds lower` (broken with Stack 2.9.1).
 * Restore building of Stack with Cabal flag `disable-git-info` (broken with
   Stack 2.11.1).
 * With `stack hoogle`, avoid the message

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -1229,13 +1229,14 @@ bounds.
 #### Basic use
 
 Values are `none` (unchanged), `upper` (add upper bounds), `lower` (add
-lower bounds), and both (and upper and lower bounds). The algorithm it follows
-is:
+lower bounds), and both (and upper and lower bounds). The algorithm Stack
+follows is:
 
-* If an upper or lower bound already exists on a dependency, it's left alone
-* When adding a lower bound, we look at the current version specified by
-  `stack.yaml`, and set it as the lower bound (e.g., `foo >= 1.2.3`)
-* When adding an upper bound, we require less than the next major version
+* If an upper or lower bound (other than `>= 0` - 'any version') already exists
+  on a dependency, it is left alone
+* When adding a lower bound, Stack looks at the current version specified by
+  `stack.yaml`, and sets it as the lower bound (e.g., `foo >= 1.2.3`)
+* When adding an upper bound, Stack sets it as less than the next major version
   (e.g., `foo < 1.3`)
 
 ~~~yaml

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -39,8 +39,8 @@ import qualified Distribution.PackageDescription.Parsec as Cabal
 import           Distribution.PackageDescription.PrettyPrint
                    ( showGenericPackageDescription )
 import           Distribution.Version
-                   ( simplifyVersionRange, orLaterVersion, earlierVersion
-                   , hasUpperBound, hasLowerBound
+                   ( earlierVersion, hasLowerBound, hasUpperBound, isAnyVersion
+                   , orLaterVersion, simplifyVersionRange
                    )
 import           Path ( (</>), parent, parseRelDir, parseRelFile )
 import           Path.IO ( ensureDir, resolveDir' )
@@ -398,7 +398,9 @@ getCabalLbs pvpBounds mrev cabalfp sourceMap = do
                 then addUpper version
                 else id
             )
-          $ ( if toAddLower && not (hasLowerBound range)
+            -- From Cabal-3.4.0.0, 'hasLowerBound isAnyVersion' is 'True'.
+          $ ( if    toAddLower
+                 && (isAnyVersion range || not (hasLowerBound range))
                 then addLower version
                 else id
             )


### PR DESCRIPTION
Also improves related online documentation.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally on Windows 11.
