### PR TITLE
Fix #6313 Make `taskProvides` a function, not a field of `Task`

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -52,7 +52,7 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-1098:21"
+  id = "OBS-STAN-0203-fki0nd-1100:21"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 #  ✦ Category:      #AntiPattern
 #  ✦ File:          src\Stack\Build\Execute.hs
@@ -63,7 +63,7 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-2626:3"
+  id = "OBS-STAN-0203-fki0nd-2631:3"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\Execute.hs

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -35,7 +35,9 @@ import           Stack.Prelude hiding ( loadPackage )
 import           Stack.Runners ( ShouldReexec (..), withConfig, withEnvConfig )
 import           Stack.Setup ( withNewLocalBuildTargets )
 import           Stack.Types.Build
-                   ( Plan (..), Task (..), TaskType (..), taskLocation )
+                   ( Plan (..), Task (..), TaskType (..), taskLocation
+                   , taskProvides
+                   )
 import           Stack.Types.Build.Exception
                    ( BuildException (..), BuildPrettyException (..) )
 import           Stack.Types.BuildConfig ( HasBuildConfig, stackYamlL )

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -35,7 +35,7 @@ import           Stack.Types.Build
                    ( CachePkgSrc (..), ConfigCache (..), Plan (..), Task (..)
                    , TaskConfigOpts (..), TaskType (..)
                    , installLocationIsMutable, taskIsTarget, taskLocation
-                   , taskTargetIsMutable, toCachePkgSrc
+                   , taskProvides, taskTargetIsMutable, toCachePkgSrc
                    )
 import           Stack.Types.Build.Exception
                    ( BadDependency (..), BuildException (..)
@@ -525,10 +525,7 @@ addFinal lp package isAllInOne buildHaddocks = do
     Right (missing, present, _minLoc) -> do
       ctx <- ask
       pure $ Right Task
-        { taskProvides = PackageIdentifier
-            (packageName package)
-            (packageVersion package)
-        , taskConfigOpts = TaskConfigOpts missing $ \missing' ->
+        { taskConfigOpts = TaskConfigOpts missing $ \missing' ->
             let allDeps = Map.union present missing'
             in  configureOpts
                   (view envConfigL ctx)
@@ -833,10 +830,7 @@ installPackageGivenDeps isAllInOne buildHaddocks ps package minstalled
     pure $ case mRightVersionInstalled of
       Just installed -> ADRFound loc installed
       Nothing -> ADRToInstall Task
-        { taskProvides = PackageIdentifier
-            (packageName package)
-            (packageVersion package)
-        , taskConfigOpts = TaskConfigOpts missing $ \missing' ->
+        { taskConfigOpts = TaskConfigOpts missing $ \missing' ->
             let allDeps = Map.union present missing'
             in  configureOpts
                   (view envConfigL ctx)

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -503,12 +503,9 @@ getSDistFileList lp deps =
           contents <- liftIO (S.readFile outFile)
           pure (T.unpack $ T.decodeUtf8With T.lenientDecode contents, cabalfp)
  where
-  package = lpPackage lp
   ac = ActionContext Set.empty [] ConcurrencyAllowed
   task = Task
-    { taskProvides =
-        PackageIdentifier (packageName package) (packageVersion package)
-    , taskType = TTLocalMutable lp
+    { taskType = TTLocalMutable lp
     , taskConfigOpts = TaskConfigOpts
         { tcoMissing = Set.empty
         , tcoOpts = \_ -> ConfigureOpts [] []

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -31,7 +31,6 @@ module Stack.Types.Package
   , lpFilesForComponents
   , memoizeRefWith
   , packageDefinedFlags
-  , packageIdent
   , packageIdentifier
   , psVersion
   , runMemoizedWith
@@ -197,12 +196,8 @@ data Package = Package
   }
   deriving (Show, Typeable)
 
-packageIdent :: Package -> PackageIdentifier
-packageIdent p = PackageIdentifier (packageName p) (packageVersion p)
-
 packageIdentifier :: Package -> PackageIdentifier
-packageIdentifier pkg =
-  PackageIdentifier (packageName pkg) (packageVersion pkg)
+packageIdentifier p = PackageIdentifier (packageName p) (packageVersion p)
 
 packageDefinedFlags :: Package -> Set FlagName
 packageDefinedFlags = M.keysSet . packageDefaultFlags


### PR DESCRIPTION
Also removes `packageIdent`, duplicating `packageIdentifier`.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
