### PR TITLE
Eliminate use of RecordWildCards

### DIFF
--- a/.hlint-test.yaml
+++ b/.hlint-test.yaml
@@ -10,9 +10,10 @@
     - NoImplicitPrelude
     - CPP
     - OverloadedLists
+      # Provided from GHC 9.2.1 (base-4.16.0.0):
+    - OverloadedRecordDot
     - OverloadedStrings
     - QuasiQuotes
-    - RecordWildCards
     - Safe
     - ScopedTypeVariables
     - TemplateHaskell

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -71,10 +71,10 @@
     - LambdaCase
     - MultiWayIf
     - OverloadedLists
+      # Provided from GHC 9.2.1 (base-4.16.0.0):
     - OverloadedRecordDot
     - OverloadedStrings
     - QuasiQuotes
-    - RecordWildCards
     - ScopedTypeVariables
     - TypeFamilies
     - UndecidableInstances

--- a/.stan.toml
+++ b/.stan.toml
@@ -54,25 +54,25 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-1126:21"
+  id = "OBS-STAN-0203-fki0nd-1134:21"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\Execute.hs
 #
-#  1125 ┃
-#  1126 ┃   newProjectRoot <- S8.pack . toFilePath <$> view projectRootL
-#  1137 ┃                     ^^^^^^^
+#  1133 ┃
+#  1134 ┃   newProjectRoot <- S8.pack . toFilePath <$> view projectRootL
+#  1135 ┃                     ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-2670:3"
+  id = "OBS-STAN-0203-fki0nd-2680:3"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\Execute.hs
 #
-#  2669 ┃
-#  2670 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
-#  2671 ┃   ^^^^^^^
+#  2679 ┃
+#  2680 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
+#  2681 ┃   ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
@@ -98,14 +98,14 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-axv1UG-346:32"
+  id = "OBS-STAN-0203-axv1UG-353:32"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Docker.hs
 #
-#  345 ┃
-#  346 ┃     hashRepoName = Hash.hash . BS.pack . takeWhile (\c -> c /= ':' && c /= '@')
-#  347 ┃                                ^^^^^^^
+#  352 ┃
+#  353 ┃     hashRepoName = Hash.hash . BS.pack . takeWhile (\c -> c /= ':' && c /= '@')
+#  354 ┃                                ^^^^^^^
 
 # Data types with non-strict fields
 # Defining lazy fields in data types can lead to unexpected space leaks

--- a/package.yaml
+++ b/package.yaml
@@ -57,7 +57,7 @@ ghc-options:
 # https://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-include-path
 - -optP-Wno-nonportable-include-path
 dependencies:
-- base >= 4.14.3.0 && < 5
+- base >= 4.16.0.0 && < 5
 - Cabal >= 3.8.1.0
 - aeson >= 2.0.3.0
 - aeson-warning-parser >= 0.1.1

--- a/src/Stack/Config/Build.hs
+++ b/src/Stack/Config/Build.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 -- | Build configuration
 module Stack.Config.Build
@@ -21,60 +21,67 @@ import           Stack.Types.BuildOpts
 
 -- | Interprets BuildOptsMonoid options.
 buildOptsFromMonoid :: BuildOptsMonoid -> BuildOpts
-buildOptsFromMonoid BuildOptsMonoid{..} = BuildOpts
+buildOptsFromMonoid buildMonoid = BuildOpts
   { boptsLibProfile = fromFirstFalse
-      (buildMonoidLibProfile <>
+      (buildMonoid.buildMonoidLibProfile <>
        FirstFalse (if tracing || profiling then Just True else Nothing))
   , boptsExeProfile = fromFirstFalse
-      (buildMonoidExeProfile <>
+      (buildMonoid.buildMonoidExeProfile <>
        FirstFalse (if tracing || profiling then Just True else Nothing))
   , boptsLibStrip = fromFirstTrue
-      (buildMonoidLibStrip <>
+      (buildMonoid.buildMonoidLibStrip <>
        FirstTrue (if noStripping then Just False else Nothing))
   , boptsExeStrip = fromFirstTrue
-      (buildMonoidExeStrip <>
+      (buildMonoid.buildMonoidExeStrip <>
        FirstTrue (if noStripping then Just False else Nothing))
-  , boptsHaddock = fromFirstFalse buildMonoidHaddock
-  , boptsHaddockOpts = haddockOptsFromMonoid buildMonoidHaddockOpts
+  , boptsHaddock = fromFirstFalse buildMonoid.buildMonoidHaddock
+  , boptsHaddockOpts = haddockOptsFromMonoid buildMonoid.buildMonoidHaddockOpts
   , boptsOpenHaddocks =
-      not isHaddockFromHackage && fromFirstFalse buildMonoidOpenHaddocks
+         not isHaddockFromHackage
+      && fromFirstFalse buildMonoid.buildMonoidOpenHaddocks
   , boptsHaddockDeps = if isHaddockFromHackage
       then Nothing
-      else getFirst buildMonoidHaddockDeps
+      else getFirst buildMonoid.buildMonoidHaddockDeps
   , boptsHaddockInternal =
-      not isHaddockFromHackage && fromFirstFalse buildMonoidHaddockInternal
+         not isHaddockFromHackage
+      && fromFirstFalse buildMonoid.buildMonoidHaddockInternal
   , boptsHaddockHyperlinkSource =
-      isHaddockFromHackage || fromFirstTrue buildMonoidHaddockHyperlinkSource
+         isHaddockFromHackage
+      || fromFirstTrue buildMonoid.buildMonoidHaddockHyperlinkSource
   , boptsHaddockForHackage = isHaddockFromHackage
-  , boptsInstallExes = fromFirstFalse buildMonoidInstallExes
-  , boptsInstallCompilerTool = fromFirstFalse buildMonoidInstallCompilerTool
-  , boptsPreFetch = fromFirstFalse buildMonoidPreFetch
-  , boptsKeepGoing = getFirst buildMonoidKeepGoing
-  , boptsKeepTmpFiles = fromFirstFalse buildMonoidKeepTmpFiles
+  , boptsInstallExes = fromFirstFalse buildMonoid.buildMonoidInstallExes
+  , boptsInstallCompilerTool =
+      fromFirstFalse buildMonoid.buildMonoidInstallCompilerTool
+  , boptsPreFetch = fromFirstFalse buildMonoid.buildMonoidPreFetch
+  , boptsKeepGoing = getFirst buildMonoid.buildMonoidKeepGoing
+  , boptsKeepTmpFiles = fromFirstFalse buildMonoid.buildMonoidKeepTmpFiles
   , boptsForceDirty =
-      isHaddockFromHackage || fromFirstFalse buildMonoidForceDirty
-  , boptsTests = fromFirstFalse buildMonoidTests
+      isHaddockFromHackage || fromFirstFalse buildMonoid.buildMonoidForceDirty
+  , boptsTests = fromFirstFalse buildMonoid.buildMonoidTests
   , boptsTestOpts =
-      testOptsFromMonoid buildMonoidTestOpts additionalArgs
-  , boptsBenchmarks = fromFirstFalse buildMonoidBenchmarks
+      testOptsFromMonoid buildMonoid.buildMonoidTestOpts additionalArgs
+  , boptsBenchmarks = fromFirstFalse buildMonoid.buildMonoidBenchmarks
   , boptsBenchmarkOpts =
-      benchmarkOptsFromMonoid buildMonoidBenchmarkOpts additionalArgs
-  , boptsReconfigure = fromFirstFalse buildMonoidReconfigure
+      benchmarkOptsFromMonoid
+        buildMonoid.buildMonoidBenchmarkOpts
+        additionalArgs
+  , boptsReconfigure = fromFirstFalse buildMonoid.buildMonoidReconfigure
   , boptsCabalVerbose =
-      fromFirst (CabalVerbosity normal) buildMonoidCabalVerbose
-  , boptsSplitObjs = fromFirstFalse buildMonoidSplitObjs
-  , boptsSkipComponents = buildMonoidSkipComponents
-  , boptsInterleavedOutput = fromFirstTrue buildMonoidInterleavedOutput
-  , boptsProgressBar = fromFirst CappedBar buildMonoidProgressBar
-  , boptsDdumpDir = getFirst buildMonoidDdumpDir
+      fromFirst (CabalVerbosity normal) buildMonoid.buildMonoidCabalVerbose
+  , boptsSplitObjs = fromFirstFalse buildMonoid.buildMonoidSplitObjs
+  , boptsSkipComponents = buildMonoid.buildMonoidSkipComponents
+  , boptsInterleavedOutput =
+      fromFirstTrue buildMonoid.buildMonoidInterleavedOutput
+  , boptsProgressBar = fromFirst CappedBar buildMonoid.buildMonoidProgressBar
+  , boptsDdumpDir = getFirst buildMonoid.buildMonoidDdumpDir
   }
  where
-  isHaddockFromHackage = fromFirstFalse buildMonoidHaddockForHackage
+  isHaddockFromHackage = fromFirstFalse buildMonoid.buildMonoidHaddockForHackage
   -- These options are not directly used in bopts, instead they
   -- transform other options.
-  tracing = getAny buildMonoidTrace
-  profiling = getAny buildMonoidProfile
-  noStripping = getAny buildMonoidNoStrip
+  tracing = getAny buildMonoid.buildMonoidTrace
+  profiling = getAny buildMonoid.buildMonoidProfile
+  noStripping = getAny buildMonoid.buildMonoidNoStrip
   -- Additional args for tracing / profiling
   additionalArgs =
     if tracing || profiling
@@ -90,30 +97,33 @@ buildOptsFromMonoid BuildOptsMonoid{..} = BuildOpts
       else Nothing
 
 haddockOptsFromMonoid :: HaddockOptsMonoid -> HaddockOpts
-haddockOptsFromMonoid HaddockOptsMonoid{..} = defaultHaddockOpts
-  { hoAdditionalArgs = hoMonoidAdditionalArgs }
+haddockOptsFromMonoid hoMonoid = defaultHaddockOpts
+  { hoAdditionalArgs = hoMonoid.hoMonoidAdditionalArgs }
 
 testOptsFromMonoid :: TestOptsMonoid -> Maybe [String] -> TestOpts
-testOptsFromMonoid TestOptsMonoid{..} madditional = defaultTestOpts
-  { toRerunTests = fromFirstTrue toMonoidRerunTests
-  , toAdditionalArgs = fromMaybe [] madditional <> toMonoidAdditionalArgs
-  , toCoverage = fromFirstFalse toMonoidCoverage
-  , toDisableRun = fromFirstFalse toMonoidDisableRun
+testOptsFromMonoid toMonoid madditional = defaultTestOpts
+  { toRerunTests = fromFirstTrue toMonoid.toMonoidRerunTests
+  , toAdditionalArgs =
+      fromMaybe [] madditional <> toMonoid.toMonoidAdditionalArgs
+  , toCoverage = fromFirstFalse toMonoid.toMonoidCoverage
+  , toDisableRun = fromFirstFalse toMonoid.toMonoidDisableRun
   , toMaximumTimeSeconds =
-      fromFirst (toMaximumTimeSeconds defaultTestOpts) toMonoidMaximumTimeSeconds
-  , toAllowStdin = fromFirstTrue toMonoidAllowStdin
+      fromFirst
+        (toMaximumTimeSeconds defaultTestOpts)
+        toMonoid.toMonoidMaximumTimeSeconds
+  , toAllowStdin = fromFirstTrue toMonoid.toMonoidAllowStdin
   }
 
 benchmarkOptsFromMonoid ::
      BenchmarkOptsMonoid
   -> Maybe [String]
   -> BenchmarkOpts
-benchmarkOptsFromMonoid BenchmarkOptsMonoid{..} madditional =
+benchmarkOptsFromMonoid beoMonoid madditional =
   defaultBenchmarkOpts
     { beoAdditionalArgs =
         fmap (\args -> unwords args <> " ") madditional <>
-        getFirst beoMonoidAdditionalArgs
+        getFirst beoMonoid.beoMonoidAdditionalArgs
     , beoDisableRun = fromFirst
         (beoDisableRun defaultBenchmarkOpts)
-        beoMonoidDisableRun
+        beoMonoid.beoMonoidDisableRun
     }

--- a/src/Stack/Config/Docker.hs
+++ b/src/Stack/Config/Docker.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude  #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Docker configuration
 module Stack.Config.Docker
@@ -68,9 +68,9 @@ dockerOptsFromMonoid ::
   -> Maybe AbstractResolver
   -> DockerOptsMonoid
   -> m DockerOpts
-dockerOptsFromMonoid mproject maresolver DockerOptsMonoid{..} = do
+dockerOptsFromMonoid mproject maresolver dockerMonoid = do
   let dockerImage =
-        case getFirst dockerMonoidRepoOrImage of
+        case getFirst dockerMonoid.dockerMonoidRepoOrImage of
           Nothing -> addDefaultTag "fpco/stack-build" mproject maresolver
           Just (DockerMonoidImage image) -> pure image
           Just (DockerMonoidRepo repo) ->
@@ -79,27 +79,51 @@ dockerOptsFromMonoid mproject maresolver DockerOptsMonoid{..} = do
               -- Repo already specified a tag or digest, so don't append default
               Just _ -> pure repo
   let dockerEnable =
-        fromFirst (getAny dockerMonoidDefaultEnable) dockerMonoidEnable
+        fromFirst
+          (getAny dockerMonoid.dockerMonoidDefaultEnable)
+          dockerMonoid.dockerMonoidEnable
       dockerRegistryLogin =
         fromFirst
-          (isJust (emptyToNothing (getFirst dockerMonoidRegistryUsername)))
-          dockerMonoidRegistryLogin
-      dockerRegistryUsername = emptyToNothing (getFirst dockerMonoidRegistryUsername)
-      dockerRegistryPassword = emptyToNothing (getFirst dockerMonoidRegistryPassword)
-      dockerAutoPull = fromFirstTrue dockerMonoidAutoPull
-      dockerDetach = fromFirstFalse dockerMonoidDetach
-      dockerPersist = fromFirstFalse dockerMonoidPersist
-      dockerContainerName = emptyToNothing (getFirst dockerMonoidContainerName)
-      dockerNetwork = emptyToNothing (getFirst dockerMonoidNetwork)
-      dockerRunArgs = dockerMonoidRunArgs
-      dockerMount = dockerMonoidMount
-      dockerMountMode = emptyToNothing (getFirst dockerMonoidMountMode)
-      dockerEnv = dockerMonoidEnv
-      dockerSetUser = getFirst dockerMonoidSetUser
+          (isJust (emptyToNothing (getFirst dockerMonoid.dockerMonoidRegistryUsername)))
+          dockerMonoid.dockerMonoidRegistryLogin
+      dockerRegistryUsername =
+        emptyToNothing (getFirst dockerMonoid.dockerMonoidRegistryUsername)
+      dockerRegistryPassword =
+        emptyToNothing (getFirst dockerMonoid.dockerMonoidRegistryPassword)
+      dockerAutoPull = fromFirstTrue dockerMonoid.dockerMonoidAutoPull
+      dockerDetach = fromFirstFalse dockerMonoid.dockerMonoidDetach
+      dockerPersist = fromFirstFalse dockerMonoid.dockerMonoidPersist
+      dockerContainerName =
+        emptyToNothing (getFirst dockerMonoid.dockerMonoidContainerName)
+      dockerNetwork = emptyToNothing (getFirst dockerMonoid.dockerMonoidNetwork)
+      dockerRunArgs = dockerMonoid.dockerMonoidRunArgs
+      dockerMount = dockerMonoid.dockerMonoidMount
+      dockerMountMode =
+        emptyToNothing (getFirst dockerMonoid.dockerMonoidMountMode)
+      dockerEnv = dockerMonoid.dockerMonoidEnv
+      dockerSetUser = getFirst dockerMonoid.dockerMonoidSetUser
       dockerRequireDockerVersion =
-        simplifyVersionRange (getIntersectingVersionRange dockerMonoidRequireDockerVersion)
-      dockerStackExe = getFirst dockerMonoidStackExe
-  pure DockerOpts{..}
+        simplifyVersionRange (getIntersectingVersionRange dockerMonoid.dockerMonoidRequireDockerVersion)
+      dockerStackExe = getFirst dockerMonoid.dockerMonoidStackExe
+  pure $ DockerOpts
+    { dockerEnable
+    , dockerImage
+    , dockerRegistryLogin
+    , dockerRegistryUsername
+    , dockerRegistryPassword
+    , dockerAutoPull
+    , dockerDetach
+    , dockerPersist
+    , dockerContainerName
+    , dockerNetwork
+    , dockerRunArgs
+    , dockerMount
+    , dockerMountMode
+    , dockerEnv
+    , dockerStackExe
+    , dockerSetUser
+    , dockerRequireDockerVersion
+    }
  where
   emptyToNothing Nothing = Nothing
   emptyToNothing (Just s)

--- a/src/Stack/Eval.hs
+++ b/src/Stack/Eval.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 -- | Types and functions related to Stack's @eval@ command.
 module Stack.Eval
@@ -24,10 +24,10 @@ data EvalOpts = EvalOpts
 -- | Function underlying the @stack eval@ command. Evaluate some Haskell code
 -- inline.
 evalCmd :: EvalOpts -> RIO Runner ()
-evalCmd EvalOpts {..} = execCmd execOpts
+evalCmd eval = execCmd execOpts
  where
-  execOpts =
-    ExecOpts { eoCmd = ExecGhc
-             , eoArgs = ["-e", evalArg]
-             , eoExtra = evalExtra
-             }
+  execOpts = ExecOpts
+    { eoCmd = ExecGhc
+    , eoArgs = ["-e", eval.evalArg]
+    , eoExtra = eval.evalExtra
+    }

--- a/src/Stack/Lock.hs
+++ b/src/Stack/Lock.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 module Stack.Lock
   ( lockCachedWanted
@@ -91,10 +91,10 @@ data Locked = Locked
   deriving (Eq, Show)
 
 instance ToJSON Locked where
-  toJSON Locked {..} =
+  toJSON lck =
     object
-      [ "snapshots" .= lckSnapshotLocations
-      , "packages" .= lckPkgImmutableLocations
+      [ "snapshots" .= lck.lckSnapshotLocations
+      , "packages" .= lck.lckPkgImmutableLocations
       ]
 
 instance FromJSON (WithJSONWarnings (Unresolved Locked)) where

--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 -- | Functions to parse Stack's \'global\' command line arguments.
 module Stack.Options.GlobalParser
@@ -116,37 +116,40 @@ globalOptsFromMonoid ::
   => Bool
   -> GlobalOptsMonoid
   -> m GlobalOpts
-globalOptsFromMonoid defaultTerminal GlobalOptsMonoid{..} = do
-  resolver <- for (getFirst globalMonoidResolver) $ \ur -> do
+globalOptsFromMonoid defaultTerminal globalMonoid = do
+  resolver <- for (getFirst globalMonoid.globalMonoidResolver) $ \ur -> do
     root <-
-      case globalMonoidResolverRoot of
+      case globalMonoid.globalMonoidResolverRoot of
         First Nothing -> getCurrentDir
         First (Just dir) -> resolveDir' dir
     resolvePaths (Just root) ur
   stackYaml <-
-    case getFirst globalMonoidStackYaml of
+    case getFirst globalMonoid.globalMonoidStackYaml of
       Nothing -> pure SYLDefault
       Just fp -> SYLOverride <$> resolveFile' fp
   pure GlobalOpts
-    { globalReExecVersion = getFirst globalMonoidReExecVersion
-    , globalDockerEntrypoint = getFirst globalMonoidDockerEntrypoint
-    , globalLogLevel = fromFirst defaultLogLevel globalMonoidLogLevel
-    , globalTimeInLog = fromFirstTrue globalMonoidTimeInLog
-    , globalRSLInLog = fromFirstFalse globalMonoidRSLInLog
-    , globalPlanInLog = fromFirstFalse globalMonoidPlanInLog
-    , globalConfigMonoid = globalMonoidConfigMonoid
+    { globalReExecVersion = getFirst globalMonoid.globalMonoidReExecVersion
+    , globalDockerEntrypoint =
+        getFirst globalMonoid.globalMonoidDockerEntrypoint
+    , globalLogLevel =
+        fromFirst defaultLogLevel globalMonoid.globalMonoidLogLevel
+    , globalTimeInLog = fromFirstTrue globalMonoid.globalMonoidTimeInLog
+    , globalRSLInLog = fromFirstFalse globalMonoid.globalMonoidRSLInLog
+    , globalPlanInLog = fromFirstFalse globalMonoid.globalMonoidPlanInLog
+    , globalConfigMonoid = globalMonoid.globalMonoidConfigMonoid
     , globalResolver = resolver
-    , globalCompiler = getFirst globalMonoidCompiler
-    , globalTerminal = fromFirst defaultTerminal globalMonoidTerminal
-    , globalStylesUpdate = globalMonoidStyles
-    , globalTermWidth = getFirst globalMonoidTermWidth
+    , globalCompiler = getFirst globalMonoid.globalMonoidCompiler
+    , globalTerminal =
+        fromFirst defaultTerminal globalMonoid.globalMonoidTerminal
+    , globalStylesUpdate = globalMonoid.globalMonoidStyles
+    , globalTermWidth = getFirst globalMonoid.globalMonoidTermWidth
     , globalStackYaml = stackYaml
     , globalLockFileBehavior =
         let defLFB =
-              case getFirst globalMonoidResolver of
+              case getFirst globalMonoid.globalMonoidResolver of
                 Nothing -> LFBReadWrite
                 _ -> LFBReadOnly
-        in  fromFirst defLFB globalMonoidLockFileBehavior
+        in  fromFirst defLFB globalMonoid.globalMonoidLockFileBehavior
     }
 
 -- | Default logging level should be something useful but not crazy.

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
 
 -- | Types and functions related to Stack's @path@ command.
 module Stack.Path
@@ -111,7 +110,20 @@ fillPathInfo = do
   piDistDir <- distRelativeDir
   piHpcDir <- hpcReportDir
   piCompiler <- getCompilerPath
-  pure PathInfo {..}
+  pure $ PathInfo
+    { piBuildConfig
+    , piSnapDb
+    , piLocalDb
+    , piGlobalDb
+    , piSnapRoot
+    , piLocalRoot
+    , piToolsDir
+    , piHoogleRoot
+    , piDistDir
+    , piHpcDir
+    , piExtraDbs
+    , piCompiler
+    }
 
 -- | Type representing information passed to all the path printers.
 data PathInfo = PathInfo

--- a/src/Stack/Types/BuildOpts.hs
+++ b/src/Stack/Types/BuildOpts.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
 
 -- | Configuration options for building.
 module Stack.Types.BuildOpts
@@ -310,7 +309,39 @@ instance FromJSON (WithJSONWarnings BuildOptsMonoid) where
     buildMonoidProgressBar <-
       First <$> o ..:? buildMonoidProgressBarName
     buildMonoidDdumpDir <- o ..:? buildMonoidDdumpDirName ..!= mempty
-    pure BuildOptsMonoid{..}
+    pure $ BuildOptsMonoid
+      { buildMonoidTrace
+      , buildMonoidProfile
+      , buildMonoidNoStrip
+      , buildMonoidLibProfile
+      , buildMonoidExeProfile
+      , buildMonoidLibStrip
+      , buildMonoidExeStrip
+      , buildMonoidHaddock
+      , buildMonoidHaddockOpts
+      , buildMonoidOpenHaddocks
+      , buildMonoidHaddockDeps
+      , buildMonoidHaddockInternal
+      , buildMonoidHaddockHyperlinkSource
+      , buildMonoidHaddockForHackage
+      , buildMonoidInstallExes
+      , buildMonoidInstallCompilerTool
+      , buildMonoidPreFetch
+      , buildMonoidKeepGoing
+      , buildMonoidKeepTmpFiles
+      , buildMonoidForceDirty
+      , buildMonoidTests
+      , buildMonoidTestOpts
+      , buildMonoidBenchmarks
+      , buildMonoidBenchmarkOpts
+      , buildMonoidReconfigure
+      , buildMonoidCabalVerbose
+      , buildMonoidSplitObjs
+      , buildMonoidSkipComponents
+      , buildMonoidInterleavedOutput
+      , buildMonoidProgressBar
+      , buildMonoidDdumpDir
+      }
 
 buildMonoidLibProfileArgName :: Text
 buildMonoidLibProfileArgName = "library-profiling"
@@ -458,7 +489,14 @@ instance FromJSON (WithJSONWarnings TestOptsMonoid) where
     toMonoidMaximumTimeSeconds <-
       First <$> o ..:? toMonoidMaximumTimeSecondsArgName
     toMonoidAllowStdin <- FirstTrue <$> o ..:? toMonoidTestsAllowStdinName
-    pure TestOptsMonoid{..}
+    pure $ TestOptsMonoid
+      { toMonoidRerunTests
+      , toMonoidAdditionalArgs
+      , toMonoidCoverage
+      , toMonoidDisableRun
+      , toMonoidMaximumTimeSeconds
+      , toMonoidAllowStdin
+      }
 
 toMonoidRerunTestsArgName :: Text
 toMonoidRerunTestsArgName = "rerun-tests"
@@ -502,7 +540,7 @@ defaultHaddockOpts = HaddockOpts {hoAdditionalArgs = []}
 instance FromJSON (WithJSONWarnings HaddockOptsMonoid) where
   parseJSON = withObjectWarnings "HaddockOptsMonoid" $ \o -> do
     hoMonoidAdditionalArgs <- o ..:? hoMonoidAdditionalArgsName ..!= []
-    pure HaddockOptsMonoid{..}
+    pure $ HaddockOptsMonoid { hoMonoidAdditionalArgs }
 
 instance Semigroup HaddockOptsMonoid where
   (<>) = mappenddefault
@@ -539,7 +577,10 @@ instance FromJSON (WithJSONWarnings BenchmarkOptsMonoid) where
   parseJSON = withObjectWarnings "BenchmarkOptsMonoid" $ \o -> do
     beoMonoidAdditionalArgs <- First <$> o ..:? beoMonoidAdditionalArgsArgName
     beoMonoidDisableRun <- First <$> o ..:? beoMonoidDisableRunArgName
-    pure BenchmarkOptsMonoid{..}
+    pure $ BenchmarkOptsMonoid
+      { beoMonoidAdditionalArgs
+      , beoMonoidDisableRun
+      }
 
 beoMonoidAdditionalArgsArgName :: Text
 beoMonoidAdditionalArgsArgName = "benchmark-arguments"

--- a/src/Stack/Types/Casa.hs
+++ b/src/Stack/Types/Casa.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude  #-}
 {-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE RecordWildCards    #-}
 
 -- | Casa configuration types.
 
@@ -26,14 +25,16 @@ data CasaOptsMonoid = CasaOptsMonoid
 
 -- | Decode uninterpreted Casa configuration options from JSON/YAML.
 instance FromJSON (WithJSONWarnings CasaOptsMonoid) where
-  parseJSON = withObjectWarnings "CasaOptsMonoid"
-    ( \o -> do
-        casaMonoidEnable <- FirstTrue <$> o ..:? casaEnableName
-        casaMonoidRepoPrefix <- First <$> o ..:? casaRepoPrefixName
-        casaMonoidMaxKeysPerRequest <-
-          First <$> o ..:? casaMaxKeysPerRequestName
-        pure CasaOptsMonoid {..}
-    )
+  parseJSON = withObjectWarnings "CasaOptsMonoid" $ \o -> do
+    casaMonoidEnable <- FirstTrue <$> o ..:? casaEnableName
+    casaMonoidRepoPrefix <- First <$> o ..:? casaRepoPrefixName
+    casaMonoidMaxKeysPerRequest <-
+      First <$> o ..:? casaMaxKeysPerRequestName
+    pure $ CasaOptsMonoid
+      { casaMonoidEnable
+      , casaMonoidRepoPrefix
+      , casaMonoidMaxKeysPerRequest
+      }
 
 -- | Left-biased combine Casa configuration options
 instance Semigroup CasaOptsMonoid where

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE MultiWayIf            #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE QuasiQuotes           #-}
-{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE ViewPatterns          #-}
 

--- a/src/Stack/Types/ConfigMonoid.hs
+++ b/src/Stack/Types/ConfigMonoid.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
 
 module Stack.Types.ConfigMonoid
   ( ConfigMonoid (..)
@@ -366,7 +365,71 @@ parseConfigMonoidObject rootDir obj = do
   configMonoidStackDeveloperMode <-
     First <$> obj ..:? configMonoidStackDeveloperModeName
 
-  pure ConfigMonoid {..}
+  pure $ ConfigMonoid
+    { configMonoidStackRoot
+    , configMonoidWorkDir
+    , configMonoidBuildOpts
+    , configMonoidDockerOpts
+    , configMonoidNixOpts
+    , configMonoidConnectionCount
+    , configMonoidHideTHLoading
+    , configMonoidPrefixTimestamps
+    , configMonoidLatestSnapshot
+    , configMonoidPackageIndex
+    , configMonoidPackageIndices
+    , configMonoidSystemGHC
+    , configMonoidInstallGHC
+    , configMonoidSkipGHCCheck
+    , configMonoidSkipMsys
+    , configMonoidCompilerCheck
+    , configMonoidCompilerRepository
+    , configMonoidRequireStackVersion
+    , configMonoidArch
+    , configMonoidGHCVariant
+    , configMonoidGHCBuild
+    , configMonoidJobs
+    , configMonoidExtraIncludeDirs
+    , configMonoidExtraLibDirs
+    , configMonoidCustomPreprocessorExts
+    , configMonoidOverrideGccPath
+    , configMonoidOverrideHpack
+    , configMonoidConcurrentTests
+    , configMonoidLocalBinPath
+    , configMonoidTemplateParameters
+    , configMonoidScmInit
+    , configMonoidGhcOptionsByName
+    , configMonoidGhcOptionsByCat
+    , configMonoidCabalConfigOpts
+    , configMonoidExtraPath
+    , configMonoidSetupInfoLocations
+    , configMonoidSetupInfoInline
+    , configMonoidLocalProgramsBase
+    , configMonoidPvpBounds
+    , configMonoidModifyCodePage
+    , configMonoidRebuildGhcOptions
+    , configMonoidApplyGhcOptions
+    , configMonoidApplyProgOptions
+    , configMonoidAllowNewer
+    , configMonoidAllowNewerDeps
+    , configMonoidDefaultTemplate
+    , configMonoidAllowDifferentUser
+    , configMonoidDumpLogs
+    , configMonoidSaveHackageCreds
+    , configMonoidHackageBaseUrl
+    , configMonoidColorWhen
+    , configMonoidStyles
+    , configMonoidHideSourcePaths
+    , configMonoidRecommendUpgrade
+    , configMonoidNotifyIfNixOnPath
+    , configMonoidNotifyIfGhcUntested
+    , configMonoidNotifyIfCabalUntested
+    , configMonoidNotifyIfArchUnknown
+    , configMonoidCasaOpts
+    , configMonoidCasaRepoPrefix
+    , configMonoidSnapshotLocation
+    , configMonoidNoRunCompile
+    , configMonoidStackDeveloperMode
+    }
 
 configMonoidWorkDirName :: Text
 configMonoidWorkDirName = "work-dir"

--- a/src/Stack/Types/Docker.hs
+++ b/src/Stack/Types/Docker.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude  #-}
 {-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE RecordWildCards    #-}
 
 -- | Docker types.
 
@@ -327,38 +326,55 @@ data DockerOptsMonoid = DockerOptsMonoid
 
 -- | Decode uninterpreted docker options from JSON/YAML.
 instance FromJSON (WithJSONWarnings DockerOptsMonoid) where
-  parseJSON = withObjectWarnings "DockerOptsMonoid"
-    ( \o -> do
-       let dockerMonoidDefaultEnable = Any True
-       dockerMonoidEnable <- First <$> o ..:? dockerEnableArgName
-       dockerMonoidRepoOrImage <- First <$>
-         (   (Just . DockerMonoidImage <$> o ..: dockerImageArgName)
-         <|> (Just . DockerMonoidRepo <$> o ..: dockerRepoArgName)
-         <|> pure Nothing
-         )
-       dockerMonoidRegistryLogin <- First <$> o ..:? dockerRegistryLoginArgName
-       dockerMonoidRegistryUsername <-
-         First <$> o ..:? dockerRegistryUsernameArgName
-       dockerMonoidRegistryPassword <-
-         First <$> o ..:? dockerRegistryPasswordArgName
-       dockerMonoidAutoPull <- FirstTrue <$> o ..:? dockerAutoPullArgName
-       dockerMonoidDetach <- FirstFalse <$> o ..:? dockerDetachArgName
-       dockerMonoidPersist <- FirstFalse <$> o ..:? dockerPersistArgName
-       dockerMonoidContainerName <- First <$> o ..:? dockerContainerNameArgName
-       dockerMonoidNetwork <- First <$> o ..:? dockerNetworkArgName
-       dockerMonoidRunArgs <- o ..:? dockerRunArgsArgName ..!= []
-       dockerMonoidMount <- o ..:? dockerMountArgName ..!= []
-       dockerMonoidMountMode <- First <$> o ..:? dockerMountModeArgName
-       dockerMonoidEnv <- o ..:? dockerEnvArgName ..!= []
-       dockerMonoidStackExe <- First <$> o ..:? dockerStackExeArgName
-       dockerMonoidSetUser <- First <$> o ..:? dockerSetUserArgName
-       dockerMonoidRequireDockerVersion <-
-         IntersectingVersionRange . unVersionRangeJSON <$>
-           ( o ..:? dockerRequireDockerVersionArgName
-             ..!= VersionRangeJSON anyVersion
-           )
-       pure DockerOptsMonoid {..}
-    )
+  parseJSON = withObjectWarnings "DockerOptsMonoid" $ \o -> do
+    let dockerMonoidDefaultEnable = Any True
+    dockerMonoidEnable <- First <$> o ..:? dockerEnableArgName
+    dockerMonoidRepoOrImage <- First <$>
+      (   (Just . DockerMonoidImage <$> o ..: dockerImageArgName)
+      <|> (Just . DockerMonoidRepo <$> o ..: dockerRepoArgName)
+      <|> pure Nothing
+      )
+    dockerMonoidRegistryLogin <- First <$> o ..:? dockerRegistryLoginArgName
+    dockerMonoidRegistryUsername <-
+      First <$> o ..:? dockerRegistryUsernameArgName
+    dockerMonoidRegistryPassword <-
+      First <$> o ..:? dockerRegistryPasswordArgName
+    dockerMonoidAutoPull <- FirstTrue <$> o ..:? dockerAutoPullArgName
+    dockerMonoidDetach <- FirstFalse <$> o ..:? dockerDetachArgName
+    dockerMonoidPersist <- FirstFalse <$> o ..:? dockerPersistArgName
+    dockerMonoidContainerName <- First <$> o ..:? dockerContainerNameArgName
+    dockerMonoidNetwork <- First <$> o ..:? dockerNetworkArgName
+    dockerMonoidRunArgs <- o ..:? dockerRunArgsArgName ..!= []
+    dockerMonoidMount <- o ..:? dockerMountArgName ..!= []
+    dockerMonoidMountMode <- First <$> o ..:? dockerMountModeArgName
+    dockerMonoidEnv <- o ..:? dockerEnvArgName ..!= []
+    dockerMonoidStackExe <- First <$> o ..:? dockerStackExeArgName
+    dockerMonoidSetUser <- First <$> o ..:? dockerSetUserArgName
+    dockerMonoidRequireDockerVersion <-
+      IntersectingVersionRange . unVersionRangeJSON <$>
+        ( o ..:? dockerRequireDockerVersionArgName
+          ..!= VersionRangeJSON anyVersion
+        )
+    pure $ DockerOptsMonoid
+      { dockerMonoidDefaultEnable
+      , dockerMonoidEnable
+      , dockerMonoidRepoOrImage
+      , dockerMonoidRegistryLogin
+      , dockerMonoidRegistryUsername
+      , dockerMonoidRegistryPassword
+      , dockerMonoidAutoPull
+      , dockerMonoidDetach
+      , dockerMonoidPersist
+      , dockerMonoidContainerName
+      , dockerMonoidNetwork
+      , dockerMonoidRunArgs
+      , dockerMonoidMount
+      , dockerMonoidMountMode
+      , dockerMonoidEnv
+      , dockerMonoidStackExe
+      , dockerMonoidSetUser
+      , dockerMonoidRequireDockerVersion
+      }
 
 -- | Left-biased combine Docker options
 instance Semigroup DockerOptsMonoid where

--- a/src/Stack/Types/Nix.hs
+++ b/src/Stack/Types/Nix.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
 
 -- | Nix types.
 module Stack.Types.Nix
@@ -63,17 +62,23 @@ data NixOptsMonoid = NixOptsMonoid
 
 -- | Decode uninterpreted nix options from JSON/YAML.
 instance FromJSON (WithJSONWarnings NixOptsMonoid) where
-  parseJSON = withObjectWarnings "NixOptsMonoid"
-    ( \o -> do
-        nixMonoidEnable        <- First <$> o ..:? nixEnableArgName
-        nixMonoidPureShell     <- First <$> o ..:? nixPureShellArgName
-        nixMonoidPackages      <- First <$> o ..:? nixPackagesArgName
-        nixMonoidInitFile      <- First <$> o ..:? nixInitFileArgName
-        nixMonoidShellOptions  <- First <$> o ..:? nixShellOptsArgName
-        nixMonoidPath          <- First <$> o ..:? nixPathArgName
-        nixMonoidAddGCRoots    <- FirstFalse <$> o ..:? nixAddGCRootsArgName
-        pure NixOptsMonoid{..}
-    )
+  parseJSON = withObjectWarnings "NixOptsMonoid" $ \o -> do
+    nixMonoidEnable        <- First <$> o ..:? nixEnableArgName
+    nixMonoidPureShell     <- First <$> o ..:? nixPureShellArgName
+    nixMonoidPackages      <- First <$> o ..:? nixPackagesArgName
+    nixMonoidInitFile      <- First <$> o ..:? nixInitFileArgName
+    nixMonoidShellOptions  <- First <$> o ..:? nixShellOptsArgName
+    nixMonoidPath          <- First <$> o ..:? nixPathArgName
+    nixMonoidAddGCRoots    <- FirstFalse <$> o ..:? nixAddGCRootsArgName
+    pure $ NixOptsMonoid
+      { nixMonoidEnable
+      , nixMonoidPureShell
+      , nixMonoidPackages
+      , nixMonoidInitFile
+      , nixMonoidShellOptions
+      , nixMonoidPath
+      , nixMonoidAddGCRoots
+      }
 
 -- | Left-biased combine Nix options
 instance Semigroup NixOptsMonoid where

--- a/src/Stack/Types/SetupInfo.hs
+++ b/src/Stack/Types/SetupInfo.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE ViewPatterns      #-}
 
 
@@ -37,7 +36,13 @@ instance FromJSON (WithJSONWarnings SetupInfo) where
       jsonSubWarningsTT (o ..:? "ghc" ..!= mempty)
     (fmap unCabalStringMap -> siStack) <-
       jsonSubWarningsTT (o ..:? "stack" ..!= mempty)
-    pure SetupInfo {..}
+    pure $ SetupInfo
+      { siSevenzExe
+      , siSevenzDll
+      , siMsys2
+      , siGHCs
+      , siStack
+      }
 
 -- | For the @siGHCs@ field maps are deeply merged. For all fields the values
 -- from the first @SetupInfo@ win.

--- a/stack.cabal
+++ b/stack.cabal
@@ -352,7 +352,7 @@ library
     , array
     , async
     , attoparsec
-    , base >=4.14.3.0 && <5
+    , base >=4.16.0.0 && <5
     , base64-bytestring
     , bytestring
     , casa-client >=0.0.2
@@ -474,7 +474,7 @@ executable stack
     , array
     , async
     , attoparsec
-    , base >=4.14.3.0 && <5
+    , base >=4.16.0.0 && <5
     , base64-bytestring
     , bytestring
     , casa-client >=0.0.2
@@ -575,7 +575,7 @@ executable stack-integration-test
     , array
     , async
     , attoparsec
-    , base >=4.14.3.0 && <5
+    , base >=4.16.0.0 && <5
     , base64-bytestring
     , bytestring
     , casa-client >=0.0.2
@@ -692,7 +692,7 @@ test-suite stack-unit-test
     , array
     , async
     , attoparsec
-    , base >=4.14.3.0 && <5
+    , base >=4.16.0.0 && <5
     , base64-bytestring
     , bytestring
     , casa-client >=0.0.2


### PR DESCRIPTION
Motivation: @theobat's [comment](https://discourse.haskell.org/t/ghc2024-community-input/8168/85?u=mpilgrem) at the Haskell Community, and the downstream discussion there.

Only implements 'step 1' (that is, does not eliminate the use of prefixes that indicate the type/data constructor in the naming of fields, to give them unique names). EDIT: My plan would be to implement 'step 2' (elimination of prefixes) separately from this pull request.

Uses `OverloadedRecordDot`, introduced from GHC 9.2.1 (`base-4.16.0.0`) - so bumps lower bound on `base` package.

Replaces:

* `f Constructor{..} = ... prefixFieldName` with (mostly) `f prefix = ... prefix.prefixFieldName`; and
* `pure Constructor{..}` with `pure $ Constructor {prefixFieldName1, ..., prefixFieldNameN}`;

and puts spaces around existing `(.) :: (b -> c) -> (a -> b) -> a -> c` operators.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
