### PR TITLE
fix final printed output of 'stack haddock'

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@ Other enhancements:
 
 * Add flag `--no-init` to Stack's `new` command to skip the initialisation of
   the newly-created project for use with Stack.
+* The HTML file paths produced at the end of `stack haddock` are printed on
+  separate lines and without a trailing dot.
 
 Bug fixes:
 

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -219,7 +219,8 @@ generateHaddockIndex descr bco dumpPackages docRelFP destDir = do
           [ flow "Updating Haddock index for"
           , style Current (fromString $ T.unpack descr)
           , "in"
-          , pretty destIndexFile <> "."
+          , "\n"
+          , pretty destIndexFile
           ]
         liftIO (mapM_ copyPkgDocs interfaceOpts)
         haddockExeName <- view $ compilerPathsL.to (toFilePath . cpHaddock)
@@ -237,7 +238,8 @@ generateHaddockIndex descr bco dumpPackages docRelFP destDir = do
           [ flow "Haddock index for"
           , style Current (fromString $ T.unpack descr)
           , flow "already up to date at"
-          , pretty destIndexFile <> "."
+          , "\n"
+          , pretty destIndexFile
           ]
  where
   toInterfaceOpt ::


### PR DESCRIPTION
Small quality-of-life change to the output of `stack haddock`, closes #6274 

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
~~* [ ] The documentation has been updated, if necessary~~


