### PR TITLE
Re #6379 Introduce `notify-if-arch-unknown` configuration option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -65,6 +65,9 @@ Other enhancements:
   `stack> build (lib + exe + test) with ghc-9.6.3`).
 * Add flag `--candidate` to Stack's `unpack` command, to allow package
   candidates to be unpacked locally.
+* Stack will notify the user if a specified architecture value is unknown to
+  Cabal (the library). In YAML configuration files, the `notify-if-arch-unknown`
+  key is introduced, to allow the notification to be muted if unwanted.
 
 Bug fixes:
 

--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -474,8 +474,9 @@ See [`setup-info`](#setup-info).
 `aarch64` / `arm64`), or other values (which are case-sensitive and treated as
 an unknown 'other' architecture of the specified name).
 
-Stack will warn the user if the specified machine architecture is an unknown
-'other' architecture.
+By default, Stack will warn the user if the specified machine architecture is an
+unknown 'other' architecture. The warning can be muted; see
+[`notify-if-arch-unknown`](#notify-if-arch-unknown)
 
 !!! note
 
@@ -1236,6 +1237,15 @@ for details).
 
 For further information, see the
 [Nix integration](nix_integration.md#configuration) documentation.
+
+### notify-if-arch-unknown
+
+:octicons-tag-24: UNRELEASED
+
+Default: `true`
+
+If the specified machine architecture value is unknown to Cabal (the library),
+should Stack notify the user of that?
 
 ### notify-if-cabal-untested
 

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -100,7 +100,7 @@ configOptsParser currentDir hide0 =
   <*> optionalFirst (strOption
         (  long "arch"
         <> metavar "ARCH"
-        <> help "System architecture, e.g. i386, x86_64."
+        <> help "System architecture, e.g. i386, x86_64, aarch64."
         <> hide
         ))
   <*> optionalFirst (ghcVariantParser (hide0 /= OuterGlobalOpts))

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -186,6 +186,9 @@ data Config = Config
     -- ^ Notify if Stack has not been tested with the GHC version?
   , configNotifyIfCabalUntested :: !Bool
     -- ^ Notify if Stack has not been tested with the Cabal version?
+  , configNotifyIfArchUnknown :: !Bool
+    -- ^ Notify if the specified machine architecture is unknown to Cabal (the
+    -- library)?
   , configNoRunCompile   :: !Bool
     -- ^ Use --no-run and --compile options when using `stack script`
   , configStackDeveloperMode  :: !Bool

--- a/src/Stack/Types/ConfigMonoid.hs
+++ b/src/Stack/Types/ConfigMonoid.hs
@@ -174,6 +174,8 @@ data ConfigMonoid = ConfigMonoid
     -- ^ See 'configNotifyIfGhcUntested'
   , configMonoidNotifyIfCabalUntested  :: !FirstTrue
     -- ^ See 'configNotifyIfCabalUntested'
+  , configMonoidNotifyIfArchUnknown  :: !FirstTrue
+    -- ^ See 'configNotifyIfArchUnknown'
   , configMonoidCasaOpts :: !CasaOptsMonoid
     -- ^ Casa configuration options.
   , configMonoidCasaRepoPrefix     :: !(First CasaRepoPrefix)
@@ -350,6 +352,8 @@ parseConfigMonoidObject rootDir obj = do
     FirstTrue <$> obj ..:? configMonoidNotifyIfGhcUntestedName
   configMonoidNotifyIfCabalUntested <-
     FirstTrue <$> obj ..:? configMonoidNotifyIfCabalUntestedName
+  configMonoidNotifyIfArchUnknown <-
+    FirstTrue <$> obj ..:? configMonoidNotifyIfArchUnknownName
   configMonoidCasaOpts <-
     jsonSubWarnings (obj ..:? configMonoidCasaOptsName ..!= mempty)
   configMonoidCasaRepoPrefix <-
@@ -535,6 +539,9 @@ configMonoidNotifyIfGhcUntestedName = "notify-if-ghc-untested"
 
 configMonoidNotifyIfCabalUntestedName :: Text
 configMonoidNotifyIfCabalUntestedName = "notify-if-cabal-untested"
+
+configMonoidNotifyIfArchUnknownName :: Text
+configMonoidNotifyIfArchUnknownName = "notify-if-arch-unknown"
 
 configMonoidCasaOptsName :: Text
 configMonoidCasaOptsName = "casa"


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally on Windows 11.
