### PR TITLE
Remove configure lock

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -54,25 +54,25 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-1129:21"
+  id = "OBS-STAN-0203-fki0nd-1126:21"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\Execute.hs
 #
-#  1128 ┃
-#  1129 ┃   newProjectRoot <- S8.pack . toFilePath <$> view projectRootL
-#  1130 ┃                     ^^^^^^^
+#  1125 ┃
+#  1126 ┃   newProjectRoot <- S8.pack . toFilePath <$> view projectRootL
+#  1137 ┃                     ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-2673:3"
+  id = "OBS-STAN-0203-fki0nd-2670:3"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\Execute.hs
 #
-#  2672 ┃
-#  2673 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
-#  2674 ┃   ^^^^^^^
+#  2669 ┃
+#  2670 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
+#  2671 ┃   ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,10 +4,6 @@
 
 Release notes:
 
-* Removed the configure lock so configuring of packages (remote and local) can
-  be done in parallel. For some builds this can result in significant speed ups.
-  Note that this also increase the effective concurrency of builds that before would
-  not use many threads. Reconsider your `--jobs` setting accordingly.
 * After an upgrade from an earlier version of Stack, on first use only,
   Stack 2.14.0 may warn that it had trouble loading the CompilerPaths cache.
 * The hash used as a key for Stack's pre-compiled package cache has changed,
@@ -30,6 +26,10 @@ Behavior changes:
 * Drop support for Intero (end of life in November 2019).
 * `stack path --stack-root` no longer sets up Stack's environment and does not
   load Stack's configuration.
+* Stack no longer locks on configuration, so packages (remote and local) can
+  be configured in parallel. This increases the effective concurrency of builds
+  that before would use fewer threads. Reconsider your `--jobs` setting
+  accordingly. See [#84](https://github.com/commercialhaskell/stack/issues/84).
 
 Other enhancements:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 Release notes:
 
+* Removed the configure lock so configuring of packages (remote and local) can
+  be done in parallel. For some builds this can result in significant speed ups.
+  Note that this also increase the effective concurrency of builds that before would
+  not use many threads. Reconsider your `--jobs` setting accordingly.
 * After an upgrade from an earlier version of Stack, on first use only,
   Stack 2.14.0 may warn that it had trouble loading the CompilerPaths cache.
 * The hash used as a key for Stack's pre-compiled package cache has changed,


### PR DESCRIPTION
This was introduced in https://github.com/commercialhaskell/stack/commit/b511d707909e214749dec5f400b80e775d35f3dd

8 years later I cannot reproduce the referenced issues under linux on a 128 thread machine building a repository with 265 local packages: https//github.com/mbj/stratosphere. I have to assume that the action concurrency / dependency tracking system is now much more durable than it was years ago. And or cabal bugs got fixed.

This change speeds up a clean build of [stratosphere](https://github.com/mbj/stratosphere) significantly.

Before this patch, after: `git clean -f -d -x` but with hot dependency cache:

Command: `STACK_YAML=stack-9.4.yaml stack build --copy-bins --fast`

Before:

```
2760.74s user 862.67s system 1065% cpu 5:39.95 total
```

With this patch:

```
2789.40s user 2542.12s system 3073% cpu 2:53.46 total
```

Without the patch most of the time I had 4-5 active `Cabal-simple` processes, with this patch it goes up to 20-30.

While stratosphere is an extreme case (200+ packages eligible to be build in concurrency) it also speeds up empty remote dependency builds signficantly:

Command: `time STACK_YAML=stack-9.4.yaml stack build --only-dependencies`

Before:

```
1139.82s user 498.41s system 670% cpu 4:04.31 total
```

After:

```
1209.23s user 568.85s system 931% cpu 3:10.92 total
```

Interesting note, at stratospheres mass siblnig packages the install lock becomes another bottleneck, trying to remove this one also in a future commit.

Please include the following checklist in your pull request:

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
