### PR TITLE
Re #6270 Step 4 Upload document archive to Hackage

### DIFF
--- a/doc/upload_command.md
+++ b/doc/upload_command.md
@@ -3,20 +3,82 @@
 # The `stack upload` command
 
 ~~~text
-stack upload [DIR] [--pvp-bounds PVP-BOUNDS] [--ignore-check]
-             [--[no-]test-tarball] [--tar-dir ARG] [--candidate]
+stack upload [ITEM] [-d|--documentation] [--pvp-bounds PVP-BOUNDS]
+             [--ignore-check] [--[no-]test-tarball] [--tar-dir ARG]
+             [--candidate] [--setup-info-yaml URL]
+             [--snapshot-location-base URL]
 ~~~
 
-Hackage accepts packages for uploading in a standard form, a compressed archive
-('tarball') in the format produced by Cabal's `sdist` action.
+By default:
 
-`stack upload` generates a file for your package, in the format accepted by
-Hackage for uploads, and uploads the package to Hackage. For example, if the
-current working directory is the root directory of your project:
+* the command uploads one or more packages. Pass the flag `--documentation`
+  (`-d` for short) to upload documentation for one or more packages; and
+
+* the upload is a package to be published or documentation for a published
+  package. Pass the flag `--candidate` to upload a
+  [package candidate](http://hackage.haskell.org/upload#candidates) or
+  documentation for a package candidate.
+
+At least one `ITEM` must be specified. For example, if the current working
+directory is a package directory:
 
 ~~~text
 stack upload .
 ~~~
+
+## Upload one or more packages
+
+Hackage accepts packages for uploading in a standard form, a compressed archive
+('tarball') in the format produced by Cabal's `sdist` action.
+
+If `ITEM` is a relative path to an sdist tarball, `stack upload` uploads the
+package to Hackage.
+
+If `ITEM` is a relative path to a package directory, `stack upload` generates a
+file for your package, in the format accepted by Hackage for uploads, and
+uploads the package to Hackage.
+
+By default:
+
+* the command will check each package for common mistakes. Pass the flag
+  `--ignore-check` to disable such checks;
+
+* Stack will not test the resulting package archive. Pass the flag
+  `--test-tarball` to cause Stack to test each resulting package archive, by
+  attempting to build it.
+
+The `--pvp-bounds <pvp_bounds_mode>` option determines whether and, if so, how
+PVP version bounds should be added to the Cabal file of the package. The
+available modes for basic use are: `none`, `lower`, `upper`, and `both`. The
+available modes for use with Cabal file revisions are `lower-revision`,
+`upper-revision` and `both-revision`.
+
+For futher information, see the
+[YAML configuration](yaml_configuration.md#pvp-bounds) documentation.
+
+The `--tar-dir <path_to_directory>` option determines whether the package
+archive should be copied to the specified directory.
+
+## Upload documentation for a package
+
+:octicons-beaker-24: Experimental
+
+:octicons-tag-24: UNRELEASED
+
+Hackage accepts documentation for a package for uploading in a standard form and
+in a compressed archive ('tarball') in the `.tar.gz` format.
+
+For further information about how to create such an archive file, see the
+documentation for the
+[`stack haddock --haddock-for-hackage`](build_command.md#-no-haddock-for-haddock-flag)
+command.
+
+If `ITEM` is a relative path to a package directory,
+`stack upload <package_directory> --documentation` uploads an existing archive
+file of documentation for the specified package to Hackage.
+
+If the `--documentation` flag is passed then flags specific to package upload
+are ignored.
 
 ## The `HACKAGE_USERNAME` and `HACKAGE_PASSWORD` environment variables
 
@@ -67,36 +129,3 @@ example:
      $Env:HACKAGE_KEY=<api_authentification_token>
      stack upload .
      ~~~
-
-## `--candidate` flag
-
-Pass the flag to upload a
-[package candidate](http://hackage.haskell.org/upload#candidates).
-
-## `--ignore-check` flag
-
-Pass the flag to disable checks of the package for common mistakes. By default,
-the command will check the package for common mistakes.
-
-## `--pvp-bounds` option
-
-The `--pvp-bounds <pvp_bounds_mode>` option determines whether and, if so, how
-PVP version bounds should be added to the Cabal file of the package. The
-available modes for basic use are: `none`, `lower`, `upper`, and `both`. The
-available modes for use with Cabal file revisions are `lower-revision`,
-`upper-revision` and `both-revision`.
-
-For futher information, see the
-[YAML configuration](yaml_configuration.md#pvp-bounds) documentation.
-
-## `--tar-dir` option
-
-The `--tar-dir <path_to_directory>` option determines whether the package
-archive should be copied to the specified directory.
-
-## `--[no-]test-tarball` flag
-
-Default: Disabled
-
-Set the flag to cause Stack to test the resulting package archive, by attempting
-to build it.

--- a/package.yaml
+++ b/package.yaml
@@ -144,6 +144,11 @@ when:
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=True
   else:
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=False
+- condition: flag(disable-stack-upload)
+  then:
+    cpp-options: -DSTACK_DISABLE_STACK_UPLOAD=True
+  else:
+    cpp-options: -DSTACK_DISABLE_STACK_UPLOAD=False
 library:
   source-dirs: src
   ghc-options:
@@ -431,5 +436,12 @@ flags:
   developer-mode:
     description: >-
       By default, output extra developer information.
+    manual: true
+    default: false
+  disable-stack-upload:
+    description: >-
+      For use only during development and debugging. Disable 'stack upload' so
+      that it does not make HTTP requests. Stack will output information about
+      the HTTP request(s) that it would have made if the command was enabled.
     manual: true
     default: false

--- a/src/Network/HTTP/StackClient.hs
+++ b/src/Network/HTTP/StackClient.hs
@@ -14,6 +14,7 @@ module Network.HTTP.StackClient
   , setRequestCheckStatus
   , setRequestMethod
   , setRequestHeader
+  , setRequestHeaders
   , addRequestHeader
   , setRequestBody
   , getResponseHeaders
@@ -37,6 +38,8 @@ module Network.HTTP.StackClient
   , hAccept
   , hContentLength
   , hContentMD5
+  , method
+  , methodPost
   , methodPut
   , formDataBody
   , partFileRequestBody
@@ -45,6 +48,7 @@ module Network.HTTP.StackClient
   , setGitHubHeaders
   , download
   , redownload
+  , requestBody
   , verifiedDownload
   , verifiedDownloadWithProgress
   , CheckHexDigest (..)
@@ -73,7 +77,7 @@ import           Data.Time.Clock
 import           Network.HTTP.Client
                    ( HttpException (..), HttpExceptionContent (..), Request
                    , RequestBody (..), Response (..), checkResponse, getUri
-                   , parseRequest, parseUrlThrow, path
+                   , method, parseRequest, parseUrlThrow, path, requestBody
                    )
 import           Network.HTTP.Client.MultipartFormData
                    ( formDataBody, partBS, partFileRequestBody, partLBS )
@@ -92,12 +96,13 @@ import qualified Network.HTTP.Download as Download
 import           Network.HTTP.Simple
                    ( addRequestHeader, getResponseBody, getResponseHeaders
                    , getResponseStatusCode, setRequestBody
-                   , setRequestCheckStatus, setRequestHeader, setRequestMethod
+                   , setRequestCheckStatus, setRequestHeader, setRequestHeaders
+                   , setRequestMethod
                    )
 import qualified Network.HTTP.Simple
                    ( httpJSON, httpLbs, httpNoBody, httpSink, withResponse )
 import           Network.HTTP.Types
-                   ( hAccept, hContentLength, hContentMD5, methodPut
+                   ( hAccept, hContentLength, hContentMD5, methodPost, methodPut
                    , notFound404
                    )
 import           Path ( Abs, File, Path )

--- a/src/Stack/BuildInfo.hs
+++ b/src/Stack/BuildInfo.hs
@@ -25,6 +25,7 @@ import           GitHash ( giCommitCount, giHash, tGitInfoCwdTry )
 import           Options.Applicative.Simple ( simpleVersion )
 #endif
 import qualified Paths_stack as Meta
+import           Stack.Constants ( isStackUploadDisabled )
 import           Stack.Prelude
 #ifndef USE_GIT_INFO
 import           Stack.Types.Version ( showStackVersion )
@@ -51,6 +52,7 @@ versionString' = showStackVersion ++ afterVersion
     , ' ' : Cabal.display buildArch
     , depsString
     , warningString
+    , stackUploadDisabledWarningString
     ]
   preReleaseString =
     case versionBranch Meta.version of
@@ -73,6 +75,14 @@ versionString' = showStackVersion ++ afterVersion
     , "official build by running 'stack upgrade --force-download'."
     ]
 #endif
+  stackUploadDisabledWarningString = if isStackUploadDisabled
+    then unlines
+      [ ""
+      , "Warning: 'stack upload' is disabled and will not make HTTP request(s). It will"
+      , "output information about the HTTP request(s) that would have been made if it"
+      , "was enabled."
+      ]
+    else ""
 
 -- | Hpack version we're compiled against
 hpackVersion :: String

--- a/src/Stack/CLI.hs
+++ b/src/Stack/CLI.hs
@@ -511,7 +511,8 @@ commandLineHandler currentDir progName isInterpreter =
 
   upload = addCommand'
     "upload"
-    "Upload a package to Hackage."
+    "Upload one or more packages, or documentation for one or more packages, \
+    \to Hackage."
     uploadCmd
     uploadOptsParser
 

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -139,6 +139,7 @@ module Stack.Constants
   , testGhcEnvRelFile
   , relFileBuildLock
   , stackDeveloperModeDefault
+  , isStackUploadDisabled
   , globalFooter
   , gitHubBasicAuthType
   , gitHubTokenEnvVar
@@ -675,6 +676,10 @@ relFileBuildLock = $(mkRelFile "build-lock")
 -- | What should the default be for stack-developer-mode
 stackDeveloperModeDefault :: Bool
 stackDeveloperModeDefault = STACK_DEVELOPER_MODE_DEFAULT
+
+-- | What should the default be for stack-developer-mode
+isStackUploadDisabled :: Bool
+isStackUploadDisabled = STACK_DISABLE_STACK_UPLOAD
 
 -- | The footer to the help for Stack's subcommands
 globalFooter :: String

--- a/src/Stack/Options/UploadParser.hs
+++ b/src/Stack/Options/UploadParser.hs
@@ -5,19 +5,68 @@ module Stack.Options.UploadParser
   ( uploadOptsParser
   ) where
 
-import           Options.Applicative ( Parser, flag, help, long )
-import           Stack.Options.SDistParser ( sdistOptsParser )
+import qualified Data.Text as T
+import           Options.Applicative
+                   ( Parser, completeWith, completer, flag, help, idm, long
+                   , metavar, option, readerError, short, strArgument, strOption
+                   , switch
+                   )
+import           Options.Applicative.Builder.Extra ( boolFlags, dirCompleter )
+import           Options.Applicative.Types ( readerAsk )
 import           Stack.Prelude
 import           Stack.Upload ( UploadOpts (..), UploadVariant (..) )
+import           Stack.Types.PvpBounds ( PvpBounds (..), parsePvpBounds )
 
 -- | Parse command line arguments for Stack's @upload@ command.
 uploadOptsParser :: Parser UploadOpts
-uploadOptsParser =
-  UploadOpts
-    <$> sdistOptsParser
-    <*> uploadVariant
-  where
-    uploadVariant = flag Publishing Candidate
-      (  long "candidate"
-      <> help "Upload as a package candidate."
+uploadOptsParser = UploadOpts
+  <$> itemsToWorkWithParser
+  <*> documentationParser
+  <*> optional pvpBoundsOption
+  <*> ignoreCheckSwitch
+  <*> buildPackageOption
+  <*> tarDirParser
+  <*> uploadVariantParser
+ where
+  itemsToWorkWithParser = many (strArgument
+    (  metavar "ITEM"
+    <> completer dirCompleter
+    <> help "A relative path to a package directory or, for package upload \
+            \only, an sdist tarball."
+    ))
+  documentationParser = flag False True
+    (  long "documentation"
+    <> short 'd'
+    <> help "Upload documentation for packages (not packages)."
+    )
+  pvpBoundsOption :: Parser PvpBounds
+  pvpBoundsOption = option readPvpBounds
+    (  long "pvp-bounds"
+    <> metavar "PVP-BOUNDS"
+    <> completeWith ["none", "lower", "upper", "both"]
+    <> help "For package upload, how PVP version bounds should be added to \
+            \Cabal file: none, lower, upper, both."
+    )
+   where
+    readPvpBounds = do
+      s <- readerAsk
+      case parsePvpBounds $ T.pack s of
+        Left e -> readerError e
+        Right v -> pure v
+  ignoreCheckSwitch = switch
+      (  long "ignore-check"
+      <> help "For package upload, do not check packages for common mistakes."
       )
+  buildPackageOption = boolFlags False
+      "test-tarball"
+      "building of the resulting sdist tarball(s), for package upload."
+      idm
+  tarDirParser = optional (strOption
+    (  long "tar-dir"
+    <> help "For package upload, if specified, copy all the tar to this \
+            \directory."
+    ))
+  uploadVariantParser = flag Publishing Candidate
+    (  long "candidate"
+    <> help "Upload as, or for, a package candidate."
+    )

--- a/stack.cabal
+++ b/stack.cabal
@@ -124,6 +124,11 @@ flag disable-git-info
   manual: True
   default: False
 
+flag disable-stack-upload
+  description: For use only during development and debugging. Disable 'stack upload' so that it does not make HTTP requests. Stack will output information about the HTTP request(s) that it would have made if the command was enabled.
+  manual: True
+  default: False
+
 flag hide-dependency-versions
   description: Hides dependency versions from 'stack --version'. Used only when building a Stack executable for official release. Note to packagers/distributors: DO NOT OVERRIDE THIS FLAG IF YOU ARE BUILDING STACK ANY OTHER WAY (e.g. using Cabal or from Hackage), as it makes debugging support requests more difficult.
   manual: True
@@ -411,6 +416,10 @@ library
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=True
   else
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=False
+  if flag(disable-stack-upload)
+    cpp-options: -DSTACK_DISABLE_STACK_UPLOAD=True
+  else
+    cpp-options: -DSTACK_DISABLE_STACK_UPLOAD=False
   if os(windows)
     other-modules:
         Stack.Constants.UsrLibDirs
@@ -530,6 +539,10 @@ executable stack
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=True
   else
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=False
+  if flag(disable-stack-upload)
+    cpp-options: -DSTACK_DISABLE_STACK_UPLOAD=True
+  else
+    cpp-options: -DSTACK_DISABLE_STACK_UPLOAD=False
   if flag(static)
     ld-options: -static -pthread
 
@@ -628,6 +641,10 @@ executable stack-integration-test
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=True
   else
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=False
+  if flag(disable-stack-upload)
+    cpp-options: -DSTACK_DISABLE_STACK_UPLOAD=True
+  else
+    cpp-options: -DSTACK_DISABLE_STACK_UPLOAD=False
   if !(flag(integration-tests))
     buildable: False
   if flag(static)
@@ -742,6 +759,10 @@ test-suite stack-unit-test
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=True
   else
     cpp-options: -DSTACK_DEVELOPER_MODE_DEFAULT=False
+  if flag(disable-stack-upload)
+    cpp-options: -DSTACK_DISABLE_STACK_UPLOAD=True
+  else
+    cpp-options: -DSTACK_DISABLE_STACK_UPLOAD=False
   if os(windows)
     other-modules:
         Stack.Ghci.FakePaths


### PR DESCRIPTION
Also adds a manual Cabal flag `disable-stack-upload` to `package.yaml`, to facilitate the debugging of `stack upload`.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally on Windows 11, including by using it to add Haddock documentation to a package candidate for `stack-2.14.0` on Hackage.
