### PR TITLE
Eliminate ambiguity; make use of GHC2021's NamedFieldPuns

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -10,11 +10,11 @@
 # Partial: base/head
 # Usage of partial function 'head' for lists
 [[ignore]]
-  id = "OBS-STAN-0001-0pmobG-86:1"
+  id = "OBS-STAN-0001-0pmobG-87:1"
 # ✦ Category:      #Partial #List
 # ✦ File:          src\Stack\Storage\User.hs
 #
-#   86 ┃ share [ mkPersist sqlSettings
+#   87 ┃ share [ mkPersist sqlSettings
 
 # Partial: base/last
 # On Windows
@@ -72,14 +72,14 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-erw24B-1022:3"
+  id = "OBS-STAN-0203-erw24B-1029:3"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\ExecuteEnv.hs
 #
-#  1021 ┃
-#  1022 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
-#  1023 ┃   ^^^^^^^
+#  1028 ┃
+#  1029 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
+#  1030 ┃   ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -328,21 +328,21 @@ splitObjsWarning =
 -- | Get the @BaseConfigOpts@ necessary for constructing configure options
 mkBaseConfigOpts :: (HasEnvConfig env)
                  => BuildOptsCLI -> RIO env BaseConfigOpts
-mkBaseConfigOpts boptsCli = do
-  bopts <- view buildOptsL
-  snapDBPath <- packageDatabaseDeps
-  localDBPath <- packageDatabaseLocal
+mkBaseConfigOpts buildOptsCLI = do
+  buildOpts <- view buildOptsL
+  snapDB <- packageDatabaseDeps
+  localDB <- packageDatabaseLocal
   snapInstallRoot <- installationRootDeps
   localInstallRoot <- installationRootLocal
-  packageExtraDBs <- packageDatabaseExtra
+  extraDBs <- packageDatabaseExtra
   pure BaseConfigOpts
-    { snapDB = snapDBPath
-    , localDB = localDBPath
-    , snapInstallRoot = snapInstallRoot
-    , localInstallRoot = localInstallRoot
-    , buildOpts = bopts
-    , buildOptsCLI = boptsCli
-    , extraDBs = packageExtraDBs
+    { snapDB
+    , localDB
+    , snapInstallRoot
+    , localInstallRoot
+    , buildOpts
+    , buildOptsCLI
+    , extraDBs
     }
 
 -- | Provide a function for loading package information from the package index
@@ -354,16 +354,16 @@ loadPackage ::
   -> [Text] -- ^ Cabal configure options
   -> RIO env Package
 loadPackage loc flags ghcOptions cabalConfigOpts = do
-  compiler <- view actualCompilerVersionL
+  compilerVersion <- view actualCompilerVersionL
   platform <- view platformL
   let pkgConfig = PackageConfig
         { enableTests = False
         , enableBenchmarks = False
-        , flags = flags
-        , ghcOptions = ghcOptions
-        , cabalConfigOpts = cabalConfigOpts
-        , compilerVersion = compiler
-        , platform = platform
+        , flags
+        , ghcOptions
+        , cabalConfigOpts
+        , compilerVersion
+        , platform
         }
   resolvePackage pkgConfig <$> loadCabalFileImmutable loc
 

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -415,11 +415,11 @@ loadLocalPackage pp = do
   pure LocalPackage
     { package = pkg
     , testBench = btpkg
-    , componentFiles = componentFiles
+    , componentFiles
     , buildHaddocks = pp.common.haddocks
     , forceDirty = bopts.forceDirty
-    , dirtyFiles = dirtyFiles
-    , newBuildCaches = newBuildCaches
+    , dirtyFiles
+    , newBuildCaches
     , cabalFile = pp.cabalFP
     , wanted = isWanted
     , components = nonLibComponents

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -166,7 +166,7 @@ gpdPackageDeps ::
   -> Platform
   -> Map FlagName Bool
   -> Map PackageName VersionRange
-gpdPackageDeps gpd ac platform flags =
+gpdPackageDeps gpd compilerVersion platform flags =
   Map.filterWithKey (const . not . isLocalLibrary) (packageDependencies pkgDesc)
  where
   isLocalLibrary name' = name' == name || name' `Set.member` subs
@@ -182,11 +182,11 @@ gpdPackageDeps gpd ac platform flags =
   pkgConfig = PackageConfig
     { enableTests = True
     , enableBenchmarks = True
-    , flags = flags
+    , flags
     , ghcOptions = []
     , cabalConfigOpts = []
-    , compilerVersion = ac
-    , platform = platform
+    , compilerVersion
+    , platform
     }
 
 -- Remove any src package flags having default values

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -24,7 +24,7 @@ import           Stack.Options.GhcBuildParser ( ghcBuildParser )
 import           Stack.Options.GhcVariantParser ( ghcVariantParser )
 import           Stack.Options.NixParser ( nixOptsParser )
 import           Stack.Options.Utils ( GlobalOptsContext (..), hideMods )
-import           Stack.Prelude
+import           Stack.Prelude hiding ( snapshotLocation )
 import           Stack.Types.ColorWhen ( readColorWhen )
 import           Stack.Types.ConfigMonoid ( ConfigMonoid (..) )
 import           Stack.Types.DumpLogs ( DumpLogs (..) )
@@ -34,35 +34,36 @@ import qualified System.FilePath as FilePath
 configOptsParser :: FilePath -> GlobalOptsContext -> Parser ConfigMonoid
 configOptsParser currentDir hide0 =
   ( \stackRoot workDir buildOpts dockerOpts nixOpts systemGHC installGHC arch
-     ghcVariant ghcBuild jobs includes libs preprocs overrideGccPath overrideHpack
-     skipGHCCheck skipMsys localBin setupInfoLocations modifyCodePage
-     allowDifferentUser dumpLogs colorWhen snapLoc noRunCompile -> mempty
-       { stackRoot = stackRoot
-       , workDir = workDir
-       , buildOpts = buildOpts
-       , dockerOpts = dockerOpts
-       , nixOpts = nixOpts
-       , systemGHC = systemGHC
-       , installGHC = installGHC
-       , skipGHCCheck = skipGHCCheck
-       , arch = arch
-       , ghcVariant = ghcVariant
-       , ghcBuild = ghcBuild
-       , jobs = jobs
-       , extraIncludeDirs = includes
-       , extraLibDirs = libs
-       , customPreprocessorExts = preprocs
-       , overrideGccPath = overrideGccPath
-       , overrideHpack = overrideHpack
-       , skipMsys = skipMsys
-       , localBinPath = localBin
-       , setupInfoLocations = setupInfoLocations
-       , modifyCodePage = modifyCodePage
-       , allowDifferentUser = allowDifferentUser
-       , dumpLogs = dumpLogs
-       , colorWhen = colorWhen
-       , snapshotLocation = snapLoc
-       , noRunCompile = noRunCompile
+     ghcVariant ghcBuild jobs extraIncludeDirs extraLibDirs
+     customPreprocessorExts overrideGccPath overrideHpack skipGHCCheck skipMsys
+     localBinPath setupInfoLocations modifyCodePage allowDifferentUser dumpLogs
+     colorWhen snapshotLocation noRunCompile -> mempty
+       { stackRoot
+       , workDir
+       , buildOpts
+       , dockerOpts
+       , nixOpts
+       , systemGHC
+       , installGHC
+       , skipGHCCheck
+       , arch
+       , ghcVariant
+       , ghcBuild
+       , jobs
+       , extraIncludeDirs
+       , extraLibDirs
+       , customPreprocessorExts
+       , overrideGccPath
+       , overrideHpack
+       , skipMsys
+       , localBinPath
+       , setupInfoLocations
+       , modifyCodePage
+       , allowDifferentUser
+       , dumpLogs
+       , colorWhen
+       , snapshotLocation
+       , noRunCompile
        }
   )
   <$> optionalFirst (absDirOption

--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -128,29 +128,27 @@ globalOptsFromMonoid defaultTerminal globalMonoid = do
     case getFirst globalMonoid.stackYaml of
       Nothing -> pure SYLDefault
       Just fp -> SYLOverride <$> resolveFile' fp
-  pure GlobalOpts
-    { reExecVersion = getFirst globalMonoid.reExecVersion
-    , dockerEntrypoint =
-        getFirst globalMonoid.dockerEntrypoint
-    , logLevel =
-        fromFirst defaultLogLevel globalMonoid.logLevel
-    , timeInLog = fromFirstTrue globalMonoid.timeInLog
-    , rslInLog = fromFirstFalse globalMonoid.rslInLog
-    , planInLog = fromFirstFalse globalMonoid.planInLog
-    , configMonoid = globalMonoid.configMonoid
-    , resolver = resolver
-    , compiler = getFirst globalMonoid.compiler
-    , terminal =
-        fromFirst defaultTerminal globalMonoid.terminal
-    , stylesUpdate = globalMonoid.styles
-    , termWidth = getFirst globalMonoid.termWidth
-    , stackYaml = stackYaml
-    , lockFileBehavior =
+  let lockFileBehavior =
         let defLFB =
               case getFirst globalMonoid.resolver of
                 Nothing -> LFBReadWrite
                 _ -> LFBReadOnly
         in  fromFirst defLFB globalMonoid.lockFileBehavior
+  pure GlobalOpts
+    { reExecVersion = getFirst globalMonoid.reExecVersion
+    , dockerEntrypoint = getFirst globalMonoid.dockerEntrypoint
+    , logLevel = fromFirst defaultLogLevel globalMonoid.logLevel
+    , timeInLog = fromFirstTrue globalMonoid.timeInLog
+    , rslInLog = fromFirstFalse globalMonoid.rslInLog
+    , planInLog = fromFirstFalse globalMonoid.planInLog
+    , configMonoid = globalMonoid.configMonoid
+    , resolver
+    , compiler = getFirst globalMonoid.compiler
+    , terminal = fromFirst defaultTerminal globalMonoid.terminal
+    , stylesUpdate = globalMonoid.styles
+    , termWidthOpt = getFirst globalMonoid.termWidthOpt
+    , stackYaml
+    , lockFileBehavior
     }
 
 -- | Default logging level should be something useful but not crazy.

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -234,29 +234,29 @@ generatePkgDescOpts ::
 generatePkgDescOpts
     installMap
     installedMap
-    omitPkgs
-    addPkgs
+    omitPackages
+    addPackages
     cabalfp
     pkg
     componentPaths
   = do
       config <- view configL
-      cabalVer <- view cabalVersionL
+      cabalVersion <- view cabalVersionL
       distDir <- distDirFromDir cabalDir
-      let generate namedComponent binfo = generateBuildInfoOpts BioInput
-            { installMap = installMap
-            , installedMap = installedMap
-            , cabalDir = cabalDir
-            , distDir = distDir
-            , omitPackages = omitPkgs
-            , addPackages = addPkgs
-            , buildInfo = binfo
+      let generate componentName buildInfo = generateBuildInfoOpts BioInput
+            { installMap
+            , installedMap
+            , cabalDir
+            , distDir
+            , omitPackages
+            , addPackages
+            , buildInfo
             , dotCabalPaths =
-                fromMaybe [] (M.lookup namedComponent componentPaths)
-            , configLibDirs =  config.extraLibDirs
-            , configIncludeDirs =  config.extraIncludeDirs
-            , componentName = namedComponent
-            , cabalVersion = cabalVer
+                fromMaybe [] (M.lookup componentName componentPaths)
+            , configLibDirs = config.extraLibDirs
+            , configIncludeDirs = config.extraIncludeDirs
+            , componentName
+            , cabalVersion
             }
       let insertInMap name compVal = M.insert name (generate name compVal)
       let translatedInsertInMap constructor name =

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -229,7 +229,7 @@ withRunnerGlobal go inner = do
     ColorAuto -> hNowSupportsANSI stderr
   termWidth <- clipWidth <$> maybe (fromMaybe defaultTerminalWidth
                                     <$> getTerminalWidth)
-                                   pure go.termWidth
+                                   pure go.termWidthOpt
   menv <- mkDefaultProcessContext
   -- MVar used to ensure the Docker entrypoint is performed exactly once.
   dockerEntrypointMVar <- newMVar False

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -694,6 +694,6 @@ getDefaultPackageConfig = do
     , flags = mempty
     , ghcOptions = []
     , cabalConfigOpts = []
-    , compilerVersion = compilerVersion
-    , platform = platform
+    , compilerVersion
+    , platform
     }

--- a/src/Stack/Storage/User.hs
+++ b/src/Stack/Storage/User.hs
@@ -349,10 +349,10 @@ loadCompilerPaths compiler build sandboxed = do
     -- We could use parseAbsFile instead of resolveFile' below to bypass some
     -- system calls, at the cost of some really wonky error messages in case
     -- someone screws up their GHC installation
-    pkgexe <- resolveFile' compilerCache.compilerCacheGhcPkgPath
-    runghc <- resolveFile' compilerCache.compilerCacheRunghcPath
+    pkg <- GhcPkgExe <$> resolveFile' compilerCache.compilerCacheGhcPkgPath
+    interpreter <- resolveFile' compilerCache.compilerCacheRunghcPath
     haddock <- resolveFile' compilerCache.compilerCacheHaddockPath
-    globaldb <- resolveDir' compilerCache.compilerCacheGlobalDb
+    globalDB <- resolveDir' compilerCache.compilerCacheGlobalDb
 
     cabalVersion <- parseVersionThrowing $
       T.unpack compilerCache.compilerCacheCabalVersion
@@ -365,20 +365,19 @@ loadCompilerPaths compiler build sandboxed = do
         Nothing -> throwIO $
           CompilerCacheArchitectureInvalid compilerCache.compilerCacheArch
         Just arch -> pure arch
-
     pure CompilerPaths
-      { compiler = compiler
+      { compiler
       , compilerVersion = compilerCache.compilerCacheActualVersion
-      , arch = arch
-      , build = build
-      , pkg = GhcPkgExe pkgexe
-      , interpreter = runghc
-      , haddock = haddock
-      , sandboxed = sandboxed
-      , cabalVersion = cabalVersion
-      , globalDB = globaldb
+      , arch
+      , build
+      , pkg
+      , interpreter
+      , haddock
+      , sandboxed
+      , cabalVersion
+      , globalDB
       , ghcInfo = compilerCache.compilerCacheInfo
-      , globalDump = globalDump
+      , globalDump
       }
 
 -- | Save compiler information. May throw exceptions!

--- a/src/Stack/Types/GlobalOpts.hs
+++ b/src/Stack/Types/GlobalOpts.hs
@@ -35,7 +35,7 @@ data GlobalOpts = GlobalOpts
   , compiler     :: !(Maybe WantedCompiler) -- ^ Compiler override
   , terminal     :: !Bool -- ^ We're in a terminal?
   , stylesUpdate :: !StylesUpdate -- ^ SGR (Ansi) codes for styles
-  , termWidth    :: !(Maybe Int) -- ^ Terminal width override
+  , termWidthOpt  :: !(Maybe Int) -- ^ Terminal width override
   , stackYaml    :: !StackYamlLoc -- ^ Override project stack.yaml
   , lockFileBehavior :: !LockFileBehavior
   }

--- a/src/Stack/Types/GlobalOptsMonoid.hs
+++ b/src/Stack/Types/GlobalOptsMonoid.hs
@@ -14,35 +14,35 @@ import           Stack.Types.Resolver ( AbstractResolver )
 
 -- | Parsed global command-line options monoid.
 data GlobalOptsMonoid = GlobalOptsMonoid
-  { reExecVersion :: !(First String)
+  { reExecVersion    :: !(First String)
     -- ^ Expected re-exec in container version
   , dockerEntrypoint :: !(First DockerEntrypoint)
     -- ^ Data used when Stack is acting as a Docker entrypoint (internal use
     -- only)
-  , logLevel     :: !(First LogLevel)
+  , logLevel         :: !(First LogLevel)
     -- ^ Log level
-  , timeInLog    :: !FirstTrue
+  , timeInLog        :: !FirstTrue
     -- ^ Whether to include timings in logs.
-  , rslInLog     :: !FirstFalse
+  , rslInLog         :: !FirstFalse
     -- ^ Whether to include raw snapshot layer (RSL) in logs.
-  , planInLog :: !FirstFalse
+  , planInLog        :: !FirstFalse
     -- ^ Whether to include debug information about the construction of the
     -- build plan in logs.
-  , configMonoid :: !ConfigMonoid
+  , configMonoid     :: !ConfigMonoid
     -- ^ Config monoid, for passing into 'loadConfig'
-  , resolver     :: !(First (Unresolved AbstractResolver))
+  , resolver         :: !(First (Unresolved AbstractResolver))
     -- ^ Resolver override
-  , resolverRoot :: !(First FilePath)
+  , resolverRoot     :: !(First FilePath)
     -- ^ root directory for resolver relative path
-  , compiler     :: !(First WantedCompiler)
+  , compiler         :: !(First WantedCompiler)
     -- ^ Compiler override
-  , terminal     :: !(First Bool)
+  , terminal         :: !(First Bool)
     -- ^ We're in a terminal?
-  , styles       :: !StylesUpdate
+  , styles           :: !StylesUpdate
     -- ^ Stack's output styles
-  , termWidth    :: !(First Int)
+  , termWidthOpt     :: !(First Int)
     -- ^ Terminal width override
-  , stackYaml    :: !(First FilePath)
+  , stackYaml        :: !(First FilePath)
     -- ^ Override project stack.yaml
   , lockFileBehavior :: !(First LockFileBehavior)
     -- ^ See 'globalLockFileBehavior'

--- a/src/Stack/Types/Runner.hs
+++ b/src/Stack/Types/Runner.hs
@@ -16,9 +16,8 @@ module Stack.Types.Runner
   ) where
 
 import           RIO.Process ( HasProcessContext (..), ProcessContext )
-import           Stack.Prelude
-import           Stack.Types.GlobalOpts ( GlobalOpts )
-import qualified Stack.Types.GlobalOpts as GlobalOpts
+import           Stack.Prelude hiding ( stylesUpdate )
+import           Stack.Types.GlobalOpts ( GlobalOpts (..) )
 import           Stack.Types.LockFileBehavior ( LockFileBehavior )
 import           Stack.Types.StackYamlLoc ( StackYamlLoc )
 
@@ -27,11 +26,11 @@ import           Stack.Types.StackYamlLoc ( StackYamlLoc )
 -- execution, and the MVar used to ensure that the Docker entrypoint is
 -- performed exactly once.
 data Runner = Runner
-  { globalOpts :: !GlobalOpts
-  , useColor   :: !Bool
-  , logFunc    :: !LogFunc
-  , termWidth  :: !Int
-  , processContext :: !ProcessContext
+  { globalOpts           :: !GlobalOpts
+  , useColor             :: !Bool
+  , logFunc              :: !LogFunc
+  , termWidth            :: !Int
+  , processContext       :: !ProcessContext
   , dockerEntrypointMVar :: !(MVar Bool)
   }
 
@@ -46,9 +45,10 @@ instance HasRunner Runner where
   runnerL = id
 
 instance HasStylesUpdate Runner where
+  stylesUpdateL :: Lens' Runner StylesUpdate
   stylesUpdateL = globalOptsL . lens
     (.stylesUpdate)
-    (\x y -> x { GlobalOpts.stylesUpdate = y })
+    (\x y -> x { stylesUpdate = y })
 
 instance HasTerm Runner where
   useColorL = lens (.useColor) (\x y -> x { useColor = y })
@@ -68,7 +68,7 @@ class HasRunner env => HasDockerEntrypointMVar env where
 
 stackYamlLocL :: HasRunner env => Lens' env StackYamlLoc
 stackYamlLocL =
-  globalOptsL . lens (.stackYaml) (\x y -> x { GlobalOpts.stackYaml = y })
+  globalOptsL . lens (.stackYaml) (\x y -> x { stackYaml = y })
 
 lockFileBehaviorL :: HasRunner env => SimpleGetter env LockFileBehavior
 lockFileBehaviorL = globalOptsL . to (.lockFileBehavior)
@@ -79,7 +79,7 @@ globalOptsL = runnerL . lens (.globalOpts) (\x y -> x { globalOpts = y })
 -- | See 'globalTerminal'
 terminalL :: HasRunner env => Lens' env Bool
 terminalL =
-  globalOptsL . lens (.terminal) (\x y -> x { GlobalOpts.terminal = y })
+  globalOptsL . lens (.terminal) (\x y -> x { terminal = y })
 
 -- | See 'globalReExecVersion'
 reExecL :: HasRunner env => SimpleGetter env Bool


### PR DESCRIPTION
This refactoring renames the `termWidth` fields of `GlobalOpts` and `GlobalOptsMonoid` `termWidthOpt`, to distinguish it from the `termWidth` field of `Runner`, avoiding certain ambiguity in a different way.

It also makes greater use of `NamedFieldPuns` that is included in `GHC2021`. In so doing, it chooses the names of local variables to make the final record updates 'cleaner'.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
