### PR TITLE
docs/nix_integration: point to new nixos wiki

### DIFF
--- a/doc/nix_integration.md
+++ b/doc/nix_integration.md
@@ -431,7 +431,7 @@ those libraries and, therefore, can't build most projects. However, GHC provided
 through Nix can be modified to find the external C libraries provided through
 Nix.
 
-[nix-language]: https://nixos.wiki/wiki/Overview_of_the_Nix_Language
+[nix-language]: https://wiki.nixos.org/wiki/Overview_of_the_Nix_Language
 [nix-manual-exprs]: http://nixos.org/manual/nix/stable/expressions/writing-nix-expressions.html
 [nix-search-packages]: https://search.nixos.org/packages
 [nixpkgs-manual-haskell]: https://haskell4nix.readthedocs.io/nixpkgs-users-guide.html?highlight=buildStackProject#how-to-build-a-haskell-project-using-stack


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org

ref: NixOS/foundation#113

Note: Fixes for the online documentation of the current Stack release (https://docs.haskellstack.org/en/stable/) should target the 'stable' branch, not the 'master' branch.

Please include the following checklist in your pull request:

* [ ] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
