### PR TITLE
Fix #6408 Depend on ansi-terminal >= 1.0.2; use hNowSupportsANSI

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -61,7 +61,7 @@ dependencies:
 - Cabal >= 3.8.1.0
 - aeson >= 2.0.3.0
 - aeson-warning-parser >= 0.1.1
-- ansi-terminal >= 1.0
+- ansi-terminal >= 1.0.2
 - array
 - async
 - attoparsec

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -143,7 +143,7 @@ import           Stack.Types.Version
                    ( IntersectingVersionRange (..), VersionCheck (..)
                    , stackVersion, withinRange
                    )
-import           System.Console.ANSI ( hSupportsANSI, setSGRCode )
+import           System.Console.ANSI ( hNowSupportsANSI, setSGRCode )
 import           System.Environment ( getEnvironment, lookupEnv )
 import           System.Info.ShortPathName ( getShortPathName )
 import           System.PosixCompat.Files ( fileOwner, getFileStatus )
@@ -433,7 +433,7 @@ configFromConfigMonoid
         Just True -> pure True
         _ -> getInContainer
     configRunner' <- view runnerL
-    useAnsi <- liftIO $ hSupportsANSI stderr
+    useAnsi <- liftIO $ hNowSupportsANSI stderr
     let stylesUpdate' = (configRunner' ^. stylesUpdateL) <>
           configMonoid.configMonoidStyles
         useColor' = configRunner'.runnerUseColor

--- a/src/Stack/DefaultColorWhen.hs
+++ b/src/Stack/DefaultColorWhen.hs
@@ -6,7 +6,7 @@ module Stack.DefaultColorWhen
 
 import           Stack.Prelude ( stdout )
 import           Stack.Types.ColorWhen ( ColorWhen (..) )
-import           System.Console.ANSI ( hSupportsANSI )
+import           System.Console.ANSI ( hNowSupportsANSI )
 import           System.Environment ( lookupEnv )
 
 -- | The default adopts the standard proposed at http://no-color.org/, that
@@ -15,6 +15,6 @@ import           System.Environment ( lookupEnv )
 defaultColorWhen :: IO ColorWhen
 defaultColorWhen = lookupEnv "NO_COLOR" >>= \case
   Just _ -> pure ColorNever
-  _ -> hSupportsANSI stdout >>= \case
+  _ -> hNowSupportsANSI stdout >>= \case
     False -> pure ColorNever
     _ -> pure ColorAuto

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -54,7 +54,7 @@ import           Stack.Types.Runner
 import           Stack.Types.StackYamlLoc ( StackYamlLoc (..) )
 import           Stack.Types.Version
                    ( minorVersion, stackMinorVersion, stackVersion )
-import           System.Console.ANSI ( hSupportsANSI )
+import           System.Console.ANSI ( hNowSupportsANSI )
 import           System.Terminal ( getTerminalWidth )
 
 -- | Type representing exceptions thrown by functions exported by the
@@ -225,7 +225,7 @@ withRunnerGlobal go inner = do
   useColor <- case colorWhen of
     ColorNever -> pure False
     ColorAlways -> pure True
-    ColorAuto -> hSupportsANSI stderr
+    ColorAuto -> hNowSupportsANSI stderr
   termWidth <- clipWidth <$> maybe (fromMaybe defaultTerminalWidth
                                     <$> getTerminalWidth)
                                    pure go.globalTermWidth

--- a/stack-ghc-9.8.1.yaml
+++ b/stack-ghc-9.8.1.yaml
@@ -5,6 +5,8 @@
 resolver: nightly-2024-01-06
 
 extra-deps:
+# nightly-2023-01-06 specifies ansi-terminal-1.0.
+- ansi-terminal-1.0.2@sha256:1f90bb88e670ce63fbf2c9216d50857f2419582f1c6791e542c3eab97ecfd364,2897
 # nightly-2023-01-06 specifies pantry-0.9.3.1@rev:0.
 - pantry-0.9.3.1@sha256:79e9be1b28a9829cb9630ca97ac5732b0843ee8d60ce26b347ecd57740305c2b,7859
 # nightly-2023-01-06 specifies tar-conduit-0.4.0

--- a/stack-ghc-9.8.1.yaml.lock
+++ b/stack-ghc-9.8.1.yaml.lock
@@ -5,6 +5,13 @@
 
 packages:
 - completed:
+    hackage: ansi-terminal-1.0.2@sha256:1f90bb88e670ce63fbf2c9216d50857f2419582f1c6791e542c3eab97ecfd364,2897
+    pantry-tree:
+      sha256: d4405abe08cf99c47f2af8534346492a5679e17a19529667b3eeddad4c0f0149
+      size: 1184
+  original:
+    hackage: ansi-terminal-1.0.2@sha256:1f90bb88e670ce63fbf2c9216d50857f2419582f1c6791e542c3eab97ecfd364,2897
+- completed:
     hackage: pantry-0.9.3.1@sha256:79e9be1b28a9829cb9630ca97ac5732b0843ee8d60ce26b347ecd57740305c2b,7859
     pantry-tree:
       sha256: 016257a65a69519e076fde13276571dfb5fcebeda3bce63a5bee9a6a87d2cc24

--- a/stack.cabal
+++ b/stack.cabal
@@ -348,7 +348,7 @@ library
       Cabal >=3.8.1.0
     , aeson >=2.0.3.0
     , aeson-warning-parser >=0.1.1
-    , ansi-terminal >=1.0
+    , ansi-terminal >=1.0.2
     , array
     , async
     , attoparsec
@@ -470,7 +470,7 @@ executable stack
       Cabal >=3.8.1.0
     , aeson >=2.0.3.0
     , aeson-warning-parser >=0.1.1
-    , ansi-terminal >=1.0
+    , ansi-terminal >=1.0.2
     , array
     , async
     , attoparsec
@@ -571,7 +571,7 @@ executable stack-integration-test
       Cabal >=3.8.1.0
     , aeson >=2.0.3.0
     , aeson-warning-parser >=0.1.1
-    , ansi-terminal >=1.0
+    , ansi-terminal >=1.0.2
     , array
     , async
     , attoparsec
@@ -688,7 +688,7 @@ test-suite stack-unit-test
     , QuickCheck
     , aeson >=2.0.3.0
     , aeson-warning-parser >=0.1.1
-    , ansi-terminal >=1.0
+    , ansi-terminal >=1.0.2
     , array
     , async
     , attoparsec

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,8 @@ extra-deps:
 # Cabal is pruned because process is a GHC boot package, and has to be specified
 # again.
 - Cabal-3.10.1.0@sha256:6d11adf7847d9734e7b02785ff831b5a0d11536bfbcefd6634b2b08411c63c94,12316
+# lts-22.0 specifies ansi-terminal-1.0
+- ansi-terminal-1.0.2@sha256:1f90bb88e670ce63fbf2c9216d50857f2419582f1c6791e542c3eab97ecfd364,2897
 # lts-22.0 specifies pantry-0.9.3.1@rev:0
 - pantry-0.9.3.1@sha256:79e9be1b28a9829cb9630ca97ac5732b0843ee8d60ce26b347ecd57740305c2b,7859
 # GHC 9.6.3 comes with process-1.6.17.0, which can segfault on macOS.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,6 +12,13 @@ packages:
   original:
     hackage: Cabal-3.10.1.0@sha256:6d11adf7847d9734e7b02785ff831b5a0d11536bfbcefd6634b2b08411c63c94,12316
 - completed:
+    hackage: ansi-terminal-1.0.2@sha256:1f90bb88e670ce63fbf2c9216d50857f2419582f1c6791e542c3eab97ecfd364,2897
+    pantry-tree:
+      sha256: d4405abe08cf99c47f2af8534346492a5679e17a19529667b3eeddad4c0f0149
+      size: 1184
+  original:
+    hackage: ansi-terminal-1.0.2@sha256:1f90bb88e670ce63fbf2c9216d50857f2419582f1c6791e542c3eab97ecfd364,2897
+- completed:
     hackage: pantry-0.9.3.1@sha256:79e9be1b28a9829cb9630ca97ac5732b0843ee8d60ce26b347ecd57740305c2b,7859
     pantry-tree:
       sha256: 016257a65a69519e076fde13276571dfb5fcebeda3bce63a5bee9a6a87d2cc24


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
