### PR TITLE
get-stack.sh: fedora/centos needs gcc-c++ for ghc9

### DIFF
--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -226,7 +226,7 @@ do_debian_install() {
 # and install the necessary dependencies explicitly.
 do_fedora_install() {
   install_dependencies() {
-    dnf_install_pkgs perl make automake gcc gmp-devel libffi zlib-devel xz tar git gnupg
+    dnf_install_pkgs perl make automake gcc gcc-c++ gmp-devel libffi zlib-devel xz tar git gnupg
   }
 
   if is_x86_64 ; then
@@ -247,7 +247,7 @@ do_fedora_install() {
 # and install the necessary dependencies explicitly.
 do_centos_install() {
   install_dependencies() {
-    yum_install_pkgs perl make automake gcc gmp-devel libffi zlib xz tar git gnupg
+    yum_install_pkgs perl make automake gcc gcc-c++ gmp-devel libffi zlib xz tar git gnupg
   }
 
   if is_x86_64 ; then


### PR DESCRIPTION
Recent ghcs need C++ for installation (since 9.2 perhaps?)
This change parallels debian/ubuntu which already install g++

Prevents the following error/mishap for example in a fresh RHEL 8 installation:
```
[petersen@localhost test-unix]$ stack install
Preparing to install GHC (tinfo6-libc6-pre232) to an isolated location. This
will not interfere with any system-level installation.
Downloaded ghc-tinfo6-libc6-pre232-9.4.6.                                      
Unpacking GHC into /home/petersen/.stack/programs/x86_64-linux/ghc-tinfo6-libc6-                                                                                /home/petersen/.stack/programs/x86_64-linux/ghc-tinfo6-libc6-pre232-9.4.6.temp/ghc-9.4.6-x86_64-unknown-linux/configure: line 7730: g++: command not found
configure: error: Failed to compile test program
Configuring GHC ...

Error: [S-7441]
       Received ExitFailure 1 when running
       Raw command: /home/petersen/.stack/programs/x86_64-linux/ghc-tinfo6-libc6-pre232-9.4.6.temp/ghc-9.4.6-x86_64-unknown-linux/configure --prefix=/home/petersen/.stack/programs/x86_64-linux/ghc-tinfo6-libc6-pre232-9.4.6/
       Run from: /home/petersen/.stack/programs/x86_64-linux/ghc-tinfo6-libc6-pre232-9.4.6.temp/ghc-9.4.6-x86_64-unknown-linux/
       
       Error encountered while configuring GHC with
         /home/petersen/.stack/programs/x86_64-linux/ghc-tinfo6-libc6-pre232-9.4.6.temp/ghc-9.4.6-x86_64-unknown-linux/configure --prefix=/home/petersen/.stack/programs/x86_64-linux/ghc-tinfo6-libc6-pre232-9.4.6/
         run in
         /home/petersen/.stack/programs/x86_64-linux/ghc-tinfo6-libc6-pre232-9.4.6.temp/ghc-9.4.6-x86_64-unknown-linux/
       
       The following directories may now contain files, but won't be used by
       Stack:
       * /home/petersen/.stack/programs/x86_64-linux/ghc-tinfo6-libc6-pre232-9.4.6.temp/
       * /home/petersen/.stack/programs/x86_64-linux/ghc-tinfo6-libc6-pre232-9.4.6/
       
       For more information consider rerunning with --verbose flag.
       
```