### PR TITLE
Build _ with ghc-x.y.z

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -63,7 +63,7 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-2666:3"
+  id = "OBS-STAN-0203-fki0nd-2668:3"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\Execute.hs

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -46,6 +46,8 @@ Other enhancements:
   found. In YAML configuration files, the `notify-if-ghc-untested` and
   `notify-if-cabal-untested` keys are introduced, to allow the notification to
   be muted if unwanted.
+* The compiler version is included in Stack's build message (e.g.
+  `stack> build (lib + exe + test) with ghc-9.4.7`).
 
 Bug fixes:
 * Fix the `Curator` instance of `ToJSON`, as regards `expect-haddock-failure`.

--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -981,7 +981,7 @@ stack build :helloworld-test
 Building all executables for `helloworld' once. After a successful build of all of them, only specified executables will be rebuilt.
 helloworld> configure (lib + exe + test)
 Configuring helloworld-0.1.0.0...
-helloworld> build (lib + exe + test)
+helloworld> build (lib + exe + test) with ghc-x.y.z
 Preprocessing library for helloworld-0.1.0.0..
 Building library for helloworld-0.1.0.0..
 [1 of 2] Compiling Lib
@@ -1024,7 +1024,7 @@ and command again:
 ~~~text
 stack build :helloworld-test
 helloworld-0.1.0.0: unregistering (local file changes: test\Spec.hs)
-helloworld> build (lib + test)
+helloworld> build (lib + test) with ghc-x.y.z
 Preprocessing library for helloworld-0.1.0.0..
 Building library for helloworld-0.1.0.0..
 Preprocessing test suite 'helloworld-test' for helloworld-0.1.0.0..

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -1985,9 +1985,12 @@ singleBuild
                       \undefined reference errors from the linker, along with \
                       \other problems."
 
+    actualCompiler <- view actualCompilerVersionL
     () <- announce
       (  "build"
       <> display (annSuffix executableBuildStatuses)
+      <> " with "
+      <> display actualCompiler
       )
     config <- view configL
     extraOpts <- extraBuildOptions wc eeBuildOpts
@@ -2017,7 +2020,6 @@ singleBuild
         else "haddock"
 
       -- For GHC 8.4 and later, provide the --quickjump option.
-      actualCompiler <- view actualCompilerVersionL
       let quickjump =
             case actualCompiler of
               ACGhc ghcVer


### PR DESCRIPTION
For #6342, have the build show which compiler version is being used by appending "with ghc-x.y.z".

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

```
$ ~/.local/bin/stack build --test --no-run-tests        

Warning: WARNING: This stack project is generated.
hlint-plugin> configure (lib)
Configuring hlint-plugin-1.0.2...
hlint-plugin> build (lib) with ghc-9.0.2
Preprocessing library for hlint-plugin-1.0.2..
Building library for hlint-plugin-1.0.2..
[1 of 2] Compiling HLint.Plugin.Settings
[2 of 2] Compiling HLint.Plugin
hlint-plugin> copy/register
Installing library in /.../hlint-plugin/.stack-work/install/x86_64-linux
  /77e1e65734194babbef5a670a7fffc8ad1833c81e4c13562134c9a797b54872d
  /9.0.2/lib/x86_64-linux-ghc-9.0.2/hlint-plugin-1.0.2-JOPnvvxdmWa2Izg7q332qw
Registering library for hlint-plugin-1.0.2..
```

```
$ ~/.local/bin/stack build --test --no-run-tests
Building all executables for stack once. After a successful build of all of them,
  only specified executables will be rebuilt.
stack> configure (lib + exe + test)
[1 of 3] Compiling Main
[2 of 3] Compiling StackSetupShim
[3 of 3] Linking ...
Configuring stack-2.14.0...
stack> build (lib + exe + test) with ghc-9.4.7
Preprocessing library for stack-2.14.0..
Building library for stack-2.14.0..
[  1 of 182] Compiling Build_stack
[  2 of 182] Compiling Network.HTTP.StackClient
...
```

