### PR TITLE
Relax template package.yaml check to support packages in a subdirectory

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ Release notes:
 
 * The hash used as a key for Stack's pre-compiled package cache has changed,
   following the dropping of support for Cabal versions older than `1.24.0.0`.
+* The check used in `stack new` now does a suffix match to find `package.yaml`
+  rather than an exact match. This supports defining templates with packages in
+  subdirectories.
 
 **Changes since v2.13.1:**
 

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -520,7 +520,7 @@ applyTemplate project template nonceParams dir templateText = do
       template
       (flow "the template does not contain any files.")
 
-  let isPkgSpec f = ".cabal" `L.isSuffixOf` f || f == "package.yaml"
+  let isPkgSpec f = ".cabal" `L.isSuffixOf` f || "package.yaml" `L.isSuffixOf` f
   unless (any isPkgSpec . M.keys $ files) $
     prettyThrowM $ TemplateInvalid
       template


### PR DESCRIPTION
When using `stack new` with a custom template, an error is thrown when trying to make a `package.yaml` at a subdirectory. For example, with a template like this:

```text
{-# START_FILE {{name}}/package.yaml #-}
... yaml contents ...
```

`stack new` would throw this error:

```text
❯ stack new my-new-project jship/default
Downloading template jship/default to create project my-new-project in directory my-new-project/...
Downloaded /Users/jship/.stack/templates/jship/default.hsfiles.

Error: [S-9490]
       Stack failed to use the template jship/default, as the template does not contain a Cabal or package.yaml file.
```

This behavior is from the current version of the code checking for an exact match with the string `"package.yaml"`: https://github.com/commercialhaskell/stack/blob/74a36d636b848fe4a8cdd46fd34b54d201bc4c24/src/Stack/New.hs#L523

This PR relaxes this restriction to just do a suffix match, which is what the `.cabal` portion of the check was already doing.

I tested this by updating the `stack` source and testing the new binary with [this template file](https://github.com/jship/stack-templates/blob/main/default.hsfiles).

---

Note: Fixes for the online documentation of the current Stack release (https://docs.haskellstack.org/en/stable/) should target the 'stable' branch, not the 'master' branch.

Please include the following checklist in your pull request:

* [X] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [ ] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
