### PR TITLE
Fix #6267 Avoid *.hi and *.o in stack-exe-src directory

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,11 @@ Major changes:
 
 Behavior changes:
 
+* Stack does not leave `*.hi` or `*.o` files in the `setup-exe-src` directory of
+  the Stack root, and deletes any corresponding to a `setup-<hash>.hs` or
+  `setup-shim-<hash>.hs` file, to avoid GHC issue
+  [#21250](https://gitlab.haskell.org/ghc/ghc/-/issues/21250).
+
 Other enhancements:
 
 * Add flag `--no-init` to Stack's `new` command to skip the initialisation of


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally on Windows.