### PR TITLE
Add docs preview and build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ _release/
 
 # MkDocs-related
 _site/
+.python-doc-virtualenv
 
 # Haskell Language Server-related
 hie.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,9 @@ directory of the repository. They are formatted in the
 [Markdown syntax](https://daringfireball.net/projects/markdown/), with some
 extensions.
 
+The docs can be previewed locally with `make docs-serve` and can be built with
+`make _site/index.html`.
+
 Those files are rendered on [haskellstack.org](http://haskellstack.org) by
 [Read the Docs](https://readthedocs.org/) using
 [MkDocs](https://www.mkdocs.org/) and the

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: docs-serve
+docs-serve:
+	$(MAKE) -C doc docs-serve
+
+_site/index.html: doc/*.md
+	$(MAKE) -C doc docs-build

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,12 @@
+PYTHON_VIRTUALENV:=.python-doc-virtualenv
+MK_DOCS_CMD:=$(PYTHON_VIRTUALENV)/bin/mkdocs
+
+../$(PYTHON_VIRTUALENV)/bin/activate:
+	python3 -m venv ../$(PYTHON_VIRTUALENV)
+	(. ../$(PYTHON_VIRTUALENV)/bin/activate && pip install -r requirements.txt)
+
+docs-serve: ../$(PYTHON_VIRTUALENV)/bin/activate
+	cd .. && $(MK_DOCS_CMD) serve
+
+docs-build: ../$(PYTHON_VIRTUALENV)/bin/activate
+	cd .. && $(MK_DOCS_CMD) build


### PR DESCRIPTION
I previewed the docs locally for #6603. I couldn't find how to do this in CONTRIBUTING.md so added a makefile recipes for previewing and building the docs.

* [ ] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

