### PR TITLE
Fix #6218 Detect musl libc in `Stack.Setup.getGhcBuilds`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,8 @@ Behavior changes:
   `--configure`\\`-c` flag and, instead, seeks to run GHC's Python `boot` and
   sh `configure` scripts, and ensure that the `happy` and `alex` executables are
   on the PATH.
+* When auto-detecting `--ghc-build` on Linux, the `musl` build is now preferred
+  over others if `libc.musl-x86_64.so.1` is found in `\lib` or `\lib64`.
 
 Other enhancements:
 

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -106,6 +106,7 @@ module Stack.Constants
   , relDirDotStackProgName
   , relDirUnderHome
   , relDirSrc
+  , relFileLibcMuslx86_64So1
   , relFileLibtinfoSo5
   , relFileLibtinfoSo6
   , relFileLibncurseswSo6
@@ -131,6 +132,7 @@ module Stack.Constants
   , relFileHadrianStackDotYaml
   , hadrianScriptsWindows
   , hadrianScriptsPosix
+  , libDirs
   , usrLibDirs
   , testGhcEnvRelFile
   , relFileBuildLock
@@ -151,7 +153,7 @@ import           Hpack.Config ( packageConfig )
 import qualified Language.Haskell.TH.Syntax as TH ( runIO, lift )
 import           Path ( (</>), mkRelDir, mkRelFile, parseAbsFile )
 import           Stack.Constants.StackProgName ( stackProgName )
-import           Stack.Constants.UsrLibDirs ( usrLibDirs )
+import           Stack.Constants.UsrLibDirs ( libDirs, usrLibDirs )
 import           Stack.Prelude
 import           Stack.Types.Compiler ( WhichCompiler (..) )
 import           System.Permissions ( osIsMacOS, osIsWindows )
@@ -554,6 +556,9 @@ relDirUnderHome = $(mkRelDir "_home")
 
 relDirSrc :: Path Rel Dir
 relDirSrc = $(mkRelDir "src")
+
+relFileLibcMuslx86_64So1 :: Path Rel File
+relFileLibcMuslx86_64So1 = $(mkRelFile "libc.musl-x86_64.so.1")
 
 relFileLibtinfoSo5 :: Path Rel File
 relFileLibtinfoSo5 = $(mkRelFile "libtinfo.so.5")

--- a/src/unix/Stack/Constants/UsrLibDirs.hs
+++ b/src/unix/Stack/Constants/UsrLibDirs.hs
@@ -4,11 +4,17 @@
 -- | The module of this name differs as between Windows and non-Windows builds.
 -- This is the non-Windows version.
 module Stack.Constants.UsrLibDirs
-  ( usrLibDirs
+  ( libDirs
+  , usrLibDirs
   ) where
 
 import          Path ( mkAbsDir )
 import          Stack.Prelude
+
+-- | Used in Stack.Setup for detecting libc.musl-x86_64.so.1, see comments at
+-- use site
+libDirs :: [Path Abs Dir]
+libDirs = [$(mkAbsDir "/lib"), $(mkAbsDir "/lib64")]
 
 -- | Used in Stack.Setup for detecting libtinfo, see comments at use site
 usrLibDirs :: [Path Abs Dir]

--- a/src/windows/Stack/Constants/UsrLibDirs.hs
+++ b/src/windows/Stack/Constants/UsrLibDirs.hs
@@ -3,10 +3,16 @@
 -- | The module of this name differs as between Windows and non-Windows builds.
 -- This is the Windows version.
 module Stack.Constants.UsrLibDirs
-  ( usrLibDirs
+  ( libDirs
+  , usrLibDirs
   ) where
 
 import          Stack.Prelude
+
+-- | Used in Stack.Setup for detecting libc.musl-x86_64.so.1, see comments at
+-- use site
+libDirs :: [Path Abs Dir]
+libDirs = []
 
 -- | Used in Stack.Setup for detecting libtinfo, see comments at use site
 usrLibDirs :: [Path Abs Dir]


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested on Alpine Linux (on WSL2). Relying on CI for other operating systems.
