### PR TITLE
Remove prefixes from field names of various types

### DIFF
--- a/src/Stack/CLI.hs
+++ b/src/Stack/CLI.hs
@@ -454,7 +454,7 @@ commandLineHandler currentDir progName isInterpreter =
     "Run a Stack script."
     globalFooter
     scriptCmd
-    (\so gom -> gom { resolverRoot = First $ Just $ takeDirectory so.soFile })
+    (\so gom -> gom { resolverRoot = First $ Just $ takeDirectory so.file })
     (globalOpts OtherCmdGlobalOpts)
     scriptOptsParser
 

--- a/src/Stack/Setup.hs
+++ b/src/Stack/Setup.hs
@@ -2732,8 +2732,8 @@ data StackReleaseInfo
     -- ^ Information on the latest available binary for the current platforms.
 
 data HaskellStackOrg = HaskellStackOrg
-  { hsoUrl :: !Text
-  , hsoVersion :: !Version
+  { url :: !Text
+  , version :: !Version
   }
   deriving Show
 
@@ -2804,8 +2804,8 @@ downloadStackReleaseInfo Nothing Nothing Nothing = do
                   -- We found a valid URL, let's use it!
                   Right version -> do
                     let hso = HaskellStackOrg
-                                { hsoUrl = loc
-                                , hsoVersion = version
+                                { url = loc
+                                , version
                                 }
                     logDebug $
                          "Downloading from haskellstack.org: "
@@ -2960,7 +2960,7 @@ downloadStackExe platforms0 archiveInfo destDir checkPath testExe = do
         String url <- KeyMap.lookup "browser_download_url" o
         Just url
     findMatch _ _ = Nothing
-  findArchive (SRIHaskellStackOrg hso) _ = pure hso.hsoUrl
+  findArchive (SRIHaskellStackOrg hso) _ = pure hso.url
 
   handleTarball :: Path Abs File -> Bool -> T.Text -> IO ()
   handleTarball tmpFile isWindows url = do
@@ -3092,4 +3092,4 @@ getDownloadVersion (SRIGitHub val) = do
   String rawName <- KeyMap.lookup "name" o
   -- drop the "v" at the beginning of the name
   parseVersion $ T.unpack (T.drop 1 rawName)
-getDownloadVersion (SRIHaskellStackOrg hso) = Just hso.hsoVersion
+getDownloadVersion (SRIHaskellStackOrg hso) = Just hso.version

--- a/src/Stack/Unpack.hs
+++ b/src/Stack/Unpack.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE NoFieldSelectors    #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
@@ -75,11 +76,11 @@ type UnpackTarget = Either PackageName PackageIdentifierRevision
 
 -- | Type representing options for the @stack unpack@ command.
 data UnpackOpts = UnpackOpts
-  { upoptsTargets :: [UnpackTarget]
+  { targets :: [UnpackTarget]
     -- ^ The packages or package candidates to be unpacked.
-  , upoptsAreCandidates :: Bool
+  , areCandidates :: Bool
     -- ^ Whether the targets are Hackage package candidates.
-  , upoptsDest :: Maybe (SomeBase Dir)
+  , dest :: Maybe (SomeBase Dir)
     -- ^ The optional directory into which a target will be unpacked into a
     -- subdirectory.
   }

--- a/src/Stack/Upgrade.hs
+++ b/src/Stack/Upgrade.hs
@@ -89,16 +89,16 @@ instance Exception UpgradePrettyException
 -- | Type representing options for upgrading Stack with a binary executable
 -- file.
 data BinaryOpts = BinaryOpts
-  { _boPlatform :: !(Maybe String)
-  , _boForce :: !Bool
+  { platform :: !(Maybe String)
+  , force :: !Bool
     -- ^ Force a download, even if the downloaded version is older than what we
     -- are.
-  , _boOnlyLocalBin :: !Bool
+  , onlyLocalBin :: !Bool
     -- ^ Only download to Stack's local binary directory.
-  , _boVersion :: !(Maybe String)
+  , version :: !(Maybe String)
     -- ^ Specific version to download
-  , _boGitHubOrg :: !(Maybe String)
-  , _boGitHubRepo :: !(Maybe String)
+  , gitHubOrg :: !(Maybe String)
+  , gitHubRepo :: !(Maybe String)
   }
   deriving Show
 
@@ -109,8 +109,8 @@ newtype SourceOpts
 
 -- | Type representing command line options for the @stack upgrade@ command.
 data UpgradeOpts = UpgradeOpts
-  { _uoBinary :: !(Maybe BinaryOpts)
-  , _uoSource :: !(Maybe SourceOpts)
+  { binary :: !(Maybe BinaryOpts)
+  , source :: !(Maybe SourceOpts)
   }
   deriving Show
 


### PR DESCRIPTION
lh/LoadHelper, rr/ResolveResult, pi/PathInfo, so/ScriptOpts, sdopts/SDistOpts, hs/HaskellStackOrg, sco/SetupCmdOpts, upopts/UnpackOpts, _bo/BinaryOpts, _uo/UpgradeOpts, uo/UploadOpts, hc/HackageCreds.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
