### PR TITLE
Remove mention of Cabal in drop-packages

### DIFF
--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -69,9 +69,11 @@ Cabal file (named `<package_name>.cabal`), see the
 Project-specific configuration options are valid only in a project-level
 configuration file (`stack.yaml`).
 
-> Note: We define **project** to mean a directory that contains a `stack.yaml`
-> file, which specifies how to build a set of packages. We define **package** to
-> be a package with a Cabal file or an Hpack `package.yaml` file.
+!!! note
+
+    We define **project** to mean a directory that contains a `stack.yaml`
+    file, which specifies how to build a set of packages. We define **package** to
+    be a package with a Cabal file or an Hpack `package.yaml` file.
 
 In your project-specific options, you specify both **which local packages** to
 build and **which dependencies to use** when building these packages. Unlike the
@@ -256,18 +258,22 @@ be included in our package. This can be used for a few different purposes, e.g.:
 
 * Ensure that packages you don't want used in your project cannot be used in a
   `package.yaml` file (e.g., for license reasons)
-* Prevent overriding of a global package like `Cabal`. For more information, see
-  Stackage issue
-  [#4425](https://github.com/commercialhaskell/stackage/issues/4425)
 * When using a custom GHC build, avoid incompatible packages (see this
   [comment](https://github.com/commercialhaskell/stack/pull/4655#issuecomment-477954429)).
 
 ~~~yaml
 drop-packages:
-- Cabal
 - buggy-package
 - package-with-unacceptable-license
 ~~~
+
+!!! info
+
+    In older snapshots, it used to be handy to drop Cabal for reasons listed in
+    Stackage issue
+    [#4425](https://github.com/commercialhaskell/stackage/issues/4425). However,
+    since around February 2020 (LTS-14.27 and nightly-2020-02-08), Cabal is not
+    directly included in snapshots, so dropping Cabal no longer has any effect.
 
 ### user-message
 


### PR DESCRIPTION
As described in the resolution to #5707, Cabal is no longer included in LTSs so this has no effect.

It would be nice to list *which* LTS dropped it -- see FIXME.

Note: Fixes for the online documentation of the current Stack release (https://docs.haskellstack.org/en/stable/) should target the 'stable' branch, not the 'master' branch.

Please include the following checklist in your pull request:

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

