### PR TITLE
Minor refactoring

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -83,14 +83,14 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-erw24B-1020:3"
+  id = "OBS-STAN-0203-erw24B-1021:3"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\ExecuteEnv.hs
 #
-#  1019 ┃
-#  1020 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
-#  1021 ┃   ^^^^^^^
+#  1020 ┃
+#  1021 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
+#  1022 ┃   ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]


### PR DESCRIPTION
Split the monster of single build into smaller parts because a lot of what's currently happening at the package level will be shared for the component based builds