### PR TITLE
Re #6377 Deprecate Stack support for Cabal < 2.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,11 @@ Behavior changes:
   be configured in parallel. This increases the effective concurrency of builds
   that before would use fewer threads. Reconsider your `--jobs` setting
   accordingly. See [#84](https://github.com/commercialhaskell/stack/issues/84).
+* Stack warns that its support for Cabal versions before `2.2.0.0` is deprecated
+  and may be removed in the next version of Stack. Removal would mean that
+  projects using snapshots earlier than `lts-12.0` or `nightly-2018-03-18`
+  (GHC 8.4.1) might no longer build. See
+  [#6377](https://github.com/commercialhaskell/stack/issues/6377).
 
 Other enhancements:
 

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -1043,6 +1043,15 @@ warnUnsupportedCompilerCabal cp didWarn = do
                  \resolver. Acceptable resolvers: lts-7.0/nightly-2016-05-26 \
                  \or later."
           ]
+    | cabalVersion < mkVersion [2, 2, 0] -> do
+        prettyWarnL
+          [ flow "Stack's support of Cabal versions below 2.2.0.0 is \
+                 \deprecated and may be removed from the next version of \
+                 \ Stack. Cabal version"
+          , fromString (versionString cabalVersion)
+          , flow "was found. Consider using a resolver that is \
+                 \lts-12.0 or later or nightly-2018-03-13 or later."
+          ]
     | cabalVersion >= mkVersion [3, 11] && notifyIfCabalUntested ->
         prettyWarnL
           [ flow "Stack has not been tested with Cabal versions 3.12 and \


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally on Windows 11. Relying on CI for other OS.
