### PR TITLE
Fix #6606 Distinguish global and project-level configuration files

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -83,14 +83,14 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-tuE+RG-234:21"
+  id = "OBS-STAN-0203-tuE+RG-234:24"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\ExecutePackage.hs
 #
 #   233 ┃
-#   234 ┃   newProjectRoot <- S8.pack . toFilePath <$> view projectRootL
-#   235 ┃                     ^^^^^^^
+#   234 ┃   newConfigFileRoot <- S8.pack . toFilePath <$> view configFileRootL
+#   235 ┃                        ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -78,6 +78,8 @@ Bug fixes:
   specified at the command line.
 * Fix a regression, introduced in Stack 2.11.1, that caused the `script` command
   to parse an (otherwise ignored) project-level configuration file.
+* Stack no longer makes recommendations about a project-level configuration file
+  when only a global configuration file is in use.
 
 ## v2.15.7 - 2024-05-12
 

--- a/doc/maintainers/stack_errors.md
+++ b/doc/maintainers/stack_errors.md
@@ -422,6 +422,7 @@ to take stock of the errors that Stack itself can raise, by reference to the
         [S-5470] | DuplicateLocalPackageNames [(PackageName, [PackageLocation])]
         [S-6854] | BadMsysEnvironment MsysEnvironment Arch
         [S-5006] | NoDefaultMsysEnvironmentBug
+        [S-8398] | ConfigFileNotProjectLevelBug
         ~~~
 
     -   `Stack.Types.Config.ParseAbsolutePathException`

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -51,7 +51,7 @@ import           Stack.Types.Build.Exception
                    , BuildPrettyException (..), ConstructPlanException (..)
                    )
 import           Stack.Types.BuildConfig
-                   ( BuildConfig (..), HasBuildConfig (..), stackYamlL )
+                   ( BuildConfig (..), HasBuildConfig (..), configFileL )
 import           Stack.Types.BuildOpts ( BuildOpts (..) )
 import           Stack.Types.BuildOptsCLI
                    ( BuildOptsCLI (..), BuildSubset (..) )
@@ -187,13 +187,13 @@ constructPlan
                 else Map.empty
           }
       else do
-        stackYaml <- view stackYamlL
+        configFile <- view configFileL
         stackRoot <- view stackRootL
         isImplicitGlobal <-
           view $ configL . to (isPCGlobalProject . (.project))
         prettyThrowM $ ConstructPlanFailed
           errs
-          stackYaml
+          configFile
           stackRoot
           isImplicitGlobal
           parents

--- a/src/Stack/Build/ExecutePackage.hs
+++ b/src/Stack/Build/ExecutePackage.hs
@@ -90,7 +90,7 @@ import qualified Stack.Types.Build as ConfigCache ( ConfigCache (..) )
 import           Stack.Types.Build.Exception
                    ( BuildException (..), BuildPrettyException (..) )
 import           Stack.Types.BuildConfig
-                   ( BuildConfig (..), HasBuildConfig (..), projectRootL )
+                   ( BuildConfig (..), HasBuildConfig (..), configFileRootL )
 import           Stack.Types.BuildOpts
                    ( BenchmarkOpts (..), BuildOpts (..), HaddockOpts (..)
                    , TestOpts (..)
@@ -231,7 +231,7 @@ ensureConfig newConfigCache pkgDir buildOpts announce cabal cabalFP task = do
           (guard . isDoesNotExistError)
           (getFileStatus (toFilePath setupConfigfp))
   newSetupConfigMod <- getNewSetupConfigMod
-  newProjectRoot <- S8.pack . toFilePath <$> view projectRootL
+  newConfigFileRoot <- S8.pack . toFilePath <$> view configFileRootL
   -- See https://github.com/commercialhaskell/stack/issues/3554. This can be
   -- dropped when Stack drops support for GHC < 8.4.
   taskAnyMissingHackEnabled <-
@@ -271,7 +271,7 @@ ensureConfig newConfigCache pkgDir buildOpts announce cabal cabalFP task = do
              /= Just (ignoreComponents newConfigCache)
           || mOldCabalMod /= Just newCabalMod
           || mOldSetupConfigMod /= newSetupConfigMod
-          || mOldProjectRoot /= Just newProjectRoot
+          || mOldProjectRoot /= Just newConfigFileRoot
 
   when task.buildTypeConfig $
     -- When build-type is Configure, we need to have a configure script in the
@@ -312,7 +312,7 @@ ensureConfig newConfigCache pkgDir buildOpts announce cabal cabalFP task = do
     -- our config mod file is newer than the file above, but this seems
     -- reasonable too.
     getNewSetupConfigMod >>= writeSetupConfigMod pkgDir
-    writePackageProjectRoot pkgDir newProjectRoot
+    writePackageProjectRoot pkgDir newConfigFileRoot
   pure needConfig
 
 -- | Make a padded prefix for log messages

--- a/src/Stack/Clean.hs
+++ b/src/Stack/Clean.hs
@@ -18,7 +18,7 @@ import           Stack.Constants.Config ( rootDistDirFromDir, workDirFromDir )
 import           Stack.Prelude
 import           Stack.Runners ( ShouldReexec (..), withConfig )
 import           Stack.Types.BuildConfig
-                   ( BuildConfig (..), HasBuildConfig (..), getProjectWorkDir )
+                   ( BuildConfig (..), HasBuildConfig (..), getWorkDir )
 import           Stack.Types.Config ( Config )
 import           Stack.Types.Runner ( Runner )
 import           Stack.Types.SourceMap ( SMWanted (..), ppRoot )
@@ -94,5 +94,5 @@ dirsToDelete cleanOpts = do
         xs -> throwM (NonLocalPackages xs)
     CleanFull -> do
       pkgWorkDirs <- mapM (workDirFromDir . ppRoot) $ Map.elems packages
-      projectWorkDir <- getProjectWorkDir
+      projectWorkDir <- getWorkDir
       pure (projectWorkDir : pkgWorkDirs)

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -105,7 +105,7 @@ cfgCmdSet cmd = do
             fmap (</> stackDotYaml) (getImplicitGlobalProjectDir conf)
           PCNoProject _extraDeps -> throwIO NoProjectConfigAvailable
           -- maybe modify the ~/.stack/config.yaml file instead?
-      CommandScopeGlobal -> pure conf.userConfigPath
+      CommandScopeGlobal -> pure conf.userGlobalConfigFile
   rawConfig <- liftIO (readFileUtf8 (toFilePath configFilePath))
   config <- either throwM pure (Yaml.decodeEither' $ encodeUtf8 rawConfig)
   newValue <- cfgCmdSetValue (parent configFilePath) cmd

--- a/src/Stack/Constants/Config.hs
+++ b/src/Stack/Constants/Config.hs
@@ -26,7 +26,7 @@ module Stack.Constants.Config
 import           Path ( (</>), mkRelDir, mkRelFile, parseRelDir )
 import           Stack.Constants ( relDirDist, relDirGhci, relDirHpc )
 import           Stack.Prelude
-import           Stack.Types.BuildConfig ( HasBuildConfig, projectRootL )
+import           Stack.Types.BuildConfig ( HasBuildConfig, configFileRootL )
 import           Stack.Types.Compiler ( compilerVersionString )
 import           Stack.Types.CompilerPaths ( compilerVersionL )
 import           Stack.Types.Config ( Config, HasConfig, stackRootL, workDirL )
@@ -37,15 +37,15 @@ import           Stack.Types.EnvConfig
 objectInterfaceDirL :: HasBuildConfig env => Getting r env (Path Abs Dir)
 objectInterfaceDirL = to $ \env -> -- FIXME is this idiomatic lens code?
   let workDir = view workDirL env
-      root = view projectRootL env
-  in  root </> workDir </> $(mkRelDir "odir/")
+      configFileRoot = view configFileRootL env
+  in  configFileRoot </> workDir </> $(mkRelDir "odir/")
 
 -- | GHCi files directory.
 ghciDirL :: HasBuildConfig env => Getting r env (Path Abs Dir)
 ghciDirL = to $ \env -> -- FIXME is this idiomatic lens code?
   let workDir = view workDirL env
-      root = view projectRootL env
-  in  root </> workDir </> relDirGhci
+      configFileRoot = view configFileRootL env
+  in  configFileRoot </> workDir </> relDirGhci
 
 -- | The directory containing the files used for dirtiness check of source
 -- files.

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -571,7 +571,7 @@ applyTemplate project template nonceParams dir templateText = do
     prettyNote $
       missingParameters
         missingKeys
-        config.userConfigPath
+        config.userGlobalConfigFile
   pure $ M.fromList results
  where
   onlyMissingKeys (Mustache.VariableNotFound ks) = map T.unpack ks

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -81,8 +81,7 @@ import           Stack.Constants (relFileCabalMacrosH, relDirLogs)
 import           Stack.Constants.Config ( distDirFromDir )
 import           Stack.PackageFile ( getPackageFile, stackPackageFileFromCabal )
 import           Stack.Prelude hiding ( Display (..) )
-import           Stack.Types.BuildConfig
-                   ( HasBuildConfig (..), getProjectWorkDir )
+import           Stack.Types.BuildConfig ( HasBuildConfig (..), getWorkDir )
 import           Stack.Types.CompCollection
                    ( CompCollection, collectionLookup, foldAndMakeCollection
                    , foldComponentToAnotherCollection, getBuildableSetText
@@ -564,11 +563,11 @@ buildLogPath ::
   -> m (Path Abs File)
 buildLogPath package' msuffix = do
   env <- ask
-  let stack = getProjectWorkDir env
+  let workDir = getWorkDir env
   fp <- parseRelFile $ concat $
     packageIdentifierString (packageIdentifier package') :
     maybe id (\suffix -> ("-" :) . (suffix :)) msuffix [".log"]
-  pure $ stack </> relDirLogs </> fp
+  pure $ workDir </> relDirLogs </> fp
 
     {- FIXME
 -- | Create a 'ProjectPackage' from a directory containing a package.

--- a/src/Stack/Runners.hs
+++ b/src/Stack/Runners.hs
@@ -281,7 +281,7 @@ shouldUpgradeCheck = do
                  [ flow "Tired of seeing this? Add"
                  , style Shell (flow "recommend-stack-upgrade: false")
                  , "to"
-                 , pretty config.userConfigPath <> "."
+                 , pretty config.userGlobalConfigFile <> "."
                  ]
             <> blankLine
         _ -> pure ()

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -21,7 +21,7 @@ module Stack.Types.Config
   , buildOptsL
   , envOverrideSettingsL
   , globalOptsL
-  , stackGlobalConfigL
+  , userGlobalConfigFileL
   , stackRootL
   , workDirL
   -- * Helper logging functions
@@ -61,8 +61,8 @@ import           Stack.Types.Version ( VersionCheck (..), VersionRange )
 data Config = Config
   { workDir                :: !(Path Rel Dir)
     -- ^ this allows to override .stack-work directory
-  , userConfigPath         :: !(Path Abs File)
-    -- ^ Path to user configuration file (usually ~/.stack/config.yaml)
+  , userGlobalConfigFile   :: !(Path Abs File)
+    -- ^ The user-specific global configuration file.
   , build                  :: !BuildOpts
     -- ^ Build configuration
   , docker                 :: !DockerOpts
@@ -288,10 +288,10 @@ stackRootL :: HasConfig s => Lens' s (Path Abs Dir)
 stackRootL =
   configL . lens (.stackRoot) (\x y -> x { stackRoot = y })
 
-stackGlobalConfigL :: HasConfig s => Lens' s (Path Abs File)
-stackGlobalConfigL = configL . lens
-  (.userConfigPath)
-  (\x y -> x { userConfigPath = y })
+userGlobalConfigFileL :: HasConfig s => Lens' s (Path Abs File)
+userGlobalConfigFileL = configL . lens
+  (.userGlobalConfigFile)
+  (\x y -> x { userGlobalConfigFile = y })
 
 buildOptsL :: HasConfig s => Lens' s BuildOpts
 buildOptsL = configL . lens (.build) (\x y -> x { build = y })

--- a/src/Stack/Types/Config/Exception.hs
+++ b/src/Stack/Types/Config/Exception.hs
@@ -161,6 +161,7 @@ data ConfigPrettyException
   | DuplicateLocalPackageNames ![(PackageName, [PackageLocation])]
   | BadMsysEnvironment !MsysEnvironment !Arch
   | NoMsysEnvironmentBug
+  | ConfigFileNotProjectLevelBug
   deriving (Show, Typeable)
 
 instance Pretty ConfigPrettyException where
@@ -229,6 +230,8 @@ instance Pretty ConfigPrettyException where
          ]
   pretty NoMsysEnvironmentBug = bugPrettyReport "[S-5006]" $
     flow "No default MSYS2 environment."
+  pretty ConfigFileNotProjectLevelBug = bugPrettyReport "[S-8398]" $
+    flow "The configuration file is not a project-level one."
 
 instance Exception ConfigPrettyException
 

--- a/src/Stack/Types/EnvConfig.hs
+++ b/src/Stack/Types/EnvConfig.hs
@@ -40,13 +40,13 @@ import           Path
                    )
 import           RIO.Process ( HasProcessContext (..) )
 import           Stack.Constants
-                   ( bindirSuffix, ghcColorForceFlag, osIsWindows, relDirCompilerTools
-                   , relDirHoogle, relDirHpc, relDirInstall, relDirPkgdb
-                   , relDirSnapshots, relFileDatabaseHoo
+                   ( bindirSuffix, ghcColorForceFlag, osIsWindows
+                   , relDirCompilerTools, relDirHoogle, relDirHpc, relDirInstall
+                   , relDirPkgdb, relDirSnapshots, relFileDatabaseHoo
                    )
 import           Stack.Prelude
 import           Stack.Types.BuildConfig
-                    ( BuildConfig (..), HasBuildConfig (..), getProjectWorkDir )
+                    ( BuildConfig (..), HasBuildConfig (..), getWorkDir )
 import           Stack.Types.BuildOptsCLI ( BuildOptsCLI )
 import           Stack.Types.Compiler
                    ( ActualCompiler (..), compilerVersionString, getGhcVersion )
@@ -163,7 +163,7 @@ installationRootDeps = do
 -- | Installation root for locals
 installationRootLocal :: HasEnvConfig env => RIO env (Path Abs Dir)
 installationRootLocal = do
-  workDir <- getProjectWorkDir
+  workDir <- getWorkDir
   psc <- useShaPathOnWindows =<< platformSnapAndCompilerRel
   pure $ workDir </> relDirInstall </> psc
 
@@ -212,7 +212,7 @@ bindirCompilerTools = do
 -- | Hoogle directory.
 hoogleRoot :: HasEnvConfig env => RIO env (Path Abs Dir)
 hoogleRoot = do
-  workDir <- getProjectWorkDir
+  workDir <- getWorkDir
   psc <- useShaPathOnWindows =<< platformSnapAndCompilerRel
   pure $ workDir </> relDirHoogle </> psc
 

--- a/src/Stack/Uninstall.hs
+++ b/src/Stack/Uninstall.hs
@@ -11,7 +11,7 @@ import           Stack.Constants ( osIsWindows )
 import           Stack.Prelude
 import           Stack.Runners ( ShouldReexec (..), withConfig )
 import           Stack.Types.Config
-                   ( Config (..), configL, stackGlobalConfigL, stackRootL )
+                   ( Config (..), configL, stackRootL, userGlobalConfigFileL )
 import           Stack.Types.Runner ( Runner )
 
 -- | Function underlying the @stack uninstall@ command. Display help for the
@@ -19,12 +19,12 @@ import           Stack.Types.Runner ( Runner )
 uninstallCmd :: () -> RIO Runner ()
 uninstallCmd () = withConfig NoReexec $ do
   stackRoot <- view stackRootL
-  globalConfig <- view stackGlobalConfigL
+  userGlobalConfigFile <- view userGlobalConfigFileL
   programsDir <- view $ configL . to (.localProgramsBase)
   localBinDir <- view $ configL . to (.localBin)
   let toStyleDoc = style Dir . fromString . toFilePath
       stackRoot' = toStyleDoc stackRoot
-      globalConfig' = toStyleDoc globalConfig
+      userGlobalConfigFile' = toStyleDoc userGlobalConfigFile
       programsDir' = toStyleDoc programsDir
       localBinDir' = toStyleDoc localBinDir
   putUtf8Builder =<< displayWithColor
@@ -40,8 +40,8 @@ uninstallCmd () = withConfig NoReexec $ do
              ]
          , hang 4 $ fillSep
              [ flow "(3) if different, the directory containing "
-             , flow "Stack's global YAML configuration file"
-             , parens globalConfig' <> ";"
+             , flow "Stack's user-specific global YAML configuration file"
+             , parens userGlobalConfigFile' <> ";"
              , "and"
              ]
          , hang 4 $ fillSep

--- a/tests/unit/Stack/ConfigSpec.hs
+++ b/tests/unit/Stack/ConfigSpec.hs
@@ -27,7 +27,7 @@ import           Stack.Config (defaultConfigYaml, loadConfig, loadConfigYaml )
 import           Stack.Options.GlobalParser ( globalOptsFromMonoid )
 import           Stack.Prelude
 import           Stack.Runners ( withBuildConfig, withRunnerGlobal )
-import           Stack.Types.BuildConfig ( BuildConfig (..), projectRootL )
+import           Stack.Types.BuildConfig ( BuildConfig (..), configFileRootL )
 import           Stack.Types.BuildOpts
                    ( BenchmarkOpts (..), BuildOpts (..), HaddockOpts (..)
                    , TestOpts (..)
@@ -293,7 +293,7 @@ spec = beforeAll setup $ do
       setCurrentDirectory childDir
       loadConfig' $ \config -> liftIO $ do
         bc <- runRIO config $ withBuildConfig ask
-        view projectRootL bc `shouldBe` parentDir
+        view configFileRootL bc `shouldBe` parentDir
 
     it "respects the STACK_YAML env variable" $ inTempDir $ do
       withSystemTempDir "config-is-here" $ \dir -> do
@@ -303,8 +303,7 @@ spec = beforeAll setup $ do
         withEnvVar "STACK_YAML" stackYamlFp $
           loadConfig' $ \config -> liftIO $ do
             bc <- runRIO config $ withBuildConfig ask
-            bc.stackYaml `shouldBe` dir </> stackDotYaml
-            parent bc.stackYaml `shouldBe` dir
+            bc.configFile `shouldBe` Right (dir </> stackDotYaml)
 
     it "STACK_YAML can be relative" $ inTempDir $ do
         parentDir <- getCurrentDirectory >>= parseAbsDir
@@ -320,7 +319,7 @@ spec = beforeAll setup $ do
         withEnvVar "STACK_YAML" (toFilePath yamlRel) $
           loadConfig' $ \config -> liftIO $ do
             bc <- runRIO config $ withBuildConfig ask
-            bc.stackYaml `shouldBe` yamlAbs
+            bc.configFile `shouldBe` Right yamlAbs
 
   describe "defaultConfigYaml" $
     it "is parseable" $ \_ -> do


### PR DESCRIPTION
Also refactors where:

* 'project' is used to refer to a file or directory that may not be within a project directory but within the Stack root; or
* `stackYaml` is used to refer to a configuration file that may be a global one as well as a project-level one.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
