### PR TITLE
Fix #6570 Apply `--flag *:[-]<flag_name` only to relevant packages

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,8 @@ Behaviour changes:
 * The `list` command, with a specified snapshot and package, also reports the
   version of the package included indirectly in the snapshot (as a boot package
   of the compiler specified by the snapshot).
+* `stack build --flag *:[-]<flag_name>` now only applies the flag setting to
+  packages for which the Cabal flag is defined, as opposed to all packages.
 
 Other enhancements:
 

--- a/doc/build_command.md
+++ b/doc/build_command.md
@@ -257,15 +257,21 @@ This overrides:
 * any use of `--flag *` (see below).
 
 `stack build --flag *:[-]<flag_name>` sets (or unsets) the specified Cabal flag
-for all packages (project packages and dependencies) (whether or not a flag of
-that name is a flag of the package).
+for all packages (project packages and dependencies) for which the flag is
+defined.
 
 This overrides:
 
-* any Cabal flag specifications for packages in the snapshot; and
+* any Cabal flag specifications for the relevant packages in the snapshot; and
 
-* any Cabal flag specifications for packages in Stack's project-level
-  configuration file (`stack.yaml`).
+* any Cabal flag specifications for the relevant packages in Stack's
+  project-level configuration file (`stack.yaml`).
+
+!!! info
+
+    `flag *:[-]<flag_name> inspects the Cabal file of each package in the
+    snapshot. Consequently, its use will add a few seconds to the duration of
+    a build.
 
 !!! note
 

--- a/doc/maintainers/stack_errors.md
+++ b/doc/maintainers/stack_errors.md
@@ -5,7 +5,7 @@
 In connection with considering Stack's support of the
 [Haskell Error Index](https://errors.haskell.org/) initiative, this page seeks
 to take stock of the errors that Stack itself can raise, by reference to the
-`master` branch of the Stack repository. Last updated: 2024-03-29.
+`master` branch of the Stack repository. Last updated: 2024-05-05.
 
 *   `Stack.main`: catches exceptions from action `commandLineHandler`.
 
@@ -381,7 +381,7 @@ to take stock of the errors that Stack itself can raise, by reference to the
         [S-6374] | SetupHsBuildFailure ExitCode (Maybe PackageIdentifier) (Path Abs File) [String] (Maybe (Path Abs File)) [Text]
         [S-8506] | TargetParseException [StyleDoc]
         [S-7086] | SomeTargetsNotBuildable [(PackageName, NamedComponent)]
-        [S-8664] | InvalidFlagSpecification (Set UnusedFlags)
+        [S-8664] | InvalidFlagSpecification [UnusedFlags]
         [S-8100] | GHCProfOptionInvalid
         [S-1727] | NotOnlyLocal [PackageName] [Text]
         [S-6362] | CompilerVersionMismatch (Maybe (ActualCompiler, Arch)) (WantedCompiler, Arch) GHCVariant CompilerBuild VersionCheck (Maybe (Path Abs File)) Text

--- a/src/Stack/Types/Build/Exception.hs
+++ b/src/Stack/Types/Build/Exception.hs
@@ -248,7 +248,7 @@ data BuildPrettyException
       [Text]     -- log contents
   | TargetParseException [StyleDoc]
   | SomeTargetsNotBuildable [(PackageName, NamedComponent)]
-  | InvalidFlagSpecification (Set UnusedFlags)
+  | InvalidFlagSpecification [UnusedFlags]
   | GHCProfOptionInvalid
   | NotOnlyLocal [PackageName] [Text]
   | CompilerVersionMismatch
@@ -310,7 +310,7 @@ instance Pretty BuildPrettyException where
     <> line
     <> flow "Invalid flag specification:"
     <> line
-    <> bulletedList (map go (Set.toList unused))
+    <> bulletedList (map go (L.sort unused))
    where
     showFlagSrc :: FlagSource -> StyleDoc
     showFlagSrc FSCommandLine = flow "(specified on the command line)"


### PR DESCRIPTION
Previously, the Cabal flags specified at the command line were added and then an action checked the validity of the flags specified for specific packages (only) (in `checkFlagsUsedThrowing`). Now, the flags are 'checked' as they are added and `applyOptsFlag` yields a value of type `RIO env (Either UnusedFlags CommonPackage)`.

Moves logic of `getLocalFiles` from module `Stack.Build.Source` to `Stack.Ghci.loadGhciPkgDescs`, as that is the only place where it is now used in the original form.

Moves logic of `checkFlagsUsedThrowing` from module `Stack.SourceMap` to `Stack.Config.fillProjectWanted`, as that is the only place where it is now used in the original form.

To avoid `Set.toList . Set.fromList`, changes error data constructor to be `InvalidFlagSpecification [UnusedFlags]`.

Note: Fixes for the online documentation of the current Stack release (https://docs.haskellstack.org/en/stable/) should target the 'stable' branch, not the 'master' branch.

Please include the following checklist in your pull request:

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally on Windows 11.
