### PR TITLE
Fix #6448 "hspec-iscover" -> "hspec-discover"

### DIFF
--- a/src/Stack/Component.hs
+++ b/src/Stack/Component.hs
@@ -106,7 +106,7 @@ stackTestFromCabal cabalTest = StackTestSuite
   }
 
 isComponentBuildable :: HasBuildInfo component => component -> Bool
-isComponentBuildable componentRec = componentRec.buildInfo.sbiBuildable
+isComponentBuildable componentRec = componentRec.buildInfo.buildable
 
 stackBuildInfoFromCabal :: BuildInfo -> StackBuildInfo
 stackBuildInfoFromCabal buildInfoV = gatherComponentToolsAndDepsFromCabal
@@ -114,13 +114,13 @@ stackBuildInfoFromCabal buildInfoV = gatherComponentToolsAndDepsFromCabal
   buildInfoV.buildToolDepends
   buildInfoV.targetBuildDepends
   StackBuildInfo
-    { sbiBuildable = buildInfoV.buildable
-    , sbiOtherModules = buildInfoV.otherModules
+    { buildable = buildInfoV.buildable
+    , otherModules = buildInfoV.otherModules
     , jsSources = buildInfoV.jsSources
     , hsSourceDirs = buildInfoV.hsSourceDirs
     , cSources = buildInfoV.cSources
-    , sbiDependency = mempty
-    , sbiUnknownTools = mempty
+    , dependency = mempty
+    , unknownTools = mempty
     , cppOptions = buildInfoV.cppOptions
     , targetBuildDepends = buildInfoV.targetBuildDepends
     , options = buildInfoV.options
@@ -171,23 +171,21 @@ gatherComponentToolsAndDepsFromCabal legacyBuildTools buildTools targetDeps =
           sbi
           (Cabal.ExeDependency pName (Cabal.mkUnqualComponentName exeName) range)
       Nothing -> sbi
-        {sbiUnknownTools = Set.insert (pack exeName) sbi.sbiUnknownTools}
+        { unknownTools = Set.insert (pack exeName) sbi.unknownTools }
   processExeDependency sbi exeDep@(Cabal.ExeDependency pName _ _)
     | isPreInstalledPackages pName = sbi
     | otherwise = sbi
-        { sbiDependency =
-            Map.insert pName (cabalExeToStackDep exeDep) sbi.sbiDependency
+        { dependency =
+            Map.insert pName (cabalExeToStackDep exeDep) sbi.dependency
         }
   processDependency sbi dep@(Cabal.Dependency pName _ _) = sbi
-    { sbiDependency =
-        Map.insert pName (cabalToStackDep dep) sbi.sbiDependency
-    }
+    { dependency = Map.insert pName (cabalToStackDep dep) sbi.dependency }
 
 componentDependencyMap ::
-     (HasField "buildInfo" r1 r2, HasField "sbiDependency" r2 a)
+     (HasField "buildInfo" r1 r2, HasField "dependency" r2 a)
   => r1
   -> a
-componentDependencyMap component = component.buildInfo.sbiDependency
+componentDependencyMap component = component.buildInfo.dependency
 
 -- | A hard-coded map for tool dependencies. If a dependency is within this map
 -- it's considered "known" (the exe will be found at the execution stage). The
@@ -201,7 +199,7 @@ isKnownLegacyExe input = case input of
   "greencard" -> justPck "greencard"
   "c2hs" -> justPck "c2hs"
   "hscolour" -> justPck "hscolour"
-  "hspec-iscover" -> justPck "hspec-discover"
+  "hspec-discover" -> justPck "hspec-discover"
   "hsx2hs" -> justPck "hsx2hs"
   "gtk2hsC2hs" -> justPck "gtk2hs-buildtools"
   "gtk2hsHookGenerator" -> justPck "gtk2hs-buildtools"

--- a/src/Stack/ComponentFile.hs
+++ b/src/Stack/ComponentFile.hs
@@ -55,7 +55,6 @@ import           Stack.Types.Component
                    ( StackBenchmark (..), StackBuildInfo (..)
                    , StackExecutable (..), StackLibrary (..)
                    , StackTestSuite (..), StackUnqualCompName (..)
-                   , sbiOtherModules
                    )
 import           Stack.Types.Config
                    ( Config (..), HasConfig (..), prettyStackDevL )
@@ -86,7 +85,7 @@ stackBenchmarkFiles bench =
     case bench.interface of
       BenchmarkExeV10 _ fp -> [DotCabalMain fp]
       BenchmarkUnsupported _ -> []
-  bnames = map DotCabalModule build.sbiOtherModules
+  bnames = map DotCabalModule build.otherModules
   build = bench.buildInfo
 
 -- | Get all files referenced by the test.
@@ -102,7 +101,7 @@ stackTestSuiteFiles test =
       TestSuiteExeV10 _ fp -> [DotCabalMain fp]
       TestSuiteLibV09 _ mn -> [DotCabalModule mn]
       TestSuiteUnsupported _ -> []
-  bnames = map DotCabalModule build.sbiOtherModules
+  bnames = map DotCabalModule build.otherModules
   build = test.buildInfo
 
 -- | Get all files referenced by the executable.
@@ -114,7 +113,7 @@ stackExecutableFiles exe =
  where
   build = exe.buildInfo
   names =
-    map DotCabalModule build.sbiOtherModules ++ [DotCabalMain exe.modulePath]
+    map DotCabalModule build.otherModules ++ [DotCabalMain exe.modulePath]
 
 -- | Get all files referenced by the library. Handle all libraries (CLib and
 -- SubLib), based on empty name or not.
@@ -131,7 +130,7 @@ stackLibraryFiles lib =
   build = lib.buildInfo
   names = bnames ++ exposed
   exposed = map DotCabalModule lib.exposedModules
-  bnames = map DotCabalModule build.sbiOtherModules
+  bnames = map DotCabalModule build.otherModules
 
 -- | Get all files referenced by the component.
 resolveComponentFiles ::

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -649,7 +649,7 @@ mainLibraryHasExposedModules package =
 
 -- | Aggregate all unknown tools from all components. Mostly meant for
 -- build tools specified in the legacy manner (build-tools:) that failed the
--- hard-coded lookup. See 'Stack.Types.Component.sbiUnknownTools' for more
+-- hard-coded lookup. See 'Stack.Types.Component.unknownTools' for more
 -- information.
 packageUnknownTools :: Package -> Set Text
 packageUnknownTools pkg = lib (bench <> tests <> flib <> sublib <> exe)
@@ -663,7 +663,7 @@ packageUnknownTools pkg = lib (bench <> tests <> flib <> sublib <> exe)
   sublib = gatherUnknownTools pkg.subLibraries
   exe = gatherUnknownTools pkg.executables
   addUnknownTools :: HasBuildInfo x => x -> Set Text -> Set Text
-  addUnknownTools = (<>) . (.buildInfo.sbiUnknownTools)
+  addUnknownTools = (<>) . (.buildInfo.unknownTools)
   gatherUnknownTools :: HasBuildInfo x => CompCollection x -> Set Text
   gatherUnknownTools = foldr' addUnknownTools mempty
 

--- a/src/Stack/Types/CompCollection.hs
+++ b/src/Stack/Types/CompCollection.hs
@@ -121,7 +121,7 @@ foldAndMakeCollection mapFn = foldl' compIterator mempty
   compIterator existingCollection component =
     compCreator existingCollection (mapFn component)
   compCreator existingCollection component
-    | component.buildInfo.sbiBuildable = existingCollection
+    | component.buildInfo.buildable = existingCollection
         { buildableOnes =
             addComponent component existingCollection.buildableOnes
         }

--- a/src/Stack/Types/Component.hs
+++ b/src/Stack/Types/Component.hs
@@ -114,21 +114,21 @@ newtype ExeName = ExeName Text
 -- dependencies, and Stack needs a Map and only a small subset of all the
 -- information in Cabal-syntax type.
 data StackBuildInfo = StackBuildInfo
-  { sbiBuildable :: !Bool
+  { buildable :: !Bool
     -- ^ Corresponding to Cabal-syntax's
     -- 'Distribution.Types.BuildInfo.buildable'. The component is buildable
     -- here.
-  , sbiDependency :: !(Map PackageName DepValue)
+  , dependency :: !(Map PackageName DepValue)
     -- ^ Corresponding to Cabal-syntax's
     -- 'Distribution.Types.BuildInfo.targetBuildDepends'. Dependencies specific
     -- to a library or executable target.
-  , sbiUnknownTools :: Set Text
+  , unknownTools :: Set Text
     -- ^ From Cabal-syntax's 'Distribution.Types.BuildInfo.buildTools'. We only
     -- keep the legacy build tool depends that we know (from a hardcoded list).
     -- We only use the deduplication aspect of the Set here, as this field is
     -- only used for error reporting in the end. This is lazy because it's an
     -- error reporting field only.
-  , sbiOtherModules :: [ModuleName]
+  , otherModules :: [ModuleName]
     -- ^ Only used in file gathering. See usage in "Stack.ComponentFile" module.
   , jsSources :: [FilePath]
     -- ^ Only used in file gathering. See usage in "Stack.ComponentFile" module.


### PR DESCRIPTION
Also removes `sbi` prefix from `StackBuildInfo` field names.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
