### PR TITLE
Fix #6554 Recognise `key:` not a single-line format

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -64,6 +64,9 @@ Bug fixes:
 
 * The `config set snapshot` and `config set resolver` commands now respect the
   presence of a synoymous key.
+* The `config set` commands support existing keys only in the form `key: value`
+  on a single line. The commands now recognise that a line `key:` does not have
+  that form.
 * Fix a regression introduced in Stack 2.15.1 that caused a 'no operation'
   `stack build` to be slower than previously.
 


### PR DESCRIPTION
Also updates content of warning.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally.
