### PR TITLE
Package components followup

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -52,7 +52,7 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-1119:21"
+  id = "OBS-STAN-0203-fki0nd-1125:21"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 #  ✦ Category:      #AntiPattern
 #  ✦ File:          src\Stack\Build\Execute.hs
@@ -63,7 +63,7 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-2661:3"
+  id = "OBS-STAN-0203-fki0nd-2667:3"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\Execute.hs

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -980,47 +980,49 @@ toActions installedMap mtestLock runInBase ee (mbuild, mfinal) =
   afinal = case mfinal of
     Nothing -> []
     Just task@Task {..} ->
-      (if taskAllInOne then id else (:)
-          Action
-              { actionId = ActionId pkgId ATBuildFinal
-              , actionDeps = addBuild
-                  (Set.map (`ActionId` ATBuild) (tcoMissing taskConfigOpts))
-              , actionDo =
-                  \ac -> runInBase $ singleBuild ac ee task installedMap True
-              , actionConcurrency = ConcurrencyAllowed
-              }) $
+      ( if taskAllInOne
+          then id
+          else (:) Action
+            { actionId = ActionId pkgId ATBuildFinal
+            , actionDeps = addBuild
+                (Set.map (`ActionId` ATBuild) (tcoMissing taskConfigOpts))
+            , actionDo =
+                \ac -> runInBase $ singleBuild ac ee task installedMap True
+            , actionConcurrency = ConcurrencyAllowed
+            }
+      ) $
       -- These are the "final" actions - running tests and benchmarks.
-      -- These are the "final" actions - running tests and benchmarks.
-      
-      -- These are the "final" actions - running tests and benchmarks.
-      (if Set.null tests then id else (:)
-          Action
-              { actionId = ActionId pkgId ATRunTests
-              , actionDeps = finalDeps
-              , actionDo = \ac -> withLock mtestLock $ runInBase $
-                  singleTest topts (Set.toList tests) ac ee task installedMap
-              -- Always allow tests tasks to run concurrently with
-              -- other tasks, particularly build tasks. Note that
-              -- 'mtestLock' can optionally make it so that only
-              -- one test is run at a time.
-              , actionConcurrency = ConcurrencyAllowed
-              }) $
-      (if Set.null benches then id else (:)
-          Action
-              { actionId = ActionId pkgId ATRunBenchmarks
-              , actionDeps = finalDeps
-              , actionDo = \ac -> runInBase $
-                  singleBench
-                    beopts
-                    (Set.toList benches)
-                    ac
-                    ee
-                    task
-                    installedMap
-                -- Never run benchmarks concurrently with any other task, see
-                -- #3663
-              , actionConcurrency = ConcurrencyDisallowed
-              })
+      ( if Set.null tests
+          then id
+          else (:) Action
+            { actionId = ActionId pkgId ATRunTests
+            , actionDeps = finalDeps
+            , actionDo = \ac -> withLock mtestLock $ runInBase $
+                singleTest topts (Set.toList tests) ac ee task installedMap
+              -- Always allow tests tasks to run concurrently with other tasks,
+              -- particularly build tasks. Note that 'mtestLock' can optionally
+              -- make it so that only one test is run at a time.
+            , actionConcurrency = ConcurrencyAllowed
+            }
+      ) $
+      ( if Set.null benches
+          then id
+          else (:) Action
+            { actionId = ActionId pkgId ATRunBenchmarks
+            , actionDeps = finalDeps
+            , actionDo = \ac -> runInBase $
+                singleBench
+                  beopts
+                  (Set.toList benches)
+                  ac
+                  ee
+                  task
+                  installedMap
+              -- Never run benchmarks concurrently with any other task, see
+              -- #3663
+            , actionConcurrency = ConcurrencyDisallowed
+            }
+      )
       []
      where
       pkgId = taskProvides task
@@ -1494,8 +1496,8 @@ withSingleContext
                 matchedDeps <-
                   forM (Map.toList customSetupDeps) $ \(name, depValue) -> do
                     let matches (PackageIdentifier name' version) =
-                          name == name' &&
-                          version `withinRange` dvVersionRange depValue
+                             name == name'
+                          && version `withinRange` dvVersionRange depValue
                     case filter (matches . fst) (Map.toList allDeps) of
                       x:xs -> do
                         unless (null xs) $
@@ -1650,15 +1652,6 @@ withSingleContext
                 ] ++
 
                 -- Apply GHC options
-
-                -- Apply GHC options
-
-                -- Apply GHC options
-
-                -- Apply GHC options
-                -- https://github.com/commercialhaskell/stack/issues/4526
-                -- https://github.com/commercialhaskell/stack/issues/4526
-                -- https://github.com/commercialhaskell/stack/issues/4526
                 -- https://github.com/commercialhaskell/stack/issues/4526
                 map
                   T.unpack

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -174,8 +174,8 @@ gpdPackageDeps gpd ac platform flags =
        $ map (C.mkPackageName . unUnqualComponentName . fst)
        $ C.condSubLibraries gpd
 
-  -- Since tests and benchmarks are both enabled, doesn't matter
-  -- if we choose modified or unmodified
+  -- Since tests and benchmarks are both enabled, doesn't matter if we choose
+  -- modified or unmodified
   pkgDesc = resolvePackageDescription pkgConfig gpd
   pkgConfig = PackageConfig
     { packageConfigEnableTests = True

--- a/src/Stack/Component.hs
+++ b/src/Stack/Component.hs
@@ -45,7 +45,8 @@ import           Stack.Types.Component
                    , StackExecutable (..), StackForeignLibrary (..)
                    , StackLibrary (..), StackTest (..), StackUnqualCompName (..)
                    )
-import           Stack.Types.Dependency ( cabalExeToStackDep, cabalToStackDep, DepValue )
+import           Stack.Types.Dependency
+                   ( DepValue, cabalExeToStackDep, cabalToStackDep )
 import           Stack.Types.NamedComponent ( NamedComponent )
 
 fromCabalName :: UnqualComponentName -> StackUnqualCompName
@@ -186,22 +187,22 @@ gatherComponentToolsAndDepsFromCabal legacyBuildTools buildTools targetDeps =
         Map.insert pName (cabalToStackDep dep) $ sbiDependency sbi
     }
 
-
--- | This is meant to process package's dependencies without recreating intermediate data reprensentation
--- for them.
-processDependencies :: ( Monad m
-                       , HasField "buildInfo" component StackBuildInfo )
+-- | This processes package's dependencies without recreating intermediate data
+-- reprensentation for them.
+processDependencies ::
+     (HasField "buildInfo" component StackBuildInfo, Monad m)
   => (PackageName -> DepValue -> m (t resT) -> m (t resT))
   -> component
   -> m (t resT)
   -> m (t resT)
-processDependencies iteratorFn component resAction = Map.foldrWithKey' iteratorFn resAction componentDeps
-  where
-    componentDeps = buildInfo.sbiDependency
-    buildInfo = component.buildInfo
+processDependencies iteratorFn component resAction =
+  Map.foldrWithKey' iteratorFn resAction componentDeps
+ where
+  componentDeps = buildInfo.sbiDependency
+  buildInfo = component.buildInfo
 
--- | A hard-coded map for tool dependencies.
--- If a dependency is within this map it's considered "known" (the exe will be found at the execution stage).
+-- | A hard-coded map for tool dependencies. If a dependency is within this map
+-- it's considered "known" (the exe will be found at the execution stage).
 -- [It also exists in Cabal](https://hackage.haskell.org/package/Cabal/docs/src/Distribution.Simple.BuildToolDepends.html#local-6989586621679259154)
 isKnownLegacyExe :: String -> Maybe PackageName
 isKnownLegacyExe input = case input of

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -489,8 +489,8 @@ projectPackageDependencies dotOpts locals =
       locals
  where
   deps pkg packageDepsSet = if dotIncludeExternal dotOpts
-               then Set.delete (packageName pkg) packageDepsSet
-               else Set.intersection localNames packageDepsSet
+    then Set.delete (packageName pkg) packageDepsSet
+    else Set.intersection localNames packageDepsSet
   localNames = Set.fromList $ map (packageName . lpPackage) locals
   lpPayload pkg loc =
     DotPayload (Just $ packageVersion pkg)

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -48,11 +48,10 @@ import           Stack.Ghci.Script
                    , scriptToLazyByteString
                    )
 import           Stack.Package
-                   ( buildableExes
-                   , buildableForeignLibs, hasBuildableMainLibrary
-                   , getPackageOpts, packageFromPackageDescription
-                   , readDotBuildinfo, resolvePackageDescription
-                   , listOfPackageDeps
+                   ( buildableExes, buildableForeignLibs, getPackageOpts
+                   , hasBuildableMainLibrary, listOfPackageDeps
+                   , packageFromPackageDescription, readDotBuildinfo
+                   , resolvePackageDescription
                    )
 import           Stack.PackageFile ( getPackageFile )
 import           Stack.Prelude
@@ -883,12 +882,8 @@ loadGhciPkgDesc buildOptsCLI name cabalfp target = do
         | otherwise = Nothing
   mbuildinfo <- forM mbuildinfofp readDotBuildinfo
   let pdp = resolvePackageDescription config gpkgdesc
-      pkg =
-        packageFromPackageDescription config (C.genPackageFlags gpkgdesc) $
-        maybe
-          pdp
-          (`C.updatePackageDescription` pdp)
-          mbuildinfo
+      pkg = packageFromPackageDescription config (C.genPackageFlags gpkgdesc) $
+        maybe pdp (`C.updatePackageDescription` pdp) mbuildinfo
   pure GhciPkgDesc
     { ghciDescPkg = pkg
     , ghciDescCabalFp = cabalfp

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -55,10 +55,7 @@ import           Stack.Build.Installed ( getInstalled, toInstallMap )
 import           Stack.Build.Source ( projectLocalPackages )
 import           Stack.Constants ( stackProgName, stackProgName' )
 import           Stack.Constants.Config ( distDirFromDir )
-import           Stack.Package
-                   ( resolvePackage
-                   , resolvePackageDescription
-                   )
+import           Stack.Package ( resolvePackage, resolvePackageDescription )
 import           Stack.Prelude
 import           Stack.Runners
                    ( ShouldReexec (..), withConfig, withDefaultEnvConfig )

--- a/src/Stack/Types/CompCollection.hs
+++ b/src/Stack/Types/CompCollection.hs
@@ -24,8 +24,8 @@ module Stack.Types.CompCollection
   , collectionKeyValueList
   , collectionMember
   , foldComponentToAnotherCollection
-  )
-where
+  ) where
+
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Set as Set
 import           Data.Foldable ( Foldable (..) )
@@ -159,9 +159,11 @@ collectionKeyValueList haystack =
 collectionMember :: Text -> CompCollection component -> Bool
 collectionMember needle haystack = isJust $ collectionLookup needle haystack
 
-foldComponentToAnotherCollection :: (Monad m)
+foldComponentToAnotherCollection ::
+     (Monad m)
   => CompCollection component
   -> (component -> m (t b) -> m (t b))
   -> m (t b)
   -> m (t b)
-foldComponentToAnotherCollection collection fn initialValue = HM.foldr' fn initialValue (asNameMap $ buildableOnes collection)
+foldComponentToAnotherCollection collection fn initialValue =
+  HM.foldr' fn initialValue (asNameMap $ buildableOnes collection)

--- a/src/Stack/Types/Dependency.hs
+++ b/src/Stack/Types/Dependency.hs
@@ -10,10 +10,10 @@ module Stack.Types.Dependency
   , isDepTypeLibrary
   ) where
 
+import           Data.Foldable ( foldr' )
+import qualified Data.Map as Map
 import qualified Distribution.PackageDescription as Cabal
 import           Distribution.Types.VersionRange ( VersionRange )
-import           Data.Foldable (foldr')
-import qualified Data.Map as Map
 import           Stack.Prelude
 
 -- | The value for a map from dependency name. This contains both the version
@@ -39,13 +39,17 @@ isDepTypeLibrary AsBuildTool = False
 cabalToStackDep :: Cabal.Dependency -> DepValue
 cabalToStackDep (Cabal.Dependency _ verRange _libNameSet) =
   DepValue{dvVersionRange = verRange, dvType = AsLibrary}
+
 cabalExeToStackDep :: Cabal.ExeDependency -> DepValue
 cabalExeToStackDep (Cabal.ExeDependency _ _name verRange) =
   DepValue{dvVersionRange = verRange, dvType = AsBuildTool}
+
 cabalSetupDepsToStackDep :: Cabal.SetupBuildInfo -> Map PackageName DepValue
-cabalSetupDepsToStackDep setupInfo = foldr' inserter mempty (Cabal.setupDepends setupInfo)
-  where
-    inserter d@(Cabal.Dependency packageName _ _) = Map.insert packageName (cabalToStackDep d)
+cabalSetupDepsToStackDep setupInfo =
+  foldr' inserter mempty (Cabal.setupDepends setupInfo)
+ where
+  inserter d@(Cabal.Dependency packageName _ _) =
+    Map.insert packageName (cabalToStackDep d)
 
 libraryDepFromVersionRange :: VersionRange -> DepValue
 libraryDepFromVersionRange range = DepValue

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -183,18 +183,16 @@ data Package = Package
   , packageCabalSpec :: !CabalSpecVersion
     -- ^ Cabal spec range
   , packageFile :: StackPackageFile
-    -- ^ The cabal sourced files related to the package at the package level
+    -- ^ The Cabal sourced files related to the package at the package level
     -- The components may have file information in their own types
   , packageTestEnabled :: Bool
-    -- ^ This is a requirement because when tests are not enabled,
-    -- stack's package dependencies should ignore test dependencies.
-    -- Directly set from packageConfigEnableTests. A previous workaround used the
-    -- buildable boolean in cabal's buildInfo.
+    -- ^ This is a requirement because when tests are not enabled, Stack's
+    -- package dependencies should ignore test dependencies. Directly set from
+    -- 'packageConfigEnableTests'.
   , packageBenchmarkEnabled :: Bool
-    -- ^ This is a requirement because when benchmark are not enabled,
-    -- stack's package dependencies should ignore benchmark dependencies.
-    -- Directly set from packageConfigEnableBenchmarks. A previous workaround used the
-    -- buildable boolean in cabal's buildInfo.
+    -- ^ This is a requirement because when benchmark are not enabled, Stack's
+    -- package dependencies should ignore benchmark dependencies. Directly set
+    -- from 'packageConfigEnableBenchmarks'.
   }
   deriving (Show, Typeable)
 


### PR DESCRIPTION
This is simply the further consequences of the design merged in #6334.

In particular, it removes the ugly wart that was `PackageDescriptionPair` and realise most of the plan/changes that I described and proposed in https://github.com/commercialhaskell/stack/issues/5920#issue-1428884484