### PR TITLE
Clear Stan suggestion: replace `foldl` with `fold'`

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -56,12 +56,6 @@
   scope = "all"
   type = "Exclude"
 
-# Anti-pattern: foldl
-[[check]]
-  id = "STAN-0202"
-  scope = "all"
-  type = "Exclude"
-
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
   id = "OBS-STAN-0203-fki0nd-1098:21"

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -16,7 +16,6 @@ import           Control.Monad.State.Strict ( State, execState, get, modify )
 import           Data.ByteString.Builder ( byteString )
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy as LBS
-import           Data.Foldable ( foldl )
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
@@ -384,11 +383,11 @@ findFileTargets locals fileTargets = do
         pure $ Right (fp, x)
   let (extraFiles, associatedFiles) = partitionEithers results
       targetMap =
-          foldl unionTargets M.empty $
+          foldl' unionTargets M.empty $
           map (\(_, (name, comp)) -> M.singleton name (TargetComps (S.singleton comp)))
               associatedFiles
       infoMap =
-          foldl (M.unionWith (<>)) M.empty $
+          foldl' (M.unionWith (<>)) M.empty $
           map (\(fp, (name, _)) -> M.singleton name [fp])
               associatedFiles
   pure (targetMap, infoMap, extraFiles)

--- a/src/Stack/Types/Build/Exception.hs
+++ b/src/Stack/Types/Build/Exception.hs
@@ -559,7 +559,7 @@ pprintExceptions exceptions stackYaml stackRoot isImplicitGlobal parentMap wante
     , Set.Set PackageName
       -- ^ Set of names of packages with one or more DependencyMismatch errors.
     )
-  filterExceptions = L.foldl go acc0 exceptions'
+  filterExceptions = L.foldl' go acc0 exceptions'
    where
     acc0 = (True, False, Map.empty, Set.empty)
     go acc (DependencyPlanFailures pkg m) = Map.foldrWithKey go' acc m


### PR DESCRIPTION
I could see no reason to retain the existing `foldl`. The combining function did not appear to be non-strict in its first argument.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
