### PR TITLE
Remove other prefixes from field names of types

### DIFF
--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -522,9 +522,9 @@ toActions installedMap mtestLock runInBase ee (mbuild, mfinal) =
           { actionId = ActionId (taskProvides task) ATBuild
           , actionDeps =
               Set.map (`ActionId` ATBuild) task.configOpts.missing
-          , actionDo =
+          , action =
               \ac -> runInBase $ singleBuild ac ee task installedMap False
-          , actionConcurrency = ConcurrencyAllowed
+          , concurrency = ConcurrencyAllowed
           }
       ]
   afinal = case mfinal of
@@ -536,9 +536,9 @@ toActions installedMap mtestLock runInBase ee (mbuild, mfinal) =
             { actionId = ActionId pkgId ATBuildFinal
             , actionDeps = addBuild
                 (Set.map (`ActionId` ATBuild) task.configOpts.missing)
-            , actionDo =
+            , action =
                 \ac -> runInBase $ singleBuild ac ee task installedMap True
-            , actionConcurrency = ConcurrencyAllowed
+            , concurrency = ConcurrencyAllowed
             }
       ) $
       -- These are the "final" actions - running tests and benchmarks.
@@ -547,12 +547,12 @@ toActions installedMap mtestLock runInBase ee (mbuild, mfinal) =
           else (:) Action
             { actionId = ActionId pkgId ATRunTests
             , actionDeps = finalDeps
-            , actionDo = \ac -> withLock mtestLock $ runInBase $
+            , action = \ac -> withLock mtestLock $ runInBase $
                 singleTest topts (Set.toList tests) ac ee task installedMap
               -- Always allow tests tasks to run concurrently with other tasks,
               -- particularly build tasks. Note that 'mtestLock' can optionally
               -- make it so that only one test is run at a time.
-            , actionConcurrency = ConcurrencyAllowed
+            , concurrency = ConcurrencyAllowed
             }
       ) $
       ( if Set.null benches
@@ -560,7 +560,7 @@ toActions installedMap mtestLock runInBase ee (mbuild, mfinal) =
           else (:) Action
             { actionId = ActionId pkgId ATRunBenchmarks
             , actionDeps = finalDeps
-            , actionDo = \ac -> runInBase $
+            , action = \ac -> runInBase $
                 singleBench
                   beopts
                   (Set.toList benches)
@@ -570,7 +570,7 @@ toActions installedMap mtestLock runInBase ee (mbuild, mfinal) =
                   installedMap
               -- Never run benchmarks concurrently with any other task, see
               -- #3663
-            , actionConcurrency = ConcurrencyDisallowed
+            , concurrency = ConcurrencyDisallowed
             }
       )
       []

--- a/src/Stack/Build/ExecuteEnv.hs
+++ b/src/Stack/Build/ExecuteEnv.hs
@@ -602,10 +602,10 @@ withSingleContext
        (  wanted
        && all
             (\(ActionId ident _) -> ident == pkgId)
-            (Set.toList ac.acRemaining)
+            (Set.toList ac.remaining)
        && ee.totalWanted == 1
        )
-    || ac.acConcurrency == ConcurrencyDisallowed
+    || ac.concurrency == ConcurrencyDisallowed
 
   withPackage inner =
     case taskType of

--- a/src/Stack/Build/ExecutePackage.hs
+++ b/src/Stack/Build/ExecutePackage.hs
@@ -456,8 +456,8 @@ singleBuild
           -- because their configure step will require that this
           -- package is built. See
           -- https://github.com/commercialhaskell/stack/issues/2787
-          (True, _) | null ac.acDownstream -> pure Nothing
-          (_, True) | null ac.acDownstream || installedMapHasThisPkg -> do
+          (True, _) | null ac.downstream -> pure Nothing
+          (_, True) | null ac.downstream || installedMapHasThisPkg -> do
             initialBuildSteps executableBuildStatuses cabal announce
             pure Nothing
           _ -> fulfillCuratorBuildExpectations
@@ -700,7 +700,7 @@ singleBuild
         let remaining =
               filter
                 (\(ActionId x _) -> x == pkgId)
-                (Set.toList ac.acRemaining)
+                (Set.toList ac.remaining)
         when (null remaining) $ removeDirRecur pkgDir
       TTLocalMutable{} -> pure ()
 

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -290,21 +290,21 @@ checkPackageDeps myName deps packages =
   go (name, range) =
     case Map.lookup name packages of
       Nothing -> Map.singleton name DepError
-        { deVersion = Nothing
-        , deNeededBy = Map.singleton myName range
+        { version = Nothing
+        , neededBy = Map.singleton myName range
         }
       Just v
         | withinRange v range -> Map.empty
         | otherwise -> Map.singleton name DepError
-            { deVersion = Just v
-            , deNeededBy = Map.singleton myName range
+            { version = Just v
+            , neededBy = Map.singleton myName range
             }
 
 type DepErrors = Map PackageName DepError
 
 data DepError = DepError
-  { deVersion :: !(Maybe Version)
-  , deNeededBy :: !(Map PackageName VersionRange)
+  { version :: !(Maybe Version)
+  , neededBy :: !(Map PackageName VersionRange)
   }
   deriving Show
 
@@ -356,7 +356,7 @@ compareBuildPlanCheck
     -- Note: order of comparison flipped, since it's better to have fewer errors.
     compare (Map.size e2) (Map.size e1)
 compareBuildPlanCheck (BuildPlanCheckFail _ e1 _) (BuildPlanCheckFail _ e2 _) =
-  let numUserPkgs e = Map.size $ Map.unions (Map.elems (fmap (.deNeededBy) e))
+  let numUserPkgs e = Map.size $ Map.unions (Map.elems (fmap (.neededBy) e))
   in  compare (numUserPkgs e2) (numUserPkgs e1)
 compareBuildPlanCheck BuildPlanCheckOk{}      BuildPlanCheckOk{}      = EQ
 compareBuildPlanCheck BuildPlanCheckOk{}      BuildPlanCheckPartial{} = GT
@@ -503,7 +503,7 @@ showCompilerErrors flags errs compiler =
   T.concat
     [ compilerVersionText compiler
     , " cannot be used for these packages:\n"
-    , showMapPackages $ Map.unions (Map.elems (fmap (.deNeededBy) errs))
+    , showMapPackages $ Map.unions (Map.elems (fmap (.neededBy) errs))
     , showDepErrors flags errs -- TODO only in debug mode
     ]
 
@@ -541,5 +541,5 @@ showDepErrors flags errs =
     ]
 
   flagVals = T.concat (map showFlags userPkgs)
-  userPkgs = Map.keys $ Map.unions (Map.elems (fmap (.deNeededBy) errs))
+  userPkgs = Map.keys $ Map.unions (Map.elems (fmap (.neededBy) errs))
   showFlags pkg = maybe "" (showPackageFlags pkg) (Map.lookup pkg flags)

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -40,7 +40,7 @@ import           RIO.List ( (\\), intercalate, isSuffixOf, isPrefixOf )
 import           RIO.NonEmpty ( nonEmpty )
 import qualified RIO.NonEmpty as NE
 import           Stack.BuildPlan
-                   ( BuildPlanCheck (..), checkSnapBuildPlan, deNeededBy
+                   ( BuildPlanCheck (..), DepError (..), checkSnapBuildPlan
                    , removeSrcPkgDefaultFlags, selectBestSnapshot
                    )
 import           Stack.Config ( getSnapshots, makeConcreteResolver )
@@ -620,7 +620,7 @@ checkBundleResolver initOpts snapshotLoc snapCandidate pkgDirs = do
       <> line
       <> indent 4 (string $ show res)
 
-  failedUserPkgs e = Map.keys $ Map.unions (Map.elems (fmap (.deNeededBy) e))
+  failedUserPkgs e = Map.keys $ Map.unions (Map.elems (fmap (.neededBy) e))
 
 getRecommendedSnapshots :: Snapshots -> NonEmpty SnapName
 getRecommendedSnapshots snapshots =

--- a/src/Stack/Options/ConfigParser.hs
+++ b/src/Stack/Options/ConfigParser.hs
@@ -79,7 +79,7 @@ configOptsParser currentDir hide0 =
         <> completer
              ( pathCompleterWith
                ( defaultPathCompleterOpts
-                   { pcoAbsolute = False, pcoFileFilter = const False }
+                   { absolute = False, fileFilter = const False }
                )
              )
         <> help "Relative path to Stack's work directory. Overrides any \


### PR DESCRIPTION
action/Action, ac/ActionContext, es/ExecuteState, pco/PathCompleterOpts, de/DepError.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
