### PR TITLE
Eliminate unsafePerformIO

### DIFF
--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -229,14 +229,18 @@ withRunnerGlobal go inner = do
                                     <$> getTerminalWidth)
                                    pure (globalTermWidth go)
   menv <- mkDefaultProcessContext
+  -- MVar used to ensure the Docker entrypoint is performed exactly once.
+  dockerEntrypointMVar <- newMVar False
   let update = globalStylesUpdate go
-  withNewLogFunc go useColor update $ \logFunc -> runRIO Runner
-    { runnerGlobalOpts = go
-    , runnerUseColor = useColor
-    , runnerLogFunc = logFunc
-    , runnerTermWidth = termWidth
-    , runnerProcessContext = menv
-    } inner
+  withNewLogFunc go useColor update $ \logFunc -> do
+    runRIO Runner
+      { runnerGlobalOpts = go
+      , runnerUseColor = useColor
+      , runnerLogFunc = logFunc
+      , runnerTermWidth = termWidth
+      , runnerProcessContext = menv
+      , runnerDockerEntrypointMVar = dockerEntrypointMVar
+      } inner
  where
   clipWidth w
     | w < minTerminalWidth = minTerminalWidth


### PR DESCRIPTION
The Stan tool reports:
~~~text
File:         src\Stack\Docker.hs
  Module:       Stack.Docker
  LoC:          652
  Observations: 1
  Extensions from .cabal:
  Extensions from module: NoImplicitPrelude, OverloadedStrings, RecordWildCards
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ┃  ✦ ID:            OBS-STAN-0212-axv1UG-562:18
 ┃  ✦ Severity:      Error
 ┃  ✦ Inspection ID: STAN-0212
 ┃  ✦ Name:          Anti-pattern: unsafe functions
 ┃  ✦ Description:   Usage of unsafe functions breaks referential transparency
 ┃  ✦ Category:      #Unsafe #AntiPattern
 ┃  ✦ File:          src\Stack\Docker.hs
 ┃
 ┃   561 ┃
 ┃   562 ┃ entrypointMVar = unsafePerformIO (newMVar False)
 ┃   563 ┃                  ^^^^^^^^^^^^^^^
 ┃
 ┃  💡 Possible solution:
 ┃      ⍟ Remove 'undefined' or at least replace with 'error' to give better error messages
 ┃      ⍟ Replace 'unsafeCoerce' with 'coerce'
 ┃      ⍟ Rewrite the code to avoid using 'unsafePerformIO' and other unsafe IO functions
~~~

In that regard, the following is an [idiom](https://wiki.haskell.org/Top_level_mutable_state) for a top level mutable state:
~~~haskell
-- | MVar used to ensure the Docker entrypoint is performed exactly once
entrypointMVar :: MVar Bool
{-# NOINLINE entrypointMVar #-}
entrypointMVar = unsafePerformIO (newMVar False)
~~~

However, this Haskell Community [discussion](https://discourse.haskell.org/t/solved-safe-elimination-of-unsafeperformio/7901) suggests that the `unsafePerformIO` can eliminated by adding the `MVar` to the environment.

There is also this blog post: https://www.fpcomplete.com/blog/readert-design-pattern/.

There is also this StackOverflow Q&A: https://stackoverflow.com/questions/15439966/when-why-use-an-mvar-over-a-tvar#:~:text=There%20is%20not%20really%20a,then%20TVar%20is%20most%20suitable.

Note: Fixes for the online documentation of the current Stack release (https://docs.haskellstack.org/en/stable/) should target the 'stable' branch, not the 'master' branch.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary