### PR TITLE
Fix #6551 Use action `getLatestApplicableVersionAndRev` only when needed

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -56,6 +56,8 @@ Bug fixes:
 
 * The `config set snapshot` and `config set resolver` commands now respect the
   presence of a synoymous key.
+* Fix a regression introduced in Stack 2.15.1 that caused a 'no operation'
+  `stack build` to be slower than previously.
 
 ## v2.15.5 - 2024-03-28
 


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
