### PR TITLE
Re #729 Add `--haddock-executables` flag

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -190,25 +190,25 @@
 
 # Anti-pattern: unsafe functions
 [[ignore]]
-  id = "OBS-STAN-0212-FNS1cF-56:17"
+  id = "OBS-STAN-0212-FNS1cF-57:17"
 # ✦ Description:   Usage of unsafe functions breaks referential transparency
 # ✦ Category:      #Unsafe #AntiPattern
 # ✦ File:          src\Stack\BuildOpts.hs
 #
-#   55 ┃
-#   56 ┃   buildMonoid = undefined :: BuildOptsMonoid
-#   57 ┃                 ^^^^^^^^^
+#   56 ┃
+#   57 ┃   buildMonoid = undefined :: BuildOptsMonoid
+#   58 ┃                 ^^^^^^^^^
 
 # Anti-pattern: unsafe functions
 [[ignore]]
-  id = "OBS-STAN-0212-FNS1cF-68:14"
+  id = "OBS-STAN-0212-FNS1cF-69:14"
 # ✦ Description:   Usage of unsafe functions breaks referential transparency
 # ✦ Category:      #Unsafe #AntiPattern
 # ✦ File:          src\Stack\BuildOpts.hs
 #
-#    67 ┃
-#    68 ┃   toMonoid = undefined :: TestOptsMonoid
-#    69 ┃              ^^^^^^^^^
+#    68 ┃
+#    69 ┃   toMonoid = undefined :: TestOptsMonoid
+#    70 ┃              ^^^^^^^^^
 
 # Anti-pattern: Pattern matching on '_'
 # Pattern matching on '_' for sum types can create maintainability issues

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,8 +30,8 @@ Other enhancements:
   command, as if it had been specified at the command line.
 * Add flag `--haddock-executables` to Stack's `build` command (including the
   `haddock` synonym for `build --haddock`) to enable also building Haddock
-  documentation for executables. Will fail for GHC versions before 9.4 due to a
-  bug in Cabal (the library).
+  documentation for executables. Due to a bug in Cabal (the library), Stack will
+  ignore the flag with a warning for GHC versions before 9.4.
 
 Bug fixes:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,10 @@ Other enhancements:
 * In YAML configuration files, the `default-init-snapshot` key is introduced to
   allow a default snapshot to be specified for use with the `stack init`
   command, as if it had been specified at the command line.
+* Add flag `--haddock-executables` to Stack's `build` command (including the
+  `haddock` synonym for `build --haddock`) to enable also building Haddock
+  documentation for executables. Will fail for GHC versions before 9.4 due to a
+  bug in Cabal (the library).
 
 Bug fixes:
 

--- a/package.yaml
+++ b/package.yaml
@@ -315,6 +315,7 @@ library:
   - Stack.Types.GlobalOpts
   - Stack.Types.GlobalOptsMonoid
   - Stack.Types.Installed
+  - Stack.Types.InterfaceOpt
   - Stack.Types.IsMutable
   - Stack.Types.LockFileBehavior
   - Stack.Types.MsysEnvironment

--- a/src/Stack/Build/ExecutePackage.hs
+++ b/src/Stack/Build/ExecutePackage.hs
@@ -609,6 +609,7 @@ realConfigAndBuild
                       , [ "--haddock-option=--hyperlinked-source"
                         | ee.buildOpts.haddockHyperlinkSource
                         ]
+                      , [ "--executables" | ee.buildOpts.haddockExecutables ]
                       , [ "--internal" | ee.buildOpts.haddockInternal  ]
                       , quickjump
                       ]

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -20,7 +20,6 @@ import qualified Data.HashSet as HS
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import           Data.Time ( UTCTime )
 import           Distribution.Text ( display )
 import           Path
                    ( (</>), addExtension, fromAbsDir, fromAbsFile, fromRelDir
@@ -50,6 +49,7 @@ import           Stack.Types.BuildOptsCLI ( BuildOptsCLI (..) )
 import           Stack.Types.DumpPackage ( DumpPackage (..) )
 import           Stack.Types.EnvConfig ( HasEnvConfig (..) )
 import           Stack.Types.GhcPkgId ( GhcPkgId )
+import           Stack.Types.InterfaceOpt ( InterfaceOpt (..) )
 import           Stack.Types.Package
                    ( InstallLocation (..), LocalPackage (..), Package (..) )
 import qualified System.FilePath as FP
@@ -222,7 +222,9 @@ generateHaddockIndex descr bco dumpPackages docRelFP destDir = do
           case eindexModTime of
             Left _ -> True
             Right indexModTime ->
-              or [mt > indexModTime | (_, mt, _, _) <- interfaceOpts]
+              or [ mt > indexModTime
+                 | mt <- map (.srcInterfaceFileModTime) interfaceOpts
+                 ]
         prettyDescr = style Current (fromString $ T.unpack descr)
     if needUpdate
       then do
@@ -243,7 +245,7 @@ generateHaddockIndex descr bco dumpPackages docRelFP destDir = do
                  [bco.snapDB, bco.localDB]
               ++ bco.buildOpts.haddockOpts.additionalArgs
               ++ ["--gen-contents", "--gen-index"]
-              ++ [x | (xs, _, _, _) <- interfaceOpts, x <- xs]
+              ++ [x | xs <- map (.readInterfaceArgs) interfaceOpts, x <- xs]
           )
       else
         prettyInfo $
@@ -257,12 +259,12 @@ generateHaddockIndex descr bco dumpPackages docRelFP destDir = do
  where
   toInterfaceOpt ::
        DumpPackage
-    -> IO (Maybe ([String], UTCTime, Path Abs File, Path Abs File))
+    -> IO (Maybe InterfaceOpt)
   toInterfaceOpt dp =
     case dp.haddockInterfaces of
       [] -> pure Nothing
       srcInterfaceFP:_ -> do
-        srcInterfaceAbsFile <- parseCollapsedAbsFile srcInterfaceFP
+        srcInterfaceFile <- parseCollapsedAbsFile srcInterfaceFP
         let (PackageIdentifier name _) = dp.packageIdent
             destInterfaceRelFP =
               docRelFP FP.</>
@@ -271,42 +273,43 @@ generateHaddockIndex descr bco dumpPackages docRelFP destDir = do
             docPathRelFP =
               fmap ((docRelFP FP.</>) . FP.takeFileName) dp.haddockHtml
             interfaces = intercalate "," $ mcons docPathRelFP [srcInterfaceFP]
+            readInterfaceArgs = [ "-i", interfaces ]
 
-        destInterfaceAbsFile <-
+        destInterfaceFile <-
           parseCollapsedAbsFile (toFilePath destDir FP.</> destInterfaceRelFP)
-        esrcInterfaceModTime <- tryGetModificationTime srcInterfaceAbsFile
+        eSrcInterfaceFileModTime <- tryGetModificationTime srcInterfaceFile
         pure $
-          case esrcInterfaceModTime of
+          case eSrcInterfaceFileModTime of
             Left _ -> Nothing
-            Right srcInterfaceModTime ->
-              Just
-                ( [ "-i", interfaces ]
-                , srcInterfaceModTime
-                , srcInterfaceAbsFile
-                , destInterfaceAbsFile
-                )
-  copyPkgDocs :: (a, UTCTime, Path Abs File, Path Abs File) -> IO ()
-  copyPkgDocs (_, srcInterfaceModTime, srcInterfaceAbsFile, destInterfaceAbsFile) = do
+            Right srcInterfaceFileModTime ->
+              Just InterfaceOpt
+                { readInterfaceArgs
+                , srcInterfaceFileModTime
+                , srcInterfaceFile
+                , destInterfaceFile
+                }
+  copyPkgDocs :: InterfaceOpt -> IO ()
+  copyPkgDocs opts = do
   -- Copy dependencies' haddocks to documentation directory.  This way,
   -- relative @../$pkg-$ver@ links work and it's easy to upload docs to a web
   -- server or otherwise view them in a non-local-filesystem context. We copy
   -- instead of symlink for two reasons: (1) symlinks aren't reliably supported
   -- on Windows, and (2) the filesystem containing dependencies' docs may not be
   -- available where viewing the docs (e.g. if building in a Docker container).
-    edestInterfaceModTime <- tryGetModificationTime destInterfaceAbsFile
+    edestInterfaceModTime <- tryGetModificationTime opts.destInterfaceFile
     case edestInterfaceModTime of
       Left _ -> doCopy
       Right destInterfaceModTime
-        | destInterfaceModTime < srcInterfaceModTime -> doCopy
+        | destInterfaceModTime < opts.srcInterfaceFileModTime -> doCopy
         | otherwise -> pure ()
    where
     doCopy = do
       ignoringAbsence (removeDirRecur destHtmlAbsDir)
       ensureDir destHtmlAbsDir
       onException
-        (copyDirRecur' (parent srcInterfaceAbsFile) destHtmlAbsDir)
+        (copyDirRecur' (parent opts.srcInterfaceFile) destHtmlAbsDir)
         (ignoringAbsence (removeDirRecur destHtmlAbsDir))
-    destHtmlAbsDir = parent destInterfaceAbsFile
+    destHtmlAbsDir = parent opts.destInterfaceFile
 
 -- | Find first DumpPackage matching the GhcPkgId
 lookupDumpPackage :: GhcPkgId

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -258,18 +258,18 @@ generateHaddockIndex descr bco dumpPackages docRelFP destDir = do
   toInterfaceOpt ::
        DumpPackage
     -> IO (Maybe ([String], UTCTime, Path Abs File, Path Abs File))
-  toInterfaceOpt DumpPackage {haddockInterfaces, packageIdent, haddockHtml} =
-    case haddockInterfaces of
+  toInterfaceOpt dp =
+    case dp.haddockInterfaces of
       [] -> pure Nothing
       srcInterfaceFP:_ -> do
         srcInterfaceAbsFile <- parseCollapsedAbsFile srcInterfaceFP
-        let (PackageIdentifier name _) = packageIdent
+        let (PackageIdentifier name _) = dp.packageIdent
             destInterfaceRelFP =
               docRelFP FP.</>
-              packageIdentifierString packageIdent FP.</>
+              packageIdentifierString dp.packageIdent FP.</>
               (packageNameString name FP.<.> "haddock")
             docPathRelFP =
-              fmap ((docRelFP FP.</>) . FP.takeFileName) haddockHtml
+              fmap ((docRelFP FP.</>) . FP.takeFileName) dp.haddockHtml
             interfaces = intercalate "," $ mcons docPathRelFP [srcInterfaceFP]
 
         destInterfaceAbsFile <-

--- a/src/Stack/Build/Haddock.hs
+++ b/src/Stack/Build/Haddock.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
@@ -22,19 +23,19 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 import           Distribution.Text ( display )
 import           Path
-                   ( (</>), addExtension, fromAbsDir, fromAbsFile, fromRelDir
-                   , parent, parseRelDir, parseRelFile
+                   ( (</>), addExtension, dirname, fileExtension, fromAbsDir
+                   , fromAbsFile, fromRelDir, parent, parseRelDir, parseRelFile
                    )
 import           Path.Extra
                    ( parseCollapsedAbsFile, toFilePathNoTrailingSep
                    , tryGetModificationTime
                    )
 import           Path.IO
-                   ( copyDirRecur', doesFileExist, ensureDir, ignoringAbsence
-                   , removeDirRecur
+                   ( copyDirRecur', doesDirExist, doesFileExist, ensureDir
+                   , ignoringAbsence, listDir, removeDirRecur
                    )
 import qualified RIO.ByteString.Lazy as BL
-import           RIO.List ( intercalate )
+import           RIO.List ( intercalate, intersperse )
 import           RIO.Process ( HasProcessContext, withWorkingDir )
 import           Stack.Constants
                    ( docDirSuffix, htmlDirSuffix, relDirAll, relFileIndexHtml )
@@ -266,15 +267,49 @@ generateHaddockIndex descr bco dumpPackages docRelFP destDir = do
       srcInterfaceFP:_ -> do
         srcInterfaceFile <- parseCollapsedAbsFile srcInterfaceFP
         let (PackageIdentifier name _) = dp.packageIdent
-            destInterfaceRelFP =
+            srcInterfaceDir = parent srcInterfaceFile
+        -- It is possible that the *.haddock file specified by the
+        -- haddock-interfaces key for an installed package may not exist. For
+        -- example, with GHC 9.6.4 on Windows, there is no
+        --
+        -- ${pkgroot}/../doc/html/libraries/rts-1.0.2\rts.haddock
+        (srcInterfaceSubDirs, _) <- doesDirExist srcInterfaceDir >>= \case
+          True -> listDir srcInterfaceDir
+          False -> pure ([], [])
+        let destInterfaceRelFP =
               docRelFP FP.</>
               packageIdentifierString dp.packageIdent FP.</>
               (packageNameString name FP.<.> "haddock")
             docPathRelFP =
               fmap ((docRelFP FP.</>) . FP.takeFileName) dp.haddockHtml
-            interfaces = intercalate "," $ mcons docPathRelFP [srcInterfaceFP]
-            readInterfaceArgs = [ "-i", interfaces ]
-
+            mkInterface :: Maybe FilePath -> FilePath -> String
+            mkInterface mDocPath file =
+              intercalate "," $ mcons mDocPath [file]
+            -- This assumes that Cabal (the library) `haddock --executables` for
+            -- component my-component of package my-package puts one *.haddock
+            -- file and associated files in directory:
+            --
+            -- my-package/my-component
+            --
+            -- Not all directories in directory my-package relate to components.
+            -- For example, my-package/src relates to the files for the
+            -- colourised code of the main library of package my-package.
+            compInterface :: Path Abs Dir -> IO (Maybe String)
+            compInterface dir = do
+              (_, files) <- listDir dir
+              pure $ toInterface <$> F.find isInterface files
+             where
+              toInterface file =
+                mkInterface compDocPathRelFP compSrcInterfaceFP
+               where
+                componentName = toFilePath $ dirname dir
+                compDocPathRelFP = (FP.</> componentName) <$> docPathRelFP
+                compSrcInterfaceFP = toFilePath file
+              isInterface file = fileExtension file == Just ".haddock"
+            interfaces = mkInterface docPathRelFP srcInterfaceFP
+        compInterfaces <- catMaybes <$> forM srcInterfaceSubDirs compInterface
+        let readInterfaceArgs =
+              "-i" : intersperse "-i" (interfaces : compInterfaces)
         destInterfaceFile <-
           parseCollapsedAbsFile (toFilePath destDir FP.</> destInterfaceRelFP)
         eSrcInterfaceFileModTime <- tryGetModificationTime srcInterfaceFile

--- a/src/Stack/BuildOpts.hs
+++ b/src/Stack/BuildOpts.hs
@@ -31,6 +31,7 @@ defaultBuildOpts = BuildOpts
   , haddockOpts = defaultHaddockOpts
   , openHaddocks = defaultFirstFalse buildMonoid.openHaddocks
   , haddockDeps = Nothing
+  , haddockExecutables = defaultFirstFalse buildMonoid.haddockExecutables
   , haddockInternal = defaultFirstFalse buildMonoid.haddockInternal
   , haddockHyperlinkSource = defaultFirstTrue buildMonoid.haddockHyperlinkSource
   , haddockForHackage = defaultFirstFalse buildMonoid.haddockForHackage

--- a/src/Stack/Config/Build.hs
+++ b/src/Stack/Config/Build.hs
@@ -54,6 +54,9 @@ buildOptsFromMonoid buildMonoid = BuildOpts
   , haddockDeps = if isHaddockFromHackage
       then Nothing
       else getFirst buildMonoid.haddockDeps
+  , haddockExecutables =
+         not isHaddockFromHackage
+      && fromFirstFalse buildMonoid.haddockExecutables
   , haddockInternal =
          not isHaddockFromHackage
       && fromFirstFalse buildMonoid.haddockInternal

--- a/src/Stack/Options/BuildMonoidParser.hs
+++ b/src/Stack/Options/BuildMonoidParser.hs
@@ -41,6 +41,7 @@ buildOptsMonoidParser hide0 = BuildOptsMonoid
   <*> haddockOptsParser hideBool
   <*> openHaddocks
   <*> haddockDeps
+  <*> haddockExecutables
   <*> haddockInternal
   <*> haddockHyperlinkSource
   <*> haddockForHackage
@@ -132,6 +133,11 @@ buildOptsMonoidParser hide0 = BuildOptsMonoid
     "haddock-deps"
     "building Haddock documentation for dependencies. (default: if building \
     \Haddock documentation, true; otherwise, false)"
+    hide
+  haddockExecutables = firstBoolFlagsFalse
+    "haddock-executables"
+    "also building Haddock documentation for all executables (like \
+    \'cabal haddock --executables')."
     hide
   haddockInternal = firstBoolFlagsFalse
     "haddock-internal"

--- a/src/Stack/Types/BuildOpts.hs
+++ b/src/Stack/Types/BuildOpts.hs
@@ -32,6 +32,9 @@ data BuildOpts = BuildOpts
     -- ^ Open haddocks in the browser?
   , haddockDeps :: !(Maybe Bool)
     -- ^ Build haddocks for dependencies?
+  , haddockExecutables :: !Bool
+    -- ^ Also build Haddock documentation for all executable components, like
+    -- @runghc Setup.hs haddock --executables@.
   , haddockInternal :: !Bool
     -- ^ Build haddocks for all symbols and packages, like
     -- @cabal haddock --internal@

--- a/src/Stack/Types/BuildOptsMonoid.hs
+++ b/src/Stack/Types/BuildOptsMonoid.hs
@@ -45,6 +45,7 @@ data BuildOptsMonoid = BuildOptsMonoid
   , haddockOpts :: !HaddockOptsMonoid
   , openHaddocks :: !FirstFalse
   , haddockDeps :: !(First Bool)
+  , haddockExecutables :: !FirstFalse
   , haddockInternal :: !FirstFalse
   , haddockHyperlinkSource :: !FirstTrue
   , haddockForHackage :: !FirstFalse
@@ -81,6 +82,7 @@ instance FromJSON (WithJSONWarnings BuildOptsMonoid) where
     haddockOpts <- jsonSubWarnings (o ..:? haddockOptsArgName ..!= mempty)
     openHaddocks <- FirstFalse <$> o ..:? openHaddocksArgName
     haddockDeps <- First <$> o ..:? haddockDepsArgName
+    haddockExecutables <- FirstFalse <$> o ..:? haddockExecutablesArgName
     haddockInternal <- FirstFalse <$> o ..:? haddockInternalArgName
     haddockHyperlinkSource <- FirstTrue <$> o ..:? haddockHyperlinkSourceArgName
     haddockForHackage <-  FirstFalse <$> o ..:? haddockForHackageArgName
@@ -115,6 +117,7 @@ instance FromJSON (WithJSONWarnings BuildOptsMonoid) where
       , haddockOpts
       , openHaddocks
       , haddockDeps
+      , haddockExecutables
       , haddockInternal
       , haddockHyperlinkSource
       , haddockForHackage
@@ -160,6 +163,9 @@ openHaddocksArgName = "open-haddocks"
 
 haddockDepsArgName :: Text
 haddockDepsArgName = "haddock-deps"
+
+haddockExecutablesArgName :: Text
+haddockExecutablesArgName = "haddock-executables"
 
 haddockInternalArgName :: Text
 haddockInternalArgName = "haddock-internal"

--- a/src/Stack/Types/InterfaceOpt.hs
+++ b/src/Stack/Types/InterfaceOpt.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoFieldSelectors  #-}
+
+-- | Type representing Haddock interface options.
+module Stack.Types.InterfaceOpt
+  ( InterfaceOpt (..)
+  ) where
+
+import           Data.Time ( UTCTime )
+import           Stack.Prelude
+
+-- | Type representing Haddock interface options.
+data InterfaceOpt = InterfaceOpt
+  { readInterfaceArgs :: ![String]
+  , srcInterfaceFileModTime :: !UTCTime
+  , srcInterfaceFile :: !(Path Abs File)
+  , destInterfaceFile :: !(Path Abs File)
+  }
+  deriving (Eq, Ord)

--- a/stack.cabal
+++ b/stack.cabal
@@ -309,6 +309,7 @@ library
       Stack.Types.GlobalOpts
       Stack.Types.GlobalOptsMonoid
       Stack.Types.Installed
+      Stack.Types.InterfaceOpt
       Stack.Types.IsMutable
       Stack.Types.LockFileBehavior
       Stack.Types.MsysEnvironment

--- a/tests/unit/Stack/ConfigSpec.hs
+++ b/tests/unit/Stack/ConfigSpec.hs
@@ -71,6 +71,7 @@ buildOptsConfig =
   "    - \"--css=/home/user/my-css\"\n" ++
   "  open-haddocks: true\n" ++
   "  haddock-deps: true\n" ++
+  "  haddock-executables: true\n" ++
   "  haddock-internal: true\n" ++
   "  haddock-hyperlink-source: false\n" ++
   "  haddock-for-hackage: false\n" ++
@@ -107,6 +108,7 @@ buildOptsHaddockForHackageConfig =
   "  haddock: true\n" ++
   "  open-haddocks: true\n" ++
   "  haddock-deps: true\n" ++
+  "  haddock-executables: true\n" ++
   "  haddock-internal: true\n" ++
   "  haddock-hyperlink-source: false\n" ++
   "  haddock-for-hackage: true\n" ++
@@ -232,6 +234,7 @@ spec = beforeAll setup $ do
           }
         bopts.openHaddocks `shouldBe` True
         bopts.haddockDeps `shouldBe` Just True
+        bopts.haddockExecutables `shouldBe` True
         bopts.haddockInternal `shouldBe` True
         bopts.haddockHyperlinkSource `shouldBe` False
         bopts.haddockForHackage `shouldBe` False


### PR DESCRIPTION
Note: This is not yet guarded for Cabal >= 3.8.1.0 and so is marked as draft. EDIT: Now guarded, but still draft while I consider how the Haddocks are included in the final indexes.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
