### PR TITLE
fix: wrong instance for qualified name of benchmarks

### DIFF
--- a/src/Stack/Types/Component.hs
+++ b/src/Stack/Types/Component.hs
@@ -181,7 +181,7 @@ instance HasField "qualifiedName" StackTestSuite NamedComponent where
   getField = CTest . (.name.unqualCompToText)
 
 instance HasField "qualifiedName" StackBenchmark NamedComponent where
-  getField = CTest . (.name.unqualCompToText)
+  getField = CBench . (.name.unqualCompToText)
 
 -- | Type synonym for a 'HasField' constraint which represent a virtual field,
 -- computed from the type, the NamedComponent constructor and the name.


### PR DESCRIPTION
Note: Fixes for the online documentation of the current Stack release (https://docs.haskellstack.org/en/stable/) should target the 'stable' branch, not the 'master' branch.

Please include the following checklist in your pull request:

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!

@mpilgrem While there is no urge to do so, I think this fix should be backported to stack 2.15, because it'll likely create wrong behaviors in ghci for benchmarks (and probably in hls then).