### PR TITLE
Remove various prefixes from field names of types

### DIFF
--- a/src/GHC/Utils/GhcPkg/Main/Compat.hs
+++ b/src/GHC/Utils/GhcPkg/Main/Compat.hs
@@ -398,8 +398,8 @@ readParseDatabase mode path = do
        [InstalledPackageInfo]
     -> GhcPkg.DbOpenMode mode GhcPkg.PackageDbLock
     -> RIO env (PackageDB mode)
-  mkPackageDB pkgs lock = do
-    pure $ PackageDB
+  mkPackageDB pkgs lock =
+    pure PackageDB
       { location = path
       , packageDbLock = lock
       , packages = pkgs

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -266,7 +266,7 @@ flagCacheKey installed = do
   installationRoot <- installationRootLocal
   case installed of
     Library _ installedInfo -> do
-      let gid = installedInfo.iliId
+      let gid = installedInfo.ghcPkgId
       pure $ configCacheKey installationRoot (ConfigCacheTypeFlagLibrary gid)
     Executable ident -> pure $
       configCacheKey installationRoot (ConfigCacheTypeFlagExecutable ident)

--- a/src/Stack/Build/ExecutePackage.hs
+++ b/src/Stack/Build/ExecutePackage.hs
@@ -999,7 +999,7 @@ singleTest topts testsToRun ac ee task installedMap = do
               idMap <- liftIO $ readTVarIO ee.ghcPkgIds
               pure $ Map.lookup (taskProvides task) idMap
           let pkgGhcIdList = case installed of
-                               Just (Library _ libInfo) -> [libInfo.iliId]
+                               Just (Library _ libInfo) -> [libInfo.ghcPkgId]
                                _ -> []
           -- doctest relies on template-haskell in QuickCheck-based tests
           thGhcId <-

--- a/src/Stack/Build/Installed.hs
+++ b/src/Stack/Build/Installed.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE NoImplicitPrelude   #-}
-{-# LANGUAGE OverloadedRecordDot #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedRecordDot   #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
 -- Determine which packages are already installed
 module Stack.Build.Installed
@@ -298,12 +299,12 @@ gatherAndTransformSubLoadHelper lh =
       (_, Library _ existingLibInfo)
     = ( pLoc
       , Library pn existingLibInfo
-          { iliSublib = Map.union
-              incomingLibInfo.iliSublib
-              existingLibInfo.iliSublib
-          , iliId = if isJust lh.lhSublibrary
-                      then existingLibInfo.iliId
-                      else incomingLibInfo.iliId
+          { subLib = Map.union
+              incomingLibInfo.subLib
+              existingLibInfo.subLib
+          , ghcPkgId = if isJust lh.lhSublibrary
+                      then existingLibInfo.ghcPkgId
+                      else incomingLibInfo.ghcPkgId
           }
       )
   onPreviousLoadHelper newVal _oldVal = newVal
@@ -316,5 +317,5 @@ gatherAndTransformSubLoadHelper lh =
       (Library (PackageIdentifier _sublibMungedPackageName version) libInfo)
     = Library
         (PackageIdentifier key version)
-        libInfo {iliSublib = Map.singleton sd.libraryName libInfo.iliId}
+        libInfo { subLib = Map.singleton sd.libraryName libInfo.ghcPkgId }
   updateAsSublib _ v = v

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -462,7 +462,7 @@ checkBuildCache oldCache files = do
   go fp _ _ | takeFileName fp == "cabal_macros.h" = pure (Set.empty, Map.empty)
   -- Common case where it's in the cache and on the filesystem.
   go fp (Just digest') (Just fci)
-      | fci.fciHash == digest' = pure (Set.empty, Map.singleton fp fci)
+      | fci.hash == digest' = pure (Set.empty, Map.singleton fp fci)
       | otherwise =
           pure (Set.singleton fp, Map.singleton fp $ FileCacheInfo digest')
   -- Missing file. Add it to dirty files, but no FileCacheInfo.

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -326,7 +326,7 @@ configFromConfigMonoid
         os = defOS
         platform = Platform arch os
         requireStackVersion = simplifyVersionRange
-          configMonoid.requireStackVersion.getIntersectingVersionRange
+          configMonoid.requireStackVersion.intersectingVersionRange
         compilerCheck = fromFirst MatchMinor configMonoid.compilerCheck
     platformVariant <- liftIO $
       maybe PlatformVariantNone PlatformVariant <$> lookupEnv platformVariantEnvVar

--- a/src/Stack/Config/Docker.hs
+++ b/src/Stack/Config/Docker.hs
@@ -20,7 +20,7 @@ import           Stack.Types.Docker
                    , DockerOptsMonoid (..), dockerImageArgName
                    )
 import           Stack.Types.Resolver ( AbstractResolver (..) )
-import           Stack.Types.Version ( getIntersectingVersionRange )
+import           Stack.Types.Version ( IntersectingVersionRange (..) )
 
 -- | Type representing exceptions thrown by functions exported by the
 -- "Stack.Config.Docker" module.
@@ -105,9 +105,9 @@ dockerOptsFromMonoid mproject maresolver dockerMonoid = do
       setUser = getFirst dockerMonoid.setUser
       requireDockerVersion =
         simplifyVersionRange
-          dockerMonoid.requireDockerVersion.getIntersectingVersionRange
+          dockerMonoid.requireDockerVersion.intersectingVersionRange
       stackExe = getFirst dockerMonoid.stackExe
-  pure $ DockerOpts
+  pure DockerOpts
     { enable
     , image
     , registryLogin

--- a/src/Stack/Config/Nix.hs
+++ b/src/Stack/Config/Nix.hs
@@ -73,7 +73,7 @@ nixOptsFromMonoid nixMonoid os = do
 
   when (not (null packages) && isJust initFile) $
     throwIO NixCannotUseShellFileAndPackagesException
-  pure $ NixOpts
+  pure NixOpts
     { enable
     , pureShell
     , packages

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -536,12 +536,12 @@ runGhci
                 ++ M.foldMapWithKey subDepsPackageUnhide exposeInternalDep
               else []
           oneWordOpts bio
-            | shouldHidePackages = bio.bioOneWordOpts ++ bio.bioPackageFlags
-            | otherwise = bio.bioOneWordOpts
+            | shouldHidePackages = bio.oneWordOpts ++ bio.packageFlags
+            | otherwise = bio.oneWordOpts
           genOpts = nubOrd
             (concatMap (concatMap (oneWordOpts . snd) . (.ghciPkgOpts)) pkgs)
           (omittedOpts, ghcOpts) = L.partition badForGhci $
-               concatMap (concatMap ((.bioOpts) . snd) . (.ghciPkgOpts)) pkgs
+               concatMap (concatMap ((.opts) . snd) . (.ghciPkgOpts)) pkgs
             ++ map
                  T.unpack
                  (  fold config.ghcOptionsByCat
@@ -623,7 +623,7 @@ writeMacrosFile ::
 writeMacrosFile outputDirectory pkgs = do
   fps <- fmap (nubOrd . catMaybes . concat) $
     forM pkgs $ \pkg -> forM pkg.ghciPkgOpts $ \(_, bio) -> do
-      let cabalMacros = bio.bioCabalMacros
+      let cabalMacros = bio.cabalMacros
       exists <- liftIO $ doesFileExist cabalMacros
       if exists
         then pure $ Just cabalMacros
@@ -1076,7 +1076,7 @@ checkForIssues pkgs =
    where
     (xs, ys) = L.partition (any f . snd) compsWithOpts
   compsWithOpts = map (\(k, bio) ->
-    (k, bio.bioOneWordOpts ++ bio.bioOpts)) compsWithBios
+    (k, bio.oneWordOpts ++ bio.opts)) compsWithBios
   compsWithBios =
     [ ((pkg.ghciPkgName, c), bio)
     | pkg <- pkgs

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -445,7 +445,7 @@ settingsFromRepoTemplatePath (RepoTemplatePath GitHub user name) = do
           basicAuthMsg altGitHubTokenEnvVar
           pure $ Just (gitHubBasicAuthType, fromString wantAltGitHubToken)
         else pure Nothing
-  pure $ TemplateDownloadSettings
+  pure TemplateDownloadSettings
     { tplDownloadUrl = concat
         [ "https://api.github.com/repos/"
         , T.unpack user

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -227,7 +227,7 @@ getSDistTarball mpvpBounds pkgDir = do
   (installedMap, _globalDumpPkgs, _snapshotDumpPkgs, _localDumpPkgs) <-
     getInstalled installMap
   let deps = Map.fromList
-        [ (pid, libInfo.iliId)
+        [ (pid, libInfo.ghcPkgId)
         | (_, Library pid libInfo) <- Map.elems installedMap]
   prettyInfoL
     [ flow "Getting the file list for"

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -139,41 +139,41 @@ extraDirs tool = do
   dir <- installDir config.localPrograms tool
   case (config.platform, toolNameString tool) of
     (Platform _ Cabal.Windows, isGHC -> True) -> pure mempty
-      { edBins =
+      { bins =
           [ dir </> relDirBin
           , dir </> relDirMingw </> relDirBin
           ]
       }
     (Platform Cabal.I386 Cabal.Windows, "msys2") -> pure mempty
-      { edBins =
+      { bins =
           [ dir </> relDirMingw32 </> relDirBin
           , dir </> relDirUsr </> relDirBin
           , dir </> relDirUsr </> relDirLocal </> relDirBin
           ]
-      , edInclude =
+      , include =
           [ dir </> relDirMingw32 </> relDirInclude
           ]
-      , edLib =
+      , lib =
           [ dir </> relDirMingw32 </> relDirLib
           , dir </> relDirMingw32 </> relDirBin
           ]
       }
     (Platform Cabal.X86_64 Cabal.Windows, "msys2") -> pure mempty
-      { edBins =
+      { bins =
           [ dir </> relDirMingw64 </> relDirBin
           , dir </> relDirUsr </> relDirBin
           , dir </> relDirUsr </> relDirLocal </> relDirBin
           ]
-      , edInclude =
+      , include =
           [ dir </> relDirMingw64 </> relDirInclude
           ]
-      , edLib =
+      , lib =
           [ dir </> relDirMingw64 </> relDirLib
           , dir </> relDirMingw64 </> relDirBin
           ]
       }
     (_, isGHC -> True) -> pure mempty
-      { edBins =
+      { bins =
           [ dir </> relDirBin
           ]
       }

--- a/src/Stack/Storage/Project.hs
+++ b/src/Stack/Storage/Project.hs
@@ -137,7 +137,7 @@ readConfigCache (Entity parentId configCacheParent) = do
     selectList [ConfigCacheComponentParent ==. parentId] []
   let pathEnvVar = configCacheParent.configCacheParentPathEnvVar
   let haddock = configCacheParent.configCacheParentHaddock
-  pure $ ConfigCache
+  pure ConfigCache
     { opts
     , deps
     , components

--- a/src/Stack/Types/BuildOptsMonoid.hs
+++ b/src/Stack/Types/BuildOptsMonoid.hs
@@ -103,7 +103,7 @@ instance FromJSON (WithJSONWarnings BuildOptsMonoid) where
     interleavedOutput <- FirstTrue <$> o ..:? interleavedOutputName
     progressBar <- First <$> o ..:? progressBarName
     ddumpDir <- o ..:? ddumpDirName ..!= mempty
-    pure $ BuildOptsMonoid
+    pure BuildOptsMonoid
       { trace
       , profile
       , noStrip
@@ -249,7 +249,7 @@ instance FromJSON (WithJSONWarnings TestOptsMonoid) where
     disableRun <- FirstFalse <$> o ..:? testDisableRunArgName
     maximumTimeSeconds <- First <$> o ..:? maximumTimeSecondsArgName
     allowStdin <- FirstTrue <$> o ..:? testsAllowStdinName
-    pure $ TestOptsMonoid
+    pure TestOptsMonoid
       { rerunTests
       , additionalArgs
       , coverage
@@ -291,7 +291,7 @@ newtype HaddockOptsMonoid = HaddockOptsMonoid
 instance FromJSON (WithJSONWarnings HaddockOptsMonoid) where
   parseJSON = withObjectWarnings "HaddockOptsMonoid" $ \o -> do
     additionalArgs <- o ..:? haddockAdditionalArgsName ..!= []
-    pure $ HaddockOptsMonoid { additionalArgs }
+    pure HaddockOptsMonoid { additionalArgs }
 
 instance Semigroup HaddockOptsMonoid where
   (<>) = mappenddefault
@@ -313,7 +313,7 @@ instance FromJSON (WithJSONWarnings BenchmarkOptsMonoid) where
   parseJSON = withObjectWarnings "BenchmarkOptsMonoid" $ \o -> do
     additionalArgs <- First <$> o ..:? benchmarkAdditionalArgsName
     disableRun <- First <$> o ..:? benchmarkDisableRunArgName
-    pure $ BenchmarkOptsMonoid
+    pure BenchmarkOptsMonoid
       { additionalArgs
       , disableRun
       }

--- a/src/Stack/Types/Casa.hs
+++ b/src/Stack/Types/Casa.hs
@@ -30,7 +30,7 @@ instance FromJSON (WithJSONWarnings CasaOptsMonoid) where
     enable <- FirstTrue <$> o ..:? casaEnableName
     repoPrefix <- First <$> o ..:? casaRepoPrefixName
     maxKeysPerRequest <- First <$> o ..:? casaMaxKeysPerRequestName
-    pure $ CasaOptsMonoid
+    pure CasaOptsMonoid
       { enable
       , repoPrefix
       , maxKeysPerRequest

--- a/src/Stack/Types/ConfigMonoid.hs
+++ b/src/Stack/Types/ConfigMonoid.hs
@@ -267,7 +267,7 @@ parseConfigMonoidObject rootDir obj = do
   compilerCheck <- First <$> obj ..:? configMonoidCompilerCheckName
   compilerRepository <- First <$> (obj ..:? configMonoidCompilerRepositoryName)
 
-  options <- Map.map (.unGhcOptions) <$>
+  options <- Map.map (.ghcOptions) <$>
     obj ..:? configMonoidGhcOptionsName ..!= (mempty :: Map GhcOptionKey GhcOptions)
 
   optionsEverything <-
@@ -329,7 +329,7 @@ parseConfigMonoidObject rootDir obj = do
   snapshotLocation <- First <$> obj ..:? configMonoidSnapshotLocationName
   noRunCompile <- FirstFalse <$> obj ..:? configMonoidNoRunCompileName
   stackDeveloperMode <- First <$> obj ..:? configMonoidStackDeveloperModeName
-  pure $ ConfigMonoid
+  pure ConfigMonoid
     { stackRoot
     , workDir
     , buildOpts

--- a/src/Stack/Types/Docker.hs
+++ b/src/Stack/Types/Docker.hs
@@ -358,7 +358,7 @@ instance FromJSON (WithJSONWarnings DockerOptsMonoid) where
         ( o ..:? dockerRequireDockerVersionArgName
           ..!= VersionRangeJSON anyVersion
         )
-    pure $ DockerOptsMonoid
+    pure DockerOptsMonoid
       { defaultEnable
       , enable
       , repoOrImage

--- a/src/Stack/Types/ExtraDirs.hs
+++ b/src/Stack/Types/ExtraDirs.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoFieldSelectors  #-}
 
 module Stack.Types.ExtraDirs
   ( ExtraDirs (..)
@@ -8,9 +9,9 @@ import           Generics.Deriving.Monoid ( mappenddefault, memptydefault )
 import           Stack.Prelude
 
 data ExtraDirs = ExtraDirs
-  { edBins :: ![Path Abs Dir]
-  , edInclude :: ![Path Abs Dir]
-  , edLib :: ![Path Abs Dir]
+  { bins :: ![Path Abs Dir]
+  , include :: ![Path Abs Dir]
+  , lib :: ![Path Abs Dir]
   }
   deriving (Show, Generic)
 

--- a/src/Stack/Types/GHCDownloadInfo.hs
+++ b/src/Stack/Types/GHCDownloadInfo.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoFieldSelectors  #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Stack.Types.GHCDownloadInfo
@@ -13,9 +14,9 @@ import           Stack.Types.DownloadInfo
                    ( DownloadInfo, parseDownloadInfoFromObject )
 
 data GHCDownloadInfo = GHCDownloadInfo
-  { gdiConfigureOpts :: [Text]
-  , gdiConfigureEnv :: Map Text Text
-  , gdiDownloadInfo :: DownloadInfo
+  { configureOpts :: [Text]
+  , configureEnv :: Map Text Text
+  , downloadInfo :: DownloadInfo
   }
   deriving Show
 
@@ -25,7 +26,7 @@ instance FromJSON (WithJSONWarnings GHCDownloadInfo) where
     configureEnv <- o ..:? "configure-env" ..!= mempty
     downloadInfo <- parseDownloadInfoFromObject o
     pure GHCDownloadInfo
-      { gdiConfigureOpts = configureOpts
-      , gdiConfigureEnv = configureEnv
-      , gdiDownloadInfo = downloadInfo
+      { configureOpts
+      , configureEnv
+      , downloadInfo
       }

--- a/src/Stack/Types/GhcOptions.hs
+++ b/src/Stack/Types/GhcOptions.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoFieldSelectors  #-}
 
 module Stack.Types.GhcOptions
   ( GhcOptions (..)
@@ -9,7 +10,7 @@ import           Data.Attoparsec.Args ( EscapingMode (Escaping), parseArgs )
 import qualified Data.Text as T
 import           Stack.Prelude
 
-newtype GhcOptions = GhcOptions { unGhcOptions :: [Text] }
+newtype GhcOptions = GhcOptions { ghcOptions :: [Text] }
 
 instance FromJSON GhcOptions where
   parseJSON = withText "GhcOptions" $ \t ->

--- a/src/Stack/Types/Installed.hs
+++ b/src/Stack/Types/Installed.hs
@@ -96,9 +96,9 @@ type InstallMap = Map PackageName (InstallLocation, Version)
 type InstalledMap = Map PackageName (InstallLocation, Installed)
 
 data InstalledLibraryInfo = InstalledLibraryInfo
-  { iliId :: GhcPkgId
-  , iliLicense :: Maybe (Either SPDX.License License)
-  , iliSublib :: Map StackUnqualCompName GhcPkgId
+  { ghcPkgId :: GhcPkgId
+  , license :: Maybe (Either SPDX.License License)
+  , subLib :: Map StackUnqualCompName GhcPkgId
   }
   deriving (Eq, Show)
 
@@ -125,7 +125,7 @@ simpleInstalledLib pkgIdentifier ghcPkgId =
 
 installedToPackageIdOpt :: InstalledLibraryInfo -> [String]
 installedToPackageIdOpt libInfo =
-  M.foldr' (iterator (++)) (pure $ toStr libInfo.iliId) libInfo.iliSublib
+  M.foldr' (iterator (++)) (pure $ toStr libInfo.ghcPkgId) libInfo.subLib
  where
   toStr ghcPkgId = "-package-id=" <> ghcPkgIdString ghcPkgId
   iterator op ghcPkgId acc = pure (toStr ghcPkgId) `op` acc
@@ -135,7 +135,7 @@ installedPackageIdentifier (Library pid _) = pid
 installedPackageIdentifier (Executable pid) = pid
 
 installedGhcPkgId :: Installed -> Maybe GhcPkgId
-installedGhcPkgId (Library _ libInfo) = Just libInfo.iliId
+installedGhcPkgId (Library _ libInfo) = Just libInfo.ghcPkgId
 installedGhcPkgId (Executable _) = Nothing
 
 -- | Get the installed Version.

--- a/src/Stack/Types/Nix.hs
+++ b/src/Stack/Types/Nix.hs
@@ -72,7 +72,7 @@ instance FromJSON (WithJSONWarnings NixOptsMonoid) where
     shellOptions  <- First <$> o ..:? nixShellOptsArgName
     path          <- First <$> o ..:? nixPathArgName
     addGCRoots    <- FirstFalse <$> o ..:? nixAddGCRootsArgName
-    pure $ NixOptsMonoid
+    pure NixOptsMonoid
       { enable
       , pureShell
       , packages

--- a/src/Stack/Types/Package.hs
+++ b/src/Stack/Types/Package.hs
@@ -157,7 +157,7 @@ instance Exception PackageException where
 
 -- | Name of an executable.
 newtype ExeName
-  = ExeName { unExeName :: Text }
+  = ExeName { exeName :: Text }
   deriving (Data, Eq, Generic, Hashable, IsString, NFData, Ord, Show, Typeable)
 
 -- | Some package info.
@@ -216,13 +216,13 @@ packageDefinedFlags = M.keysSet . (.defaultFlags)
 
 -- | GHC options based on cabal information and ghc-options.
 data BuildInfoOpts = BuildInfoOpts
-  { bioOpts :: [String]
-  , bioOneWordOpts :: [String]
-  , bioPackageFlags :: [String]
+  { opts :: [String]
+  , oneWordOpts :: [String]
+  , packageFlags :: [String]
     -- ^ These options can safely have 'nubOrd' applied to them, as there are no
     -- multi-word options (see
     -- https://github.com/commercialhaskell/stack/issues/1255)
-  , bioCabalMacros :: Path Abs File
+  , cabalMacros :: Path Abs File
   }
   deriving Show
 
@@ -314,7 +314,7 @@ data LocalPackage = LocalPackage
   deriving Show
 
 newtype MemoizedWith env a
-  = MemoizedWith { unMemoizedWith :: RIO env a }
+  = MemoizedWith { memoizedWith :: RIO env a }
   deriving (Applicative, Functor, Monad)
 
 memoizeRefWith :: MonadIO m => RIO env a -> m (MemoizedWith env a)
@@ -354,7 +354,7 @@ lpFilesForComponents components lp = runMemoizedWith $ do
   pure $ mconcat (M.elems (M.restrictKeys componentFiles components))
 
 newtype FileCacheInfo = FileCacheInfo
-  { fciHash :: SHA256
+  { hash :: SHA256
   }
   deriving (Eq, Generic, Show, Typeable)
 
@@ -412,11 +412,11 @@ installedMapGhcPkgId ::
 installedMapGhcPkgId pkgId@(PackageIdentifier pkgName version) installedLib =
   finalMap
  where
-  finalMap = M.insert pkgId installedLib.iliId baseMap
+  finalMap = M.insert pkgId installedLib.ghcPkgId baseMap
   baseMap =
     M.mapKeysMonotonic
       (toCabalMungedPackageIdentifier pkgName version)
-      installedLib.iliSublib
+      installedLib.subLib
 
 -- | Creates a 'MungedPackageName' identifier.
 toCabalMungedPackageIdentifier ::

--- a/src/Stack/Types/TemplateName.hs
+++ b/src/Stack/Types/TemplateName.hs
@@ -54,9 +54,9 @@ data TemplatePath
 
 -- | Details for how to access a template from a remote repo.
 data RepoTemplatePath = RepoTemplatePath
-  { rtpService  :: RepoService
-  , rtpUser     :: Text
-  , rtpTemplate :: Text
+  { service  :: RepoService
+  , user     :: Text
+  , template :: Text
   }
   deriving (Eq, Ord, Show)
 

--- a/src/Stack/Types/Version.hs
+++ b/src/Stack/Types/Version.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoFieldSelectors  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns      #-}
 
@@ -34,7 +35,7 @@ import           Stack.Prelude hiding ( Vector, pretty )
 import           Text.PrettyPrint ( render )
 
 newtype IntersectingVersionRange = IntersectingVersionRange
-  { getIntersectingVersionRange :: Cabal.VersionRange }
+  { intersectingVersionRange :: Cabal.VersionRange }
   deriving Show
 
 instance Semigroup IntersectingVersionRange where


### PR DESCRIPTION
ed/ExtraDirs, gdi/GHCDownloadInfo, un/GhcOptions, ili/InstalledLibraryInfo, un/ExeName, bio/BuildInfoOpts, un/MemoizedWith, fci/FileCacheHash, si/SetupInfo, rtp/RepoTemplatePath, get/IntersectingVersionRange.

Also remove redundant `$` in `pure $ Constructor { ... }`.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
