### PR TITLE
Fix #6257 Allow MSYS2 to install on different drive to sys temp dir's

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,8 @@ Bug fixes:
 
 * Restore message suffix `due to warnings` with `dump-logs: warning` (broken
   with Stack 2.11.1).
+* On Windows, the `local-programs-path` directory can now be on a different
+  drive to the system temporary directory and MSYS2 will still be installed.
 
 ## v2.13.0.1 (release candidate) - 2023-09-16
 

--- a/stack.cabal
+++ b/stack.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.35.5.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -40,10 +40,8 @@ extra-source-files:
     doc/clean_command.md
     doc/config_command.md
     doc/CONTRIBUTING.md
-    doc/coverage.md
     doc/custom_snapshot.md
     doc/debugging.md
-    doc/dependency_visualization.md
     doc/dev_containers.md
     doc/developing_on_windows.md
     doc/docker_command.md


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally on Windows.
