### PR TITLE
Build with NoFieldSelectors

### DIFF
--- a/.hlint-test.yaml
+++ b/.hlint-test.yaml
@@ -9,6 +9,7 @@
   - name:
     - NoImplicitPrelude
     - CPP
+    - NoFieldSelectors
     - OverloadedLists
       # Provided from GHC 9.2.1 (base-4.16.0.0):
     - OverloadedRecordDot

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -70,6 +70,7 @@
     - GeneralizedNewtypeDeriving
     - LambdaCase
     - MultiWayIf
+    - NoFieldSelectors
     - OverloadedLists
       # Provided from GHC 9.2.1 (base-4.16.0.0):
     - OverloadedRecordDot

--- a/.stan.toml
+++ b/.stan.toml
@@ -25,7 +25,7 @@
 # Infinite: base/isSuffixOf
 # Usage of the 'isSuffixOf' function that hangs on infinite lists
 [[ignore]]
-  id = "OBS-STAN-0102-luLR/n-522:30"
+  id = "OBS-STAN-0102-luLR/n-523:30"
 # ✦ Category:      #Infinite #List
 # ✦ File:          src\Stack\New.hs
 #
@@ -36,7 +36,7 @@
 # Infinite: base/isSuffixOf
 # Usage of the 'isSuffixOf' function that hangs on infinite lists
 [[ignore]]
-  id = "OBS-STAN-0102-luLR/n-522:65"
+  id = "OBS-STAN-0102-luLR/n-523:65"
 # ✦ Category:      #Infinite #List
 # ✦ File:          src\Stack\New.hs
 #
@@ -54,47 +54,47 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-1134:21"
+  id = "OBS-STAN-0203-fki0nd-1132:21"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\Execute.hs
 #
-#  1133 ┃
-#  1134 ┃   newProjectRoot <- S8.pack . toFilePath <$> view projectRootL
-#  1135 ┃                     ^^^^^^^
+#  1131 ┃
+#  1132 ┃   newProjectRoot <- S8.pack . toFilePath <$> view projectRootL
+#  1133 ┃                     ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-fki0nd-2680:3"
+  id = "OBS-STAN-0203-fki0nd-2678:3"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\Execute.hs
 #
-#  2679 ┃
-#  2680 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
-#  2681 ┃   ^^^^^^^
+#  2677 ┃
+#  2678 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
+#  2679 ┃   ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-hTeu0Y-380:17"
+  id = "OBS-STAN-0203-hTeu0Y-381:17"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Init.hs
 #
-#  379 ┃
-#  380 ┃   commentHelp = BC.pack .  intercalate "\n" . map commentLine
-#  381 ┃                 ^^^^^^^
+#  380 ┃
+#  381 ┃   commentHelp = BC.pack .  intercalate "\n" . map commentLine
+#  382 ┃                 ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-hTeu0Y-397:26"
+  id = "OBS-STAN-0203-hTeu0Y-398:26"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Init.hs
 #
-#  396 ┃
-#  397 ┃         <> B.byteString (BC.pack $ concat
-#  398 ┃                          ^^^^^^^
+#  397 ┃
+#  398 ┃         <> B.byteString (BC.pack $ concat
+#  399 ┃                          ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
@@ -169,6 +169,28 @@
 #  483 ┃     path <- makeRelativeToProject "src/setup-shim/StackSetupShim.hs"
 #  484 ┃     embedFile path)
 #  485 ┃
+
+# Anti-pattern: unsafe functions
+[[ignore]]
+  id = "OBS-STAN-0212-H4Wfj/-151:17"
+# ✦ Description:   Usage of unsafe functions breaks referential transparency
+# ✦ Category:      #Unsafe #AntiPattern
+# ✦ File:          src\Stack\Types\BuildOpts.hs
+#
+#  150 ┃
+#  151 ┃   buildMonoid = undefined :: BuildOptsMonoid
+#  152 ┃                 ^^^^^^^^^
+
+# Anti-pattern: unsafe functions
+[[ignore]]
+  id = "OBS-STAN-0212-H4Wfj/-480:14"
+# ✦ Description:   Usage of unsafe functions breaks referential transparency
+# ✦ Category:      #Unsafe #AntiPattern
+# ✦ File:          src\Stack\Types\BuildOpts.hs
+#
+#   479 ┃
+#   480 ┃   toMonoid = undefined :: TestOptsMonoid
+#   481 ┃              ^^^^^^^^^
 
 # Anti-pattern: Pattern matching on '_'
 # Pattern matching on '_' for sum types can create maintainability issues

--- a/src/Stack.hs
+++ b/src/Stack.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE GADTs               #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
 -- | Main Stack tool entry point.
@@ -77,9 +78,9 @@ main = do
       throwIO exitCode
     Right (globalMonoid, run) -> do
       global <- globalOptsFromMonoid isTerminal globalMonoid
-      when (globalLogLevel global == LevelDebug) $
+      when (global.globalLogLevel == LevelDebug) $
         hPutStrLn stderr versionString'
-      case globalReExecVersion global of
+      case global.globalReExecVersion of
         Just expectVersion -> do
           expectVersion' <- parseVersionThrowing expectVersion
           unless (checkVersion MatchMinor expectVersion' stackVersion) $

--- a/src/Stack/CLI.hs
+++ b/src/Stack/CLI.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Stack.CLI
   ( commandLineHandler
@@ -456,7 +457,7 @@ commandLineHandler currentDir progName isInterpreter =
     ( \so gom ->
         gom
           { globalMonoidResolverRoot =
-              First $ Just $ takeDirectory $ soFile so
+              First $ Just $ takeDirectory so.soFile
           }
     )
     (globalOpts OtherCmdGlobalOpts)

--- a/src/Stack/Clean.hs
+++ b/src/Stack/Clean.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude  #-}
-{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Types and functions related to Stack's @clean@ and @purge@ commands.
 module Stack.Clean
@@ -80,7 +81,7 @@ cleanDir dir = do
 
 dirsToDelete :: CleanOpts -> RIO BuildConfig [Path Abs Dir]
 dirsToDelete cleanOpts = do
-  packages <- view $ buildConfigL.to (smwProject . bcSMWanted)
+  packages <- view $ buildConfigL . to (.bcSMWanted.smwProject)
   case cleanOpts of
     CleanShallow [] ->
       -- Filter out packages listed as extra-deps

--- a/src/Stack/Component.hs
+++ b/src/Stack/Component.hs
@@ -171,16 +171,16 @@ gatherComponentToolsAndDepsFromCabal legacyBuildTools buildTools targetDeps =
           sbi
           (Cabal.ExeDependency pName (Cabal.mkUnqualComponentName exeName) range)
       Nothing -> sbi
-        {sbiUnknownTools = Set.insert (pack exeName) $ sbiUnknownTools sbi}
+        {sbiUnknownTools = Set.insert (pack exeName) sbi.sbiUnknownTools}
   processExeDependency sbi exeDep@(Cabal.ExeDependency pName _ _)
     | isPreInstalledPackages pName = sbi
     | otherwise = sbi
         { sbiDependency =
-            Map.insert pName (cabalExeToStackDep exeDep) $ sbiDependency sbi
+            Map.insert pName (cabalExeToStackDep exeDep) sbi.sbiDependency
         }
   processDependency sbi dep@(Cabal.Dependency pName _ _) = sbi
     { sbiDependency =
-        Map.insert pName (cabalToStackDep dep) $ sbiDependency sbi
+        Map.insert pName (cabalToStackDep dep) sbi.sbiDependency
     }
 
 componentDependencyMap ::

--- a/src/Stack/Config/Build.hs
+++ b/src/Stack/Config/Build.hs
@@ -109,7 +109,7 @@ testOptsFromMonoid toMonoid madditional = defaultTestOpts
   , toDisableRun = fromFirstFalse toMonoid.toMonoidDisableRun
   , toMaximumTimeSeconds =
       fromFirst
-        (toMaximumTimeSeconds defaultTestOpts)
+        defaultTestOpts.toMaximumTimeSeconds
         toMonoid.toMonoidMaximumTimeSeconds
   , toAllowStdin = fromFirstTrue toMonoid.toMonoidAllowStdin
   }
@@ -124,6 +124,6 @@ benchmarkOptsFromMonoid beoMonoid madditional =
         fmap (\args -> unwords args <> " ") madditional <>
         getFirst beoMonoid.beoMonoidAdditionalArgs
     , beoDisableRun = fromFirst
-        (beoDisableRun defaultBenchmarkOpts)
+        defaultBenchmarkOpts.beoDisableRun
         beoMonoid.beoMonoidDisableRun
     }

--- a/src/Stack/Config/Docker.hs
+++ b/src/Stack/Config/Docker.hs
@@ -38,7 +38,7 @@ instance Exception ConfigDockerException where
           (_, Just aresolver) ->
             T.unpack $ utf8BuilderToText $ display aresolver
           (Just project, Nothing) ->
-            T.unpack $ utf8BuilderToText $ display $ projectResolver project
+            T.unpack $ utf8BuilderToText $ display project.projectResolver
       , "\nUse an LTS resolver, or set the '"
       , T.unpack dockerImageArgName
       , "' explicitly, in your configuration file."]
@@ -56,7 +56,7 @@ addDefaultTag base mproject maresolver = do
     Just (ARResolver (RSLSynonym lts@(LTS _ _))) -> pure lts
     Just _aresolver -> exc
     Nothing ->
-      case projectResolver <$> mproject of
+      case (.projectResolver) <$> mproject of
         Just (RSLSynonym lts@(LTS _ _)) -> pure lts
         _ -> exc
   pure $ base ++ ":" ++ show lts
@@ -103,7 +103,8 @@ dockerOptsFromMonoid mproject maresolver dockerMonoid = do
       dockerEnv = dockerMonoid.dockerMonoidEnv
       dockerSetUser = getFirst dockerMonoid.dockerMonoidSetUser
       dockerRequireDockerVersion =
-        simplifyVersionRange (getIntersectingVersionRange dockerMonoid.dockerMonoidRequireDockerVersion)
+        simplifyVersionRange
+          dockerMonoid.dockerMonoidRequireDockerVersion.getIntersectingVersionRange
       dockerStackExe = getFirst dockerMonoid.dockerMonoidStackExe
   pure $ DockerOpts
     { dockerEnable

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE OverloadedLists     #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
 -- | Make changes to project or global configuration.
@@ -89,7 +90,7 @@ cfgCmdSet cmd = do
   configFilePath <-
     case configCmdSetScope cmd of
       CommandScopeProject -> do
-        mstackYamlOption <- view $ globalOptsL.to globalStackYaml
+        mstackYamlOption <- view $ globalOptsL . to (.globalStackYaml)
         mstackYaml <- getProjectConfig mstackYamlOption
         case mstackYaml of
           PCProject stackYaml -> pure stackYaml
@@ -97,7 +98,7 @@ cfgCmdSet cmd = do
             fmap (</> stackDotYaml) (getImplicitGlobalProjectDir conf)
           PCNoProject _extraDeps -> throwIO NoProjectConfigAvailable
           -- maybe modify the ~/.stack/config.yaml file instead?
-      CommandScopeGlobal -> pure (configUserConfigPath conf)
+      CommandScopeGlobal -> pure conf.configUserConfigPath
   rawConfig <- liftIO (readFileUtf8 (toFilePath configFilePath))
   config <- either throwM pure (Yaml.decodeEither' $ encodeUtf8 rawConfig)
   newValue <- cfgCmdSetValue (parent configFilePath) cmd
@@ -347,7 +348,7 @@ data EnvVarAction = EVASet !Text | EVAUnset
 cfgCmdEnv :: EnvSettings -> RIO EnvConfig ()
 cfgCmdEnv es = do
   origEnv <- liftIO $ Map.fromList . map (first fromString) <$> getEnvironment
-  mkPC <- view $ configL.to configProcessContextSettings
+  mkPC <- view $ configL . to (.configProcessContextSettings)
   pc <- liftIO $ mkPC es
   let newEnv = pc ^. envVarsL
       actions = Map.merge

--- a/src/Stack/Dot.hs
+++ b/src/Stack/Dot.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Functions related to Stack's @dot@ command.
 module Stack.Dot
@@ -41,7 +42,7 @@ printGraph dotOpts locals graph = do
   liftIO $ Text.putStrLn "}"
  where
   filteredLocals =
-    Set.filter (\local' -> local' `Set.notMember` dotPrune dotOpts) locals
+    Set.filter (\local' -> local' `Set.notMember` dotOpts.dotPrune) locals
 
 -- | Print the local nodes with a different style depending on options
 printLocalNodes ::
@@ -53,7 +54,7 @@ printLocalNodes dotOpts locals =
   liftIO $ Text.putStrLn (Text.intercalate "\n" lpNodes)
  where
   applyStyle :: Text -> Text
-  applyStyle n = if dotIncludeExternal dotOpts
+  applyStyle n = if dotOpts.dotIncludeExternal
                    then n <> " [style=dashed];"
                    else n <> " [style=solid];"
   lpNodes :: [Text]

--- a/src/Stack/Exec.hs
+++ b/src/Stack/Exec.hs
@@ -107,7 +107,7 @@ execCmd opts =
     unless (null targets) $ build Nothing
 
     config <- view configL
-    menv <- liftIO $ configProcessContextSettings config eo.eoEnvSettings
+    menv <- liftIO $ config.configProcessContextSettings eo.eoEnvSettings
     withProcessContext menv $ do
       -- Add RTS options to arguments
       let argsWithRts args = if null eo.eoRtsOptions
@@ -144,7 +144,7 @@ execCmd opts =
     map ("-package-id=" ++) <$> mapM getPkgId pkgs
 
   getRunCmd args = do
-    packages <- view $ buildConfigL . to (smwProject . bcSMWanted)
+    packages <- view $ buildConfigL . to (.bcSMWanted.smwProject)
     pkgComponents <- for (Map.elems packages) ppComponents
     let executables = concatMap (filter isCExe . Set.toList) pkgComponents
     let (exe, args') = case args of
@@ -162,12 +162,12 @@ execCmd opts =
 
   getGhcCmd pkgs args = do
     pkgopts <- getPkgOpts pkgs
-    compiler <- view $ compilerPathsL . to cpCompiler
+    compiler <- view $ compilerPathsL . to (.cpCompiler)
     pure (toFilePath compiler, pkgopts ++ args)
 
   getRunGhcCmd pkgs args = do
     pkgopts <- getPkgOpts pkgs
-    interpret <- view $ compilerPathsL . to cpInterpreter
+    interpret <- view $ compilerPathsL . to (.cpInterpreter)
     pure (toFilePath interpret, pkgopts ++ args)
 
   runWithPath :: Maybe FilePath -> RIO EnvConfig () -> RIO EnvConfig ()

--- a/src/Stack/GhcPkg.hs
+++ b/src/Stack/GhcPkg.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Functions for the GHC package database.
 
@@ -168,7 +169,7 @@ unregisterGhcPkgIds ::
   -> NonEmpty (Either PackageIdentifier GhcPkgId)
   -> RIO env ()
 unregisterGhcPkgIds isWarn pkgexe pkgDb epgids = do
-  globalDb <- view $ compilerPathsL.to cpGlobalDB
+  globalDb <- view $ compilerPathsL . to (.cpGlobalDB)
   eres <- try $ do
     ghcPkgUnregisterForce globalDb pkgDb hasIpid pkgarg_strs
     -- ghcPkgUnregisterForce does not perform an effective

--- a/src/Stack/Ghci/Script.hs
+++ b/src/Stack/Ghci/Script.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 module Stack.Ghci.Script
   ( GhciScript
@@ -44,7 +45,7 @@ scriptToLazyByteString = toLazyByteString . scriptToBuilder
 scriptToBuilder :: GhciScript -> Builder
 scriptToBuilder backwardScript = mconcat $ fmap commandToBuilder script
  where
-  script = reverse $ unGhciScript backwardScript
+  script = reverse backwardScript.unGhciScript
 
 scriptToFile :: Path Abs File -> GhciScript -> IO ()
 scriptToFile path script =

--- a/src/Stack/IDE.hs
+++ b/src/Stack/IDE.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
 -- | Types and functions related to Stack's @ide@ command.
@@ -72,12 +73,12 @@ listPackages ::
   -> ListPackagesCmd
   -> RIO env ()
 listPackages stream flag = do
-  packages <- view $ buildConfigL.to (smwProject . bcSMWanted)
+  packages <- view $ buildConfigL . to (.bcSMWanted.smwProject)
   let strs = case flag of
         ListPackageNames ->
           map packageNameString (Map.keys packages)
         ListPackageCabalFiles ->
-          map (toFilePath . ppCabalFP) (Map.elems packages)
+          map (toFilePath . (.ppCabalFP)) (Map.elems packages)
   mapM_ (outputFunc stream) strs
 
 -- | List the targets in the current project.
@@ -87,7 +88,7 @@ listTargets ::
   -> (NamedComponent -> Bool)
   -> RIO env ()
 listTargets stream isCompType = do
-  packages <- view $ buildConfigL.to (smwProject . bcSMWanted)
+  packages <- view $ buildConfigL . to (.bcSMWanted.smwProject)
   pairs <- concat <$> Map.traverseWithKey toNameAndComponent packages
   outputFunc stream $ T.unpack $ T.intercalate "\n" $
     map renderPkgComponent pairs

--- a/src/Stack/List.hs
+++ b/src/Stack/List.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
 -- | Types and functions related to Stack's @list@ command.
@@ -34,7 +35,7 @@ instance Exception ListPrettyException
 -- | Function underlying the @stack list@ command. List packages.
 listCmd :: [String] -> RIO Runner ()
 listCmd names = withConfig NoReexec $ do
-  mresolver <- view $ globalOptsL.to globalResolver
+  mresolver <- view $ globalOptsL . to (.globalResolver)
   mSnapshot <- forM mresolver $ \resolver -> do
     concrete <- makeConcreteResolver resolver
     loc <- completeSnapshotLocation concrete

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 module Stack.Options.Completion
   ( ghcOptsCompleter
@@ -62,7 +63,7 @@ buildConfigCompleter inner = mkCompleter $ \inputRaw -> do
 
 targetCompleter :: Completer
 targetCompleter = buildConfigCompleter $ \input -> do
-  packages <- view $ buildConfigL.to (smwProject . bcSMWanted)
+  packages <- view $ buildConfigL . to (.bcSMWanted.smwProject)
   comps <- for packages ppComponents
   pure $
     concatMap
@@ -75,7 +76,7 @@ targetCompleter = buildConfigCompleter $ \input -> do
 flagCompleter :: Completer
 flagCompleter = buildConfigCompleter $ \input -> do
   bconfig <- view buildConfigL
-  gpds <- for (smwProject $ bcSMWanted bconfig) ppGPD
+  gpds <- for bconfig.bcSMWanted.smwProject ppGPD
   let wildcardFlags
         = nubOrd
         $ concatMap (\(name, gpd) ->
@@ -90,8 +91,8 @@ flagCompleter = buildConfigCompleter $ \input -> do
         let flname = C.unFlagName $ C.flagName fl
         in  (if flagEnabled name fl then "-" else "") ++ flname
       prjFlags =
-        case configProject (bcConfig bconfig) of
-          PCProject (p, _) -> projectFlags p
+        case bconfig.bcConfig.configProject of
+          PCProject (p, _) -> p.projectFlags
           PCGlobalProject -> mempty
           PCNoProject _ -> mempty
       flagEnabled name fl =
@@ -106,7 +107,7 @@ flagCompleter = buildConfigCompleter $ \input -> do
 
 projectExeCompleter :: Completer
 projectExeCompleter = buildConfigCompleter $ \input -> do
-  packages <- view $ buildConfigL.to (smwProject . bcSMWanted)
+  packages <- view $ buildConfigL . to (.bcSMWanted.smwProject)
   gpds <- Map.traverseWithKey (const ppGPD) packages
   pure
     $ filter (input `isPrefixOf`)

--- a/src/Stack/Options/NixParser.hs
+++ b/src/Stack/Options/NixParser.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Stack.Options.NixParser
   ( nixOptsParser
@@ -65,7 +66,7 @@ nixOptsParser hide0 = overrideActivation <$>
  where
   hide = hideMods hide0
   overrideActivation m =
-    if fromFirst False (nixMonoidPureShell m)
-      then m { nixMonoidEnable = (First . Just . fromFirst True) (nixMonoidEnable m) }
+    if fromFirst False m.nixMonoidPureShell
+      then m { nixMonoidEnable = (First . Just . fromFirst True) m.nixMonoidEnable }
       else m
   textArgsOption = fmap (map T.pack) . argsOption

--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude  #-}
-{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 module Stack.PackageDump
   ( Line
@@ -169,14 +170,14 @@ sinkMatching :: Monad m
              -> ConduitM DumpPackage o m (Map PackageName DumpPackage)
 sinkMatching allowed =
     Map.fromList
-  . map (pkgName . dpPackageIdent &&& id)
+  . map (pkgName . (.dpPackageIdent) &&& id)
   . Map.elems
   . pruneDeps
       id
-      dpGhcPkgId
-      dpDepends
+      (.dpGhcPkgId)
+      (.dpDepends)
       const -- Could consider a better comparison in the future
-  <$> (CL.filter (isAllowed . dpPackageIdent) .| CL.consume)
+  <$> (CL.filter (isAllowed . (.dpPackageIdent)) .| CL.consume)
  where
   isAllowed (PackageIdentifier name version) =
     case Map.lookup name allowed of

--- a/src/Stack/Path.hs
+++ b/src/Stack/Path.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Types and functions related to Stack's @path@ command.
 module Stack.Path
@@ -53,7 +54,7 @@ path :: [Text] -> RIO Runner ()
 -- Distinguish a request for only the Stack root, as such a request does not
 -- require 'withDefaultEnvConfig'.
 path [key] | key == stackRootOptionName' = do
-  clArgs <- view $ globalOptsL.to globalConfigMonoid
+  clArgs <- view $ globalOptsL . to (.globalConfigMonoid)
   liftIO $ do
     (_, stackRoot, _) <- determineStackRootAndOwnership clArgs
     T.putStrLn $ T.pack $ toFilePathNoTrailingSep stackRoot
@@ -87,13 +88,14 @@ runHaddock x action = local modifyConfig $
     withDefaultEnvConfig action
  where
   modifyConfig = set
-    (globalOptsL.globalOptsBuildOptsMonoidL.buildOptsMonoidHaddockL) (Just x)
+    (globalOptsL . globalOptsBuildOptsMonoidL . buildOptsMonoidHaddockL)
+    (Just x)
 
 fillPathInfo :: HasEnvConfig env => RIO env PathInfo
 fillPathInfo = do
   -- We must use a BuildConfig from an EnvConfig to ensure that it contains the
   -- full environment info including GHC paths etc.
-  piBuildConfig <- view $ envConfigL.buildConfigL
+  piBuildConfig <- view $ envConfigL . buildConfigL
   -- This is the modified 'bin-path',
   -- including the local GHC or MSYS if not configured to operate on
   -- global GHC.
@@ -102,7 +104,7 @@ fillPathInfo = do
   piSnapDb <- packageDatabaseDeps
   piLocalDb <- packageDatabaseLocal
   piExtraDbs <- packageDatabaseExtra
-  piGlobalDb <- view $ compilerPathsL.to cpGlobalDB
+  piGlobalDb <- view $ compilerPathsL . to (.cpGlobalDB)
   piSnapRoot <- installationRootDeps
   piLocalRoot <- installationRootLocal
   piToolsDir <- bindirCompilerTools
@@ -142,40 +144,40 @@ data PathInfo = PathInfo
   }
 
 instance HasPlatform PathInfo where
-  platformL = configL.platformL
+  platformL = configL . platformL
   {-# INLINE platformL #-}
-  platformVariantL = configL.platformVariantL
+  platformVariantL = configL . platformVariantL
   {-# INLINE platformVariantL #-}
 
 instance HasLogFunc PathInfo where
-  logFuncL = configL.logFuncL
+  logFuncL = configL . logFuncL
 
 instance HasRunner PathInfo where
-  runnerL = configL.runnerL
+  runnerL = configL . runnerL
 
 instance HasStylesUpdate PathInfo where
-  stylesUpdateL = runnerL.stylesUpdateL
+  stylesUpdateL = runnerL . stylesUpdateL
 
 instance HasTerm PathInfo where
-  useColorL = runnerL.useColorL
-  termWidthL = runnerL.termWidthL
+  useColorL = runnerL . useColorL
+  termWidthL = runnerL . termWidthL
 
 instance HasGHCVariant PathInfo where
-  ghcVariantL = configL.ghcVariantL
+  ghcVariantL = configL . ghcVariantL
   {-# INLINE ghcVariantL #-}
 
 instance HasConfig PathInfo where
-  configL = buildConfigL.lens bcConfig (\x y -> x { bcConfig = y })
+  configL = buildConfigL . lens (.bcConfig) (\x y -> x { bcConfig = y })
   {-# INLINE configL #-}
 
 instance HasPantryConfig PathInfo where
-  pantryConfigL = configL.pantryConfigL
+  pantryConfigL = configL . pantryConfigL
 
 instance HasProcessContext PathInfo where
-  processContextL = configL.processContextL
+  processContextL = configL . processContextL
 
 instance HasBuildConfig PathInfo where
-  buildConfigL = lens piBuildConfig (\x y -> x { piBuildConfig = y })
+  buildConfigL = lens (.piBuildConfig) (\x y -> x { piBuildConfig = y })
                  . buildConfigL
 
 data UseHaddocks a
@@ -194,16 +196,18 @@ paths :: [(String, Text, UseHaddocks (PathInfo -> Text))]
 paths =
   [ ( "Global Stack root directory"
     , stackRootOptionName'
-    , WithoutHaddocks $ view (stackRootL.to toFilePathNoTrailingSep.to T.pack))
+    , WithoutHaddocks $
+        view (stackRootL . to toFilePathNoTrailingSep . to T.pack))
   , ( "Global Stack configuration file"
     , T.pack stackGlobalConfigOptionName
-    , WithoutHaddocks $ view (stackGlobalConfigL.to toFilePath.to T.pack))
+    , WithoutHaddocks $ view (stackGlobalConfigL . to toFilePath . to T.pack))
   , ( "Project root (derived from stack.yaml file)"
     , "project-root"
-    , WithoutHaddocks $ view (projectRootL.to toFilePathNoTrailingSep.to T.pack))
+    , WithoutHaddocks $
+        view (projectRootL . to toFilePathNoTrailingSep . to T.pack))
   , ( "Configuration location (where the stack.yaml file is)"
     , "config-location"
-    , WithoutHaddocks $ view (stackYamlL.to toFilePath.to T.pack))
+    , WithoutHaddocks $ view (stackYamlL . to toFilePath . to T.pack))
   , ( "PATH environment variable"
     , "bin-path"
     , WithoutHaddocks $
@@ -211,73 +215,73 @@ paths =
   , ( "Install location for GHC and other core tools (see 'stack ls tools' command)"
     , "programs"
     , WithoutHaddocks $
-        view (configL.to configLocalPrograms.to toFilePathNoTrailingSep.to T.pack))
+        view (configL . to (.configLocalPrograms) . to toFilePathNoTrailingSep . to T.pack))
   , ( "Compiler binary (e.g. ghc)"
     , "compiler-exe"
-    , WithoutHaddocks $ T.pack . toFilePath . piCompiler )
+    , WithoutHaddocks $ T.pack . toFilePath . (.piCompiler) )
   , ( "Directory containing the compiler binary (e.g. ghc)"
     , "compiler-bin"
-    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . parent . piCompiler )
+    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . parent . (.piCompiler) )
   , ( "Directory containing binaries specific to a particular compiler"
     , "compiler-tools-bin"
-    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . piToolsDir )
+    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . (.piToolsDir) )
   , ( "Directory where Stack installs executables (e.g. ~/.local/bin (Unix-like OSs) or %APPDATA%\\local\\bin (Windows))"
     , "local-bin"
     , WithoutHaddocks $
-        view $ configL.to configLocalBin.to toFilePathNoTrailingSep.to T.pack)
+        view $ configL . to (.configLocalBin) . to toFilePathNoTrailingSep . to T.pack)
   , ( "Extra include directories"
     , "extra-include-dirs"
     , WithoutHaddocks $
-        T.intercalate ", " . map T.pack . configExtraIncludeDirs . view configL )
+        T.intercalate ", " . map T.pack . (.configExtraIncludeDirs) . view configL )
   , ( "Extra library directories"
     , "extra-library-dirs"
     , WithoutHaddocks $
-        T.intercalate ", " . map T.pack . configExtraLibDirs . view configL )
+        T.intercalate ", " . map T.pack . (.configExtraLibDirs) . view configL )
   , ( "Snapshot package database"
     , "snapshot-pkg-db"
-    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . piSnapDb )
+    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . (.piSnapDb) )
   , ( "Local project package database"
     , "local-pkg-db"
-    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . piLocalDb )
+    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . (.piLocalDb) )
   , ( "Global package database"
     , "global-pkg-db"
-    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . piGlobalDb )
+    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . (.piGlobalDb) )
   , ( "GHC_PACKAGE_PATH environment variable"
     , "ghc-package-path"
     , WithoutHaddocks $
         \pi' -> mkGhcPackagePath
                   True
-                  (piLocalDb pi')
-                  (piSnapDb pi')
-                  (piExtraDbs pi')
-                  (piGlobalDb pi')
+                  pi'.piLocalDb
+                  pi'.piSnapDb
+                  pi'.piExtraDbs
+                  pi'.piGlobalDb
     )
   , ( "Snapshot installation root"
     , "snapshot-install-root"
     , WithoutHaddocks $
-        T.pack . toFilePathNoTrailingSep . piSnapRoot )
+        T.pack . toFilePathNoTrailingSep . (.piSnapRoot) )
   , ( "Local project installation root"
     , "local-install-root"
-    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . piLocalRoot )
+    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . (.piLocalRoot) )
   , ( "Snapshot documentation root"
     , "snapshot-doc-root"
     , UseHaddocks $
-        \pi' -> T.pack (toFilePathNoTrailingSep (piSnapRoot pi' </> docDirSuffix))
+        \pi' -> T.pack (toFilePathNoTrailingSep (pi'.piSnapRoot </> docDirSuffix))
     )
   , ( "Local project documentation root"
     , "local-doc-root"
     , UseHaddocks $
-        \pi' -> T.pack (toFilePathNoTrailingSep (piLocalRoot pi' </> docDirSuffix))
+        \pi' -> T.pack (toFilePathNoTrailingSep (pi'.piLocalRoot </> docDirSuffix))
     )
   , ( "Local project documentation root"
     , "local-hoogle-root"
-    , UseHaddocks $ T.pack . toFilePathNoTrailingSep . piHoogleRoot)
+    , UseHaddocks $ T.pack . toFilePathNoTrailingSep . (.piHoogleRoot))
   , ( "Dist work directory, relative to package directory"
     , "dist-dir"
-    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . piDistDir )
+    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . (.piDistDir) )
   , ( "Where HPC reports and tix files are stored"
     , "local-hpc-root"
-    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . piHpcDir )
+    , WithoutHaddocks $ T.pack . toFilePathNoTrailingSep . (.piHpcDir) )
   ]
 
 -- | 'Text' equivalent of 'stackRootOptionName'.

--- a/src/Stack/Prelude.hs
+++ b/src/Stack/Prelude.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude         #-}
-{-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 module Stack.Prelude
   ( withSystemTempDir
@@ -284,10 +285,10 @@ instance Monoid FirstTrue where
 
 -- | Get the 'Bool', defaulting to 'True'
 fromFirstTrue :: FirstTrue -> Bool
-fromFirstTrue = fromMaybe True . getFirstTrue
+fromFirstTrue = fromMaybe True . (.getFirstTrue)
 
 -- | Helper for filling in default values
-defaultFirstTrue :: (a -> FirstTrue) -> Bool
+defaultFirstTrue :: FirstTrue -> Bool
 defaultFirstTrue _ = True
 
 -- | Like @First Bool@, but the default is @False@.
@@ -305,10 +306,10 @@ instance Monoid FirstFalse where
 
 -- | Get the 'Bool', defaulting to 'False'
 fromFirstFalse :: FirstFalse -> Bool
-fromFirstFalse = fromMaybe False . getFirstFalse
+fromFirstFalse = fromMaybe False . (.getFirstFalse)
 
 -- | Helper for filling in default values
-defaultFirstFalse :: (a -> FirstFalse) -> Bool
+defaultFirstFalse :: FirstFalse -> Bool
 defaultFirstFalse _ = False
 
 -- | Write a @Builder@ to a file and atomically rename.

--- a/src/Stack/Query.hs
+++ b/src/Stack/Query.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Types and functions related to Stack's @query@ command.
 module Stack.Query
@@ -107,8 +108,8 @@ queryBuildInfo selectors0 =
 rawBuildInfo :: HasEnvConfig env => RIO env Value
 rawBuildInfo = do
   locals <- projectLocalPackages
-  wantedCompiler <- view $ wantedCompilerVersionL.to (utf8BuilderToText . display)
-  actualCompiler <- view $ actualCompilerVersionL.to compilerVersionText
+  wantedCompiler <- view $ wantedCompilerVersionL . to (utf8BuilderToText . display)
+  actualCompiler <- view $ actualCompilerVersionL . to compilerVersionText
   pure $ object
     [ "locals" .= Object (KeyMap.fromList $ map localToPair locals)
     , "compiler" .= object
@@ -118,10 +119,10 @@ rawBuildInfo = do
     ]
  where
   localToPair lp =
-    (Key.fromText $ T.pack $ packageNameString $ packageName p, value)
+    (Key.fromText $ T.pack $ packageNameString p.packageName, value)
    where
-    p = lpPackage lp
+    p = lp.lpPackage
     value = object
-      [ "version" .= CabalString (packageVersion p)
-      , "path" .= toFilePath (parent $ lpCabalFile lp)
+      [ "version" .= CabalString p.packageVersion
+      , "path" .= toFilePath (parent lp.lpCabalFile)
       ]

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ViewPatterns        #-}
 
 module Stack.Setup.Installed
   ( getCompilerVersion
@@ -135,8 +136,8 @@ getCompilerVersion wc exe =
 extraDirs :: HasConfig env => Tool -> RIO env ExtraDirs
 extraDirs tool = do
   config <- view configL
-  dir <- installDir (configLocalPrograms config) tool
-  case (configPlatform config, toolNameString tool) of
+  dir <- installDir config.configLocalPrograms tool
+  case (config.configPlatform, toolNameString tool) of
     (Platform _ Cabal.Windows, isGHC -> True) -> pure mempty
       { edBins =
           [ dir </> relDirBin

--- a/src/Stack/SetupCmd.hs
+++ b/src/Stack/SetupCmd.hs
@@ -34,7 +34,7 @@ data SetupCmdOpts = SetupCmdOpts
 -- | Function underlying the @stack setup@ command.
 setupCmd :: SetupCmdOpts -> RIO Runner ()
 setupCmd sco = withConfig YesReexec $ do
-  installGHC <- view $ configL . to configInstallGHC
+  installGHC <- view $ configL . to (.configInstallGHC)
   if installGHC
     then
        withBuildConfig $ do
@@ -43,7 +43,7 @@ setupCmd sco = withConfig YesReexec $ do
            Just v -> pure (v, MatchMinor, Nothing)
            Nothing -> (,,)
              <$> view wantedCompilerVersionL
-             <*> view (configL . to configCompilerCheck)
+             <*> view (configL . to (.configCompilerCheck))
              <*> (Just <$> view stackYamlL)
        setup sco wantedCompiler compilerCheck mstack
     else
@@ -64,7 +64,7 @@ setup ::
   -> RIO env ()
 setup sco wantedCompiler compilerCheck mstack = do
   config <- view configL
-  sandboxedGhc <- cpSandboxed . fst <$> ensureCompilerAndMsys SetupOpts
+  sandboxedGhc <- (.cpSandboxed) . fst <$> ensureCompilerAndMsys SetupOpts
     { soptsInstallIfMissing = True
     , soptsUseSystem = config.configSystemGHC && not sco.scoForceReinstall
     , soptsWantedCompiler = wantedCompiler

--- a/src/Stack/Types/Build/ConstructPlan.hs
+++ b/src/Stack/Types/Build/ConstructPlan.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 -- | A module providing types and related helper functions used in module
 -- "Stack.Build.ConstructPlan".
@@ -126,14 +127,14 @@ adrVersion (ADRToInstall task) = pkgVersion $ taskProvides task
 adrVersion (ADRFound _ installed) = installedVersion installed
 
 adrHasLibrary :: AddDepRes -> Bool
-adrHasLibrary (ADRToInstall task) = case taskType task of
-  TTLocalMutable lp -> packageHasLibrary $ lpPackage lp
+adrHasLibrary (ADRToInstall task) = case task.taskType of
+  TTLocalMutable lp -> packageHasLibrary lp.lpPackage
   TTRemotePackage _ p _ -> packageHasLibrary p
  where
   -- make sure we consider sub-libraries as libraries too
   packageHasLibrary :: Package -> Bool
   packageHasLibrary p =
-    hasBuildableMainLibrary p || not (null (packageSubLibraries p))
+    hasBuildableMainLibrary p || not (null p.packageSubLibraries)
 adrHasLibrary (ADRFound _ Library{}) = True
 adrHasLibrary (ADRFound _ Executable{}) = False
 
@@ -165,51 +166,51 @@ data Ctx = Ctx
   }
 
 instance HasPlatform Ctx where
-  platformL = configL.platformL
+  platformL = configL . platformL
   {-# INLINE platformL #-}
-  platformVariantL = configL.platformVariantL
+  platformVariantL = configL . platformVariantL
   {-# INLINE platformVariantL #-}
 
 instance HasGHCVariant Ctx where
-  ghcVariantL = configL.ghcVariantL
+  ghcVariantL = configL . ghcVariantL
   {-# INLINE ghcVariantL #-}
 
 instance HasLogFunc Ctx where
-  logFuncL = configL.logFuncL
+  logFuncL = configL . logFuncL
 
 instance HasRunner Ctx where
-  runnerL = configL.runnerL
+  runnerL = configL . runnerL
 
 instance HasStylesUpdate Ctx where
-  stylesUpdateL = runnerL.stylesUpdateL
+  stylesUpdateL = runnerL . stylesUpdateL
 
 instance HasTerm Ctx where
-  useColorL = runnerL.useColorL
-  termWidthL = runnerL.termWidthL
+  useColorL = runnerL . useColorL
+  termWidthL = runnerL . termWidthL
 
 instance HasConfig Ctx where
-  configL = buildConfigL.lens bcConfig (\x y -> x { bcConfig = y })
+  configL = buildConfigL . lens (.bcConfig) (\x y -> x { bcConfig = y })
   {-# INLINE configL #-}
 
 instance HasPantryConfig Ctx where
-  pantryConfigL = configL.pantryConfigL
+  pantryConfigL = configL . pantryConfigL
 
 instance HasProcessContext Ctx where
-  processContextL = configL.processContextL
+  processContextL = configL . processContextL
 
 instance HasBuildConfig Ctx where
-  buildConfigL = envConfigL.lens
-    envConfigBuildConfig
+  buildConfigL = envConfigL . lens
+    (.envConfigBuildConfig)
     (\x y -> x { envConfigBuildConfig = y })
 
 instance HasSourceMap Ctx where
-  sourceMapL = envConfigL.sourceMapL
+  sourceMapL = envConfigL . sourceMapL
 
 instance HasCompiler Ctx where
-  compilerPathsL = envConfigL.compilerPathsL
+  compilerPathsL = envConfigL . compilerPathsL
 
 instance HasEnvConfig Ctx where
-  envConfigL = lens ctxEnvConfig (\x y -> x { ctxEnvConfig = y })
+  envConfigL = lens (.ctxEnvConfig) (\x y -> x { ctxEnvConfig = y })
 
 -- | State to be maintained during the calculation of local packages
 -- to unregister.

--- a/src/Stack/Types/BuildConfig.hs
+++ b/src/Stack/Types/BuildConfig.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE NoImplicitPrelude     #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 module Stack.Types.BuildConfig
   ( BuildConfig (..)
@@ -45,36 +46,36 @@ data BuildConfig = BuildConfig
   }
 
 instance HasPlatform BuildConfig where
-  platformL = configL.platformL
+  platformL = configL . platformL
   {-# INLINE platformL #-}
-  platformVariantL = configL.platformVariantL
+  platformVariantL = configL . platformVariantL
   {-# INLINE platformVariantL #-}
 
 instance HasGHCVariant BuildConfig where
-  ghcVariantL = configL.ghcVariantL
+  ghcVariantL = configL . ghcVariantL
   {-# INLINE ghcVariantL #-}
 
 instance HasProcessContext BuildConfig where
-  processContextL = configL.processContextL
+  processContextL = configL . processContextL
 
 instance HasPantryConfig BuildConfig where
-  pantryConfigL = configL.pantryConfigL
+  pantryConfigL = configL . pantryConfigL
 
 instance HasConfig BuildConfig where
-  configL = lens bcConfig (\x y -> x { bcConfig = y })
+  configL = lens (.bcConfig) (\x y -> x { bcConfig = y })
 
 instance HasRunner BuildConfig where
-  runnerL = configL.runnerL
+  runnerL = configL . runnerL
 
 instance HasLogFunc BuildConfig where
-  logFuncL = runnerL.logFuncL
+  logFuncL = runnerL . logFuncL
 
 instance HasStylesUpdate BuildConfig where
-  stylesUpdateL = runnerL.stylesUpdateL
+  stylesUpdateL = runnerL . stylesUpdateL
 
 instance HasTerm BuildConfig where
-  useColorL = runnerL.useColorL
-  termWidthL = runnerL.termWidthL
+  useColorL = runnerL . useColorL
+  termWidthL = runnerL . termWidthL
 
 class HasConfig env => HasBuildConfig env where
   buildConfigL :: Lens' env BuildConfig
@@ -84,11 +85,11 @@ instance HasBuildConfig BuildConfig where
   {-# INLINE buildConfigL #-}
 
 stackYamlL :: HasBuildConfig env => Lens' env (Path Abs File)
-stackYamlL = buildConfigL.lens bcStackYaml (\x y -> x { bcStackYaml = y })
+stackYamlL = buildConfigL . lens (.bcStackYaml) (\x y -> x { bcStackYaml = y })
 
 -- | Directory containing the project's stack.yaml file
 projectRootL :: HasBuildConfig env => Getting r env (Path Abs Dir)
-projectRootL = stackYamlL.to parent
+projectRootL = stackYamlL . to parent
 
 -- | Per-project work dir
 getProjectWorkDir :: (HasBuildConfig env, MonadReader env m) => m (Path Abs Dir)
@@ -100,4 +101,4 @@ getProjectWorkDir = do
 -- | The compiler specified by the @SnapshotDef@. This may be different from the
 -- actual compiler used!
 wantedCompilerVersionL :: HasBuildConfig s => Getting r s WantedCompiler
-wantedCompilerVersionL = buildConfigL.to (smwCompiler . bcSMWanted)
+wantedCompilerVersionL = buildConfigL . to (.bcSMWanted.smwCompiler)

--- a/src/Stack/Types/BuildOpts.hs
+++ b/src/Stack/Types/BuildOpts.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Configuration options for building.
 module Stack.Types.BuildOpts
@@ -112,36 +113,42 @@ data BuildOpts = BuildOpts
 
 defaultBuildOpts :: BuildOpts
 defaultBuildOpts = BuildOpts
-  { boptsLibProfile = defaultFirstFalse buildMonoidLibProfile
-  , boptsExeProfile = defaultFirstFalse buildMonoidExeProfile
-  , boptsLibStrip = defaultFirstTrue buildMonoidLibStrip
-  , boptsExeStrip = defaultFirstTrue buildMonoidExeStrip
+  { boptsLibProfile = defaultFirstFalse buildMonoid.buildMonoidLibProfile
+  , boptsExeProfile = defaultFirstFalse buildMonoid.buildMonoidExeProfile
+  , boptsLibStrip = defaultFirstTrue buildMonoid.buildMonoidLibStrip
+  , boptsExeStrip = defaultFirstTrue buildMonoid.buildMonoidExeStrip
   , boptsHaddock = False
   , boptsHaddockOpts = defaultHaddockOpts
-  , boptsOpenHaddocks = defaultFirstFalse buildMonoidOpenHaddocks
+  , boptsOpenHaddocks = defaultFirstFalse buildMonoid.buildMonoidOpenHaddocks
   , boptsHaddockDeps = Nothing
-  , boptsHaddockInternal = defaultFirstFalse buildMonoidHaddockInternal
+  , boptsHaddockInternal =
+      defaultFirstFalse buildMonoid.buildMonoidHaddockInternal
   , boptsHaddockHyperlinkSource =
-      defaultFirstTrue buildMonoidHaddockHyperlinkSource
-  , boptsHaddockForHackage = defaultFirstFalse buildMonoidHaddockForHackage
-  , boptsInstallExes = defaultFirstFalse buildMonoidInstallExes
-  , boptsInstallCompilerTool = defaultFirstFalse buildMonoidInstallCompilerTool
-  , boptsPreFetch = defaultFirstFalse buildMonoidPreFetch
+      defaultFirstTrue buildMonoid.buildMonoidHaddockHyperlinkSource
+  , boptsHaddockForHackage =
+      defaultFirstFalse buildMonoid.buildMonoidHaddockForHackage
+  , boptsInstallExes = defaultFirstFalse buildMonoid.buildMonoidInstallExes
+  , boptsInstallCompilerTool =
+      defaultFirstFalse buildMonoid.buildMonoidInstallCompilerTool
+  , boptsPreFetch = defaultFirstFalse buildMonoid.buildMonoidPreFetch
   , boptsKeepGoing = Nothing
-  , boptsKeepTmpFiles = defaultFirstFalse buildMonoidKeepTmpFiles
-  , boptsForceDirty = defaultFirstFalse buildMonoidForceDirty
-  , boptsTests = defaultFirstFalse buildMonoidTests
+  , boptsKeepTmpFiles = defaultFirstFalse buildMonoid.buildMonoidKeepTmpFiles
+  , boptsForceDirty = defaultFirstFalse buildMonoid.buildMonoidForceDirty
+  , boptsTests = defaultFirstFalse buildMonoid.buildMonoidTests
   , boptsTestOpts = defaultTestOpts
-  , boptsBenchmarks = defaultFirstFalse buildMonoidBenchmarks
+  , boptsBenchmarks = defaultFirstFalse buildMonoid.buildMonoidBenchmarks
   , boptsBenchmarkOpts = defaultBenchmarkOpts
-  , boptsReconfigure = defaultFirstFalse buildMonoidReconfigure
+  , boptsReconfigure = defaultFirstFalse buildMonoid.buildMonoidReconfigure
   , boptsCabalVerbose = CabalVerbosity normal
-  , boptsSplitObjs = defaultFirstFalse buildMonoidSplitObjs
+  , boptsSplitObjs = defaultFirstFalse buildMonoid.buildMonoidSplitObjs
   , boptsSkipComponents = []
-  , boptsInterleavedOutput = defaultFirstTrue buildMonoidInterleavedOutput
+  , boptsInterleavedOutput =
+      defaultFirstTrue buildMonoid.buildMonoidInterleavedOutput
   , boptsProgressBar = CappedBar
   , boptsDdumpDir = Nothing
   }
+ where
+  buildMonoid = undefined :: BuildOptsMonoid
 
 defaultBuildOptsCLI ::BuildOptsCLI
 defaultBuildOptsCLI = BuildOptsCLI
@@ -173,7 +180,7 @@ boptsCLIFlagsByName =
   Map.fromList .
   mapMaybe go .
   Map.toList .
-  boptsCLIFlags
+  (.boptsCLIFlags)
  where
   go (ACFAllProjectPackages, _) = Nothing
   go (ACFByName name, flags) = Just (name, flags)
@@ -198,7 +205,7 @@ data BuildOptsCLI = BuildOptsCLI
 -- | Generate a list of --PROG-option="<argument>" arguments for all PROGs.
 boptsCLIAllProgOptions :: BuildOptsCLI -> [Text]
 boptsCLIAllProgOptions boptsCLI =
-  concatMap progOptionArgs (boptsCLIProgsOptions boptsCLI)
+  concatMap progOptionArgs boptsCLI.boptsCLIProgsOptions
  where
   -- Generate a list of --PROG-option="<argument>" arguments for a PROG.
   progOptionArgs :: (Text, [Text]) -> [Text]
@@ -462,13 +469,15 @@ data TestOpts = TestOpts
 
 defaultTestOpts :: TestOpts
 defaultTestOpts = TestOpts
-  { toRerunTests = defaultFirstTrue toMonoidRerunTests
+  { toRerunTests = defaultFirstTrue toMonoid.toMonoidRerunTests
   , toAdditionalArgs = []
-  , toCoverage = defaultFirstFalse toMonoidCoverage
-  , toDisableRun = defaultFirstFalse toMonoidDisableRun
+  , toCoverage = defaultFirstFalse toMonoid.toMonoidCoverage
+  , toDisableRun = defaultFirstFalse toMonoid.toMonoidDisableRun
   , toMaximumTimeSeconds = Nothing
-  , toAllowStdin = defaultFirstTrue toMonoidAllowStdin
+  , toAllowStdin = defaultFirstTrue toMonoid.toMonoidAllowStdin
   }
+ where
+  toMonoid = undefined :: TestOptsMonoid
 
 data TestOptsMonoid = TestOptsMonoid
   { toMonoidRerunTests :: !FirstTrue
@@ -606,7 +615,7 @@ newtype CabalVerbosity
   deriving (Eq, Show)
 
 toFirstCabalVerbosity :: FirstFalse -> First CabalVerbosity
-toFirstCabalVerbosity vf = First $ getFirstFalse vf <&> \p ->
+toFirstCabalVerbosity vf = First $ vf.getFirstFalse <&> \p ->
   if p then verboseLevel else normalLevel
  where
   verboseLevel = CabalVerbosity verbose
@@ -624,32 +633,32 @@ instance Parsec CabalVerbosity where
 
 buildOptsMonoidHaddockL :: Lens' BuildOptsMonoid (Maybe Bool)
 buildOptsMonoidHaddockL =
-  lens (getFirstFalse . buildMonoidHaddock)
+  lens (.buildMonoidHaddock.getFirstFalse)
     (\buildMonoid t -> buildMonoid {buildMonoidHaddock = FirstFalse t})
 
 buildOptsMonoidTestsL :: Lens' BuildOptsMonoid (Maybe Bool)
 buildOptsMonoidTestsL =
-  lens (getFirstFalse . buildMonoidTests)
+  lens (.buildMonoidTests.getFirstFalse)
     (\buildMonoid t -> buildMonoid {buildMonoidTests = FirstFalse t})
 
 buildOptsMonoidBenchmarksL :: Lens' BuildOptsMonoid (Maybe Bool)
 buildOptsMonoidBenchmarksL =
-  lens (getFirstFalse . buildMonoidBenchmarks)
+  lens (.buildMonoidBenchmarks.getFirstFalse)
     (\buildMonoid t -> buildMonoid {buildMonoidBenchmarks = FirstFalse t})
 
 buildOptsMonoidInstallExesL :: Lens' BuildOptsMonoid (Maybe Bool)
 buildOptsMonoidInstallExesL =
-  lens (getFirstFalse . buildMonoidInstallExes)
+  lens (.buildMonoidInstallExes.getFirstFalse)
     (\buildMonoid t -> buildMonoid {buildMonoidInstallExes = FirstFalse t})
 
 buildOptsInstallExesL :: Lens' BuildOpts Bool
 buildOptsInstallExesL =
-  lens boptsInstallExes
+  lens (.boptsInstallExes)
     (\bopts t -> bopts {boptsInstallExes = t})
 
 buildOptsHaddockL :: Lens' BuildOpts Bool
 buildOptsHaddockL =
-  lens boptsHaddock
+  lens (.boptsHaddock)
     (\bopts t -> bopts {boptsHaddock = t})
 
 -- Type representing formats of Stack's progress bar when building.

--- a/src/Stack/Types/CompilerPaths.hs
+++ b/src/Stack/Types/CompilerPaths.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Stack.Types.CompilerPaths
   ( CompilerPaths (..)
@@ -61,20 +62,20 @@ newtype GhcPkgExe
   deriving Show
 
 cabalVersionL :: HasCompiler env => SimpleGetter env Version
-cabalVersionL = compilerPathsL.to cpCabalVersion
+cabalVersionL = compilerPathsL . to (.cpCabalVersion)
 
 compilerVersionL :: HasCompiler env => SimpleGetter env ActualCompiler
-compilerVersionL = compilerPathsL.to cpCompilerVersion
+compilerVersionL = compilerPathsL . to (.cpCompilerVersion)
 
 cpWhich :: (MonadReader env m, HasCompiler env) => m WhichCompiler
-cpWhich = view $ compilerPathsL.to (whichCompiler.cpCompilerVersion)
+cpWhich = view $ compilerPathsL . to (whichCompiler . (.cpCompilerVersion))
 
 -- | Get the path for the given compiler ignoring any local binaries.
 --
 -- https://github.com/commercialhaskell/stack/issues/1052
 getCompilerPath :: HasCompiler env => RIO env (Path Abs File)
-getCompilerPath = view $ compilerPathsL.to cpCompiler
+getCompilerPath = view $ compilerPathsL . to (.cpCompiler)
 
 -- | Get the 'GhcPkgExe' from a 'HasCompiler' environment
 getGhcPkgExe :: HasCompiler env => RIO env GhcPkgExe
-getGhcPkgExe = view $ compilerPathsL.to cpPkg
+getGhcPkgExe = view $ compilerPathsL . to (.cpPkg)

--- a/src/Stack/Types/Component.hs
+++ b/src/Stack/Types/Component.hs
@@ -168,19 +168,19 @@ instance HasField "qualifiedName" StackLibrary NamedComponent where
     | rawName == mempty = CLib
     | otherwise = CSubLib rawName
     where
-      rawName = unqualCompToText v.name
+      rawName = v.name.unqualCompToText
 
 instance HasField "qualifiedName" StackForeignLibrary NamedComponent where
-  getField = CFlib . unqualCompToText . (.name)
+  getField = CFlib . (.name.unqualCompToText)
 
 instance HasField "qualifiedName" StackExecutable NamedComponent where
-  getField = CExe . unqualCompToText . (.name)
+  getField = CExe . (.name.unqualCompToText)
 
 instance HasField "qualifiedName" StackTestSuite NamedComponent where
-  getField = CTest . unqualCompToText . (.name)
+  getField = CTest . (.name.unqualCompToText)
 
 instance HasField "qualifiedName" StackBenchmark NamedComponent where
-  getField = CTest . unqualCompToText . (.name)
+  getField = CTest . (.name.unqualCompToText)
 
 -- | Type synonym for a 'HasField' constraint which represent a virtual field,
 -- computed from the type, the NamedComponent constructor and the name.

--- a/src/Stack/Types/ConfigMonoid.hs
+++ b/src/Stack/Types/ConfigMonoid.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 module Stack.Types.ConfigMonoid
   ( ConfigMonoid (..)
@@ -241,7 +242,7 @@ parseConfigMonoidObject rootDir obj = do
     FirstFalse <$> obj ..:? configMonoidSkipGHCCheckName
   configMonoidSkipMsys <- FirstFalse <$> obj ..:? configMonoidSkipMsysName
   configMonoidRequireStackVersion <-
-    IntersectingVersionRange . unVersionRangeJSON <$>
+    IntersectingVersionRange . (.unVersionRangeJSON) <$>
       ( obj ..:? configMonoidRequireStackVersionName
           ..!= VersionRangeJSON anyVersion
       )
@@ -275,8 +276,8 @@ parseConfigMonoidObject rootDir obj = do
   configMonoidCompilerRepository <-
     First <$> (obj ..:? configMonoidCompilerRepositoryName)
 
-  options <-
-    Map.map unGhcOptions <$> obj ..:? configMonoidGhcOptionsName ..!= mempty
+  options <- Map.map (.unGhcOptions) <$>
+    obj ..:? configMonoidGhcOptionsName ..!= (mempty :: Map GhcOptionKey GhcOptions)
 
   optionsEverything <-
     case (Map.lookup GOKOldEverything options, Map.lookup GOKEverything options) of

--- a/src/Stack/Types/Curator.hs
+++ b/src/Stack/Types/Curator.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Module exporting the 'Curator' type, used to represent Stack's
 -- project-specific @curator@ option, which supports the needs of the
@@ -35,14 +36,14 @@ data Curator = Curator
 
 instance ToJSON Curator where
   toJSON c = object
-    [ "skip-test" .= Set.map CabalString (curatorSkipTest c)
-    , "expect-test-failure" .= Set.map CabalString (curatorExpectTestFailure c)
-    , "skip-bench" .= Set.map CabalString (curatorSkipBenchmark c)
+    [ "skip-test" .= Set.map CabalString c.curatorSkipTest
+    , "expect-test-failure" .= Set.map CabalString c.curatorExpectTestFailure
+    , "skip-bench" .= Set.map CabalString c.curatorSkipBenchmark
     , "expect-benchmark-failure" .=
-        Set.map CabalString (curatorExpectTestFailure c)
-    , "skip-haddock" .= Set.map CabalString (curatorSkipHaddock c)
+        Set.map CabalString c.curatorExpectTestFailure
+    , "skip-haddock" .= Set.map CabalString c.curatorSkipHaddock
     , "expect-haddock-failure" .=
-        Set.map CabalString (curatorExpectHaddockFailure c)
+        Set.map CabalString c.curatorExpectHaddockFailure
     ]
 
 instance FromJSON (WithJSONWarnings Curator) where

--- a/src/Stack/Types/Dependency.hs
+++ b/src/Stack/Types/Dependency.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Stack.Types.Dependency
   ( DepValue (..)
@@ -43,8 +44,8 @@ data DepLibrary = DepLibrary
   deriving (Eq, Show)
 
 getDepSublib :: DepValue -> Maybe (Set StackUnqualCompName)
-getDepSublib val = case dvType val of
-  AsLibrary libVal -> Just $ dlSublib libVal
+getDepSublib val = case val.dvType of
+  AsLibrary libVal -> Just libVal.dlSublib
   _ -> Nothing
 
 defaultDepLibrary :: DepLibrary

--- a/src/Stack/Types/DependencyTree.hs
+++ b/src/Stack/Types/DependencyTree.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 module Stack.Types.DependencyTree
   ( DependencyTree (..)
@@ -47,7 +48,7 @@ dependencyToJSON pkg (deps, payload) =
                             , "dependencies" .= Set.map packageNameString deps
                             ]
       loc = catMaybes
-              [("location" .=) . pkgLocToJSON <$> payloadLocation payload]
+              [("location" .=) . pkgLocToJSON <$> payload.payloadLocation]
   in  object $ fieldsAlwaysPresent ++ loc
 
 pkgLocToJSON :: PackageLocation -> Value
@@ -82,8 +83,8 @@ pkgLocToJSON (PLImmutable (PLIRepo repo _)) = object
 licenseText :: DotPayload -> Text
 licenseText payload =
   maybe "<unknown>" (Text.pack . display . either licenseFromSPDX id)
-                    (payloadLicense payload)
+                    payload.payloadLicense
 
 versionText :: DotPayload -> Text
 versionText payload =
-  maybe "<unknown>" (Text.pack . display) (payloadVersion payload)
+  maybe "<unknown>" (Text.pack . display) payload.payloadVersion

--- a/src/Stack/Types/Docker.hs
+++ b/src/Stack/Types/Docker.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude  #-}
-{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Docker types.
 
@@ -351,7 +352,7 @@ instance FromJSON (WithJSONWarnings DockerOptsMonoid) where
     dockerMonoidStackExe <- First <$> o ..:? dockerStackExeArgName
     dockerMonoidSetUser <- First <$> o ..:? dockerSetUserArgName
     dockerMonoidRequireDockerVersion <-
-      IntersectingVersionRange . unVersionRangeJSON <$>
+      IntersectingVersionRange . (.unVersionRangeJSON) <$>
         ( o ..:? dockerRequireDockerVersionArgName
           ..!= VersionRangeJSON anyVersion
         )

--- a/src/Stack/Types/DumpPackage.hs
+++ b/src/Stack/Types/DumpPackage.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Stack.Types.DumpPackage
   ( DumpPackage (..)
@@ -49,7 +50,7 @@ data SublibDump = SublibDump
   deriving (Eq, Read, Show)
 
 dpParentLibIdent :: DumpPackage -> Maybe PackageIdentifier
-dpParentLibIdent dp = case (dpSublib dp, dpPackageIdent dp) of
+dpParentLibIdent dp = case (dp.dpSublib, dp.dpPackageIdent) of
   (Nothing, _) -> Nothing
   (Just sublibDump, PackageIdentifier _ v) ->
     Just $ PackageIdentifier libParentPackageName v

--- a/src/Stack/Types/EnvConfig.hs
+++ b/src/Stack/Types/EnvConfig.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Stack.Types.EnvConfig
   ( EnvConfig (..)
@@ -71,45 +72,45 @@ data EnvConfig = EnvConfig
   }
 
 instance HasConfig EnvConfig where
-  configL = buildConfigL.lens bcConfig (\x y -> x { bcConfig = y })
+  configL = buildConfigL . lens (.bcConfig) (\x y -> x { bcConfig = y })
   {-# INLINE configL #-}
 
 instance HasBuildConfig EnvConfig where
-  buildConfigL = envConfigL.lens
-    envConfigBuildConfig
+  buildConfigL = envConfigL . lens
+    (.envConfigBuildConfig)
     (\x y -> x { envConfigBuildConfig = y })
 
 instance HasPlatform EnvConfig where
-  platformL = configL.platformL
+  platformL = configL . platformL
   {-# INLINE platformL #-}
-  platformVariantL = configL.platformVariantL
+  platformVariantL = configL . platformVariantL
   {-# INLINE platformVariantL #-}
 
 instance HasGHCVariant EnvConfig where
-  ghcVariantL = configL.ghcVariantL
+  ghcVariantL = configL . ghcVariantL
   {-# INLINE ghcVariantL #-}
 
 instance HasProcessContext EnvConfig where
-  processContextL = configL.processContextL
+  processContextL = configL . processContextL
 
 instance HasPantryConfig EnvConfig where
-  pantryConfigL = configL.pantryConfigL
+  pantryConfigL = configL . pantryConfigL
 
 instance HasCompiler EnvConfig where
-  compilerPathsL = to envConfigCompilerPaths
+  compilerPathsL = to (.envConfigCompilerPaths)
 
 instance HasRunner EnvConfig where
-  runnerL = configL.runnerL
+  runnerL = configL . runnerL
 
 instance HasLogFunc EnvConfig where
-  logFuncL = runnerL.logFuncL
+  logFuncL = runnerL . logFuncL
 
 instance HasStylesUpdate EnvConfig where
-  stylesUpdateL = runnerL.stylesUpdateL
+  stylesUpdateL = runnerL . stylesUpdateL
 
 instance HasTerm EnvConfig where
-  useColorL = runnerL.useColorL
-  termWidthL = runnerL.termWidthL
+  useColorL = runnerL . useColorL
+  termWidthL = runnerL . termWidthL
 
 class (HasBuildConfig env, HasSourceMap env, HasCompiler env) => HasEnvConfig env where
   envConfigL :: Lens' env EnvConfig
@@ -122,7 +123,7 @@ class HasSourceMap env where
   sourceMapL :: Lens' env SourceMap
 
 instance HasSourceMap EnvConfig where
-  sourceMapL = lens envConfigSourceMap (\x y -> x { envConfigSourceMap = y })
+  sourceMapL = lens (.envConfigSourceMap) (\x y -> x { envConfigSourceMap = y })
 
 shouldForceGhcColorFlag ::
      (HasEnvConfig env, HasRunner env)
@@ -176,7 +177,7 @@ hoogleDatabasePath = do
 platformSnapAndCompilerRel :: HasEnvConfig env => RIO env (Path Rel Dir)
 platformSnapAndCompilerRel = do
   platform <- platformGhcRelDir
-  smh <- view $ envConfigL.to envConfigSourceMapHash
+  smh <- view $ envConfigL . to (.envConfigSourceMapHash)
   name <- smRelDir smh
   ghc <- compilerVersionDir
   useShaPathOnWindows (platform </> name </> ghc)
@@ -187,7 +188,7 @@ platformGhcRelDir ::
   => m (Path Rel Dir)
 platformGhcRelDir = do
   cp <- view compilerPathsL
-  let cbSuffix = compilerBuildSuffix $ cpBuild cp
+  let cbSuffix = compilerBuildSuffix cp.cpBuild
   verOnly <- platformGhcVerOnlyRelDirStr
   parseRelDir (mconcat [ verOnly, cbSuffix ])
 
@@ -239,7 +240,7 @@ packageDatabaseLocal = do
 packageDatabaseExtra ::
      (HasEnvConfig env, MonadReader env m)
   => m [Path Abs Dir]
-packageDatabaseExtra = view $ buildConfigL.to bcExtraPackageDBs
+packageDatabaseExtra = view $ buildConfigL . to (.bcExtraPackageDBs)
 
 -- | Where HPC reports and tix files get stored.
 hpcReportDir :: HasEnvConfig env => RIO env (Path Abs Dir)
@@ -263,7 +264,7 @@ extraBinDirs = do
 -- than that specified in the 'SnapshotDef' and returned by
 -- 'wantedCompilerVersionL'.
 actualCompilerVersionL :: HasSourceMap env => SimpleGetter env ActualCompiler
-actualCompilerVersionL = sourceMapL.to smCompiler
+actualCompilerVersionL = sourceMapL . to (.smCompiler)
 
 -- | Relative directory for the platform and GHC identifier without GHC bindist
 -- build

--- a/src/Stack/Types/GlobalOpts.hs
+++ b/src/Stack/Types/GlobalOpts.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Stack.Types.GlobalOpts
   ( GlobalOpts (..)
@@ -42,9 +43,9 @@ data GlobalOpts = GlobalOpts
 globalOptsBuildOptsMonoidL :: Lens' GlobalOpts BuildOptsMonoid
 globalOptsBuildOptsMonoidL =
   lens
-    globalConfigMonoid
+    (.globalConfigMonoid)
     (\x y -> x { globalConfigMonoid = y })
   .
   lens
-    configMonoidBuildOpts
+    (.configMonoidBuildOpts)
     (\x y -> x { configMonoidBuildOpts = y })

--- a/src/Stack/Types/Installed.hs
+++ b/src/Stack/Types/Installed.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 -- | This module contains all the types related to the idea of installing a
 -- package in the pkg-db or an executable on the file system.
@@ -124,7 +125,7 @@ simpleInstalledLib pkgIdentifier ghcPkgId =
 
 installedToPackageIdOpt :: InstalledLibraryInfo -> [String]
 installedToPackageIdOpt libInfo =
-  M.foldr' (iterator (++)) (pure $ toStr (iliId libInfo)) (iliSublib libInfo)
+  M.foldr' (iterator (++)) (pure $ toStr libInfo.iliId) libInfo.iliSublib
  where
   toStr ghcPkgId = "-package-id=" <> ghcPkgIdString ghcPkgId
   iterator op ghcPkgId acc = pure (toStr ghcPkgId) `op` acc
@@ -134,7 +135,7 @@ installedPackageIdentifier (Library pid _) = pid
 installedPackageIdentifier (Executable pid) = pid
 
 installedGhcPkgId :: Installed -> Maybe GhcPkgId
-installedGhcPkgId (Library _ libInfo) = Just $ iliId libInfo
+installedGhcPkgId (Library _ libInfo) = Just libInfo.iliId
 installedGhcPkgId (Executable _) = Nothing
 
 -- | Get the installed Version.

--- a/src/Stack/Types/PackageFile.hs
+++ b/src/Stack/Types/PackageFile.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude          #-}
-{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 -- | The facility for retrieving all files from the main Stack
 -- 'Stack.Types.Package' type. This was moved into its own module to allow
@@ -33,40 +34,40 @@ data GetPackageFileContext = GetPackageFileContext
   }
 
 instance HasPlatform GetPackageFileContext where
-  platformL = configL.platformL
+  platformL = configL . platformL
   {-# INLINE platformL #-}
-  platformVariantL = configL.platformVariantL
+  platformVariantL = configL . platformVariantL
   {-# INLINE platformVariantL #-}
 
 instance HasGHCVariant GetPackageFileContext where
-  ghcVariantL = configL.ghcVariantL
+  ghcVariantL = configL . ghcVariantL
   {-# INLINE ghcVariantL #-}
 
 instance HasLogFunc GetPackageFileContext where
-  logFuncL = configL.logFuncL
+  logFuncL = configL . logFuncL
 
 instance HasRunner GetPackageFileContext where
-  runnerL = configL.runnerL
+  runnerL = configL . runnerL
 
 instance HasStylesUpdate GetPackageFileContext where
-  stylesUpdateL = runnerL.stylesUpdateL
+  stylesUpdateL = runnerL . stylesUpdateL
 
 instance HasTerm GetPackageFileContext where
-  useColorL = runnerL.useColorL
-  termWidthL = runnerL.termWidthL
+  useColorL = runnerL . useColorL
+  termWidthL = runnerL . termWidthL
 
 instance HasConfig GetPackageFileContext where
-  configL = buildConfigL.lens bcConfig (\x y -> x { bcConfig = y })
+  configL = buildConfigL . lens (.bcConfig) (\x y -> x { bcConfig = y })
   {-# INLINE configL #-}
 
 instance HasBuildConfig GetPackageFileContext where
-  buildConfigL = lens ctxBuildConfig (\x y -> x { ctxBuildConfig = y })
+  buildConfigL = lens (.ctxBuildConfig) (\x y -> x { ctxBuildConfig = y })
 
 instance HasPantryConfig GetPackageFileContext where
-  pantryConfigL = configL.pantryConfigL
+  pantryConfigL = configL . pantryConfigL
 
 instance HasProcessContext GetPackageFileContext where
-  processContextL = configL.processContextL
+  processContextL = configL . processContextL
 
 -- | A path resolved from the Cabal file, which is either main-is or
 -- an exposed/internal/referenced module.

--- a/src/Stack/Types/Runner.hs
+++ b/src/Stack/Types/Runner.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Stack.Types.Runner
   ( Runner (..)
@@ -32,25 +33,27 @@ data Runner = Runner
   }
 
 instance HasLogFunc Runner where
-  logFuncL = lens runnerLogFunc (\x y -> x { runnerLogFunc = y })
+  logFuncL = lens (.runnerLogFunc) (\x y -> x { runnerLogFunc = y })
 
 instance HasProcessContext Runner where
   processContextL =
-    lens runnerProcessContext (\x y -> x { runnerProcessContext = y })
+    lens (.runnerProcessContext) (\x y -> x { runnerProcessContext = y })
 
 instance HasRunner Runner where
   runnerL = id
 
 instance HasStylesUpdate Runner where
-  stylesUpdateL = globalOptsL.
-                  lens globalStylesUpdate (\x y -> x { globalStylesUpdate = y })
+  stylesUpdateL = globalOptsL . lens
+    (.globalStylesUpdate)
+    (\x y -> x { globalStylesUpdate = y })
 instance HasTerm Runner where
-  useColorL = lens runnerUseColor (\x y -> x { runnerUseColor = y })
-  termWidthL = lens runnerTermWidth (\x y -> x { runnerTermWidth = y })
+  useColorL = lens (.runnerUseColor) (\x y -> x { runnerUseColor = y })
+  termWidthL = lens (.runnerTermWidth) (\x y -> x { runnerTermWidth = y })
 
 instance HasDockerEntrypointMVar Runner where
-  dockerEntrypointMVarL =
-    lens runnerDockerEntrypointMVar (\x y -> x { runnerDockerEntrypointMVar = y })
+  dockerEntrypointMVarL = lens
+    (.runnerDockerEntrypointMVar)
+    (\x y -> x { runnerDockerEntrypointMVar = y })
 
 -- | Class for environment values which have a 'Runner'.
 class (HasProcessContext env, HasLogFunc env) => HasRunner env where
@@ -62,21 +65,25 @@ class HasRunner env => HasDockerEntrypointMVar env where
 
 stackYamlLocL :: HasRunner env => Lens' env StackYamlLoc
 stackYamlLocL =
-  globalOptsL.lens globalStackYaml (\x y -> x { globalStackYaml = y })
+  globalOptsL . lens (.globalStackYaml) (\x y -> x { globalStackYaml = y })
 
 lockFileBehaviorL :: HasRunner env => SimpleGetter env LockFileBehavior
-lockFileBehaviorL = globalOptsL.to globalLockFileBehavior
+lockFileBehaviorL = globalOptsL . to (.globalLockFileBehavior)
 
 globalOptsL :: HasRunner env => Lens' env GlobalOpts
-globalOptsL = runnerL.lens runnerGlobalOpts (\x y -> x { runnerGlobalOpts = y })
+globalOptsL = runnerL . lens
+  (.runnerGlobalOpts)
+  (\x y -> x { runnerGlobalOpts = y })
 
 -- | See 'globalTerminal'
 terminalL :: HasRunner env => Lens' env Bool
-terminalL = globalOptsL.lens globalTerminal (\x y -> x { globalTerminal = y })
+terminalL = globalOptsL . lens
+  (.globalTerminal)
+  (\x y -> x { globalTerminal = y })
 
 -- | See 'globalReExecVersion'
 reExecL :: HasRunner env => SimpleGetter env Bool
-reExecL = globalOptsL.to (isJust . globalReExecVersion)
+reExecL = globalOptsL . to (isJust . (.globalReExecVersion))
 
 rslInLogL :: HasRunner env => SimpleGetter env Bool
-rslInLogL = globalOptsL.to globalRSLInLog
+rslInLogL = globalOptsL . to (.globalRSLInLog)

--- a/src/Stack/Types/SetupInfo.hs
+++ b/src/Stack/Types/SetupInfo.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ViewPatterns        #-}
 
 
 module Stack.Types.SetupInfo
@@ -49,19 +50,20 @@ instance FromJSON (WithJSONWarnings SetupInfo) where
 instance Semigroup SetupInfo where
   l <> r =
     SetupInfo
-    { siSevenzExe = siSevenzExe l <|> siSevenzExe r
-    , siSevenzDll = siSevenzDll l <|> siSevenzDll r
-    , siMsys2 = siMsys2 l <> siMsys2 r
-    , siGHCs = Map.unionWith (<>) (siGHCs l) (siGHCs r)
-    , siStack = Map.unionWith (<>) (siStack l) (siStack r) }
+      { siSevenzExe = l.siSevenzExe <|> r.siSevenzExe
+      , siSevenzDll = l.siSevenzDll <|> r.siSevenzDll
+      , siMsys2 = l.siMsys2 <> r.siMsys2
+      , siGHCs = Map.unionWith (<>) l.siGHCs r.siGHCs
+      , siStack = Map.unionWith (<>) l.siStack r.siStack
+      }
 
 instance Monoid SetupInfo where
   mempty =
     SetupInfo
-    { siSevenzExe = Nothing
-    , siSevenzDll = Nothing
-    , siMsys2 = Map.empty
-    , siGHCs = Map.empty
-    , siStack = Map.empty
-    }
+      { siSevenzExe = Nothing
+      , siSevenzDll = Nothing
+      , siMsys2 = Map.empty
+      , siGHCs = Map.empty
+      , siStack = Map.empty
+      }
   mappend = (<>)

--- a/src/Stack/Types/SourceMap.hs
+++ b/src/Stack/Types/SourceMap.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 -- | A sourcemap maps a package name to how it should be built, including source
 -- code, flags, options, etc. This module contains various stages of source map
@@ -169,11 +170,11 @@ smRelDir :: (MonadThrow m) => SourceMapHash -> m (Path Rel Dir)
 smRelDir (SourceMapHash smh) = parseRelDir $ T.unpack $ SHA256.toHexText smh
 
 ppGPD :: MonadIO m => ProjectPackage -> m GenericPackageDescription
-ppGPD = liftIO . cpGPD . ppCommon
+ppGPD = liftIO . (.ppCommon.cpGPD)
 
 -- | Root directory for the given 'ProjectPackage'
 ppRoot :: ProjectPackage -> Path Abs Dir
-ppRoot = parent . ppCabalFP
+ppRoot = parent . (.ppCabalFP)
 
 -- | All components available in the given 'ProjectPackage'
 ppComponents :: MonadIO m => ProjectPackage -> m (Set NamedComponent)

--- a/src/Stack/Uninstall.hs
+++ b/src/Stack/Uninstall.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Function related to Stack's @uninstall@ command.
 module Stack.Uninstall
@@ -21,8 +22,8 @@ uninstallCmd :: () -> RIO Runner ()
 uninstallCmd () = withConfig NoReexec $ do
   stackRoot <- view stackRootL
   globalConfig <- view stackGlobalConfigL
-  programsDir <- view $ configL.to configLocalProgramsBase
-  localBinDir <- view $ configL.to configLocalBin
+  programsDir <- view $ configL . to (.configLocalProgramsBase)
+  localBinDir <- view $ configL . to (.configLocalBin)
   let toStyleDoc = style Dir . fromString . toFilePath
       stackRoot' = toStyleDoc stackRoot
       globalConfig' = toStyleDoc globalConfig

--- a/src/Stack/Unpack.hs
+++ b/src/Stack/Unpack.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
 -- | Functions related to Stack's @unpack@ command.
@@ -92,7 +93,7 @@ unpackCmd (UnpackOpts targets areCandidates Nothing) =
   unpackCmd (UnpackOpts targets areCandidates (Just $ Rel relDirRoot))
 unpackCmd (UnpackOpts targets areCandidates (Just dstPath)) =
   withConfig NoReexec $ do
-    mresolver <- view $ globalOptsL.to globalResolver
+    mresolver <- view $ globalOptsL . to (.globalResolver)
     mSnapshot <- forM mresolver $ \resolver -> do
       concrete <- makeConcreteResolver resolver
       loc <- completeSnapshotLocation concrete
@@ -127,7 +128,7 @@ unpackPackages mSnapshot dest targets areCandidates = do
               \will be ignored."
       <> line
   locs1 <- forM pirs $ \pir -> do
-    hackageBaseUrl <- view $ configL.to configHackageBaseUrl
+    hackageBaseUrl <- view $ configL . to (.configHackageBaseUrl)
     let rpli = if areCandidates
           then
             let -- Ignoring revisions for package candidates.

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude     #-}
-{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Types and functions related to Stack's @upgrade@ command.
 module Stack.Upgrade
@@ -117,7 +118,7 @@ data UpgradeOpts = UpgradeOpts
 upgradeCmd :: UpgradeOpts -> RIO Runner ()
 upgradeCmd upgradeOpts = do
   go <- view globalOptsL
-  case globalResolver go of
+  case go.globalResolver of
     Just _ -> prettyThrowIO ResolverOptionInvalid
     Nothing -> withGlobalProject $ upgrade maybeGitHash upgradeOpts
 
@@ -197,7 +198,7 @@ binaryUpgrade (BinaryOpts mplatform force' onlyLocalBin mver morg mrepo) =
     when toUpgrade $ do
       config <- view configL
       downloadStackExe
-        platforms0 archiveInfo (configLocalBin config) (not onlyLocalBin) $
+        platforms0 archiveInfo config.configLocalBin (not onlyLocalBin) $
           \tmpFile -> do
             -- Sanity check!
             ec <- rawSystem (toFilePath tmpFile) ["--version"]
@@ -293,5 +294,5 @@ sourceUpgrade builtHash (SourceOpts gitRepo) =
       local (over globalOptsL (modifyGO dir))
         $ withConfig NoReexec
         $ withEnvConfig AllowNoTargets boptsCLI
-        $ local (set (buildOptsL.buildOptsInstallExesL) True)
+        $ local (set (buildOptsL . buildOptsInstallExesL) True)
         $ build Nothing

--- a/src/windows/Stack/Docker/Handlers.hs
+++ b/src/windows/Stack/Docker/Handlers.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 -- | The module of this name differs as between Windows and non-Windows builds.
 -- This is the Windows version.
@@ -26,13 +27,13 @@ handleSignals ::
 handleSignals docker keepStdinOpen containerID = do
   let args' = concat
         [ ["start"]
-        , ["-a" | not (dockerDetach docker)]
+        , ["-a" | not docker.dockerDetach]
         , ["-i" | keepStdinOpen]
         , [containerID]
         ]
   finally
     (try $ proc "docker" args' $ runProcess_ . setDelegateCtlc False)
-    ( unless (dockerPersist docker || dockerDetach docker) $
+    ( unless (docker.dockerPersist || docker.dockerDetach) $
         readProcessNull "docker" ["rm", "-f", containerID]
           `catch` (\(_ :: ExitCodeException) -> pure ())
     )

--- a/src/windows/System/Posix/User.hs
+++ b/src/windows/System/Posix/User.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE NoFieldSelectors    #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+
 -- | The module of this name differs as between Windows and non-Windows builds.
 -- This is the Windows version. Non-Windows builds rely on the unix package,
 -- which exposes a module of the same name.
@@ -47,3 +50,6 @@ data UserEntry = UserEntry
     , homeDirectory :: String
     , userShell     :: String
     } deriving (Eq, Read, Show)
+
+homeDirectory :: UserEntry -> String
+homeDirectory ue = ue.homeDirectory

--- a/tests/unit/Stack/ConfigSpec.hs
+++ b/tests/unit/Stack/ConfigSpec.hs
@@ -190,7 +190,7 @@ spec = beforeAll setup $ do
     it "parses build config options" $ inTempDir $ do
      writeFile (toFilePath stackDotYaml) buildOptsConfig
      loadConfig' $ \config -> liftIO $ do
-      let bopts = configBuild  config
+      let bopts = config.configBuild
       bopts.boptsLibProfile `shouldBe` True
       bopts.boptsExeProfile `shouldBe` True
       bopts.boptsHaddock `shouldBe` True

--- a/tests/unit/Stack/LockSpec.hs
+++ b/tests/unit/Stack/LockSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE QuasiQuotes         #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
 module Stack.LockSpec
@@ -58,7 +59,7 @@ snapshots:
     compiler: ghc-8.6.5
 packages: []
 |]
-        pkgImm <- lckPkgImmutableLocations <$> decodeLocked lockFile
+        pkgImm <- (.lckPkgImmutableLocations) <$> decodeLocked lockFile
         pkgImm `shouldBe` []
     it "parses lock file (empty with LTS resolver)" $ do
         let lockFile :: ByteString
@@ -76,7 +77,7 @@ snapshots:
     compiler: ghc-8.6.5
 packages: []
 |]
-        pkgImm <- lckPkgImmutableLocations <$> decodeLocked lockFile
+        pkgImm <- (.lckPkgImmutableLocations) <$> decodeLocked lockFile
         pkgImm `shouldBe` []
     it "parses lock file (LTS, wai + warp)" $ do
         let lockFile :: ByteString
@@ -120,7 +121,7 @@ packages:
       sha256: f808e075811b002563d24c393ce115be826bb66a317d38da22c513ee42b7443a
     commit: d11d63f1a6a92db8c637a8d33e7953ce6194a3e0
 |]
-        pkgImm <- lckPkgImmutableLocations <$> decodeLocked lockFile
+        pkgImm <- (.lckPkgImmutableLocations) <$> decodeLocked lockFile
         let waiSubdirRepo subdir =
               Repo { repoType = RepoGit
                    , repoUrl = "https://github.com/yesodweb/wai.git"

--- a/tests/unit/Stack/NixSpec.hs
+++ b/tests/unit/Stack/NixSpec.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 module Stack.NixSpec
   ( sampleConfigNixEnabled
@@ -72,42 +73,42 @@ spec = beforeAll setup $ do
   describe "nix disabled in config file" $
     around_ (withStackDotYaml sampleConfigNixDisabled) $ do
       it "sees that the nix shell is not enabled" $ loadConfig' mempty $ \config ->
-        nixEnable (configNix config) `shouldBe` False
+         config.configNix.nixEnable `shouldBe` False
       describe "--nix given on command line" $
         it "sees that the nix shell is enabled" $
           loadConfig' (parseOpts ["--nix"]) $ \config ->
-          nixEnable (configNix config) `shouldBe` trueOnNonWindows
+          config.configNix.nixEnable `shouldBe` trueOnNonWindows
       describe "--nix-pure given on command line" $
         it "sees that the nix shell is enabled" $
           loadConfig' (parseOpts ["--nix-pure"]) $ \config ->
-          nixEnable (configNix config) `shouldBe` trueOnNonWindows
+          config.configNix.nixEnable `shouldBe` trueOnNonWindows
       describe "--no-nix given on command line" $
         it "sees that the nix shell is not enabled" $
           loadConfig' (parseOpts ["--no-nix"]) $ \config ->
-          nixEnable (configNix config) `shouldBe` False
+          config.configNix.nixEnable `shouldBe` False
       describe "--no-nix-pure given on command line" $
         it "sees that the nix shell is not enabled" $
           loadConfig' (parseOpts ["--no-nix-pure"]) $ \config ->
-          nixEnable (configNix config) `shouldBe` False
+          config.configNix.nixEnable `shouldBe` False
   describe "nix enabled in config file" $
     around_ (withStackDotYaml sampleConfigNixEnabled) $ do
       it "sees that the nix shell is enabled" $
         loadConfig' mempty $ \config ->
-        nixEnable (configNix config) `shouldBe` trueOnNonWindows
+        config.configNix.nixEnable `shouldBe` trueOnNonWindows
       describe "--no-nix given on command line" $
         it "sees that the nix shell is not enabled" $
           loadConfig' (parseOpts ["--no-nix"]) $ \config ->
-          nixEnable (configNix config) `shouldBe` False
+          config.configNix.nixEnable `shouldBe` False
       describe "--nix-pure given on command line" $
         it "sees that the nix shell is enabled" $
           loadConfig' (parseOpts ["--nix-pure"]) $ \config ->
-          nixEnable (configNix config) `shouldBe` trueOnNonWindows
+          config.configNix.nixEnable `shouldBe` trueOnNonWindows
       describe "--no-nix-pure given on command line" $
         it "sees that the nix shell is enabled" $
           loadConfig' (parseOpts ["--no-nix-pure"]) $ \config ->
-          nixEnable (configNix config) `shouldBe` trueOnNonWindows
+          config.configNix.nixEnable `shouldBe` trueOnNonWindows
       it "sees that the only package asked for is glpk and asks for the correct GHC derivation" $ loadConfig' mempty $ \config -> do
-        nixPackages (configNix config) `shouldBe` ["glpk"]
+        config.configNix.nixPackages `shouldBe` ["glpk"]
         v <- parseVersionThrowing "9.0.2"
         ghc <- either throwIO pure $ nixCompiler (WCGhc v)
         ghc `shouldBe` "haskell.compiler.ghc902"


### PR DESCRIPTION
Refactor to allow the `Stack` package to build with `--ghc-options -XNoFieldSelectors`. This is intended as a prelude to removing prefixes from the names of fields.

This current step is done by making use of `OverloadedRecordDot`.

Something like `prefixFieldName prefix` becomes `prefix.prefixFieldName`. Something like `f prefixFieldName` becomes `f (.prefixFieldName)` - and 'chains of dots' are simplified.

In a couple of places, the compiler needed help with types:

* `Stack.Types.ConfigMonoid` (`(mempty :: Map GhcOptionKey GhcOptions)`)
* `Stack.Build.Cache` (`let decode :: MonadIO m => m BuildCache`)
* the use of `undefined :: <type>` in `Stack.Types.BuildOpts.defaultBuildOpts` and `defaultTestOpts`

I also did not follow why the `$` was still needed (but it is) in moving from (in `Stack.Build.Execute`):
~~~haskell
(fmap . fmap) (getField @"interface") <$> collectionKeyValueList $ packageTestSuites package
~~~

to

~~~haskell
(fmap . fmap) (getField @"interface") <$> collectionKeyValueList $ package.packageTestSuites
~~~

EDIT: I now follow the need for the `$`. The expression is equivalent to:
~~~haskell
((fmap . fmap) (getField @"interface") <$> collectionKeyValueList) package.packageTestSuites
~~~

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
