### PR TITLE
docs: Update Arch Linux package URL in install_and_upgrade.md

### DIFF
--- a/doc/install_and_upgrade.md
+++ b/doc/install_and_upgrade.md
@@ -130,8 +130,8 @@ GitHub repository.
 
     === "Arch Linux"
 
-        The Arch community package repository provides an official
-        [package](https://www.archlinux.org/packages/community/x86_64/stack/).
+        The Arch extra package repository provides an official
+        [package](https://www.archlinux.org/packages/extra/x86_64/stack/).
         You can install it with the command:
 
         ~~~text


### PR DESCRIPTION
The old URL returns 404 now.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary
