### PR TITLE
Rename certain fields and variables for consistency

### DIFF
--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -155,9 +155,9 @@ constructPlan
     econfig <- view envConfigL
     globalCabalVersion <- view $ compilerPathsL . to (.cabalVersion)
     sources <- getSources globalCabalVersion
-    mcur <- view $ buildConfigL . to (.curator)
-    pathEnvVar' <- liftIO $ maybe mempty T.pack <$> lookupEnv "PATH"
-    let ctx = mkCtx econfig globalCabalVersion sources mcur pathEnvVar'
+    curator <- view $ buildConfigL . to (.curator)
+    pathEnvVar <- liftIO $ maybe mempty T.pack <$> lookupEnv "PATH"
+    let ctx = mkCtx econfig globalCabalVersion sources curator pathEnvVar
         targetPackageNames = Map.keys sourceMap.targets.targets
         -- Ignore the result of 'getCachedDepOrAddDep'.
         onTarget = void . getCachedDepOrAddDep
@@ -204,17 +204,17 @@ constructPlan
 
   hasBaseInDeps = Map.member (mkPackageName "base") sourceDeps
 
-  mkCtx econfig globalCabalVersion sources mcur pathEnvVar' = Ctx
+  mkCtx ctxEnvConfig globalCabalVersion sources curator pathEnvVar = Ctx
     { baseConfigOpts = baseConfigOpts0
-    , loadPackage = \w x y z -> runRIO econfig $
+    , loadPackage = \w x y z -> runRIO ctxEnvConfig $
         applyForceCustomBuild globalCabalVersion <$> loadPackage0 w x y z
     , combinedMap = combineMap sources installedMap
-    , ctxEnvConfig = econfig
+    , ctxEnvConfig
     , callStack = []
     , wanted = Map.keysSet sourceMap.targets.targets
     , localNames = Map.keysSet sourceProject
-    , mcurator = mcur
-    , pathEnvVar = pathEnvVar'
+    , curator
+    , pathEnvVar
     }
 
   toEither :: (k, Either e v) -> Either e (k, v)
@@ -662,7 +662,7 @@ installPackage name ps minstalled = do
               -- test/benchmark failure could prevent library from being
               -- available to its dependencies but when it's already available
               -- it's OK to do that
-              splitRequired <- expectedTestOrBenchFailures <$> asks (.mcurator)
+              splitRequired <- expectedTestOrBenchFailures <$> asks (.curator)
               let isAllInOne = not splitRequired
               adr <- installPackageGivenDeps
                 isAllInOne lp.buildHaddocks ps tb minstalled deps

--- a/src/Stack/Build/ExecutePackage.hs
+++ b/src/Stack/Build/ExecutePackage.hs
@@ -369,8 +369,8 @@ singleBuild
       case mprecompiled of
         Just precompiled -> copyPreCompiled ee task pkgId precompiled
         Nothing -> do
-          mcurator <- view $ buildConfigL . to (.curator)
-          realConfigAndBuild cache mcurator allDepsMap
+          curator <- view $ buildConfigL . to (.curator)
+          realConfigAndBuild cache curator allDepsMap
     case minstalled of
       Nothing -> pure ()
       Just installed -> do
@@ -380,7 +380,7 @@ singleBuild
  where
   pkgId = taskProvides task
   PackageIdentifier pname _ = pkgId
-  doHaddock mcurator package =
+  doHaddock curator package =
        task.buildHaddock
     && not isFinalBuild
        -- Works around haddock failing on bytestring-builder since it has no
@@ -388,7 +388,7 @@ singleBuild
     && mainLibraryHasExposedModules package
        -- Special help for the curator tool to avoid haddocks that are known
        -- to fail
-    && maybe True (Set.notMember pname . (.skipHaddock)) mcurator
+    && maybe True (Set.notMember pname . (.skipHaddock)) curator
 
   buildingFinals = isFinalBuild || task.allInOne
   enableTests = buildingFinals && any isCTest (taskComponents task)

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -833,7 +833,7 @@ withBuildConfig inner = do
     pure Project
       { userMsg = Nothing
       , packages = []
-      , dependencies = map (RPLImmutable . flip RPLIHackage Nothing) extraDeps
+      , extraDeps = map (RPLImmutable . flip RPLIHackage Nothing) extraDeps
       , flagsByPkg = mempty
       , resolver = r
       , compiler = Nothing
@@ -867,11 +867,11 @@ fillProjectWanted stackYamlFP config project locCache snapCompiler snapPackages 
             (RPLImmutable (RPLIRepo repo rpm)) -> Just (repo, rpm)
             _ -> Nothing
         )
-        project.dependencies
+        project.extraDeps
   logDebug ("Prefetching git repos: " <> display (T.pack (show gitRepos)))
   fetchReposRaw gitRepos
 
-  (deps0, mcompleted) <- fmap unzip . forM project.dependencies $ \rpl -> do
+  (deps0, mcompleted) <- fmap unzip . forM project.extraDeps $ \rpl -> do
     (pl, mCompleted) <- case rpl of
        RPLImmutable rpli -> do
          (compl, mcompl) <-

--- a/src/Stack/Init.hs
+++ b/src/Stack/Init.hs
@@ -281,10 +281,10 @@ initProject currDir initOpts mresolver = do
     PLImmutable . cplComplete <$>
       completePackageLocation
         (RPLIHackage (PackageIdentifierRevision n v CFILatest) Nothing)
-  let p = Project
+  let project = Project
         { userMsg = if userMsg == "" then Nothing else Just userMsg
         , packages = resolvedRelative <$> Map.elems rbundle
-        , dependencies = map toRawPL deps
+        , extraDeps = map toRawPL deps
         , flagsByPkg = removeSrcPkgDefaultFlags gpds flags
         , resolver = snapshotLoc
         , compiler = Nothing
@@ -336,7 +336,7 @@ initProject currDir initOpts mresolver = do
         else "Writing configuration to"
     , style File (fromString reldest) <> "."
     ]
-  writeBinaryFileAtomic dest $ renderStackYaml p
+  writeBinaryFileAtomic dest $ renderStackYaml project
     (Map.elems $ fmap (makeRelDir . parent . fst) ignored)
     (map (makeRelDir . parent) dupPkgs)
   prettyInfoS

--- a/src/Stack/Types/Build/ConstructPlan.hs
+++ b/src/Stack/Types/Build/ConstructPlan.hs
@@ -161,7 +161,7 @@ data Ctx = Ctx
   , callStack      :: ![PackageName]
   , wanted         :: !(Set PackageName)
   , localNames     :: !(Set PackageName)
-  , mcurator       :: !(Maybe Curator)
+  , curator       :: !(Maybe Curator)
   , pathEnvVar     :: !Text
   }
 

--- a/src/Stack/Types/ProjectAndConfigMonoid.hs
+++ b/src/Stack/Types/ProjectAndConfigMonoid.hs
@@ -43,7 +43,7 @@ parseProjectAndConfigMonoid rootDir =
     let dropPackages = Set.map unCabalString drops
     pure $ do
       deps' <- mapM (resolvePaths (Just rootDir)) deps
-      let dependencies =
+      let extraDeps =
             concatMap toList (deps' :: [NonEmpty RawPackageLocation])
       resolver <- resolvePaths (Just rootDir) resolver'
       let project = Project
@@ -52,7 +52,7 @@ parseProjectAndConfigMonoid rootDir =
             , compiler -- FIXME make sure resolver' isn't SLCompiler
             , extraPackageDBs
             , packages
-            , dependencies
+            , extraDeps
             , flagsByPkg
             , curator
             , dropPackages


### PR DESCRIPTION
`project.dependencies` -> `project.extraDeps`.

`curator` consistently (replacing `mcurator`, `mcur`).

Makes greater use of `NamedFieldPuns`.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
