### PR TITLE
Clear Stan suggestion; use `fromMaybe mempty` not `fold`

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -121,12 +121,6 @@
   scope = "all"
   type = "Exclude"
 
-# Anti-pattern: Foldable methods on possibly error-prone structures
-[[check]]
-  id = "STAN-0207"
-  scope = "all"
-  type = "Exclude"
-
 # Anti-pattern: Slow 'length' for Text
 # On Windows
 [[check]]

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1554,7 +1554,7 @@ withSingleContext ActionContext {..} ee@ExecuteEnv {..} task@Task {..} allDeps m
                     (sinkWithTimestamps prefixWithTimestamps h)
                     (sinkWithTimestamps prefixWithTimestamps h)
                 OTConsole mprefix ->
-                  let prefix = fold mprefix
+                  let prefix = fromMaybe mempty mprefix
                   in  void $ sinkProcessStderrStdout
                         (toFilePath exeName)
                         fullArgs


### PR DESCRIPTION
Clears Stan report:
~~~text
  File:         src\Stack\Build\Execute.hs
  Module:       Stack.Build.Execute
  LoC:          2749
  Observations: 1
  Extensions from .cabal:
  Extensions from module: NoImplicitPrelude, DataKinds, OverloadedStrings, RecordWildCards, TypeFamilies
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ┃  ✦ ID:            OBS-STAN-0207-fki0nd-1557:32
 ┃  ✦ Severity:      PotentialBug
 ┃  ✦ Inspection ID: STAN-0207
 ┃  ✦ Name:          Anti-pattern: Foldable methods on possibly error-prone structures
 ┃  ✦ Description:   Usage of Foldable methods on (,), Maybe, Either
 ┃  ✦ Category:      #AntiPattern
 ┃  ✦ File:          src\Stack\Build\Execute.hs
 ┃
 ┃  1556 ┃
 ┃  1557 ┃                   let prefix = fold mprefix
 ┃  1558 ┃                                ^^^^
 ┃
 ┃  💡 Possible solution:
 ┃      ⍟ Use more explicit functions with specific monomorphic types
~~~

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
