### PR TITLE
Minor refactoring

### DIFF
--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -71,9 +71,9 @@ import           Stack.Types.EnvConfig
                    , installationRootDeps, installationRootLocal
                    , platformGhcRelDir
                    )
-import           Stack.Types.GhcPkgId ( GhcPkgId, ghcPkgIdString )
+import           Stack.Types.GhcPkgId ( ghcPkgIdString )
 import           Stack.Types.Installed
-                   (InstalledLibraryInfo (..), installedGhcPkgId )
+                   (InstalledLibraryInfo (..), foldOnGhcPkgId' )
 import           Stack.Types.NamedComponent ( NamedComponent (..) )
 import           Stack.Types.SourceMap ( smRelDir )
 import           System.PosixCompat.Files
@@ -376,7 +376,6 @@ writePrecompiledCache ::
   -> ConfigureOpts
   -> Bool -- ^ build haddocks
   -> Installed -- ^ library
-  -> [GhcPkgId] -- ^ sub-libraries, in the GhcPkgId format
   -> Set Text -- ^ executables
   -> RIO env ()
 writePrecompiledCache
@@ -385,24 +384,26 @@ writePrecompiledCache
     copts
     buildHaddocks
     mghcPkgId
-    subLibs
     exes
   = do
       key <- getPrecompiledCacheKey loc copts buildHaddocks
       ec <- view envConfigL
       let stackRootRelative = makeRelative (view stackRootL ec)
-      mlibpath <-
-        traverse (pathFromPkgId stackRootRelative) (installedGhcPkgId mghcPkgId)
-      subLibPaths <- mapM (pathFromPkgId stackRootRelative) subLibs
       exes' <- forM (Set.toList exes) $ \exe -> do
         name <- parseRelFile $ T.unpack exe
         stackRootRelative $
            baseConfigOpts.snapInstallRoot </> bindirSuffix </> name
-      let precompiled = PrecompiledCache
-            { library = mlibpath
-            , subLibs = subLibPaths
+      let installedLibToPath libName ghcPkgId pcAction = do
+            libPath <- pathFromPkgId stackRootRelative ghcPkgId
+            pc <- pcAction
+            pure $ case libName of
+              Nothing -> pc{library = Just libPath}
+              _ -> pc{subLibs = libPath : pc.subLibs}
+      precompiled <- foldOnGhcPkgId' installedLibToPath mghcPkgId (pure PrecompiledCache
+            { library = Nothing
+            , subLibs = []
             , exes = exes'
-            }
+            })
       savePrecompiledCache key precompiled
       -- reuse precompiled cache with haddocks also in case when haddocks are
       -- not required

--- a/src/Stack/Types/CompCollection.hs
+++ b/src/Stack/Types/CompCollection.hs
@@ -30,13 +30,13 @@ module Stack.Types.CompCollection
   , foldComponentToAnotherCollection
   ) where
 
-import qualified Data.HashMap.Strict as HM
 import qualified Data.Set as Set
 import           Stack.Prelude
 import           Stack.Types.Component
                    ( HasBuildInfo, HasName, StackBuildInfo (..)
                    , StackUnqualCompName (..)
                    )
+import qualified Data.Map as M
 
 -- | A type representing collections of components, distinguishing buildable
 -- components and non-buildable components.
@@ -62,33 +62,15 @@ instance Monoid (CompCollection component) where
     }
 
 instance Foldable CompCollection where
-  foldMap fn collection = foldMap fn collection.buildableOnes.asNameMap
-  foldr' fn c collection = HM.foldr' fn c collection.buildableOnes.asNameMap
-  null = HM.null . (.buildableOnes.asNameMap)
+  foldMap fn collection = foldMap fn collection.buildableOnes
+  foldr' fn c collection = M.foldr' fn c collection.buildableOnes
+  null = M.null . (.buildableOnes)
 
--- | A type representing a collection of components, including a cache of
--- the components' names.
-data InnerCollection component = InnerCollection
-  { asNameMap :: !(HashMap StackUnqualCompName component)
-  , asNameSet :: !(Set StackUnqualCompName)
-    -- ^ Strictly, this field is redundant. It is provided as a cache for speed.
-    -- It is assumed, but not checked, that 'asNameSet' is always equal to
-    -- @keySet . asNameMap@. It takes O(n) to compute it from 'asNameMap'.
-    -- 'addComponent' should be used to add new members to the collection.
-  }
-  deriving (Show)
-
-instance Semigroup (InnerCollection component) where
-  a <> b = InnerCollection
-    { asNameMap = a.asNameMap <> b.asNameMap
-    , asNameSet = a.asNameSet <> b.asNameSet
-    }
-
-instance Monoid (InnerCollection component) where
-  mempty = InnerCollection
-    { asNameMap = mempty
-    , asNameSet = mempty
-    }
+-- | While the @HashMap@ is a more suitable choice for @Text@ based keys in general 
+-- (it scales better), constant factors are largely dominant for maps with less than
+-- 1000 keys. Package with more than 100 components are extremely unlikely, so we keep
+-- a simple @Map@.
+type InnerCollection component = Map StackUnqualCompName component
 
 -- | A function to add a component to a collection of components. Ensures that
 -- both 'asNameMap' and 'asNameSet' are updated consistently.
@@ -99,12 +81,7 @@ addComponent ::
   -> InnerCollection component
      -- ^ Existing collection of components.
   -> InnerCollection component
-addComponent componentV collection =
-  let nameV = componentV.name
-  in  collection
-        { asNameMap=HM.insert nameV componentV collection.asNameMap
-        , asNameSet=Set.insert nameV collection.asNameSet
-        }
+addComponent component = M.insert component.name component
 
 -- | For the given function and foldable data structure of components of type
 -- @compA@, iterates on the elements of that structure and maps each element to
@@ -133,7 +110,7 @@ foldAndMakeCollection mapFn = foldl' compIterator mempty
 -- | Get the names of the buildable components in the given collection, as a
 -- 'Set' of 'StackUnqualCompName'.
 getBuildableSet :: CompCollection component -> Set StackUnqualCompName
-getBuildableSet = (.buildableOnes.asNameSet)
+getBuildableSet = M.keysSet . (.buildableOnes)
 
 -- | Get the names of the buildable components in the given collection, as a
 -- 'Set' of 'Text'.
@@ -170,14 +147,14 @@ collectionLookup ::
      -- ^ Collection of components.
   -> Maybe component
 collectionLookup needle haystack =
-  HM.lookup (StackUnqualCompName needle) haystack.buildableOnes.asNameMap
+  M.lookup (StackUnqualCompName needle) haystack.buildableOnes
 
 -- | For a given collection of components, yields a list of pairs for buildable
 -- components of the name of the component and the component.
 collectionKeyValueList :: CompCollection component -> [(Text, component)]
 collectionKeyValueList haystack =
       (\(StackUnqualCompName k, !v) -> (k, v))
-  <$> HM.toList haystack.buildableOnes.asNameMap
+  <$> M.toList haystack.buildableOnes
 
 -- | Yields 'True' if, and only if, the given collection of components includes
 -- a buildable component with the given name.
@@ -202,4 +179,4 @@ foldComponentToAnotherCollection ::
      -- ^ Starting value.
   -> m a
 foldComponentToAnotherCollection collection fn initialValue =
-  HM.foldr' fn initialValue collection.buildableOnes.asNameMap
+  M.foldr' fn initialValue collection.buildableOnes

--- a/src/Stack/Types/Installed.hs
+++ b/src/Stack/Types/Installed.hs
@@ -17,7 +17,6 @@ module Stack.Types.Installed
   , simpleInstalledLib
   , installedToPackageIdOpt
   , installedPackageIdentifier
-  , installedGhcPkgId
   , installedVersion
   , foldOnGhcPkgId'
   ) where
@@ -134,10 +133,6 @@ installedToPackageIdOpt libInfo =
 installedPackageIdentifier :: Installed -> PackageIdentifier
 installedPackageIdentifier (Library pid _) = pid
 installedPackageIdentifier (Executable pid) = pid
-
-installedGhcPkgId :: Installed -> Maybe GhcPkgId
-installedGhcPkgId (Library _ libInfo) = Just libInfo.ghcPkgId
-installedGhcPkgId (Executable _) = Nothing
 
 -- | A strict fold over the @GhcPkgId@ of the given installed package.
 -- This will iterate on both sub and main librarie(s) if any.


### PR DESCRIPTION
This includes two types of refactorings : 
- Some simplifications and function isolation of basic tasks (plus docs) in ExecutePackage
- A change in the CompCollection to use a simple Map rather than the original HashMap. The rationale for using a HasMap was that it scaled better for text/bytestring based keys (see [this benchmark](https://github.com/haskell-perf/dictionaries)), but after a careful attempt at reproducing this in smaller scenarios, It seemed the opposite was true (slightly better times for simple Map below 1000 keys). Given the expected number of components in packages, it seems it made sense to go back to a simple Map.