### PR TITLE
Remove prefixes from field names of various types

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -43,24 +43,24 @@
 # Infinite: base/isSuffixOf
 # Usage of the 'isSuffixOf' function that hangs on infinite lists
 [[ignore]]
-  id = "OBS-STAN-0102-luLR/n-523:30"
+  id = "OBS-STAN-0102-luLR/n-524:30"
 # ✦ Category:      #Infinite #List
 # ✦ File:          src\Stack\New.hs
 #
-#  522 ┃
-#  523 ┃   let isPkgSpec f = ".cabal" `L.isSuffixOf` f || "package.yaml" `L.isSuffixOf` f
-#  524 ┃                              ^^^^^^^^^^^^^^
+#  523 ┃
+#  524 ┃   let isPkgSpec f = ".cabal" `L.isSuffixOf` f || "package.yaml" `L.isSuffixOf` f
+#  525 ┃                              ^^^^^^^^^^^^^^
 
 # Infinite: base/isSuffixOf
 # Usage of the 'isSuffixOf' function that hangs on infinite lists
 [[ignore]]
-  id = "OBS-STAN-0102-luLR/n-523:65"
+  id = "OBS-STAN-0102-luLR/n-524:65"
 # ✦ Category:      #Infinite #List
 # ✦ File:          src\Stack\New.hs
 #
-#  522 ┃
-#  523 ┃   let isPkgSpec f = ".cabal" `L.isSuffixOf` f || "package.yaml" `L.isSuffixOf` f
-#  524 ┃                                                                 ^^^^^^^^^^^^^^
+#  523 ┃
+#  524 ┃   let isPkgSpec f = ".cabal" `L.isSuffixOf` f || "package.yaml" `L.isSuffixOf` f
+#  525 ┃                                                                 ^^^^^^^^^^^^^^
 
 # Infinite: base/length
 # Usage of the 'length' function that hangs on infinite lists
@@ -116,14 +116,14 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-axv1UG-353:32"
+  id = "OBS-STAN-0203-axv1UG-354:32"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Docker.hs
 #
-#  352 ┃
-#  353 ┃     hashRepoName = Hash.hash . BS.pack . takeWhile (\c -> c /= ':' && c /= '@')
-#  354 ┃                                ^^^^^^^
+#  353 ┃
+#  354 ┃     hashRepoName = Hash.hash . BS.pack . takeWhile (\c -> c /= ':' && c /= '@')
+#  355 ┃                                ^^^^^^^
 
 # Data types with non-strict fields
 # Defining lazy fields in data types can lead to unexpected space leaks

--- a/package.yaml
+++ b/package.yaml
@@ -279,7 +279,6 @@ library:
   - Stack.Types.BuildOpts
   - Stack.Types.BuildOptsCLI
   - Stack.Types.BuildOptsMonoid
-
   - Stack.Types.CabalConfigKey
   - Stack.Types.Cache
   - Stack.Types.Casa
@@ -299,6 +298,7 @@ library:
   - Stack.Types.DependencyTree
   - Stack.Types.Docker
   - Stack.Types.DockerEntrypoint
+  - Stack.Types.DotConfig
   - Stack.Types.DotOpts
   - Stack.Types.DownloadInfo
   - Stack.Types.DumpLogs

--- a/src/Stack/Docker.hs
+++ b/src/Stack/Docker.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE NoFieldSelectors    #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
@@ -235,8 +236,8 @@ runContainerAndExit = do
       | otherwise -> throwM (NotPulledException image)
   projectRoot <- getProjectRoot
   sandboxDir <- projectDockerSandboxDir projectRoot
-  let ic = imageInfo.iiConfig
-      imageEnvVars = map (break (== '=')) ic.icEnv
+  let ic = imageInfo.config
+      imageEnvVars = map (break (== '=')) ic.env
       platformVariant = show $ hashRepoName image
       stackRoot = view stackRootL config
       sandboxHomeDir = sandboxDir </> homeDirName
@@ -323,8 +324,8 @@ runContainerAndExit = do
            -- Disable the deprecated entrypoint in FP Complete-generated images
         , [ "--entrypoint=/usr/bin/env"
           |  isJust (lookupImageEnv oldSandboxIdEnvVar imageEnvVars)
-          && (  ic.icEntrypoint == ["/usr/local/sbin/docker-entrypoint"]
-             || ic.icEntrypoint == ["/root/entrypoint.sh"]
+          && (  ic.entrypoint == ["/usr/local/sbin/docker-entrypoint"]
+             || ic.entrypoint == ["/root/entrypoint.sh"]
              )
           ]
         , concatMap (\(k,v) -> ["-e", k ++ "=" ++ v]) envVars
@@ -627,10 +628,10 @@ oldSandboxIdEnvVar = "DOCKER_SANDBOX_ID"
 
 -- | Parsed result of @docker inspect@.
 data Inspect = Inspect
-  { iiConfig      :: ImageConfig
-  , iiCreated     :: UTCTime
-  , iiId          :: Text
-  , iiVirtualSize :: Maybe Integer
+  { config      :: ImageConfig
+  , created     :: UTCTime
+  , iiId        :: Text
+  , virtualSize :: Maybe Integer
   }
   deriving Show
 
@@ -646,8 +647,8 @@ instance FromJSON Inspect where
 
 -- | Parsed @Config@ section of @docker inspect@ output.
 data ImageConfig = ImageConfig
-  { icEnv :: [String]
-  , icEntrypoint :: [String]
+  { env :: [String]
+  , entrypoint :: [String]
   }
   deriving Show
 

--- a/src/Stack/Eval.hs
+++ b/src/Stack/Eval.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE NoImplicitPrelude   #-}
-{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NoFieldSelectors      #-}
+{-# LANGUAGE OverloadedRecordDot   #-}
 
 -- | Types and functions related to Stack's @eval@ command.
 module Stack.Eval
@@ -16,8 +18,8 @@ import           Stack.Types.Runner ( Runner )
 
 -- Type representing command line options for the @stack eval@ command.
 data EvalOpts = EvalOpts
-  { evalArg :: !String
-  , evalExtra :: !ExecOptsExtra
+  { arg :: !String
+  , extra :: !ExecOptsExtra
   }
   deriving Show
 
@@ -27,7 +29,7 @@ evalCmd :: EvalOpts -> RIO Runner ()
 evalCmd eval = execCmd execOpts
  where
   execOpts = ExecOpts
-    { eoCmd = ExecGhc
-    , eoArgs = ["-e", eval.evalArg]
-    , eoExtra = eval.evalExtra
+    { cmd = ExecGhc
+    , args = ["-e", eval.arg]
+    , extra = eval.extra
     }

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude     #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NoFieldSelectors      #-}
 {-# LANGUAGE OverloadedRecordDot   #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
@@ -147,19 +148,19 @@ instance Exception GhciPrettyException
 -- | Typre respresenting command line options for the @stack ghci@ and
 -- @stack repl@ commands.
 data GhciOpts = GhciOpts
-  { ghciTargets            :: ![Text]
-  , ghciArgs               :: ![String]
-  , ghciGhcOptions         :: ![String]
-  , ghciFlags              :: !(Map ApplyCLIFlag (Map FlagName Bool))
-  , ghciGhcCommand         :: !(Maybe FilePath)
-  , ghciNoLoadModules      :: !Bool
-  , ghciAdditionalPackages :: ![String]
-  , ghciMainIs             :: !(Maybe Text)
-  , ghciLoadLocalDeps      :: !Bool
-  , ghciSkipIntermediate   :: !Bool
-  , ghciHidePackages       :: !(Maybe Bool)
-  , ghciNoBuild            :: !Bool
-  , ghciOnlyMain           :: !Bool
+  { targets            :: ![Text]
+  , args               :: ![String]
+  , ghcOptions         :: ![String]
+  , flags              :: !(Map ApplyCLIFlag (Map FlagName Bool))
+  , ghcCommand         :: !(Maybe FilePath)
+  , noLoadModules      :: !Bool
+  , additionalPackages :: ![String]
+  , mainIs             :: !(Maybe Text)
+  , loadLocalDeps      :: !Bool
+  , skipIntermediate   :: !Bool
+  , hidePackages       :: !(Maybe Bool)
+  , noBuild            :: !Bool
+  , onlyMain           :: !Bool
   }
   deriving Show
 
@@ -168,22 +169,22 @@ data GhciOpts = GhciOpts
 -- NOTE: GhciPkgInfo has paths as list instead of a Set to preserve files order
 -- as a workaround for bug https://ghc.haskell.org/trac/ghc/ticket/13786
 data GhciPkgInfo = GhciPkgInfo
-  { ghciPkgName :: !PackageName
-  , ghciPkgOpts :: ![(NamedComponent, BuildInfoOpts)]
-  , ghciPkgDir :: !(Path Abs Dir)
-  , ghciPkgModules :: !ModuleMap
-  , ghciPkgCFiles :: ![Path Abs File] -- ^ C files.
-  , ghciPkgMainIs :: !(Map NamedComponent [Path Abs File])
-  , ghciPkgTargetFiles :: !(Maybe [Path Abs File])
-  , ghciPkgPackage :: !Package
+  { name :: !PackageName
+  , opts :: ![(NamedComponent, BuildInfoOpts)]
+  , dir :: !(Path Abs Dir)
+  , modules :: !ModuleMap
+  , cFiles :: ![Path Abs File] -- ^ C files.
+  , mainIs :: !(Map NamedComponent [Path Abs File])
+  , targetFiles :: !(Maybe [Path Abs File])
+  , package :: !Package
   }
   deriving Show
 
 -- | Type representing loaded package description and related information.
 data GhciPkgDesc = GhciPkgDesc
-  { ghciDescPkg :: !Package
-  , ghciDescCabalFp :: !(Path Abs File)
-  , ghciDescTarget :: !Target
+  { package :: !Package
+  , cabalFP :: !(Path Abs File)
+  , target :: !Target
   }
 
 -- Mapping from a module name to a map with all of the paths that use that name.
@@ -202,10 +203,10 @@ ghciCmd :: GhciOpts -> RIO Runner ()
 ghciCmd ghciOpts =
   let boptsCLI = defaultBuildOptsCLI
         -- using only additional packages, targets then get overridden in `ghci`
-        { targetsCLI = map T.pack ghciOpts.ghciAdditionalPackages
+        { targetsCLI = map T.pack ghciOpts.additionalPackages
         , initialBuildSteps = True
-        , flags = ghciOpts.ghciFlags
-        , ghcOptions = map T.pack ghciOpts.ghciGhcOptions
+        , flags = ghciOpts.flags
+        , ghcOptions = map T.pack ghciOpts.ghcOptions
         }
   in  withConfig YesReexec $ withEnvConfig AllowNoTargets boptsCLI $ do
         bopts <- view buildOptsL
@@ -224,7 +225,7 @@ ghci :: HasEnvConfig env => GhciOpts -> RIO env ()
 ghci opts = do
   let buildOptsCLI = defaultBuildOptsCLI
         { targetsCLI = []
-        , flags = opts.ghciFlags
+        , flags = opts.flags
         }
   sourceMap <- view $ envConfigL . to (.sourceMap)
   installMap <- toInstallMap sourceMap
@@ -240,9 +241,9 @@ ghci opts = do
         , global = sourceMap.globalPkgs
         }
   -- Parse --main-is argument.
-  mainIsTargets <- parseMainIsTargets buildOptsCLI sma opts.ghciMainIs
+  mainIsTargets <- parseMainIsTargets buildOptsCLI sma opts.mainIs
   -- Parse to either file targets or build targets
-  etargets <- preprocessTargets buildOptsCLI sma opts.ghciTargets
+  etargets <- preprocessTargets buildOptsCLI sma opts.targets
   (inputTargets, mfileTargets) <- case etargets of
     Right packageTargets -> pure (packageTargets, Nothing)
     Left rawFileTargets -> do
@@ -262,12 +263,12 @@ ghci opts = do
         M.intersectionWith getInternalDependencies inputTargets localMap
       relevantDependencies = M.filter (any isCSubLib) internalDependencies
   -- Check if additional package arguments are sensible.
-  addPkgs <- checkAdditionalPackages opts.ghciAdditionalPackages
+  addPkgs <- checkAdditionalPackages opts.additionalPackages
   -- Load package descriptions.
   pkgDescs <- loadGhciPkgDescs buildOptsCLI localTargets
   -- If necessary, ask user about which main module to load.
   bopts <- view buildOptsL
-  mainFile <- if opts.ghciNoLoadModules
+  mainFile <- if opts.noLoadModules
     then pure Nothing
     else do
       -- Figure out package files, in order to ask the user about which main
@@ -429,15 +430,15 @@ getAllLocalTargets ghciOpts targets0 mainIsTargets localMap = do
                 Nothing -> Nothing
   -- Figure out
   let extraLoadDeps =
-        getExtraLoadDeps ghciOpts.ghciLoadLocalDeps localMap directlyWanted
-  if    (ghciOpts.ghciSkipIntermediate && not ghciOpts.ghciLoadLocalDeps)
+        getExtraLoadDeps ghciOpts.loadLocalDeps localMap directlyWanted
+  if    (ghciOpts.skipIntermediate && not ghciOpts.loadLocalDeps)
      || null extraLoadDeps
     then pure directlyWanted
     else do
       let extraList' =
             map (fromPackageName . fst) extraLoadDeps :: [StyleDoc]
           extraList = mkNarrativeList (Just Current) False extraList'
-      if ghciOpts.ghciLoadLocalDeps
+      if ghciOpts.loadLocalDeps
         then prettyInfo $
           fillSep $
                 [ flow "The following libraries will also be loaded into \
@@ -471,12 +472,12 @@ getAllNonLocalTargets targets = do
 
 buildDepsAndInitialSteps :: HasEnvConfig env => GhciOpts -> [Text] -> RIO env ()
 buildDepsAndInitialSteps ghciOpts localTargets = do
-  let targets = localTargets ++ map T.pack ghciOpts.ghciAdditionalPackages
+  let targets = localTargets ++ map T.pack ghciOpts.additionalPackages
   -- If necessary, do the build, for local packagee targets, only do
   -- 'initialBuildSteps'.
   case nonEmpty targets of
     -- only new local targets could appear here
-    Just nonEmptyTargets | not ghciOpts.ghciNoBuild -> do
+    Just nonEmptyTargets | not ghciOpts.noBuild -> do
       eres <- buildLocalTargets nonEmptyTargets
       case eres of
         Right () -> pure ()
@@ -519,7 +520,7 @@ runGhci
           pkgopts = hidePkgOpts ++ genOpts ++ ghcOpts
           shouldHidePackages = fromMaybe
             (not (null pkgs && null exposePackages))
-            ghciOpts.ghciHidePackages
+            ghciOpts.hidePackages
           hidePkgOpts =
             if shouldHidePackages
               then
@@ -538,14 +539,14 @@ runGhci
             | shouldHidePackages = bio.oneWordOpts ++ bio.packageFlags
             | otherwise = bio.oneWordOpts
           genOpts = nubOrd
-            (concatMap (concatMap (oneWordOpts . snd) . (.ghciPkgOpts)) pkgs)
+            (concatMap (concatMap (oneWordOpts . snd) . (.opts)) pkgs)
           (omittedOpts, ghcOpts) = L.partition badForGhci $
-               concatMap (concatMap ((.opts) . snd) . (.ghciPkgOpts)) pkgs
+               concatMap (concatMap ((.opts) . snd) . (.opts)) pkgs
             ++ map
                  T.unpack
                  (  fold config.ghcOptionsByCat
                     -- ^ include everything, locals, and targets
-                 ++ concatMap (getUserOptions . (.ghciPkgName)) pkgs
+                 ++ concatMap (getUserOptions . (.name)) pkgs
                  )
           getUserOptions pkg =
             M.findWithDefault [] pkg config.ghcOptionsByName
@@ -569,7 +570,7 @@ runGhci
       prettyInfoL
         ( flow "Configuring GHCi with the following packages:"
         : mkNarrativeList (Just Current) False
-            (map (fromPackageName . (.ghciPkgName)) pkgs :: [StyleDoc])
+            (map (fromPackageName . (.name)) pkgs :: [StyleDoc])
         )
       compilerExeName <-
         view $ compilerPathsL . to (.compiler) . to toFilePath
@@ -577,7 +578,7 @@ runGhci
             menv <-
               liftIO $ config.processContextSettings defaultEnvSettings
             withPackageWorkingDir $ withProcessContext menv $ exec
-              (fromMaybe compilerExeName ghciOpts.ghciGhcCommand)
+              (fromMaybe compilerExeName ghciOpts.ghcCommand)
               ( ("--interactive" : ) $
                 -- This initial "-i" resets the include directories to not
                 -- include CWD. If there aren't any packages, CWD is included.
@@ -585,12 +586,12 @@ runGhci
                      odir
                   <> pkgopts
                   <> extras
-                  <> ghciOpts.ghciGhcOptions
-                  <> ghciOpts.ghciArgs
+                  <> ghciOpts.ghcOptions
+                  <> ghciOpts.args
               )
           withPackageWorkingDir =
             case pkgs of
-              [pkg] -> withWorkingDir (toFilePath pkg.ghciPkgDir)
+              [pkg] -> withWorkingDir (toFilePath pkg.dir)
               _ -> id
       -- Since usage of 'exec' does not pure, we cannot do any cleanup on ghci
       -- exit. So, instead leave the generated files. To make this more
@@ -604,14 +605,14 @@ runGhci
       ensureDir ghciDir
       ensureDir tmpDirectory
       macrosOptions <- writeMacrosFile ghciDir pkgs
-      if ghciOpts.ghciNoLoadModules
+      if ghciOpts.noLoadModules
         then execGhci macrosOptions
         else do
           checkForDuplicateModules pkgs
           scriptOptions <-
             writeGhciScript
               tmpDirectory
-              (renderScript pkgs mainFile ghciOpts.ghciOnlyMain extraFiles)
+              (renderScript pkgs mainFile ghciOpts.onlyMain extraFiles)
           execGhci (macrosOptions ++ scriptOptions)
 
 writeMacrosFile ::
@@ -621,7 +622,7 @@ writeMacrosFile ::
   -> RIO env [String]
 writeMacrosFile outputDirectory pkgs = do
   fps <- fmap (nubOrd . catMaybes . concat) $
-    forM pkgs $ \pkg -> forM pkg.ghciPkgOpts $ \(_, bio) -> do
+    forM pkgs $ \pkg -> forM pkg.opts $ \(_, bio) -> do
       let cabalMacros = bio.cabalMacros
       exists <- liftIO $ doesFileExist cabalMacros
       if exists
@@ -670,7 +671,7 @@ renderScript pkgs mainFile onlyMain extraFiles = do
   let addPhase = cmdAdd $ S.fromList (map Left allModules ++ addMain)
       addMain = maybe [] (L.singleton . Right) mainFile
       modulePhase = cmdModule $ S.fromList allModules
-      allModules = nubOrd $ concatMap (M.keys . (.ghciPkgModules)) pkgs
+      allModules = nubOrd $ concatMap (M.keys . (.modules)) pkgs
   case getFileTargets pkgs <> extraFiles of
     [] ->
       if onlyMain
@@ -684,7 +685,7 @@ renderScript pkgs mainFile onlyMain extraFiles = do
 -- Hacky check if module / main phase should be omitted. This should be
 -- improved if / when we have a better per-component load.
 getFileTargets :: [GhciPkgInfo] -> [Path Abs File]
-getFileTargets = concatMap (concat . maybeToList . (.ghciPkgTargetFiles))
+getFileTargets = concatMap (concat . maybeToList . (.targetFiles))
 
 -- | Figure out the main-is file to load based on the targets. Asks the user for
 -- input if there is more than one candidate main-is file.
@@ -755,18 +756,18 @@ figureOutMainFile bopts mainIsTargets targets0 packages =
     mainIsTargets
   candidates = do
     pkg <- packages
-    case M.lookup pkg.ghciPkgName targets of
+    case M.lookup pkg.name targets of
       Nothing -> []
       Just target -> do
         (component,mains) <-
           M.toList $
           M.filterWithKey (\k _ -> k `S.member` wantedComponents)
-                          pkg.ghciPkgMainIs
+                          pkg.mainIs
         main <- mains
-        pure (pkg.ghciPkgName, component, main)
+        pure (pkg.name, component, main)
        where
         wantedComponents =
-          wantedPackageComponents bopts target pkg.ghciPkgPackage
+          wantedPackageComponents bopts target pkg.package
   renderCandidate c@(pkgName, namedComponent, mainIs) =
     let candidateIndex =
           fromString . show . (+1) . fromMaybe 0 . L.elemIndex c
@@ -841,7 +842,7 @@ loadGhciPkgDesc ::
   -> Path Abs File
   -> Target
   -> RIO env GhciPkgDesc
-loadGhciPkgDesc buildOptsCLI name cabalfp target = do
+loadGhciPkgDesc buildOptsCLI name cabalFP target = do
   econfig <- view envConfigL
   compilerVersion <- view actualCompilerVersionL
   let sm = econfig.sourceMap
@@ -872,24 +873,25 @@ loadGhciPkgDesc buildOptsCLI name cabalfp target = do
   -- retain that GenericPackageDescription in the relevant data
   -- structures to avoid reparsing.
   (gpdio, _name, _cabalfp) <-
-    loadCabalFilePath (Just stackProgName') (parent cabalfp)
+    loadCabalFilePath (Just stackProgName') (parent cabalFP)
   gpkgdesc <- liftIO $ gpdio YesPrintWarnings
 
   -- Source the package's *.buildinfo file created by configure if any. See
   -- https://www.haskell.org/cabal/users-guide/developing-packages.html#system-dependent-parameters
   buildinfofp <- parseRelFile (packageNameString name ++ ".buildinfo")
-  hasDotBuildinfo <- doesFileExist (parent cabalfp </> buildinfofp)
+  hasDotBuildinfo <- doesFileExist (parent cabalFP </> buildinfofp)
   let mbuildinfofp
-        | hasDotBuildinfo = Just (parent cabalfp </> buildinfofp)
+        | hasDotBuildinfo = Just (parent cabalFP </> buildinfofp)
         | otherwise = Nothing
   mbuildinfo <- forM mbuildinfofp readDotBuildinfo
   let pdp = resolvePackageDescription config gpkgdesc
-      pkg = packageFromPackageDescription config (C.genPackageFlags gpkgdesc) $
-        maybe pdp (`C.updatePackageDescription` pdp) mbuildinfo
+      package =
+        packageFromPackageDescription config (C.genPackageFlags gpkgdesc) $
+          maybe pdp (`C.updatePackageDescription` pdp) mbuildinfo
   pure GhciPkgDesc
-    { ghciDescPkg = pkg
-    , ghciDescCabalFp = cabalfp
-    , ghciDescTarget = target
+    { package
+    , cabalFP
+    , target
     }
 
 getGhciPkgInfos ::
@@ -902,9 +904,9 @@ getGhciPkgInfos ::
 getGhciPkgInfos installMap addPkgs mfileTargets localTargets = do
   (installedMap, _, _, _) <- getInstalled installMap
   let localLibs =
-        [ desc.ghciDescPkg.name
+        [ desc.package.name
         | desc <- localTargets
-        , hasLocalComp isCLib desc.ghciDescTarget
+        , hasLocalComp isCLib desc.target
         ]
   forM localTargets $ \pkgDesc ->
     makeGhciPkgInfo installMap installedMap localLibs addPkgs mfileTargets pkgDesc
@@ -921,9 +923,9 @@ makeGhciPkgInfo ::
   -> RIO env GhciPkgInfo
 makeGhciPkgInfo installMap installedMap locals addPkgs mfileTargets pkgDesc = do
   bopts <- view buildOptsL
-  let pkg = pkgDesc.ghciDescPkg
-      cabalfp = pkgDesc.ghciDescCabalFp
-      target = pkgDesc.ghciDescTarget
+  let pkg = pkgDesc.package
+      cabalfp = pkgDesc.cabalFP
+      target = pkgDesc.target
       name = pkg.name
   (mods, files, opts) <-
     getPackageOpts pkg installMap installedMap locals addPkgs cabalfp
@@ -931,21 +933,21 @@ makeGhciPkgInfo installMap installedMap locals addPkgs mfileTargets pkgDesc = do
       filterWanted = M.filterWithKey (\k _ -> k `S.member` allWanted)
       allWanted = wantedPackageComponents bopts target pkg
   pure GhciPkgInfo
-    { ghciPkgName = name
-    , ghciPkgOpts = M.toList filteredOpts
-    , ghciPkgDir = parent cabalfp
-    , ghciPkgModules = unionModuleMaps $
-      map
-        ( \(comp, mp) -> M.map
-            (\fp -> M.singleton fp (S.singleton (pkg.name, comp)))
-            mp
-        )
-        (M.toList (filterWanted mods))
-    , ghciPkgMainIs = M.map (mapMaybe dotCabalMainPath) files
-    , ghciPkgCFiles = mconcat
+    { name
+    , opts = M.toList filteredOpts
+    , dir = parent cabalfp
+    , modules = unionModuleMaps $
+        map
+          ( \(comp, mp) -> M.map
+              (\fp -> M.singleton fp (S.singleton (pkg.name, comp)))
+              mp
+          )
+          (M.toList (filterWanted mods))
+    , mainIs = M.map (mapMaybe dotCabalMainPath) files
+    , cFiles = mconcat
         (M.elems (filterWanted (M.map (mapMaybe dotCabalCFilePath) files)))
-    , ghciPkgTargetFiles = mfileTargets >>= M.lookup name
-    , ghciPkgPackage = pkg
+    , targetFiles = mfileTargets >>= M.lookup name
+    , package = pkg
     }
 
 -- NOTE: this should make the same choices as the components code in
@@ -1077,9 +1079,9 @@ checkForIssues pkgs =
   compsWithOpts = map (\(k, bio) ->
     (k, bio.oneWordOpts ++ bio.opts)) compsWithBios
   compsWithBios =
-    [ ((pkg.ghciPkgName, c), bio)
+    [ ((pkg.name, c), bio)
     | pkg <- pkgs
-    , (c, bio) <- pkg.ghciPkgOpts
+    , (c, bio) <- pkg.opts
     ]
 
 -- TODO: Should this also tell the user the filepaths, not just the
@@ -1101,7 +1103,7 @@ checkForDuplicateModules pkgs =
   duplicates =
     filter (\(_, mp) -> M.size mp > 1) $
     M.toList $
-    unionModuleMaps (map (.ghciPkgModules) pkgs)
+    unionModuleMaps (map (.modules) pkgs)
   prettyDuplicate ::
        (ModuleName, Map (Path Abs File) (Set (PackageName, NamedComponent)))
     -> StyleDoc

--- a/src/Stack/Ls.hs
+++ b/src/Stack/Ls.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE NoFieldSelectors    #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
@@ -84,9 +85,9 @@ data LsCmds
 -- | Type representing command line options for the @stack ls snapshots@
 -- command.
 data SnapshotOpts = SnapshotOpts
-  { soptViewType :: LsView
-  , soptLtsSnapView :: Bool
-  , soptNightlySnapView :: Bool
+  { viewType :: LsView
+  , ltsSnapView :: Bool
+  , nightlySnapView :: Bool
   }
   deriving (Eq, Ord, Show)
 
@@ -105,9 +106,9 @@ data SnapshotType
   deriving (Eq, Ord, Show)
 
 data ListDepsOpts = ListDepsOpts
-  { listDepsFormat :: !ListDepsFormat
+  { format :: !ListDepsFormat
     -- ^ Format of printing dependencies
-  , listDepsDotOpts :: !DotOpts
+  , dotOpts :: !DotOpts
     -- ^ The normal dot options.
   }
 
@@ -118,9 +119,9 @@ data ListDepsFormat
   | ListDepsConstraints
 
 data ListDepsFormatOpts = ListDepsFormatOpts
-  { listDepsSep :: !Text
+  { sep :: !Text
     -- ^ Separator between the package name and details.
-  , listDepsLicense :: !Bool
+  , license :: !Bool
     -- ^ Print dependency licenses instead of versions.
   }
 
@@ -134,9 +135,9 @@ data ListDepsTextFilter
 -- | Type representing command line options for the @stack ls stack-colors@ and
 -- @stack ls stack-colours@ commands.
 data ListStylesOpts = ListStylesOpts
-  { coptBasic   :: Bool
-  , coptSGR     :: Bool
-  , coptExample :: Bool
+  { basic   :: Bool
+  , sgr     :: Bool
+  , example :: Bool
   }
   deriving (Eq, Ord, Show)
 
@@ -146,8 +147,8 @@ newtype ListToolsOpts
 
 data Snapshot = Snapshot
   { snapId :: Text
-  , snapTitle :: Text
-  , snapTime :: Text
+  , title :: Text
+  , time :: Text
   }
   deriving (Eq, Ord, Show)
 
@@ -167,11 +168,11 @@ instance FromJSON SnapshotData where
   parseJSON _ = mempty
 
 toSnapshot :: [Value] -> Snapshot
-toSnapshot [String sid, String stitle, String stime] =
+toSnapshot [String snapId, String title, String time] =
   Snapshot
-    { snapId = sid
-    , snapTitle = stitle
-    , snapTime = stime
+    { snapId
+    , title
+    , time
     }
 toSnapshot val = impureThrow $ ParseFailure val
 
@@ -179,11 +180,11 @@ parseSnapshot :: Value -> A.Parser Snapshot
 parseSnapshot = A.withArray "array of snapshot" (pure . toSnapshot . V.toList)
 
 displayTime :: Snapshot -> [Text]
-displayTime snap = [snap.snapTime]
+displayTime snap = [snap.time]
 
 displaySnap :: Snapshot -> [Text]
 displaySnap snap =
-  ["Resolver name: " <> snap.snapId, "\n" <> snap.snapTitle <> "\n\n"]
+  ["Resolver name: " <> snap.snapId, "\n" <> snap.title <> "\n\n"]
 
 displaySingleSnap :: [Snapshot] -> Text
 displaySingleSnap snapshots =
@@ -237,7 +238,7 @@ handleLocal lsOpts = do
   let snapData = L.sort snapData'
   case lsOpts.lsView of
     LsSnapshot sopt ->
-      case (sopt.soptLtsSnapView, sopt.soptNightlySnapView) of
+      case (sopt.ltsSnapView, sopt.nightlySnapView) of
         (True, False) ->
           liftIO $
           displayLocalSnapshot isStdoutTerminal $
@@ -260,7 +261,7 @@ handleRemote lsOpts = do
   let snapData = getResponseBody result
   case lsOpts.lsView of
     LsSnapshot sopt ->
-      case (sopt.soptLtsSnapView, sopt.soptNightlySnapView) of
+      case (sopt.ltsSnapView, sopt.nightlySnapView) of
         (True, False) ->
           liftIO $
           displaySnapshotData isStdoutTerminal $
@@ -280,7 +281,7 @@ lsCmd :: LsCmdOpts -> RIO Runner ()
 lsCmd lsOpts =
   case lsOpts.lsView of
     LsSnapshot sopt ->
-      case sopt.soptViewType of
+      case sopt.viewType of
         Local -> handleLocal lsOpts
         Remote -> handleRemote lsOpts
     LsDependencies depOpts -> listDependencies depOpts
@@ -294,9 +295,9 @@ listStylesCmd opts = do
   -- This is the same test as is used in Stack.Types.Runner.withRunner
   let useColor = view useColorL lc
       styles = elems $ defaultStyles // stylesUpdate (view stylesUpdateL lc)
-      isComplex = not opts.coptBasic
-      showSGR = isComplex && opts.coptSGR
-      showExample = isComplex && opts.coptExample && useColor
+      isComplex = not opts.basic
+      showSGR = isComplex && opts.sgr
+      showExample = isComplex && opts.example && useColor
       styleReports = L.map (styleReport showSGR showExample) styles
   liftIO $
     T.putStrLn $ T.intercalate (if isComplex then "\n" else ":") styleReports
@@ -330,9 +331,9 @@ listToolsCmd opts = do
 
 listDependencies :: ListDepsOpts -> RIO Runner ()
 listDependencies opts = do
-  let dotOpts = opts.listDepsDotOpts
+  let dotOpts = opts.dotOpts
   (pkgs, resultGraph) <- createPrunedDependencyGraph dotOpts
-  liftIO $ case opts.listDepsFormat of
+  liftIO $ case opts.format of
     ListDepsTree treeOpts ->
       T.putStrLn "Packages"
       >> printTree treeOpts dotOpts 0 [] (treeRoots opts pkgs) resultGraph
@@ -362,7 +363,7 @@ listDependencies opts = do
 
 treeRoots :: ListDepsOpts -> Set PackageName -> Set PackageName
 treeRoots opts projectPackages' =
-  let targets = opts.listDepsDotOpts.dotTargets
+  let targets = opts.dotOpts.dotTargets
   in  if null targets
         then projectPackages'
         else Set.fromList $ map (mkPackageName . T.unpack) targets
@@ -420,12 +421,12 @@ treeNodePrefix t (_:ns) d remainingDepth = treeNodePrefix (t <> "│ ") ns d rem
 
 listDepsLine :: ListDepsFormatOpts -> PackageName -> DotPayload -> Text
 listDepsLine opts name payload =
-  T.pack (packageNameString name) <> opts.listDepsSep <>
+  T.pack (packageNameString name) <> opts.sep <>
   payloadText opts payload
 
 payloadText :: ListDepsFormatOpts -> DotPayload -> Text
 payloadText opts payload =
-  if opts.listDepsLicense
+  if opts.license
     then licenseText payload
     else versionText payload
 

--- a/src/Stack/Types/DotConfig.hs
+++ b/src/Stack/Types/DotConfig.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NoFieldSelectors      #-}
+{-# LANGUAGE OverloadedRecordDot   #-}
+
+module Stack.Types.DotConfig
+  ( DotConfig (..)
+  ) where
+
+import           RIO.Process ( HasProcessContext (..) )
+import           Stack.Prelude hiding ( Display (..), pkgName, loadPackage )
+import           Stack.Types.BuildConfig
+                   ( BuildConfig (..), HasBuildConfig (..) )
+import           Stack.Types.Config ( HasConfig (..) )
+import           Stack.Types.DumpPackage ( DumpPackage (..) )
+import           Stack.Types.EnvConfig ( HasSourceMap (..) )
+import           Stack.Types.GHCVariant ( HasGHCVariant (..) )
+import           Stack.Types.Platform ( HasPlatform (..) )
+import           Stack.Types.Runner ( HasRunner (..) )
+import           Stack.Types.SourceMap ( SourceMap (..) )
+
+data DotConfig = DotConfig
+  { buildConfig :: !BuildConfig
+  , sourceMap :: !SourceMap
+  , globalDump :: ![DumpPackage]
+  }
+
+instance HasLogFunc DotConfig where
+  logFuncL = runnerL . logFuncL
+
+instance HasPantryConfig DotConfig where
+  pantryConfigL = configL . pantryConfigL
+
+instance HasTerm DotConfig where
+  useColorL = runnerL . useColorL
+  termWidthL = runnerL . termWidthL
+
+instance HasStylesUpdate DotConfig where
+  stylesUpdateL = runnerL . stylesUpdateL
+
+instance HasGHCVariant DotConfig where
+  ghcVariantL = configL . ghcVariantL
+  {-# INLINE ghcVariantL #-}
+
+instance HasPlatform DotConfig where
+  platformL = configL . platformL
+  {-# INLINE platformL #-}
+  platformVariantL = configL . platformVariantL
+  {-# INLINE platformVariantL #-}
+
+instance HasRunner DotConfig where
+  runnerL = configL . runnerL
+
+instance HasProcessContext DotConfig where
+  processContextL = runnerL . processContextL
+
+instance HasConfig DotConfig where
+  configL = buildConfigL . lens (.config) (\x y -> x { config = y })
+  {-# INLINE configL #-}
+
+instance HasBuildConfig DotConfig where
+  buildConfigL = lens (.buildConfig) (\x y -> x { buildConfig = y })
+
+instance HasSourceMap DotConfig where
+  sourceMapL = lens (.sourceMap) (\x y -> x { sourceMap = y })

--- a/stack.cabal
+++ b/stack.cabal
@@ -292,6 +292,7 @@ library
       Stack.Types.DependencyTree
       Stack.Types.Docker
       Stack.Types.DockerEntrypoint
+      Stack.Types.DotConfig
       Stack.Types.DotOpts
       Stack.Types.DownloadInfo
       Stack.Types.DumpLogs

--- a/tests/unit/Stack/LockSpec.hs
+++ b/tests/unit/Stack/LockSpec.hs
@@ -59,7 +59,7 @@ snapshots:
     compiler: ghc-8.6.5
 packages: []
 |]
-        pkgImm <- (.lckPkgImmutableLocations) <$> decodeLocked lockFile
+        pkgImm <- (.pkgImmutableLocations) <$> decodeLocked lockFile
         pkgImm `shouldBe` []
     it "parses lock file (empty with LTS resolver)" $ do
         let lockFile :: ByteString
@@ -77,7 +77,7 @@ snapshots:
     compiler: ghc-8.6.5
 packages: []
 |]
-        pkgImm <- (.lckPkgImmutableLocations) <$> decodeLocked lockFile
+        pkgImm <- (.pkgImmutableLocations) <$> decodeLocked lockFile
         pkgImm `shouldBe` []
     it "parses lock file (LTS, wai + warp)" $ do
         let lockFile :: ByteString
@@ -121,7 +121,7 @@ packages:
       sha256: f808e075811b002563d24c393ce115be826bb66a317d38da22c513ee42b7443a
     commit: d11d63f1a6a92db8c637a8d33e7953ce6194a3e0
 |]
-        pkgImm <- (.lckPkgImmutableLocations) <$> decodeLocked lockFile
+        pkgImm <- (.pkgImmutableLocations) <$> decodeLocked lockFile
         let waiSubdirRepo subdir =
               Repo { repoType = RepoGit
                    , repoUrl = "https://github.com/yesodweb/wai.git"


### PR DESCRIPTION
Also moves `DotConfig` to its own module to avoid ambiguity.

hropts/HpcReportOpts, ii/Inspect, ic/ImageConfig, eval/EvalOpts, eo/ExecOpts, eo/ExecOptsExtra, eo/ExecOpts, ghci/GhciOpts, ghciPkg/GhciPkgInfo, ghciDesc/GhciPkgDesc, ll/LockedLocation, lck/Locked, sopt/SnapshotOpts, listDeps/ListDepsOpts, listDeps/ListDepsFormatOpts, copt/ListStyleOpts, snap/Snapshot, newOpts/NewOpts, tpl/TemplateDownloadSettings, dc/DotConfig.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
