### PR TITLE
Re #6531 Allow cross-OS use of `release.hs`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -217,7 +217,7 @@ jobs:
         # (Note that the online documentation for '--docker-stack-exe image'
         # specifies that the host Stack and image Stack must have the same
         # version number.)
-        /usr/local/bin/stack etc/scripts/release.hs build --alpine --build-args --docker-stack-exe=image
+        /usr/local/bin/stack etc/scripts/release.hs build --alpine --stack-args --docker-stack-exe=image
 
     - name: Upload bindist
       if: needs.configuration.outputs.test-arm64 == 'true'

--- a/etc/scripts/release.hs
+++ b/etc/scripts/release.hs
@@ -28,7 +28,7 @@ import           Development.Shake
                    ( Action, Change (..), pattern Chatty, CmdOption (..), Rules
                    , ShakeOptions (..), Stdout (..), (%>), actionOnException
                    , alwaysRerun, cmd, command_, copyFileChanged
-                   , getDirectoryFiles, liftIO, need, phony, putNormal
+                   , getDirectoryFiles, liftIO, need, phony, putInfo
                    , removeFilesAfter, shakeArgsWith, shakeOptions, want
                    )
 import           Development.Shake.FilePath
@@ -202,7 +202,7 @@ rules global args = do
 
   releaseDir </> binaryPkgZipFileName %> \out -> do
     stageFiles <- getBinaryPkgStageFiles
-    putNormal $ "zip " ++ out
+    putInfo $ "zip " ++ out
     liftIO $ do
       entries <- forM stageFiles $ \stageFile -> do
         Zip.readEntry

--- a/etc/scripts/release.hs
+++ b/etc/scripts/release.hs
@@ -11,6 +11,25 @@
 -- directly. As GHC 9.6.4 boot packages Cabal and Cabal-syntax expose modules
 -- with the same names, the language extension PackageImports is required.
 
+-- EXPERIMENTAL
+
+-- release.hs can be run on macOS/AArch64, using a Docker image for
+-- Alpine Linux/AArch64, in order to create a statically-linked Linux/AArch64
+-- version of Stack:
+--
+-- Install pre-requisites:
+--
+-- > brew install docker
+-- > brew install colima
+--
+-- Start colima (with sufficient memory for Stack's integration tests) and run
+-- script:
+--
+-- > colima start --memory 4 # The default 2 GB is likely insufficient
+-- > stack etc/scripts/release.hs check --alpine --stack-args=--docker-stack-exe=image
+-- > stack etc/scripts/release.hs build --alpine --stack-args=--docker-stack-exe=image
+-- > colima stop
+
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE PackageImports      #-}
 {-# LANGUAGE PatternSynonyms     #-}

--- a/etc/scripts/release.hs
+++ b/etc/scripts/release.hs
@@ -72,6 +72,7 @@ main = shakeArgsWith
     let gAllowDirty = False
         Platform arch _ = buildPlatform
         gArch = arch
+        gTargetOS = platformOS
         gBinarySuffix = ""
         gTestHaddocks = True
         gProjectRoot = "" -- Set to real value below.
@@ -88,6 +89,7 @@ main = shakeArgsWith
             , gProjectRoot
             , gHomeDir
             , gArch
+            , gTargetOS
             , gBinarySuffix
             , gTestHaddocks
             , gBuildArgs
@@ -140,6 +142,7 @@ options =
                    , "--system-ghc"
                    , "--no-install-ghc"
                    ]
+            , gTargetOS = Linux
             }
       )
       "Build a statically-linked binary using an Alpine Linux Docker image."
@@ -355,7 +358,7 @@ rules global args = do
   releaseBinDir = releaseDir </> "bin"
 
   binaryPkgFileNames =
-    case platformOS of
+    case global.gTargetOS of
       Windows ->
         [ binaryExeFileName
         , binaryPkgZipFileName
@@ -376,7 +379,7 @@ rules global args = do
     , "-"
     , stackVersionStr global
     , "-"
-    , display platformOS
+    , display global.gTargetOS
     , "-"
     , display global.gArch
     , if null global.gBinarySuffix then "" else "-" ++ global.gBinarySuffix
@@ -492,6 +495,7 @@ data Global = Global
   , gProjectRoot :: !FilePath
   , gHomeDir :: !FilePath
   , gArch :: !Arch
+  , gTargetOS :: !OS
   , gBinarySuffix :: !String
   , gTestHaddocks :: !Bool
   , gBuildArgs :: [String]

--- a/tests/integration/tests/4095-utf8-pure-nix/Main.hs
+++ b/tests/integration/tests/4095-utf8-pure-nix/Main.hs
@@ -1,5 +1,9 @@
 import StackTest
 
+import Control.Monad ( unless )
+import Data.Maybe ( isJust )
+import System.Environment ( lookupEnv )
+
 -- This test requires that Nix is installed and that the NIX_PATH has been set
 -- so as to allow the path <nixpkgs> to be used.
 main :: IO ()
@@ -11,5 +15,11 @@ main
       logInfo "Disabled on macOS as it takes too long to run, since it tries \
               \to build GHC."
   | otherwise = do
-       stack ["build", "--nix-pure"]
-       stack ["exec", "--nix-pure", "ShowUnicode"]
+      isInContainer <- getInContainer
+      unless isInContainer $ do
+         stack ["build", "--nix-pure"]
+         stack ["exec", "--nix-pure", "ShowUnicode"]
+
+-- | 'True' if we are currently running inside a Docker container.
+getInContainer :: IO Bool
+getInContainer = isJust <$> lookupEnv "STACK_IN_CONTAINER"


### PR DESCRIPTION
This pull request folds the idea of #6533 into `etc/scripts/release.hs` itself, and extends it.

Currently, the Linux/AArch64 job in `integration-tests.yml` makes use of:
~~~bash
/usr/local/bin/stack etc/scripts/release.hs build --alpine --build-args --docker-stack-exe=image
~~~

You can't use a Docker container on GitHub's macOS/M1-based `macos-14`, but the idea is that you could use on macOS/AArch64 locally:
~~~zsh
stack etc/scripts/release.hs build --alpine --stack-args --docker-stack-exe=image
~~~

It also seeks to do the same with `release.hs check`, so that you can use on macOS/AArch64 locally:
~~~zsh
stack etc/scripts/release.hs check --alpine --stack-args --docker-stack-exe=image
~~~

The pull request introduces `--stack-args`, as `--docker-stack-exe` is a global flag, not a `stack build` flag. As before, when `--alpine` is passed the global flags `--docker`, `--system-ghc` and `--no-install-ghc` are specified.

The pull request distinguishes the target OS from the platform OS. When `--alpine` is passed, the target OS is set to `Linux`.

In the case of `release.hs check`, the commands are run by the platform's Stack (with `stack exec`) so that they can be run in a Docker container, if necessary. This is also done when `stack --version` is examined.

With:
~~~zsh
stack --docker --docker-stack-exe-image --system-ghc --no-install-ghc exec stack -- ...
~~~

the second Stack (the one provided by the Docker image) needs its own `--system-ghc --no-install-ghc`, so those flags are added to `gCheckStackArgs` when `--alpine` is passed.

The deprecated `putNormal` is replaced by `putInfo`.

This is being tested locally on a Mac mini/M1. The `4095-utf8-pure-nix` was failing because Nix can't be used in a Docker container. So, a guard has been added.

One other test was failing: `4783-doctest-deps`. That is still being investigated and so this pull request is still draft.

Please include the following checklist in your pull request:

* [ ] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [ ] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Local testing and also relying on CI.