### PR TITLE
Remove runner prefix from Runner field names

### DIFF
--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -437,7 +437,7 @@ configFromConfigMonoid
     useAnsi <- liftIO $ hNowSupportsANSI stderr
     let stylesUpdate' = (configRunner' ^. stylesUpdateL) <>
           configMonoid.configMonoidStyles
-        useColor' = configRunner'.runnerUseColor
+        useColor' = configRunner'.useColor
         mUseColor = do
           colorWhen <- getFirst configMonoid.configMonoidColorWhen
           pure $ case colorWhen of
@@ -449,7 +449,7 @@ configFromConfigMonoid
           & processContextL .~ origEnv
           & stylesUpdateL .~ stylesUpdate'
           & useColorL .~ useColor''
-        go = configRunner'.runnerGlobalOpts
+        go = configRunner'.globalOpts
     pic <-
       case getFirst configMonoid.configMonoidPackageIndex of
         Nothing ->

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE NoImplicitPrelude   #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedRecordDot #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedRecordDot   #-}
+{-# LANGUAGE OverloadedStrings     #-}
 
 -- | Utilities for running stack commands.
 --
@@ -235,12 +236,12 @@ withRunnerGlobal go inner = do
   let update = go.stylesUpdate
   withNewLogFunc go useColor update $ \logFunc -> do
     runRIO Runner
-      { runnerGlobalOpts = go
-      , runnerUseColor = useColor
-      , runnerLogFunc = logFunc
-      , runnerTermWidth = termWidth
-      , runnerProcessContext = menv
-      , runnerDockerEntrypointMVar = dockerEntrypointMVar
+      { globalOpts = go
+      , useColor = useColor
+      , logFunc = logFunc
+      , termWidth = termWidth
+      , processContext = menv
+      , dockerEntrypointMVar = dockerEntrypointMVar
       } inner
  where
   clipWidth w


### PR DESCRIPTION
The qualified import of `Stack.Types.GlobalOpts` in `Stack.Types.Runner` was to avoid problems with ambiguous record updates.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
