### PR TITLE
Re #6267 Move removal of `*.hi` and `*.o` to after their creation

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -72,14 +72,14 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-erw24B-1034:3"
+  id = "OBS-STAN-0203-erw24B-1031:3"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\ExecuteEnv.hs
 #
-#  1033 ┃
-#  1034 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
-#  1035 ┃   ^^^^^^^
+#  1030 ┃
+#  1031 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
+#  1032 ┃   ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]

--- a/src/Stack/Build/ExecuteEnv.hs
+++ b/src/Stack/Build/ExecuteEnv.hs
@@ -288,11 +288,6 @@ withExecuteEnv
           setupO =  setupSrcDir </> setupOName
       setupHsExists <- doesFileExist setupHs
       unless setupHsExists $ writeBinaryFileAtomic setupHs simpleSetupCode
-      -- See https://github.com/commercialhaskell/stack/issues/6267. Remove any
-      -- historical *.hi or *.o files. This can be dropped when Stack drops
-      -- support for the problematic versions of GHC.
-      ignoringAbsence (removeFile setupHi)
-      ignoringAbsence (removeFile setupO)
       let setupShimStub = "setup-shim-" ++ simpleSetupHash
       setupShimFileName <- parseRelFile (setupShimStub ++ ".hs")
       setupShimHiName <- parseRelFile (setupShimStub ++ ".hi")
@@ -303,12 +298,14 @@ withExecuteEnv
       setupShimHsExists <- doesFileExist setupShimHs
       unless setupShimHsExists $
         writeBinaryFileAtomic setupShimHs setupGhciShimCode
+      setupExe <- getSetupExe setupHs setupShimHs tempDir
       -- See https://github.com/commercialhaskell/stack/issues/6267. Remove any
       -- historical *.hi or *.o files. This can be dropped when Stack drops
       -- support for the problematic versions of GHC.
+      ignoringAbsence (removeFile setupHi)
+      ignoringAbsence (removeFile setupO)
       ignoringAbsence (removeFile setupShimHi)
       ignoringAbsence (removeFile setupShimO)
-      setupExe <- getSetupExe setupHs setupShimHs tempDir
       cabalPkgVer <- view cabalVersionL
       globalDB <- view $ compilerPathsL . to (.globalDB)
       let globalDumpPkgs = toDumpPackagesByGhcPkgId globalPackages


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
