### PR TITLE
Re #6374 Refactor `stack unpack` command line options

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -81,31 +81,31 @@
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Init.hs
 #
-#  378 ┃
-#  379 ┃   commentHelp = BC.pack .  intercalate "\n" . map commentLine
-#  380 ┃                 ^^^^^^^
+#  379 ┃
+#  380 ┃   commentHelp = BC.pack .  intercalate "\n" . map commentLine
+#  381 ┃                 ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
   id = "OBS-STAN-0203-hTeu0Y-397:26"
-#  ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
-#  ✦ Category:      #AntiPattern
-#  ✦ File:          src\Stack\Init.hs
+# ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
+# ✦ Category:      #AntiPattern
+# ✦ File:          src\Stack\Init.hs
 #
-#   395 ┃
-#   396 ┃         <> B.byteString (BC.pack $ concat
-#   397 ┃                          ^^^^^^^
+#  396 ┃
+#  397 ┃         <> B.byteString (BC.pack $ concat
+#  398 ┃                          ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
   id = "OBS-STAN-0203-axv1UG-346:32"
-#  ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
-#  ✦ Category:      #AntiPattern
-#  ✦ File:          src\Stack\Docker.hs
+# ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
+# ✦ Category:      #AntiPattern
+# ✦ File:          src\Stack\Docker.hs
 #
-#   346 ┃
-#   347 ┃     hashRepoName = Hash.hash . BS.pack . takeWhile (\c -> c /= ':' && c /= '@')
-#   348 ┃                                ^^^^^^^
+#  345 ┃
+#  346 ┃     hashRepoName = Hash.hash . BS.pack . takeWhile (\c -> c /= ':' && c /= '@')
+#  347 ┃                                ^^^^^^^
 
 # Data types with non-strict fields
 # Defining lazy fields in data types can lead to unexpected space leaks
@@ -159,16 +159,16 @@
 
 # Anti-pattern: unsafe functions
 [[ignore]]
-  id = "OBS-STAN-0212-5rtOmw-477:33"
+  id = "OBS-STAN-0212-5rtOmw-481:33"
 # ✦ Description:   Usage of unsafe functions breaks referential transparency
-#  ✦ Category:      #Unsafe #AntiPattern
-#  ✦ File:          src\Stack\Constants.hs
+# ✦ Category:      #Unsafe #AntiPattern
+# ✦ File:          src\Stack\Constants.hs
 #
-#   476 ┃
-#   477 ┃ setupGhciShimCode = byteString $(do
-#   478 ┃     path <- makeRelativeToProject "src/setup-shim/StackSetupShim.hs"
-#   479 ┃     embedFile path)
-#   480 ┃
+#  480 ┃
+#  481 ┃ setupGhciShimCode = byteString $(do
+#  482 ┃     path <- makeRelativeToProject "src/setup-shim/StackSetupShim.hs"
+#  483 ┃     embedFile path)
+#  484 ┃
 
 # Anti-pattern: Pattern matching on '_'
 # Pattern matching on '_' for sum types can create maintainability issues

--- a/doc/unpack_command.md
+++ b/doc/unpack_command.md
@@ -3,7 +3,7 @@
 # The `stack unpack` command
 
 ~~~text
-stack unpack PACKAGE [--to ARG]
+stack unpack PACKAGE [--to DIR]
 ~~~
 
 `stack unpack` downloads an archive file for one or more specified packages from

--- a/package.yaml
+++ b/package.yaml
@@ -244,6 +244,7 @@ library:
   - Stack.Options.ScriptParser
   - Stack.Options.SetupParser
   - Stack.Options.TestParser
+  - Stack.Options.UnpackParser
   - Stack.Options.UpgradeParser
   - Stack.Options.UploadParser
   - Stack.Options.Utils

--- a/src/Stack/CLI.hs
+++ b/src/Stack/CLI.hs
@@ -14,7 +14,7 @@ import           Options.Applicative
                    , overFailure, renderFailure, strArgument, switch )
 import           Options.Applicative.Help ( errorHelp, stringChunk, vcatChunks )
 import           Options.Applicative.Builder.Extra
-                   ( boolFlags, extraHelpOption, textOption )
+                   ( boolFlags, extraHelpOption )
 import           Options.Applicative.Complicated
                    ( addCommand, addSubCommands, complicatedOptions )
 import           RIO.NonEmpty ( (<|) )
@@ -59,6 +59,7 @@ import           Stack.Options.PathParser ( pathParser )
 import           Stack.Options.SDistParser ( sdistOptsParser )
 import           Stack.Options.ScriptParser ( scriptOptsParser )
 import           Stack.Options.SetupParser ( setupOptsParser )
+import           Stack.Options.UnpackParser ( unpackOptsParser )
 import           Stack.Options.UpgradeParser ( upgradeOptsParser )
 import           Stack.Options.UploadParser ( uploadOptsParser )
 import           Stack.Options.Utils ( GlobalOptsContext (..) )
@@ -498,14 +499,7 @@ commandLineHandler currentDir progName isInterpreter =
     "unpack"
     "Unpack one or more packages locally."
     unpackCmd
-    ( (,)
-        <$> some (strArgument $ metavar "PACKAGE")
-        <*> optional (textOption
-              (  long "to"
-              <> help "Optional path to unpack the package into (will \
-                      \unpack into subdirectory)."
-              ))
-    )
+    unpackOptsParser
 
   update = addCommand'
     "update"

--- a/src/Stack/Constants.hs
+++ b/src/Stack/Constants.hs
@@ -52,6 +52,7 @@ module Stack.Constants
   , relDirGhciScript
   , relDirPantry
   , relDirPrograms
+  , relDirRoot
   , relDirUpperPrograms
   , relDirStackProgName
   , relDirStackWork
@@ -394,6 +395,9 @@ relDirPantry = $(mkRelDir "pantry")
 
 relDirPrograms :: Path Rel Dir
 relDirPrograms = $(mkRelDir "programs")
+
+relDirRoot :: Path Rel Dir
+relDirRoot = $(mkRelDir ".")
 
 relDirUpperPrograms :: Path Rel Dir
 relDirUpperPrograms = $(mkRelDir "Programs")

--- a/src/Stack/Options/UnpackParser.hs
+++ b/src/Stack/Options/UnpackParser.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | Functions to parse command line arguments for Stack's @unpack@ command.
+module Stack.Options.UnpackParser
+  ( unpackOptsParser
+  ) where
+
+import qualified Data.Text as T
+import           Options.Applicative
+                   ( Parser, ReadM, argument, eitherReader, help, long, metavar
+                   , option
+                   )
+import           Path ( SomeBase (..), parseSomeDir )
+import           Stack.Prelude
+import           Stack.Unpack ( UnpackOpts (..), UnpackTarget)
+
+-- | Parse command line arguments for Stack's @unpack@ command.
+unpackOptsParser :: Parser UnpackOpts
+unpackOptsParser = UnpackOpts
+  <$> some unpackTargetParser
+  <*> optional dirParser
+
+unpackTargetParser :: Parser UnpackTarget
+unpackTargetParser = argument unpackTargetReader
+  (  metavar "PACKAGE"
+  <> help "A package, referred to by name only or by identifier (including, \
+          \optionally, a Hackage revision as '@rev:<number>' or \
+          \'@sha256:<sha>') (can be specified multiple times)."
+  )
+
+unpackTargetReader :: ReadM UnpackTarget
+unpackTargetReader = eitherReader $ \s ->
+  case parsePackageIdentifierRevision $ T.pack s of
+    Right pir -> Right (Right pir)
+    Left _ -> case parsePackageName s of
+      Just pn -> Right (Left pn)
+      Nothing ->
+        Left $ s <> " is an invalid way to refer to a package to be unpacked."
+
+dirParser :: Parser (SomeBase Dir)
+dirParser = option dirReader
+  (  long "to"
+  <> metavar "DIR"
+  <> help "Optionally, a directory to unpack into. A package will be unpacked \
+          \ into a subdirectory."
+  )
+
+dirReader :: ReadM (SomeBase Dir)
+dirReader = eitherReader $ \s ->
+  case parseSomeDir s of
+    Just dir -> Right dir
+    Nothing ->
+      Left $ s <> " is an invalid way to refer to a directory."

--- a/stack.cabal
+++ b/stack.cabal
@@ -238,6 +238,7 @@ library
       Stack.Options.ScriptParser
       Stack.Options.SetupParser
       Stack.Options.TestParser
+      Stack.Options.UnpackParser
       Stack.Options.UpgradeParser
       Stack.Options.UploadParser
       Stack.Options.Utils


### PR DESCRIPTION
Also captures certain errors in the command line options parser.

Also updates the in-app help.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally on Windows 11.
