### PR TITLE
Make `taskAnyMissing` a function, not field

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -52,7 +52,7 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-1110:21"
+  id = "OBS-STAN-0203-fki0nd-1111:21"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 #  ✦ Category:      #AntiPattern
 #  ✦ File:          src\Stack\Build\Execute.hs
@@ -63,7 +63,7 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-2643:3"
+  id = "OBS-STAN-0203-fki0nd-2656:3"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\Execute.hs

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -642,7 +642,6 @@ addFinal lp package isAllInOne buildHaddocks = do
         , taskType = TTLocalMutable lp
         , taskAllInOne = isAllInOne
         , taskCachePkgSrc = CacheSrcLocal (toFilePath (parent (lpCabalFile lp)))
-        , taskAnyMissing = not $ Set.null missing
         , taskBuildTypeConfig = packageBuildTypeConfig package
         }
   tell mempty { wFinals = Map.singleton (packageName package) res }
@@ -961,7 +960,6 @@ installPackageGivenDeps isAllInOne buildHaddocks ps package minstalled
                 TTRemotePackage mutable package pkgLoc
         , taskAllInOne = isAllInOne
         , taskCachePkgSrc = toCachePkgSrc ps
-        , taskAnyMissing = not $ Set.null missing
         , taskBuildTypeConfig = packageBuildTypeConfig package
         }
 

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -63,16 +63,12 @@ import           Stack.Prelude
 import           Stack.Runners
                    ( ShouldReexec (..), withConfig, withDefaultEnvConfig )
 import           Stack.SourceMap ( mkProjectPackage )
-import           Stack.Types.Build
-                   ( CachePkgSrc (..), Task (..), TaskConfigOpts (..)
-                   , TaskType (..)
-                   )
+import           Stack.Types.Build ( TaskType (..) )
 import           Stack.Types.BuildConfig
                    ( BuildConfig (..), HasBuildConfig (..), stackYamlL )
 import           Stack.Types.BuildOpts
                    ( BuildOpts (..), defaultBuildOpts, defaultBuildOptsCLI )
 import           Stack.Types.Config ( Config (..), HasConfig (..) )
-import           Stack.Types.ConfigureOpts ( ConfigureOpts (..) )
 import           Stack.Types.EnvConfig
                    ( EnvConfig (..), HasEnvConfig (..), actualCompilerVersionL )
 import           Stack.Types.GhcPkgId ( GhcPkgId )
@@ -493,7 +489,7 @@ getSDistFileList lp deps =
       [] [] [] Nothing -- provide empty list of globals. This is a hack around
                        -- custom Setup.hs files
       $ \ee ->
-      withSingleContext ac ee task deps (Just "sdist") $
+      withSingleContext ac ee taskType deps (Just "sdist") $
         \_package cabalfp _pkgDir cabal _announce _outputType -> do
           let outFile = toFilePath tmpdir FP.</> "source-files-list"
           cabal
@@ -504,19 +500,7 @@ getSDistFileList lp deps =
           pure (T.unpack $ T.decodeUtf8With T.lenientDecode contents, cabalfp)
  where
   ac = ActionContext Set.empty [] ConcurrencyAllowed
-  task = Task
-    { taskType = TTLocalMutable lp
-    , taskConfigOpts = TaskConfigOpts
-        { tcoMissing = Set.empty
-        , tcoOpts = \_ -> ConfigureOpts [] []
-        }
-    , taskBuildHaddock = False
-    , taskPresent = Map.empty
-    , taskAllInOne = True
-    , taskCachePkgSrc = CacheSrcLocal (toFilePath (parent $ lpCabalFile lp))
-    , taskAnyMissing = True
-    , taskBuildTypeConfig = False
-    }
+  taskType = TTLocalMutable lp
 
 normalizeTarballPaths ::
      (HasRunner env, HasTerm env)

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -9,10 +9,13 @@ module Stack.Types.Build
   , Installed (..)
   , psVersion
   , Task (..)
+  , taskAnyMissing
   , taskIsTarget
   , taskLocation
   , taskProvides
   , taskTargetIsMutable
+  , taskTypeLocation
+  , taskTypePackageIdentifier
   , LocalPackage (..)
   , Plan (..)
   , TestOpts (..)
@@ -43,6 +46,7 @@ import           Database.Persist.Sql
                    , PersistValue (PersistText), SqlType (SqlString)
                    )
 import           Path ( parent )
+import qualified RIO.Set as Set
 import           Stack.Prelude
 import           Stack.Types.BuildOpts
                    ( BenchmarkOpts (..), BuildOpts (..), BuildSubset (..)
@@ -121,26 +125,21 @@ toCachePkgSrc (PSFilePath lp) =
   CacheSrcLocal (toFilePath (parent (lpCabalFile lp)))
 toCachePkgSrc PSRemote{} = CacheSrcUpstream
 
--- | A task to perform when building
+-- | A type representing tasks to perform when building.
 data Task = Task
   { taskType            :: !TaskType
-    -- ^ the task type, telling us how to build this
+    -- ^ The task type, telling us how to build this
   , taskConfigOpts      :: !TaskConfigOpts
+    -- ^ A set of the package identifiers of dependencies for which 'GhcPkgId'
+    -- are missing and a function which yields configure options, given a
+    -- dictionary of those identifiers and their 'GhcPkgId'.
   , taskBuildHaddock    :: !Bool
   , taskPresent         :: !(Map PackageIdentifier GhcPkgId)
-    -- ^ GhcPkgIds of already-installed dependencies
+    -- ^ A dictionary of the package identifiers of already-installed
+    -- dependencies, and their 'GhcPkgId'.
   , taskAllInOne        :: !Bool
     -- ^ indicates that the package can be built in one step
   , taskCachePkgSrc     :: !CachePkgSrc
-  , taskAnyMissing      :: !Bool
-    -- ^ Were any of the dependencies missing? The reason this is necessary is...
-    -- hairy. And as you may expect, a bug in Cabal. See:
-    -- <https://github.com/haskell/cabal/issues/4728#issuecomment-337937673>.
-    -- The problem is that Cabal may end up generating the same package ID for a
-    -- dependency, even if the ABI has changed. As a result, without this field,
-    -- Stack would think that a reconfigure is unnecessary, when in fact we _do_
-    -- need to reconfigure. The details here suck. We really need proper hashes
-    -- for package identifiers.
   , taskBuildTypeConfig :: !Bool
     -- ^ Is the build type of this package Configure. Check out
     -- ensureConfigureScript in Stack.Build.Execute for the motivation
@@ -172,6 +171,11 @@ data TaskType
     -- ^ Building something from the package index (upstream).
   deriving Show
 
+-- | Were any of the dependencies missing?
+
+taskAnyMissing :: Task -> Bool
+taskAnyMissing task = not $ Set.null $ tcoMissing $ taskConfigOpts task
+
 -- | A function to yield the package name and version of a given 'TaskType'
 -- value.
 taskTypePackageIdentifier :: TaskType -> PackageIdentifier
@@ -184,14 +188,19 @@ taskIsTarget t =
     TTLocalMutable lp -> lpWanted lp
     _ -> False
 
-taskLocation :: Task -> InstallLocation
-taskLocation task =
-  case taskType task of
-    TTLocalMutable _ -> Local
-    TTRemotePackage Mutable _ _ -> Local
-    TTRemotePackage Immutable _ _ -> Snap
+-- | A function to yield the relevant database (write-only or mutable) of a
+-- given 'TaskType' value.
+taskTypeLocation :: TaskType -> InstallLocation
+taskTypeLocation (TTLocalMutable _) = Local
+taskTypeLocation (TTRemotePackage Mutable _ _) = Local
+taskTypeLocation (TTRemotePackage Immutable _ _) = Snap
 
--- | A funtion to yield the package name and version to be built by the given
+-- | A function to yield the relevant database (write-only or mutable) of the
+-- given task.
+taskLocation :: Task -> InstallLocation
+taskLocation = taskTypeLocation . taskType
+
+-- | A function to yield the package name and version to be built by the given
 -- task.
 taskProvides :: Task -> PackageIdentifier
 taskProvides = taskTypePackageIdentifier . taskType


### PR DESCRIPTION
The motivation for this is similar to the approach to `taskProvides`: the `taskAnyMissing` field is determined by the value of other fields.

Also reorders test as `(taskAnyMissingHackEnabled && taskAnyMissing task)`.

Also passes `TaskType` rather than `Task`, to avoid use of `TaskType` values with dummy fields.

Also improves related Haddock documentation and code comments.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
