### PR TITLE
Remove dp/pp prefixes from DepPackage ProjectPackage field names

### DIFF
--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -299,10 +299,10 @@ constructPlan
       pure $ PSFilePath lp
     bopts <- view $ configL . to (.build)
     deps <- for sourceDeps $ \dp ->
-      case dp.dpLocation of
+      case dp.location of
         PLImmutable loc ->
           pure $
-            PSRemote loc (getPLIVersion loc) dp.dpFromSnapshot dp.dpCommon
+            PSRemote loc (getPLIVersion loc) dp.fromSnapshot dp.common
         PLMutable dir -> do
           pp <- mkProjectPackage YesPrintWarnings dir (shouldHaddockDeps bopts)
           lp <- loadLocalPackage' pp

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -40,7 +40,7 @@ toInstallMap :: MonadIO m => SourceMap -> m InstallMap
 toInstallMap sourceMap = do
   projectInstalls <-
     for sourceMap.smProject $ \pp -> do
-      version <- loadVersion pp.ppCommon
+      version <- loadVersion pp.common
       pure (Local, version)
   depInstalls <-
     for sourceMap.smDeps $ \dp ->

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -44,10 +44,10 @@ toInstallMap sourceMap = do
       pure (Local, version)
   depInstalls <-
     for sourceMap.smDeps $ \dp ->
-      case dp.dpLocation of
+      case dp.location of
         PLImmutable pli -> pure (Snap, getPLIVersion pli)
         PLMutable _ -> do
-          version <- loadVersion dp.dpCommon
+          version <- loadVersion dp.common
           pure (Local, version)
   pure $ projectInstalls <> depInstalls
 

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -543,7 +543,7 @@ parseTargets needTargets haddockDeps boptscli smActual = do
   (errs1, concat -> rawTargets) <- fmap partitionEithers $ forM rawInput $
     parseRawTargetDirs workingDir locals
 
-  let depLocs = Map.map (.dpLocation) smActual.smaDeps
+  let depLocs = Map.map (.location) smActual.smaDeps
 
   (errs2, resolveResults) <- fmap partitionEithers $ forM rawTargets $
     resolveRawTarget smActual depLocs

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -386,7 +386,7 @@ checkSnapBuildPlan pkgDirs flags snapCandidate = do
   let compiler = sma.smaCompiler
       globalVersion (GlobalPackageVersion v) = v
       depVersion dep
-        | PLImmutable loc <- dep.dpLocation = Just $ packageLocationVersion loc
+        | PLImmutable loc <- dep.location = Just $ packageLocationVersion loc
         | otherwise = Nothing
       snapPkgs = Map.union
         (Map.mapMaybe depVersion sma.smaDeps)

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -381,7 +381,7 @@ checkSnapBuildPlan ::
 checkSnapBuildPlan pkgDirs flags snapCandidate = do
   platform <- view platformL
   sma <- snapCandidate pkgDirs
-  gpds <- liftIO $ forM (Map.elems sma.smaProject) (.ppCommon.gpd)
+  gpds <- liftIO $ forM (Map.elems sma.smaProject) (.common.gpd)
 
   let compiler = sma.smaCompiler
       globalVersion (GlobalPackageVersion v) = v

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -892,11 +892,11 @@ fillProjectWanted stackYamlFP config project locCache snapCompiler snapPackages 
        RPLMutable p ->
          pure (PLMutable p, Nothing)
     dp <- additionalDepPackage (shouldHaddockDeps bopts) pl
-    pure ((dp.dpCommon.name, dp), mCompleted)
+    pure ((dp.common.name, dp), mCompleted)
 
   checkDuplicateNames $
     map (second (PLMutable . (.ppResolvedDir))) packages0 ++
-    map (second (.dpLocation)) deps0
+    map (second (.location)) deps0
 
   let packages1 = Map.fromList packages0
       snPackages = snapPackages
@@ -914,13 +914,13 @@ fillProjectWanted stackYamlFP config project locCache snapCompiler snapPackages 
       packages2 = mergeApply packages1 pFlags $
         \_ p flags -> p{ ppCommon = p.ppCommon { CommonPackage.flags = flags } }
       deps2 = mergeApply deps1 pFlags $
-        \_ d flags -> d{ dpCommon = d.dpCommon { CommonPackage.flags = flags } }
+        \_ d flags -> d{ common = d.common { CommonPackage.flags = flags } }
 
   checkFlagsUsedThrowing pFlags FSStackYaml packages1 deps1
 
   let pkgGhcOptions = config.ghcOptionsByName
       deps = mergeApply deps2 pkgGhcOptions $
-        \_ d options -> d{ dpCommon = d.dpCommon { ghcOptions = options } }
+        \_ d options -> d{ common = d.common { ghcOptions = options } }
       packages = mergeApply packages2 pkgGhcOptions $
         \_ p options -> p{ ppCommon = p.ppCommon { ghcOptions = options } }
       unusedPkgGhcOptions =

--- a/src/Stack/DependencyGraph.hs
+++ b/src/Stack/DependencyGraph.hs
@@ -256,7 +256,7 @@ createDepLoader sourceMap globalDumpMap globalIdMap loadPackageDeps pkgName =
   projectPackageDeps = loadDeps <$> Map.lookup pkgName sourceMap.smProject
    where
     loadDeps pp = do
-      pkg <- loadCommonPackage pp.ppCommon
+      pkg <- loadCommonPackage pp.common
       pure (setOfPackageDeps pkg, payloadFromLocal pkg Nothing)
 
   dependencyDeps =
@@ -264,7 +264,7 @@ createDepLoader sourceMap globalDumpMap globalIdMap loadPackageDeps pkgName =
    where
     loadDeps DepPackage{ location = PLMutable dir } = do
       pp <- mkProjectPackage YesPrintWarnings dir False
-      pkg <- loadCommonPackage pp.ppCommon
+      pkg <- loadCommonPackage pp.common
       pure (setOfPackageDeps pkg, payloadFromLocal pkg (Just $ PLMutable dir))
 
     loadDeps dp@DepPackage{ location = PLImmutable loc } = do

--- a/src/Stack/DependencyGraph.hs
+++ b/src/Stack/DependencyGraph.hs
@@ -262,13 +262,13 @@ createDepLoader sourceMap globalDumpMap globalIdMap loadPackageDeps pkgName =
   dependencyDeps =
     loadDeps <$> Map.lookup pkgName sourceMap.smDeps
    where
-    loadDeps DepPackage{dpLocation=PLMutable dir} = do
+    loadDeps DepPackage{ location = PLMutable dir } = do
       pp <- mkProjectPackage YesPrintWarnings dir False
       pkg <- loadCommonPackage pp.ppCommon
       pure (setOfPackageDeps pkg, payloadFromLocal pkg (Just $ PLMutable dir))
 
-    loadDeps dp@DepPackage{dpLocation=PLImmutable loc} = do
-      let common = dp.dpCommon
+    loadDeps dp@DepPackage{ location = PLImmutable loc } = do
+      let common = dp.common
       gpd <- liftIO common.gpd
       let PackageIdentifier name version = PD.package $ PD.packageDescription gpd
           flags = common.flags

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -423,7 +423,7 @@ getAllLocalTargets ghciOpts targets0 mainIsTargets localMap = do
   let directlyWanted = flip mapMaybe (M.toList packages) $
         \(name, pp) ->
               case M.lookup name targets of
-                Just simpleTargets -> Just (name, (pp.ppCabalFP, simpleTargets))
+                Just simpleTargets -> Just (name, (pp.cabalFP, simpleTargets))
                 Nothing -> Nothing
   -- Figure out
   let extraLoadDeps =
@@ -846,15 +846,15 @@ loadGhciPkgDesc buildOptsCLI name cabalfp target = do
       -- Currently this source map is being build with
       -- the default targets
       sourceMapGhcOptions = fromMaybe [] $
-        ((.ppCommon.ghcOptions) <$> M.lookup name sm.smProject)
+        ((.common.ghcOptions) <$> M.lookup name sm.smProject)
         <|>
         ((.common.ghcOptions) <$> M.lookup name sm.smDeps)
       sourceMapCabalConfigOpts = fromMaybe [] $
-        ( (.ppCommon.cabalConfigOpts) <$> M.lookup name sm.smProject)
+        ( (.common.cabalConfigOpts) <$> M.lookup name sm.smProject)
         <|>
         ((.common.cabalConfigOpts) <$> M.lookup name sm.smDeps)
       sourceMapFlags =
-        maybe mempty (.ppCommon.flags) $ M.lookup name sm.smProject
+        maybe mempty (.common.flags) $ M.lookup name sm.smProject
       config = PackageConfig
         { enableTests = True
         , enableBenchmarks = True

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -848,11 +848,11 @@ loadGhciPkgDesc buildOptsCLI name cabalfp target = do
       sourceMapGhcOptions = fromMaybe [] $
         ((.ppCommon.ghcOptions) <$> M.lookup name sm.smProject)
         <|>
-        ((.dpCommon.ghcOptions) <$> M.lookup name sm.smDeps)
+        ((.common.ghcOptions) <$> M.lookup name sm.smDeps)
       sourceMapCabalConfigOpts = fromMaybe [] $
         ( (.ppCommon.cabalConfigOpts) <$> M.lookup name sm.smProject)
         <|>
-        ((.dpCommon.cabalConfigOpts) <$> M.lookup name sm.smDeps)
+        ((.common.cabalConfigOpts) <$> M.lookup name sm.smDeps)
       sourceMapFlags =
         maybe mempty (.ppCommon.flags) $ M.lookup name sm.smProject
       config = PackageConfig

--- a/src/Stack/Hoogle.hs
+++ b/src/Stack/Hoogle.hs
@@ -157,7 +157,7 @@ hoogleCmd (args, setup, rebuild, startServer) =
       sourceMap <- view $ sourceMapL . to (.smDeps)
       case Map.lookup hooglePackageName sourceMap of
         Just hoogleDep ->
-          case hoogleDep.dpLocation of
+          case hoogleDep.location of
             PLImmutable pli ->
               T.pack . packageIdentifierString <$>
                   restrictMinHoogleVersion muted (packageLocationIdent pli)

--- a/src/Stack/IDE.hs
+++ b/src/Stack/IDE.hs
@@ -78,7 +78,7 @@ listPackages stream flag = do
         ListPackageNames ->
           map packageNameString (Map.keys packages)
         ListPackageCabalFiles ->
-          map (toFilePath . (.ppCabalFP)) (Map.elems packages)
+          map (toFilePath . (.cabalFP)) (Map.elems packages)
   mapM_ (outputFunc stream) strs
 
 -- | List the targets in the current project.

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -612,7 +612,7 @@ buildExtractedTarball pkgDir = do
           $  localPackage.package.name
           == localPackageToBuild.package.name
   pathsToKeep <- Map.fromList <$> filterM
-    (fmap not . isPathToRemove . resolvedAbsolute . (.ppResolvedDir) . snd)
+    (fmap not . isPathToRemove . resolvedAbsolute . (.resolvedDir) . snd)
     (Map.toList envConfig.buildConfig.smWanted.smwProject)
   pp <- mkProjectPackage YesPrintWarnings pkgDir False
   let adjustEnvForBuild env =
@@ -625,7 +625,7 @@ buildExtractedTarball pkgDir = do
               }
         in  set envConfigL updatedEnvConfig env
       updatePackagesInSourceMap sm =
-        sm {smProject = Map.insert pp.ppCommon.name pp pathsToKeep}
+        sm {smProject = Map.insert pp.common.name pp pathsToKeep}
   local adjustEnvForBuild $ build Nothing
 
 -- | Version of 'checkSDistTarball' that first saves lazy bytestring to

--- a/src/Stack/Script.hs
+++ b/src/Stack/Script.hs
@@ -333,7 +333,7 @@ hashSnapshot = do
   sourceMap <- view $ envConfigL . to (.sourceMap)
   compilerInfo <- getCompilerInfo
   let eitherPliHash (pn, dep)
-        | PLImmutable pli <- dep.dpLocation = Right $ immutableLocSha pli
+        | PLImmutable pli <- dep.location = Right $ immutableLocSha pli
         | otherwise = Left pn
       deps = Map.toList sourceMap.smDeps
   case partitionEithers (map eitherPliHash deps) of
@@ -351,14 +351,14 @@ mapSnapshotPackageModules = do
   (_installedMap, globalDumpPkgs, snapshotDumpPkgs, _localDumpPkgs) <-
     getInstalled installMap
   let globals = dumpedPackageModules sourceMap.smGlobal globalDumpPkgs
-      notHidden = Map.filter (not . (.dpHidden))
+      notHidden = Map.filter (not . (.hidden))
       notHiddenDeps = notHidden sourceMap.smDeps
       installedDeps = dumpedPackageModules notHiddenDeps snapshotDumpPkgs
       dumpPkgs =
         Set.fromList $ map (pkgName . (.packageIdent)) snapshotDumpPkgs
       notInstalledDeps = Map.withoutKeys notHiddenDeps dumpPkgs
   otherDeps <- for notInstalledDeps $ \dep -> do
-    gpd <- liftIO dep.dpCommon.gpd
+    gpd <- liftIO dep.common.gpd
     Set.fromList <$> allExposedModules gpd
   -- source map construction process should guarantee unique package names in
   -- these maps

--- a/src/Stack/SourceMap.hs
+++ b/src/Stack/SourceMap.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE NoImplicitPrelude   #-}
-{-# LANGUAGE OverloadedRecordDot #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedRecordDot   #-}
+{-# LANGUAGE OverloadedStrings     #-}
 
 module Stack.SourceMap
   ( mkProjectPackage
@@ -63,9 +64,9 @@ mkProjectPackage printWarnings dir buildHaddocks = do
   (gpd, name, cabalfp) <-
     loadCabalFilePath (Just stackProgName') (resolvedAbsolute dir)
   pure ProjectPackage
-    { ppCabalFP = cabalfp
-    , ppResolvedDir = dir
-    , ppCommon =
+    { cabalFP = cabalfp
+    , resolvedDir = dir
+    , common =
         CommonPackage
           { gpd = gpd printWarnings
           , name = name
@@ -236,7 +237,7 @@ getUnusedPackageFlags ::
   -> Map PackageName DepPackage
   -> m (Maybe UnusedFlags)
 getUnusedPackageFlags (name, userFlags) source prj deps =
-  let maybeCommon =     fmap (.ppCommon) (Map.lookup name prj)
+  let maybeCommon =     fmap (.common) (Map.lookup name prj)
                     <|> fmap (.common) (Map.lookup name deps)
   in  case maybeCommon of
         -- Package is not available as project or dependency
@@ -297,7 +298,7 @@ loadProjectSnapshotCandidate loc printWarnings buildHaddocks = do
   pure $ \projectPackages -> do
     prjPkgs <- fmap Map.fromList . for projectPackages $ \resolved -> do
       pp <- mkProjectPackage printWarnings resolved buildHaddocks
-      pure (pp.ppCommon.name, pp)
+      pure (pp.common.name, pp)
     compiler <- either throwIO pure $ wantedToActual $ snapshotCompiler snapshot
     pure
       SMActual

--- a/src/Stack/SourceMap.hs
+++ b/src/Stack/SourceMap.hs
@@ -96,10 +96,10 @@ additionalDepPackage buildHaddocks pl = do
         run <- askRunInIO
         pure (name, run $ loadCabalFileImmutable pli)
   pure DepPackage
-    { dpLocation = pl
-    , dpHidden = False
-    , dpFromSnapshot = NotFromSnapshot
-    , dpCommon =
+    { location = pl
+    , hidden = False
+    , fromSnapshot = NotFromSnapshot
+    , common =
         CommonPackage
           { gpd = gpdio
           , name = name
@@ -120,10 +120,10 @@ snapToDepPackage ::
 snapToDepPackage buildHaddocks name sp = do
   run <- askRunInIO
   pure DepPackage
-    { dpLocation = PLImmutable sp.spLocation
-    , dpHidden = sp.spHidden
-    , dpFromSnapshot = FromSnapshot
-    , dpCommon =
+    { location = PLImmutable sp.spLocation
+    , hidden = sp.spHidden
+    , fromSnapshot = FromSnapshot
+    , common =
         CommonPackage
           { gpd = run $ loadCabalFileImmutable sp.spLocation
           , name = name
@@ -237,7 +237,7 @@ getUnusedPackageFlags ::
   -> m (Maybe UnusedFlags)
 getUnusedPackageFlags (name, userFlags) source prj deps =
   let maybeCommon =     fmap (.ppCommon) (Map.lookup name prj)
-                    <|> fmap (.dpCommon) (Map.lookup name deps)
+                    <|> fmap (.common) (Map.lookup name deps)
   in  case maybeCommon of
         -- Package is not available as project or dependency
         Nothing ->

--- a/src/Stack/Types/SourceMap.hs
+++ b/src/Stack/Types/SourceMap.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE NoImplicitPrelude   #-}
-{-# LANGUAGE NoFieldSelectors    #-}
-{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NoFieldSelectors      #-}
+{-# LANGUAGE OverloadedRecordDot   #-}
 
 -- | A sourcemap maps a package name to how it should be built, including source
 -- code, flags, options, etc. This module contains various stages of source map
@@ -63,12 +64,12 @@ data FromSnapshot
 
 -- | A view of a dependency package, specified in stack.yaml
 data DepPackage = DepPackage
-  { dpCommon :: !CommonPackage
-  , dpLocation :: !PackageLocation
-  , dpHidden :: !Bool
+  { common :: !CommonPackage
+  , location :: !PackageLocation
+  , hidden :: !Bool
     -- ^ Should the package be hidden after registering? Affects the script
     -- interpreter's module name import parser.
-  , dpFromSnapshot :: !FromSnapshot
+  , fromSnapshot :: !FromSnapshot
     -- ^ Needed to ignore bounds between snapshot packages
     -- See https://github.com/commercialhaskell/stackage/issues/3185
   }

--- a/src/Stack/Types/SourceMap.hs
+++ b/src/Stack/Types/SourceMap.hs
@@ -76,9 +76,9 @@ data DepPackage = DepPackage
 
 -- | A view of a project package needed for resolving components
 data ProjectPackage = ProjectPackage
-  { ppCommon :: !CommonPackage
-  , ppCabalFP :: !(Path Abs File)
-  , ppResolvedDir :: !(ResolvedPath Dir)
+  { common :: !CommonPackage
+  , cabalFP :: !(Path Abs File)
+  , resolvedDir :: !(ResolvedPath Dir)
   }
 
 -- | A view of a package installed in the global package database also could
@@ -172,11 +172,11 @@ smRelDir :: (MonadThrow m) => SourceMapHash -> m (Path Rel Dir)
 smRelDir (SourceMapHash smh) = parseRelDir $ T.unpack $ SHA256.toHexText smh
 
 ppGPD :: MonadIO m => ProjectPackage -> m GenericPackageDescription
-ppGPD = liftIO . (.ppCommon.gpd)
+ppGPD = liftIO . (.common.gpd)
 
 -- | Root directory for the given 'ProjectPackage'
 ppRoot :: ProjectPackage -> Path Abs Dir
-ppRoot = parent . (.ppCabalFP)
+ppRoot = parent . (.cabalFP)
 
 -- | All components available in the given 'ProjectPackage'
 ppComponents :: MonadIO m => ProjectPackage -> m (Set NamedComponent)


### PR DESCRIPTION
Makes use of import alias technique to avoid ambiguous record updates.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
