### PR TITLE
Use 'sub-library' terminology consistently

### DIFF
--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -372,8 +372,8 @@ checkComponentsBuildable lps =
     , c <- Set.toList (lpUnbuildable lp)
     ]
 
--- | Find if any sublibrary dependency (other than internal libraries) exists in
--- each project package.
+-- | Find if any sub-library dependency (other than internal libraries) exists
+-- in each project package.
 checkSubLibraryDependencies :: HasTerm env => [ProjectPackage] -> RIO env ()
 checkSubLibraryDependencies projectPackages =
   forM_ projectPackages $ \projectPackage -> do

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -1161,10 +1161,10 @@ addPackageDeps package = do
       TTLocalMutable lp -> packageHasLibrary $ lpPackage lp
       TTRemotePackage _ p _ -> packageHasLibrary p
 
-  -- make sure we consider internal libraries as libraries too
+  -- make sure we consider sub-libraries as libraries too
   packageHasLibrary :: Package -> Bool
   packageHasLibrary p =
-    not (Set.null (packageInternalLibraries p)) ||
+    not (Set.null (packageSubLibraries p)) ||
     case packageLibraries p of
       HasLibraries _ -> True
       NoLibraries -> False

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -181,7 +181,7 @@ isAllowed :: InstallMap
 isAllowed installMap mloc dp = case Map.lookup name installMap of
   Nothing ->
     -- If the sourceMap has nothing to say about this package,
-    -- check if it represents a sublibrary first
+    -- check if it represents a sub-library first
     -- See: https://github.com/commercialhaskell/stack/issues/3899
     case dpParentLibIdent dp of
       Just (PackageIdentifier parentLibName version') ->

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -49,7 +49,7 @@ import           Stack.Types.EnvConfig
                    )
 import           Stack.Types.FileDigestCache ( readFileDigest )
 import           Stack.Types.NamedComponent
-                   ( NamedComponent (..), isCInternalLib )
+                   ( NamedComponent (..), isCSubLib )
 import           Stack.Types.Package
                    ( FileCacheInfo (..), LocalPackage (..), Package (..)
                    , PackageConfig (..), PackageLibraries (..)
@@ -280,7 +280,7 @@ splitComponents =
  where
   go a b c [] = (Set.fromList $ a [], Set.fromList $ b [], Set.fromList $ c [])
   go a b c (CLib:xs) = go a b c xs
-  go a b c (CInternalLib x:xs) = go (a . (x:)) b c xs
+  go a b c (CSubLib x:xs) = go (a . (x:)) b c xs
   go a b c (CExe x:xs) = go (a . (x:)) b c xs
   go a b c (CTest x:xs) = go a (b . (x:)) c xs
   go a b c (CBench x:xs) = go a b (c . (x:)) xs
@@ -348,7 +348,7 @@ loadLocalPackage pp = do
                   HasLibraries _ -> True
           in     hasLibrary
               || not (Set.null nonLibComponents)
-              || not (Set.null $ packageInternalLibraries pkg)
+              || not (Set.null $ packageSubLibraries pkg)
 
       filterSkippedComponents =
         Set.filter (not . (`elem` boptsSkipComponents bopts))
@@ -510,7 +510,7 @@ getPackageFilesForTargets pkg cabalFP nonLibComponents = do
   (components',compFiles,otherFiles,warnings) <-
     getPackageFiles (packageFiles pkg) cabalFP
   let necessaryComponents =
-        Set.insert CLib $ Set.filter isCInternalLib (M.keysSet components')
+        Set.insert CLib $ Set.filter isCSubLib (M.keysSet components')
       components = necessaryComponents `Set.union` nonLibComponents
       componentsFiles = M.map
         (\files ->

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -260,7 +260,7 @@ resolveRawTarget sma allLocs (ri, rt) =
   -- 'ComponentName'
   isCompNamed :: ComponentName -> NamedComponent -> Bool
   isCompNamed _ CLib = False
-  isCompNamed t1 (CInternalLib t2) = t1 == t2
+  isCompNamed t1 (CSubLib t2) = t1 == t2
   isCompNamed t1 (CExe t2) = t1 == t2
   isCompNamed t1 (CTest t2) = t1 == t2
   isCompNamed t1 (CBench t2) = t1 == t2

--- a/src/Stack/ComponentFile.hs
+++ b/src/Stack/ComponentFile.hs
@@ -332,7 +332,7 @@ componentOutputDir :: NamedComponent -> Path Abs Dir -> Path Abs Dir
 componentOutputDir namedComponent distDir =
   case namedComponent of
     CLib -> buildDir distDir
-    CInternalLib name -> makeTmp name
+    CSubLib name -> makeTmp name
     CExe name -> makeTmp name
     CTest name -> makeTmp name
     CBench name -> makeTmp name
@@ -551,7 +551,7 @@ componentBuildDir cabalVer component distDir
   | otherwise =
       case component of
         CLib -> buildDir distDir
-        CInternalLib name -> buildDir distDir </> componentNameToDir name
+        CSubLib name -> buildDir distDir </> componentNameToDir name
         CExe name -> buildDir distDir </> componentNameToDir name
         CTest name -> buildDir distDir </> componentNameToDir name
         CBench name -> buildDir distDir </> componentNameToDir name

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -791,7 +791,7 @@ figureOutMainFile bopts mainIsTargets targets0 packages =
   renderComp c =
     case c of
       CLib -> "lib"
-      CInternalLib name -> "internal-lib:" <> fromString (T.unpack name)
+      CSubLib name -> "sub-lib:" <> fromString (T.unpack name)
       CExe name -> "exe:" <> fromString (T.unpack name)
       CTest name -> "test:" <> fromString ( T.unpack name)
       CBench name -> "bench:" <> fromString (T.unpack name)
@@ -939,9 +939,9 @@ wantedPackageComponents _ (TargetComps cs) _ = cs
 wantedPackageComponents bopts (TargetAll PTProject) pkg = S.fromList $
   (case packageLibraries pkg of
     NoLibraries -> []
-    HasLibraries names -> CLib : map CInternalLib (S.toList names)) ++
+    HasLibraries names -> CLib : map CSubLib (S.toList names)) ++
   map CExe (S.toList (packageExes pkg)) <>
-  map CInternalLib (S.toList $ packageInternalLibraries pkg) <>
+  map CSubLib (S.toList $ packageSubLibraries pkg) <>
   (if boptsTests bopts then map CTest (M.keys (packageTests pkg)) else []) <>
   (if boptsBenchmarks bopts then map CBench (S.toList (packageBenchmarks pkg)) else [])
 wantedPackageComponents _ _ _ = S.empty

--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -206,8 +206,8 @@ conduitDumpPackage = (.| CL.catMaybes) $ eachSection $ do
               _ -> Nothing
       depends <- mapMaybeM parseDepend $ concatMap T.words $ parseM "depends"
 
-      -- Handle sublibs by recording the name of the parent library
-      -- If name of parent library is missing, this is not a sublib.
+      -- Handle sub-libraries by recording the name of the parent library
+      -- If name of parent library is missing, this is not a sub-library.
       let mkParentLib n = PackageIdentifier n version
           parentLib = mkParentLib <$> (parseS "package-name" >>=
                                        parsePackageNameThrowing . T.unpack)

--- a/src/Stack/PackageFile.hs
+++ b/src/Stack/PackageFile.hs
@@ -71,7 +71,7 @@ packageDescModulesAndFiles pkg = do
     fmap
       foldTuples
       ( mapM
-          (asModuleAndFileMap internalLibComponent libraryFiles)
+          (asModuleAndFileMap subLibComponent libraryFiles)
           (subLibraries pkg)
       )
   (executableMods, exeDotCabalFiles, exeWarnings) <-
@@ -106,8 +106,8 @@ packageDescModulesAndFiles pkg = do
   pure (modules, files, dfiles, warnings)
  where
   libComponent = const CLib
-  internalLibComponent =
-    CInternalLib . T.pack . maybe
+  subLibComponent =
+    CSubLib . T.pack . maybe
       "" Cabal.unUnqualComponentName . libraryNameString . libName
   exeComponent = CExe . T.pack . Cabal.unUnqualComponentName . exeName
   testComponent = CTest . T.pack . Cabal.unUnqualComponentName . testName

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -303,12 +303,12 @@ getCabalLbs pvpBounds mrev cabalfp sourceMap = do
     prettyThrowIO $ CabalFilePathsInconsistentBug cabalfp cabalfp'
   installMap <- toInstallMap sourceMap
   (installedMap, _, _, _) <- getInstalled installMap
-  let internalPackages = Set.fromList $
+  let subLibPackages = Set.fromList $
           gpdPackageName gpd
         : map
             (Cabal.unqualComponentNameToPackageName . fst)
             (Cabal.condSubLibraries gpd)
-      gpd' = gtraverseT (addBounds internalPackages installMap installedMap) gpd
+      gpd' = gtraverseT (addBounds subLibPackages installMap installedMap) gpd
       gpd'' =
         case mrev of
           Nothing -> gpd'
@@ -402,8 +402,8 @@ getCabalLbs pvpBounds mrev cabalfp sourceMap = do
     -> InstalledMap
     -> Dependency
     -> Dependency
-  addBounds internalPackages installMap installedMap dep =
-    if name `Set.member` internalPackages
+  addBounds subLibPackages installMap installedMap dep =
+    if name `Set.member` subLibPackages
       then dep
       else case foundVersion of
         Nothing -> dep

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -218,13 +218,13 @@ data Plan = Plan
   }
   deriving Show
 
--- | Information on a compiled package: the library conf file (if relevant),
--- the sublibraries (if present) and all of the executable paths.
+-- | Information on a compiled package: the library .conf file (if relevant),
+-- the sub-libraries (if present) and all of the executable paths.
 data PrecompiledCache base = PrecompiledCache
   { pcLibrary :: !(Maybe (Path base File))
     -- ^ .conf file inside the package database
   , pcSubLibs :: ![Path base File]
-    -- ^ .conf file inside the package database, for each of the sublibraries
+    -- ^ .conf file inside the package database, for each of the sub-libraries
   , pcExes    :: ![Path base File]
     -- ^ Full paths to executables
   }

--- a/src/Stack/Types/NamedComponent.hs
+++ b/src/Stack/Types/NamedComponent.hs
@@ -9,9 +9,9 @@ module Stack.Types.NamedComponent
   , exeComponents
   , testComponents
   , benchComponents
-  , internalLibComponents
+  , subLibComponents
   , isCLib
-  , isCInternalLib
+  , isCSubLib
   , isCExe
   , isCTest
   , isCBench
@@ -24,7 +24,7 @@ import           Stack.Prelude
 -- | A single, fully resolved component of a package
 data NamedComponent
   = CLib
-  | CInternalLib !Text
+  | CSubLib !Text
   | CExe !Text
   | CTest !Text
   | CBench !Text
@@ -32,7 +32,7 @@ data NamedComponent
 
 renderComponent :: NamedComponent -> Text
 renderComponent CLib = "lib"
-renderComponent (CInternalLib x) = "internal-lib:" <> x
+renderComponent (CSubLib x) = "sub-lib:" <> x
 renderComponent (CExe x) = "exe:" <> x
 renderComponent (CTest x) = "test:" <> x
 renderComponent (CBench x) = "bench:" <> x
@@ -62,19 +62,19 @@ benchComponents = Set.fromList . mapMaybe mBenchName . Set.toList
   mBenchName (CBench name) = Just name
   mBenchName _ = Nothing
 
-internalLibComponents :: Set NamedComponent -> Set Text
-internalLibComponents = Set.fromList . mapMaybe mInternalName . Set.toList
+subLibComponents :: Set NamedComponent -> Set Text
+subLibComponents = Set.fromList . mapMaybe mSubLibName . Set.toList
  where
-  mInternalName (CInternalLib name) = Just name
-  mInternalName _ = Nothing
+  mSubLibName (CSubLib name) = Just name
+  mSubLibName _ = Nothing
 
 isCLib :: NamedComponent -> Bool
 isCLib CLib{} = True
 isCLib _ = False
 
-isCInternalLib :: NamedComponent -> Bool
-isCInternalLib CInternalLib{} = True
-isCInternalLib _ = False
+isCSubLib :: NamedComponent -> Bool
+isCSubLib CSubLib{} = True
+isCSubLib _ = False
 
 isCExe :: NamedComponent -> Bool
 isCExe CExe{} = True

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -132,12 +132,11 @@ instance Exception PackageException where
   displayException ComponentNotParsedBug = bugReport "[S-4623]"
     "Component names should always parse as directory names."
 
--- | Libraries in a package. Since Cabal 2.0, internal libraries are a
--- thing.
+-- | Libraries in a package. Since Cabal 2.0, sub-libraries are a thing.
 data PackageLibraries
   = NoLibraries
   | HasLibraries !(Set Text)
-    -- ^ the foreign library names, sub libraries get built automatically
+    -- ^ the foreign library names, sub-libraries get built automatically
     -- without explicit component name passing
  deriving (Show, Typeable)
 
@@ -175,8 +174,8 @@ data Package = Package
     -- ^ Defaults for unspecified flags.
   , packageLibraries :: !PackageLibraries
     -- ^ does the package have a buildable library stanza?
-  , packageInternalLibraries :: !(Set Text)
-    -- ^ names of internal libraries
+  , packageSubLibraries :: !(Set Text)
+    -- ^ Names of sub-libraries
   , packageTests :: !(Map Text TestSuiteInterface)
     -- ^ names and interfaces of test suites
   , packageBenchmarks :: !(Set Text)


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
