### PR TITLE
Refactoring toward cabal

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -83,14 +83,14 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-tuE+RG-234:24"
+  id = "OBS-STAN-0203-tuE+RG-236:24"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\ExecutePackage.hs
 #
-#   233 ┃
-#   234 ┃   newConfigFileRoot <- S8.pack . toFilePath <$> view configFileRootL
-#   235 ┃                        ^^^^^^^
+#   235 ┃
+#   236 ┃   newConfigFileRoot <- S8.pack . toFilePath <$> view configFileRootL
+#   237 ┃                        ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]

--- a/package.yaml
+++ b/package.yaml
@@ -83,6 +83,7 @@ dependencies:
 - fsnotify >= 0.4.1
 - generic-deriving
 - ghc-boot
+- hashable
 - hi-file-parser >= 0.1.6.0
 - hpack >= 0.36.0
 - hpc

--- a/src/Path/CheckInstall.hs
+++ b/src/Path/CheckInstall.hs
@@ -14,7 +14,11 @@ import qualified System.FilePath as FP
 -- | Checks if the installed executable will be available on the user's PATH.
 -- This doesn't use @envSearchPath menv@ because it includes paths only visible
 -- when running in the Stack environment.
-warnInstallSearchPathIssues :: HasConfig env => FilePath -> [String] -> RIO env ()
+warnInstallSearchPathIssues ::
+     HasConfig env
+  => FilePath
+  -> [String]
+  -> RIO env ()
 warnInstallSearchPathIssues destDir installed = do
   searchPath <- liftIO FP.getSearchPath
   destDirIsInPATH <- liftIO $

--- a/src/Path/CheckInstall.hs
+++ b/src/Path/CheckInstall.hs
@@ -6,7 +6,6 @@ module Path.CheckInstall
   ) where
 
 import           Control.Monad.Extra ( (&&^), anyM )
-import qualified Data.Text as T
 import           Stack.Prelude
 import           Stack.Types.Config ( HasConfig )
 import qualified System.Directory as D
@@ -15,7 +14,7 @@ import qualified System.FilePath as FP
 -- | Checks if the installed executable will be available on the user's PATH.
 -- This doesn't use @envSearchPath menv@ because it includes paths only visible
 -- when running in the Stack environment.
-warnInstallSearchPathIssues :: HasConfig env => FilePath -> [Text] -> RIO env ()
+warnInstallSearchPathIssues :: HasConfig env => FilePath -> [String] -> RIO env ()
 warnInstallSearchPathIssues destDir installed = do
   searchPath <- liftIO FP.getSearchPath
   destDirIsInPATH <- liftIO $
@@ -26,7 +25,7 @@ warnInstallSearchPathIssues destDir installed = do
       searchPath
   if destDirIsInPATH
     then forM_ installed $ \exe -> do
-      mexePath <- (liftIO . D.findExecutable . T.unpack) exe
+      mexePath <- (liftIO . D.findExecutable) exe
       case mexePath of
         Just exePath -> do
           exeDir <-
@@ -34,12 +33,12 @@ warnInstallSearchPathIssues destDir installed = do
           unless (exeDir `FP.equalFilePath` destDir) $
             prettyWarnL
               [ flow "The"
-              , style File . fromString . T.unpack $ exe
+              , style File . fromString $ exe
               , flow "executable found on the PATH environment variable is"
               , style File . fromString $ exePath
               , flow "and not the version that was just installed."
               , flow "This means that"
-              , style File . fromString . T.unpack $ exe
+              , style File . fromString $ exe
               , "calls on the command line will not use this version."
               ]
         Nothing ->
@@ -47,7 +46,7 @@ warnInstallSearchPathIssues destDir installed = do
             [ flow "Installation path"
             , style Dir . fromString $ destDir
             , flow "is on the PATH but the"
-            , style File . fromString . T.unpack $ exe
+            , style File . fromString $ exe
             , flow "executable that was just installed could not be found on \
                    \the PATH."
             ]

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -20,7 +20,6 @@ import           Data.List ( (\\) )
 import           Data.List.Extra ( groupSort )
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import qualified Data.Text as T
 -- import qualified Distribution.PackageDescription as C
 -- import           Distribution.Types.Dependency ( Dependency (..), depLibraries )
 import           Distribution.Version ( mkVersion )
@@ -52,6 +51,7 @@ import           Stack.Types.BuildOptsMonoid
                    )
 import           Stack.Types.Compiler ( getGhcVersion )
 import           Stack.Types.CompilerPaths ( HasCompiler, cabalVersionL )
+import           Stack.Types.ComponentUtils ( StackUnqualCompName, unqualCompToString )
 import           Stack.Types.Config
                    ( Config (..), HasConfig (..), buildOptsL
                    )
@@ -266,7 +266,7 @@ warnIfExecutablesWithSameNameCouldBeOverwritten locals plan = do
             ","
             [ style
                 PkgComponent
-                (fromString $ packageNameString p <> ":" <> T.unpack exe)
+                (fromString $ packageNameString p <> ":" <> unqualCompToString exe)
             | p <- pkgs
             ]
     prettyWarnL $
@@ -295,7 +295,7 @@ warnIfExecutablesWithSameNameCouldBeOverwritten locals plan = do
   --                   , package names for other project packages that have an
   --                     executable with the same name
   --                   )
-  warnings :: Map Text ([PackageName],[PackageName])
+  warnings :: Map StackUnqualCompName ([PackageName],[PackageName])
   warnings =
     Map.mapMaybe
       (\(pkgsToBuild, localPkgs) ->
@@ -315,7 +315,7 @@ warnIfExecutablesWithSameNameCouldBeOverwritten locals plan = do
             -- Both cases warrant a warning.
             Just (NE.toList pkgsToBuild, otherLocals))
       (Map.intersectionWith (,) exesToBuild localExes)
-  exesToBuild :: Map Text (NonEmpty PackageName)
+  exesToBuild :: Map StackUnqualCompName (NonEmpty PackageName)
   exesToBuild =
     collect
       [ (exe, pkgName')
@@ -323,7 +323,7 @@ warnIfExecutablesWithSameNameCouldBeOverwritten locals plan = do
       , TTLocalMutable lp <- [task.taskType]
       , exe <- (Set.toList . exeComponents . (.components)) lp
       ]
-  localExes :: Map Text (NonEmpty PackageName)
+  localExes :: Map StackUnqualCompName (NonEmpty PackageName)
   localExes =
     collect
       [ (exe, pkg.name)

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -51,10 +51,10 @@ import           Stack.Types.BuildOptsMonoid
                    )
 import           Stack.Types.Compiler ( getGhcVersion )
 import           Stack.Types.CompilerPaths ( HasCompiler, cabalVersionL )
-import           Stack.Types.ComponentUtils ( StackUnqualCompName, unqualCompToString )
+import           Stack.Types.ComponentUtils
+                   ( StackUnqualCompName, unqualCompToString )
 import           Stack.Types.Config
-                   ( Config (..), HasConfig (..), buildOptsL
-                   )
+                   ( Config (..), HasConfig (..), buildOptsL )
 import           Stack.Types.ConfigureOpts ( BaseConfigOpts (..) )
 import           Stack.Types.EnvConfig
                    ( EnvConfig (..), HasEnvConfig (..), HasSourceMap

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -63,6 +63,7 @@ import           Stack.Types.Build
                    )
 import           Stack.Types.Cache ( ConfigCacheType (..) )
 import           Stack.Types.CompilerPaths ( cabalVersionL )
+import           Stack.Types.ComponentUtils ( StackUnqualCompName, unqualCompToString )
 import           Stack.Types.Config ( stackRootL )
 import           Stack.Types.ConfigureOpts
                    ( BaseConfigOpts (..), ConfigureOpts (..) )
@@ -134,7 +135,6 @@ buildCacheFile dir component = do
   cachesDir <- buildCachesDir dir
   smh <- view $ envConfigL . to (.sourceMapHash)
   smDirName <- smRelDir smh
-  let nonLibComponent prefix name = prefix <> "-" <> T.unpack name
   cacheFileName <- parseRelFile $ componentCachePath component
   pure $ cachesDir </> smDirName </> cacheFileName
 
@@ -370,7 +370,7 @@ writePrecompiledCache ::
   -> ConfigureOpts
   -> Bool -- ^ build haddocks
   -> Installed -- ^ library
-  -> Set Text -- ^ executables
+  -> Set StackUnqualCompName -- ^ executables
   -> RIO env ()
 writePrecompiledCache
     baseConfigOpts
@@ -384,7 +384,7 @@ writePrecompiledCache
       ec <- view envConfigL
       let stackRootRelative = makeRelative (view stackRootL ec)
       exes' <- forM (Set.toList exes) $ \exe -> do
-        name <- parseRelFile $ T.unpack exe
+        name <- parseRelFile $ unqualCompToString exe
         stackRootRelative $
            baseConfigOpts.snapInstallRoot </> bindirSuffix </> name
       let installedLibToPath libName ghcPkgId pcAction = do

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -74,7 +74,7 @@ import           Stack.Types.EnvConfig
 import           Stack.Types.GhcPkgId ( ghcPkgIdString )
 import           Stack.Types.Installed
                    (InstalledLibraryInfo (..), foldOnGhcPkgId' )
-import           Stack.Types.NamedComponent ( NamedComponent (..) )
+import           Stack.Types.NamedComponent ( NamedComponent (..), componentCachePath )
 import           Stack.Types.SourceMap ( smRelDir )
 import           System.PosixCompat.Files
                    ( modificationTime, getFileStatus, setFileTimes )
@@ -135,13 +135,7 @@ buildCacheFile dir component = do
   smh <- view $ envConfigL . to (.sourceMapHash)
   smDirName <- smRelDir smh
   let nonLibComponent prefix name = prefix <> "-" <> T.unpack name
-  cacheFileName <- parseRelFile $ case component of
-    CLib -> "lib"
-    CSubLib name -> nonLibComponent "sub-lib" name
-    CFlib name -> nonLibComponent "flib" name
-    CExe name -> nonLibComponent "exe" name
-    CTest name -> nonLibComponent "test" name
-    CBench name -> nonLibComponent "bench" name
+  cacheFileName <- parseRelFile $ componentCachePath component
   pure $ cachesDir </> smDirName </> cacheFileName
 
 -- | Try to read the dirtiness cache for the given package directory.

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -35,7 +35,6 @@ import qualified Data.ByteArray as Mem ( convert )
 import           Data.ByteString.Builder ( byteString )
 import qualified Data.Map as M
 import qualified Data.Set as Set
-import qualified Data.Text as T
 import qualified Data.Yaml as Yaml
 import           Foreign.C.Types ( CTime )
 import           Path ( (</>), filename, parent, parseRelFile )

--- a/src/Stack/Build/Cache.hs
+++ b/src/Stack/Build/Cache.hs
@@ -62,7 +62,8 @@ import           Stack.Types.Build
                    )
 import           Stack.Types.Cache ( ConfigCacheType (..) )
 import           Stack.Types.CompilerPaths ( cabalVersionL )
-import           Stack.Types.ComponentUtils ( StackUnqualCompName, unqualCompToString )
+import           Stack.Types.ComponentUtils
+                   ( StackUnqualCompName, unqualCompToString )
 import           Stack.Types.Config ( stackRootL )
 import           Stack.Types.ConfigureOpts
                    ( BaseConfigOpts (..), ConfigureOpts (..) )
@@ -74,10 +75,11 @@ import           Stack.Types.EnvConfig
 import           Stack.Types.GhcPkgId ( ghcPkgIdString )
 import           Stack.Types.Installed
                    (InstalledLibraryInfo (..), foldOnGhcPkgId' )
-import           Stack.Types.NamedComponent ( NamedComponent (..), componentCachePath )
+import           Stack.Types.NamedComponent
+                   ( NamedComponent (..), componentCachePath )
 import           Stack.Types.SourceMap ( smRelDir )
 import           System.PosixCompat.Files
-                   ( modificationTime, getFileStatus, setFileTimes )
+                   ( getFileStatus, modificationTime, setFileTimes )
 
 -- | Directory containing files to mark an executable as installed
 exeInstalledDir :: (HasEnvConfig env)

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -1183,7 +1183,8 @@ checkAndWarnForUnknownTools p = do
   -- From Cabal 1.12, build-tools can specify another executable in the same
   -- package.
   notPackageExe toolName =
-    MaybeT $ skipIf $ collectionMember (unqualCompFromText toolName) p.executables
+    MaybeT $ skipIf $
+      collectionMember (unqualCompFromText toolName) p.executables
   warn name = MaybeT . pure . Just $ ToolWarning (ExeName name) p.name
   skipIf p' = pure $ if p' then Nothing else Just ()
 

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -59,6 +59,7 @@ import           Stack.Types.CompCollection ( collectionMember )
 import           Stack.Types.Compiler ( WhichCompiler (..) )
 import           Stack.Types.CompilerPaths
                    ( CompilerPaths (..), HasCompiler (..) )
+import           Stack.Types.ComponentUtils ( unqualCompFromText )
 import           Stack.Types.Config ( Config (..), HasConfig (..), stackRootL )
 import           Stack.Types.ConfigureOpts ( BaseConfigOpts (..) )
 import qualified Stack.Types.ConfigureOpts as ConfigureOpts
@@ -1182,7 +1183,7 @@ checkAndWarnForUnknownTools p = do
   -- From Cabal 1.12, build-tools can specify another executable in the same
   -- package.
   notPackageExe toolName =
-    MaybeT $ skipIf $ collectionMember toolName p.executables
+    MaybeT $ skipIf $ collectionMember (unqualCompFromText toolName) p.executables
   warn name = MaybeT . pure . Just $ ToolWarning (ExeName name) p.name
   skipIf p' = pure $ if p' then Nothing else Just ()
 

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -64,7 +64,8 @@ import           Stack.Types.BuildOptsCLI ( BuildOptsCLI (..) )
 import           Stack.Types.BuildOptsMonoid ( ProgressBarFormat (..) )
 import           Stack.Types.Compiler ( ActualCompiler (..) )
 import           Stack.Types.CompilerPaths ( HasCompiler (..), getGhcPkgExe )
-import           Stack.Types.ComponentUtils ( StackUnqualCompName, unqualCompToString )
+import           Stack.Types.ComponentUtils
+                   ( StackUnqualCompName, unqualCompToString )
 import           Stack.Types.Config
                    ( Config (..), HasConfig (..), buildOptsL )
 import           Stack.Types.ConfigureOpts
@@ -285,7 +286,7 @@ copyExecutables exes = do
 
   installed <- forMaybeM (Map.toList exes) $ \(name, loc) -> do
     let strName = unqualCompToString name
-    let bindir =
+        bindir =
             case loc of
                 Snap -> snapBin
                 Local -> localBin

--- a/src/Stack/Build/ExecutePackage.hs
+++ b/src/Stack/Build/ExecutePackage.hs
@@ -108,7 +108,9 @@ import           Stack.Types.CompilerPaths
                    )
 import qualified Stack.Types.Component as Component
 import           Stack.Types.ComponentUtils
-                   ( StackUnqualCompName, unqualCompToText, unqualCompToString, toCabalName )
+                   ( StackUnqualCompName, toCabalName, unqualCompToString
+                   , unqualCompToText
+                   )
 import           Stack.Types.Config ( Config (..), HasConfig (..) )
 import           Stack.Types.ConfigureOpts
                    ( BaseConfigOpts (..), ConfigureOpts (..) )
@@ -1305,7 +1307,11 @@ primaryComponentOptions lp =
   ++ map
        (T.unpack . T.append "lib:")
        (getBuildableListText package.subLibraries)
-  ++ Set.toList (Set.mapMonotonic (\s -> "exe:" ++ unqualCompToString s) (exesToBuild lp))
+  ++ Set.toList
+       ( Set.mapMonotonic
+           (\s -> "exe:" ++ unqualCompToString s)
+           (exesToBuild lp)
+       )
  where
   package = lp.package
 

--- a/src/Stack/Build/ExecutePackage.hs
+++ b/src/Stack/Build/ExecutePackage.hs
@@ -120,7 +120,7 @@ import           Stack.Types.EnvConfig
                    , appropriateGhcColorFlag
                    )
 import           Stack.Types.EnvSettings ( EnvSettings (..) )
-import           Stack.Types.GhcPkgId ( GhcPkgId, unGhcPkgId )
+import           Stack.Types.GhcPkgId ( GhcPkgId, ghcPkgIdToText )
 import           Stack.Types.GlobalOpts ( GlobalOpts (..) )
 import           Stack.Types.Installed
                    ( InstallLocation (..), Installed (..), InstalledMap
@@ -1077,7 +1077,7 @@ singleTest topts testsToRun ac ee task installedMap = do
                 <> foldMap
                      ( \ghcId ->
                             "package-id "
-                         <> display (unGhcPkgId ghcId)
+                         <> display (ghcPkgIdToText ghcId)
                          <> "\n"
                      )
                      (pkgGhcIdList ++ thGhcId:Map.elems allDepsMap)

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -25,7 +25,7 @@ import qualified Pantry.SHA256 as SHA256
 import           Stack.Build.Cache ( tryGetBuildCache )
 import           Stack.Build.Haddock ( shouldHaddockDeps )
 import           Stack.Package
-                   ( buildableBenchmarks, buildableExes, buildableTestSuites
+                   ( buildableBenchmarksComp, buildableExesComp, buildableTestSuitesComp
                    , hasBuildableMainLibrary, resolvePackage
                    )
 import           Stack.PackageFile ( getPackageFile )
@@ -361,17 +361,17 @@ loadLocalPackage pp = do
             let (_s, e, t, b) = splitComponents $ Set.toList comps
             in  (e, t, b)
           Just (TargetAll _packageType) ->
-            ( buildableExes pkg
+            ( buildableExesComp pkg
             , if    bopts.tests
                  && maybe True (Set.notMember name . (.skipTest)) mcurator
-                then buildableTestSuites pkg
+                then buildableTestSuitesComp pkg
                 else Set.empty
             , if    bopts.benchmarks
                  && maybe
                       True
                       (Set.notMember name . (.skipBenchmark))
                       mcurator
-                then buildableBenchmarks pkg
+                then buildableBenchmarksComp pkg
                 else Set.empty
             )
           Nothing -> mempty
@@ -466,9 +466,9 @@ loadLocalPackage pp = do
       -- through component parsing, but the components aren't present, then they
       -- must not be buildable.
     , unbuildable = toComponents
-        (exes `Set.difference` buildableExes pkg)
-        (tests `Set.difference` buildableTestSuites pkg)
-        (benches `Set.difference` buildableBenchmarks pkg)
+        (exes `Set.difference` buildableExesComp pkg)
+        (tests `Set.difference` buildableTestSuitesComp pkg)
+        (benches `Set.difference` buildableBenchmarksComp pkg)
     }
 
 -- | Compare the current filesystem state to the cached information, and

--- a/src/Stack/Build/Source.hs
+++ b/src/Stack/Build/Source.hs
@@ -25,7 +25,7 @@ import qualified Pantry.SHA256 as SHA256
 import           Stack.Build.Cache ( tryGetBuildCache )
 import           Stack.Build.Haddock ( shouldHaddockDeps )
 import           Stack.Package
-                   ( buildableBenchmarksComp, buildableExesComp, buildableTestSuitesComp
+                   ( buildableBenchmarks, buildableExes, buildableTestSuites
                    , hasBuildableMainLibrary, resolvePackage
                    )
 import           Stack.PackageFile ( getPackageFile )
@@ -361,17 +361,17 @@ loadLocalPackage pp = do
             let (_s, e, t, b) = splitComponents $ Set.toList comps
             in  (e, t, b)
           Just (TargetAll _packageType) ->
-            ( buildableExesComp pkg
+            ( buildableExes pkg
             , if    bopts.tests
                  && maybe True (Set.notMember name . (.skipTest)) mcurator
-                then buildableTestSuitesComp pkg
+                then buildableTestSuites pkg
                 else Set.empty
             , if    bopts.benchmarks
                  && maybe
                       True
                       (Set.notMember name . (.skipBenchmark))
                       mcurator
-                then buildableBenchmarksComp pkg
+                then buildableBenchmarks pkg
                 else Set.empty
             )
           Nothing -> mempty
@@ -466,9 +466,9 @@ loadLocalPackage pp = do
       -- through component parsing, but the components aren't present, then they
       -- must not be buildable.
     , unbuildable = toComponents
-        (exes `Set.difference` buildableExesComp pkg)
-        (tests `Set.difference` buildableTestSuitesComp pkg)
-        (benches `Set.difference` buildableBenchmarksComp pkg)
+        (exes `Set.difference` buildableExes pkg)
+        (tests `Set.difference` buildableTestSuites pkg)
+        (benches `Set.difference` buildableBenchmarks pkg)
     }
 
 -- | Compare the current filesystem state to the cached information, and

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -270,8 +270,8 @@ resolveRawTarget sma allLocs (rawInput, rt) =
     (CFlib t2') -> t1' == t2'
     (CTest t2') -> t1' == t2'
     (CBench t2') -> t1' == t2'
-    where t1' = unqualCompFromText t1
-
+   where
+    t1' = unqualCompFromText t1
 
   go (RTComponent cname) = do
     -- Associated list from component name to package that defines it. We use an

--- a/src/Stack/Build/Target.hs
+++ b/src/Stack/Build/Target.hs
@@ -80,6 +80,7 @@ import           Stack.Prelude
 import           Stack.Types.BuildConfig
                    ( BuildConfig (..), HasBuildConfig (..) )
 import           Stack.Types.BuildOptsCLI ( BuildOptsCLI (..) )
+import           Stack.Types.ComponentUtils ( unqualCompFromText )
 import           Stack.Types.Config ( Config (..) )
 import           Stack.Types.NamedComponent
                    ( NamedComponent (..), renderComponent )
@@ -226,9 +227,9 @@ parseRawTarget t =
 
   parseCompType t' =
     case t' of
-      "exe" -> Just CExe
-      "test" -> Just CTest
-      "bench" -> Just CBench
+      "exe" -> Just (CExe . unqualCompFromText)
+      "test" -> Just (CTest . unqualCompFromText)
+      "bench" -> Just (CBench . unqualCompFromText)
       _ -> Nothing
 
 --------------------------------------------------------------------------------
@@ -263,11 +264,14 @@ resolveRawTarget sma allLocs (rawInput, rt) =
   -- 'ComponentName'
   isCompNamed :: ComponentName -> NamedComponent -> Bool
   isCompNamed _ CLib = False
-  isCompNamed t1 (CSubLib t2) = t1 == t2
-  isCompNamed t1 (CExe t2) = t1 == t2
-  isCompNamed t1 (CFlib t2) = t1 == t2
-  isCompNamed t1 (CTest t2) = t1 == t2
-  isCompNamed t1 (CBench t2) = t1 == t2
+  isCompNamed t1 t2 = case t2 of
+    (CSubLib t2') -> t1' == t2'
+    (CExe t2') -> t1' == t2'
+    (CFlib t2') -> t1' == t2'
+    (CTest t2') -> t1' == t2'
+    (CBench t2') -> t1' == t2'
+    where t1' = unqualCompFromText t1
+
 
   go (RTComponent cname) = do
     -- Associated list from component name to package that defines it. We use an

--- a/src/Stack/Component.hs
+++ b/src/Stack/Component.hs
@@ -22,7 +22,6 @@ module Stack.Component
   , stackBenchmarkFromCabal
   , stackTestFromCabal
   , foldOnNameAndBuildInfo
-  , stackUnqualToQual
   , componentDependencyMap
   , fromCabalName
   ) where
@@ -47,13 +46,6 @@ import           Stack.Types.Component
                    )
 import           Stack.Types.ComponentUtils ( fromCabalName )
 import           Stack.Types.Dependency ( cabalExeToStackDep, cabalToStackDep )
-import           Stack.Types.NamedComponent ( NamedComponent )
-
-stackUnqualToQual ::
-     (Text -> NamedComponent)
-  -> StackUnqualCompName
-  -> NamedComponent
-stackUnqualToQual c (StackUnqualCompName n) = c n
 
 foldOnNameAndBuildInfo ::
      ( HasField "buildInfo" a StackBuildInfo

--- a/src/Stack/ComponentFile.hs
+++ b/src/Stack/ComponentFile.hs
@@ -55,7 +55,8 @@ import           Stack.Types.Component
                    , StackExecutable (..), StackLibrary (..)
                    , StackTestSuite (..), StackUnqualCompName (..)
                    )
-import           Stack.Types.ComponentUtils ( unqualCompToString, emptyCompName )
+import           Stack.Types.ComponentUtils
+                   ( emptyCompName, unqualCompToString )
 import           Stack.Types.Config
                    ( Config (..), HasConfig (..), prettyStackDevL )
 import           Stack.Types.NamedComponent ( NamedComponent (..) )
@@ -552,9 +553,9 @@ componentNameToDir = componentNameToDirNormOrTmp False
 componentNameToDirNormOrTmp :: Bool -> StackUnqualCompName -> Path Rel Dir
 componentNameToDirNormOrTmp isTemp name =
   fromMaybe (throw $ ComponentNotParsedBug sName) (parseRelDir fullName)
-  where
-    fullName = if isTemp then sName <> "/" <> sName <> "-tmp" else sName
-    sName = unqualCompToString name
+ where
+  fullName = if isTemp then sName <> "/" <> sName <> "-tmp" else sName
+  sName = unqualCompToString name
 
 -- | See 'Distribution.Simple.LocalBuildInfo.componentBuildDir'
 componentBuildDir :: NamedComponent -> Path Abs Dir -> Path Abs Dir

--- a/src/Stack/ComponentFile.hs
+++ b/src/Stack/ComponentFile.hs
@@ -55,6 +55,7 @@ import           Stack.Types.Component
                    , StackExecutable (..), StackLibrary (..)
                    , StackTestSuite (..), StackUnqualCompName (..)
                    )
+import           Stack.Types.ComponentUtils ( unqualCompToString, emptyCompName )
 import           Stack.Types.Config
                    ( Config (..), HasConfig (..), prettyStackDevL )
 import           Stack.Types.NamedComponent ( NamedComponent (..) )
@@ -77,7 +78,7 @@ stackBenchmarkFiles ::
      StackBenchmark
   -> RIO GetPackageFileContext (NamedComponent, ComponentFile)
 stackBenchmarkFiles bench =
-  resolveComponentFiles (CBench bench.name.unqualCompToText) build names
+  resolveComponentFiles (CBench bench.name) build names
  where
   names = bnames <> exposed
   exposed =
@@ -92,7 +93,7 @@ stackTestSuiteFiles ::
      StackTestSuite
   -> RIO GetPackageFileContext (NamedComponent, ComponentFile)
 stackTestSuiteFiles test =
-  resolveComponentFiles (CTest test.name.unqualCompToText) build names
+  resolveComponentFiles (CTest test.name) build names
  where
   names = bnames <> exposed
   exposed =
@@ -108,7 +109,7 @@ stackExecutableFiles ::
      StackExecutable
   -> RIO GetPackageFileContext (NamedComponent, ComponentFile)
 stackExecutableFiles exe =
-  resolveComponentFiles (CExe exe.name.unqualCompToText) build names
+  resolveComponentFiles (CExe exe.name) build names
  where
   build = exe.buildInfo
   names =
@@ -122,9 +123,9 @@ stackLibraryFiles ::
 stackLibraryFiles lib =
   resolveComponentFiles componentName build names
  where
-  componentRawName = lib.name.unqualCompToText
+  componentRawName = lib.name
   componentName
-    | componentRawName == mempty = CLib
+    | componentRawName == emptyCompName = CLib
     | otherwise = CSubLib componentRawName
   build = lib.buildInfo
   names = bnames ++ exposed
@@ -341,7 +342,7 @@ componentOutputDir namedComponent distDir =
     CBench name -> makeTmp name
  where
   makeTmp name =
-    buildDir distDir </> componentNameToDir (name <> "/" <> name <> "-tmp")
+    buildDir distDir </> componentNameToDirNormOrTmp True name
 
 -- | Try to resolve the list of base names in the given directory by
 -- looking for unique instances of base names applied with the given
@@ -545,10 +546,15 @@ buildDir distDir = distDir </> relDirBuild
 
 -- NOTE: don't export this, only use it for valid paths based on
 -- component names.
-componentNameToDir :: Text -> Path Rel Dir
-componentNameToDir name =
-  fromMaybe (throw $ ComponentNotParsedBug sName) (parseRelDir sName)
-  where sName = T.unpack name
+componentNameToDir :: StackUnqualCompName -> Path Rel Dir
+componentNameToDir = componentNameToDirNormOrTmp False
+
+componentNameToDirNormOrTmp :: Bool -> StackUnqualCompName -> Path Rel Dir
+componentNameToDirNormOrTmp isTemp name =
+  fromMaybe (throw $ ComponentNotParsedBug sName) (parseRelDir fullName)
+  where
+    fullName = if isTemp then sName <> "/" <> sName <> "-tmp" else sName
+    sName = unqualCompToString name
 
 -- | See 'Distribution.Simple.LocalBuildInfo.componentBuildDir'
 componentBuildDir :: NamedComponent -> Path Abs Dir -> Path Abs Dir

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -398,7 +398,8 @@ generateHpcReportForTargets opts tixFiles targetNames = do
                     ++ testName'
                     ++ ".tix"
                     )
-                  where testName' = unqualCompToString testName
+                 where
+                  testName' = unqualCompToString testName
                 _ -> prettyThrowIO $ NonTestSuiteTarget name
           TargetAll PTProject -> do
             pkgPath <- hpcPkgPath name
@@ -621,7 +622,7 @@ findPackageFieldForBuiltPackage pkgDir pkgId subLibs field = do
   let subLibNames =
         Set.map (LSubLibName . mkUnqualComponentName . T.unpack) subLibs
       libraryNames = Set.insert LMainLibName subLibNames
-      mungedPackageIds = Set.map (computeCompatPackageId pkgId) libraryNames 
+      mungedPackageIds = Set.map (computeCompatPackageId pkgId) libraryNames
   distDir <- distDirFromDir pkgDir
   ghcPkgExe <- getGhcPkgExe
   let inplaceDir = distDir </> relDirPackageConfInplace
@@ -642,7 +643,7 @@ findPackageFieldForBuiltPackage pkgDir pkgId subLibs field = do
     <> fromString (toFilePath inplaceDir)
     <> " for munged packages matching "
     <> fromString pkgIdStr
-  (errors, keys) <-  
+  (errors, keys) <-
     partitionEithers <$> traverse extractField (Set.toList mungedPackageIds)
   case errors of
     (a:_) -> pure $ Left a -- the first error only, since they're repeated anyway

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -57,6 +57,7 @@ import           Stack.Types.BuildConfig
 import           Stack.Types.Compiler ( getGhcVersion )
 import           Stack.Types.CompilerPaths ( getGhcPkgExe )
 import           Stack.Types.CompCollection ( getBuildableSetText )
+import           Stack.Types.ComponentUtils ( unqualCompToString )
 import           Stack.Types.BuildOptsCLI
                    ( BuildOptsCLI (..), defaultBuildOptsCLI )
 import           Stack.Types.EnvConfig
@@ -392,11 +393,12 @@ generateHpcReportForTargets opts tixFiles targetNames = do
               \case
                 CTest testName -> (pkgPath </>) <$>
                   parseRelFile
-                    (  T.unpack testName
+                    (  testName'
                     ++ "/"
-                    ++ T.unpack testName
+                    ++ testName'
                     ++ ".tix"
                     )
+                  where testName' = unqualCompToString testName
                 _ -> prettyThrowIO $ NonTestSuiteTarget name
           TargetAll PTProject -> do
             pkgPath <- hpcPkgPath name

--- a/src/Stack/Exec.hs
+++ b/src/Stack/Exec.hs
@@ -31,7 +31,8 @@ import           Stack.Types.BuildOptsCLI
                    ( BuildOptsCLI (..), defaultBuildOptsCLI )
 import           Stack.Types.CompilerPaths
                    ( CompilerPaths (..), HasCompiler (..), getGhcPkgExe )
-import           Stack.Types.ComponentUtils ( unqualCompFromString, unqualCompToText )
+import           Stack.Types.ComponentUtils
+                   ( unqualCompFromString, unqualCompToText )
 import           Stack.Types.Config ( Config (..), HasConfig (..) )
 import           Stack.Types.EnvConfig ( EnvConfig )
 import           Stack.Types.EnvSettings ( EnvSettings (..) )
@@ -182,11 +183,12 @@ execCmd opts =
     packages <- view $ buildConfigL . to (.smWanted.project)
     pkgComponents <- for (Map.elems packages) ppComponents
     let executables = concatMap (filter isCExe . Set.toList) pkgComponents
-    let (exe, args') = case args of
+        (exe, args') = case args of
           [] -> (firstExe, args)
-          x:xs -> case L.find (\y -> y == CExe (unqualCompFromString x)) executables of
-            Nothing -> (firstExe, args)
-            argExe -> (argExe, xs)
+          x:xs -> let matchesExecutable y = y == CExe (unqualCompFromString x)
+                  in  case L.find matchesExecutable executables of
+                        Nothing -> (firstExe, args)
+                        argExe -> (argExe, xs)
          where
           firstExe = listToMaybe executables
     case exe of

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -46,8 +46,8 @@ import           Stack.Ghci.Script
                    , scriptToLazyByteString
                    )
 import           Stack.Package
-                   ( buildableForeignLibsComp, buildableSubLibsComp, buildableExesComp
-                   , buildableTestSuitesComp, buildableBenchmarksComp, getPackageOpts
+                   ( buildableForeignLibs, buildableSubLibs, buildableExes
+                   , buildableTestSuites, buildableBenchmarks, getPackageOpts
                    , hasBuildableMainLibrary, listOfPackageDeps
                    , packageFromPackageDescription, readDotBuildinfo
                    , resolvePackageDescription, topSortPackageComponent
@@ -957,15 +957,15 @@ wantedPackageComponents bopts (TargetAll PTProject) pkg =
          else S.empty
      )
   <> S.mapMonotonic CExe buildableExes'
-  <> S.mapMonotonic CSubLib buildableSubLibs
-  <> (if bopts.tests then S.mapMonotonic CTest buildableTestSuites else S.empty)
-  <> (if bopts.benchmarks then S.mapMonotonic CBench buildableBenchmarks else S.empty)
+  <> S.mapMonotonic CSubLib buildableSubLibs'
+  <> (if bopts.tests then S.mapMonotonic CTest buildableTestSuites' else S.empty)
+  <> (if bopts.benchmarks then S.mapMonotonic CBench buildableBenchmarks' else S.empty)
  where
-  buildableForeignLibs' = buildableForeignLibsComp pkg
-  buildableSubLibs = buildableSubLibsComp pkg
-  buildableExes' = buildableExesComp pkg
-  buildableTestSuites = buildableTestSuitesComp pkg
-  buildableBenchmarks = buildableBenchmarksComp pkg
+  buildableForeignLibs' = buildableForeignLibs pkg
+  buildableSubLibs' = buildableSubLibs pkg
+  buildableExes' = buildableExes pkg
+  buildableTestSuites' = buildableTestSuites pkg
+  buildableBenchmarks' = buildableBenchmarks pkg
 wantedPackageComponents _ _ _ = S.empty
 
 checkForIssues :: HasTerm env => [GhciPkgInfo] -> RIO env ()

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -46,7 +46,8 @@ import           Stack.Ghci.Script
                    , scriptToLazyByteString
                    )
 import           Stack.Package
-                   ( buildableExes, buildableForeignLibs, getPackageOpts
+                   ( buildableForeignLibsComp, buildableSubLibsComp, buildableExesComp
+                   , buildableTestSuitesComp, buildableBenchmarksComp, getPackageOpts
                    , hasBuildableMainLibrary, listOfPackageDeps
                    , packageFromPackageDescription, readDotBuildinfo
                    , resolvePackageDescription, topSortPackageComponent
@@ -63,7 +64,6 @@ import qualified Stack.Types.BuildOpts as BenchmarkOpts ( BenchmarkOpts (..) )
 import qualified Stack.Types.BuildOpts as TestOpts ( TestOpts (..) )
 import           Stack.Types.BuildOptsCLI
                    ( ApplyCLIFlag (..), BuildOptsCLI (..), defaultBuildOptsCLI )
-import           Stack.Types.CompCollection ( getBuildableListText )
 import           Stack.Types.CompilerPaths
                    ( CompilerPaths (..), HasCompiler (..) )
 import           Stack.Types.Config ( Config (..), HasConfig (..), buildOptsL )
@@ -951,21 +951,21 @@ makeGhciPkgInfo installMap installedMap locals addPkgs mfileTargets pkgDesc = do
 -- (differently).
 wantedPackageComponents :: BuildOpts -> Target -> Package -> Set NamedComponent
 wantedPackageComponents _ (TargetComps cs) _ = cs
-wantedPackageComponents bopts (TargetAll PTProject) pkg = S.fromList $
+wantedPackageComponents bopts (TargetAll PTProject) pkg =
      ( if hasBuildableMainLibrary pkg
-         then CLib : map CSubLib buildableForeignLibs'
-         else []
+         then S.insert CLib (S.mapMonotonic CSubLib buildableForeignLibs')
+         else S.empty
      )
-  <> map CExe buildableExes'
-  <> map CSubLib buildableSubLibs
-  <> (if bopts.tests then map CTest buildableTestSuites else [])
-  <> (if bopts.benchmarks then map CBench buildableBenchmarks else [])
+  <> S.mapMonotonic CExe buildableExes'
+  <> S.mapMonotonic CSubLib buildableSubLibs
+  <> (if bopts.tests then S.mapMonotonic CTest buildableTestSuites else S.empty)
+  <> (if bopts.benchmarks then S.mapMonotonic CBench buildableBenchmarks else S.empty)
  where
-  buildableForeignLibs' = S.toList $ buildableForeignLibs pkg
-  buildableSubLibs = getBuildableListText pkg.subLibraries
-  buildableExes' = S.toList $ buildableExes pkg
-  buildableTestSuites = getBuildableListText pkg.testSuites
-  buildableBenchmarks = getBuildableListText pkg.benchmarks
+  buildableForeignLibs' = buildableForeignLibsComp pkg
+  buildableSubLibs = buildableSubLibsComp pkg
+  buildableExes' = buildableExesComp pkg
+  buildableTestSuites = buildableTestSuitesComp pkg
+  buildableBenchmarks = buildableBenchmarksComp pkg
 wantedPackageComponents _ _ _ = S.empty
 
 checkForIssues :: HasTerm env => [GhciPkgInfo] -> RIO env ()

--- a/src/Stack/Ghci.hs
+++ b/src/Stack/Ghci.hs
@@ -46,7 +46,7 @@ import           Stack.Ghci.Script
                    , scriptToLazyByteString
                    )
 import           Stack.Package
-                   ( buildableForeignLibs, buildableSubLibs, buildableExes
+                   ( buildableExes, buildableForeignLibs, buildableSubLibs
                    , buildableTestSuites, buildableBenchmarks, getPackageOpts
                    , hasBuildableMainLibrary, listOfPackageDeps
                    , packageFromPackageDescription, readDotBuildinfo
@@ -958,8 +958,14 @@ wantedPackageComponents bopts (TargetAll PTProject) pkg =
      )
   <> S.mapMonotonic CExe buildableExes'
   <> S.mapMonotonic CSubLib buildableSubLibs'
-  <> (if bopts.tests then S.mapMonotonic CTest buildableTestSuites' else S.empty)
-  <> (if bopts.benchmarks then S.mapMonotonic CBench buildableBenchmarks' else S.empty)
+  <> ( if bopts.tests
+         then S.mapMonotonic CTest buildableTestSuites'
+         else S.empty
+     )
+  <> ( if bopts.benchmarks
+         then S.mapMonotonic CBench buildableBenchmarks'
+         else S.empty
+     )
  where
   buildableForeignLibs' = buildableForeignLibs pkg
   buildableSubLibs' = buildableSubLibs pkg

--- a/src/Stack/Options/BuildMonoidParser.hs
+++ b/src/Stack/Options/BuildMonoidParser.hs
@@ -7,7 +7,6 @@ module Stack.Options.BuildMonoidParser
   , cabalVerbosityParser
   ) where
 
-import qualified Data.Text as T
 import           Distribution.Parsec ( eitherParsec )
 import           Options.Applicative
                    ( Parser, eitherReader, flag, help, long, metavar, option
@@ -27,6 +26,7 @@ import           Stack.Types.BuildOptsMonoid
                    ( BuildOptsMonoid (..), CabalVerbosity, readProgressBarFormat
                    , toFirstCabalVerbosity
                    )
+import           Stack.Types.ComponentUtils ( unqualCompFromString )
 
 buildOptsMonoidParser :: GlobalOptsContext -> Parser BuildOptsMonoid
 buildOptsMonoidParser hide0 = BuildOptsMonoid
@@ -214,7 +214,7 @@ buildOptsMonoidParser hide0 = BuildOptsMonoid
     ++ splitObjsWarning
     )
     hide
-  skipComponents = many (fmap T.pack (strOption
+  skipComponents = many (fmap unqualCompFromString (strOption
     (  long "skip"
     <> help "Skip given component (can be specified multiple times)."
     <> hide

--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -34,7 +34,6 @@ import           Stack.Component ( fromCabalName )
 import           Stack.GhcPkg ( createDatabase )
 import           Stack.Prelude
 import           Stack.Types.CompilerPaths ( GhcPkgExe (..), HasCompiler (..) )
-import           Stack.Types.Component ( StackUnqualCompName(..) )
 import           Stack.Types.ComponentUtils ( unqualCompFromText )
 import           Stack.Types.DumpPackage ( DumpPackage (..), SublibDump (..) )
 import           Stack.Types.GhcPkgId ( GhcPkgId, parseGhcPkgId )

--- a/src/Stack/PackageDump.hs
+++ b/src/Stack/PackageDump.hs
@@ -35,6 +35,7 @@ import           Stack.GhcPkg ( createDatabase )
 import           Stack.Prelude
 import           Stack.Types.CompilerPaths ( GhcPkgExe (..), HasCompiler (..) )
 import           Stack.Types.Component ( StackUnqualCompName(..) )
+import           Stack.Types.ComponentUtils ( unqualCompFromText )
 import           Stack.Types.DumpPackage ( DumpPackage (..), SublibDump (..) )
 import           Stack.Types.GhcPkgId ( GhcPkgId, parseGhcPkgId )
 
@@ -261,7 +262,7 @@ conduitDumpPackage = (.| CL.catMaybes) $ eachSection $ do
               fromCabalName libName'
             MungedPackageName _parentPackageName _ -> ""
           libName =
-            maybe getLibNameFromLegacyName StackUnqualCompName maybeLibName
+            maybe getLibNameFromLegacyName unqualCompFromText maybeLibName
           sublib = flip SublibDump libName <$> maybePackageName
           parseQuoted key =
             case mapM (P.parseOnly (argsParser NoEscaping)) val of

--- a/src/Stack/Types/Build.hs
+++ b/src/Stack/Types/Build.hs
@@ -58,6 +58,7 @@ import           Stack.Types.BuildOpts
                    ( BenchmarkOpts (..), BuildOpts (..), TestOpts (..) )
 import           Stack.Types.BuildOptsCLI
                    ( BuildSubset (..), FileWatchOpts (..) )
+import           Stack.Types.ComponentUtils ( StackUnqualCompName )
 import           Stack.Types.ConfigureOpts
                    ( BaseConfigOpts, ConfigureOpts, PackageConfigureOpts
                    , configureOpts
@@ -230,7 +231,7 @@ data Plan = Plan
     -- ^ Final actions to be taken (test, benchmark, etc)
   , unregisterLocal :: !(Map GhcPkgId (PackageIdentifier, Text))
     -- ^ Text is reason we're unregistering, for display only
-  , installExes :: !(Map Text InstallLocation)
+  , installExes :: !(Map StackUnqualCompName InstallLocation)
     -- ^ Executables that should be installed after successful building
   }
   deriving Show

--- a/src/Stack/Types/Build/ConstructPlan.hs
+++ b/src/Stack/Types/Build/ConstructPlan.hs
@@ -31,6 +31,7 @@ import           Stack.Types.Build.Exception ( ConstructPlanException )
 import           Stack.Types.BuildConfig
                    ( BuildConfig (..), HasBuildConfig(..) )
 import           Stack.Types.CompilerPaths ( HasCompiler (..) )
+import           Stack.Types.ComponentUtils ( StackUnqualCompName )
 import           Stack.Types.Config ( HasConfig (..) )
 import           Stack.Types.ConfigureOpts ( BaseConfigOpts )
 import           Stack.Types.Curator ( Curator )
@@ -90,7 +91,7 @@ data W = W
   { wFinals :: !(Map PackageName (Either ConstructPlanException Task))
     -- ^ A dictionary of package names, and either a final task to perform when
     -- building the package or an exception.
-  , wInstall :: !(Map Text InstallLocation)
+  , wInstall :: !(Map StackUnqualCompName InstallLocation)
     -- ^ A dictionary of executables to be installed, and location where the
     -- executable's binary is placed.
   , wDirty :: !(Map PackageName Text)

--- a/src/Stack/Types/Build/Exception.hs
+++ b/src/Stack/Types/Build/Exception.hs
@@ -32,6 +32,7 @@ import           Stack.Prelude
 import           Stack.Types.Compiler ( ActualCompiler, compilerVersionString )
 import           Stack.Types.CompilerBuild
                    ( CompilerBuild, compilerBuildSuffix )
+import           Stack.Types.ComponentUtils ( StackUnqualCompName, unqualCompToString )
 import           Stack.Types.DumpPackage ( DumpPackage )
 import           Stack.Types.UnusedFlags ( FlagSource (..), UnusedFlags (..) )
 import           Stack.Types.GHCVariant ( GHCVariant, ghcVariantSuffix )
@@ -54,7 +55,7 @@ data BuildException
       (Path Abs File) -- stack.yaml
   | TestSuiteFailure
       PackageIdentifier
-      (Map Text (Maybe ExitCode))
+      (Map StackUnqualCompName (Maybe ExitCode))
       (Maybe (Path Abs File))
       S.ByteString
   | TestSuiteTypeUnsupported TestSuiteInterface
@@ -120,7 +121,7 @@ instance Exception BuildException where
         [ ["Test suite failure for package " ++ packageIdentifierString ident]
         , flip map (Map.toList codes) $ \(name, mcode) -> concat
             [ "    "
-            , T.unpack name
+            , unqualCompToString name
             , ": "
             , case mcode of
                 Nothing -> " executable not found"

--- a/src/Stack/Types/Build/Exception.hs
+++ b/src/Stack/Types/Build/Exception.hs
@@ -251,7 +251,7 @@ data BuildPrettyException
   | SomeTargetsNotBuildable [(PackageName, NamedComponent)]
   | InvalidFlagSpecification [UnusedFlags]
   | GHCProfOptionInvalid
-  | NotOnlyLocal [PackageName] [Text]
+  | NotOnlyLocal [PackageName] [StackUnqualCompName]
   | CompilerVersionMismatch
       (Maybe (ActualCompiler, Arch)) -- found
       (WantedCompiler, Arch) -- expected
@@ -388,7 +388,7 @@ instance Pretty BuildPrettyException where
               fillSep
                 ( "Executables:"
                 : mkNarrativeList Nothing False
-                    (map (fromString . T.unpack) exes :: [StyleDoc])
+                    (map (fromString . unqualCompToString) exes :: [StyleDoc])
                 )
            <> line
   pretty ( CompilerVersionMismatch

--- a/src/Stack/Types/Build/Exception.hs
+++ b/src/Stack/Types/Build/Exception.hs
@@ -32,7 +32,8 @@ import           Stack.Prelude
 import           Stack.Types.Compiler ( ActualCompiler, compilerVersionString )
 import           Stack.Types.CompilerBuild
                    ( CompilerBuild, compilerBuildSuffix )
-import           Stack.Types.ComponentUtils ( StackUnqualCompName, unqualCompToString )
+import           Stack.Types.ComponentUtils
+                   ( StackUnqualCompName, unqualCompToString )
 import           Stack.Types.DumpPackage ( DumpPackage )
 import           Stack.Types.UnusedFlags ( FlagSource (..), UnusedFlags (..) )
 import           Stack.Types.GHCVariant ( GHCVariant, ghcVariantSuffix )

--- a/src/Stack/Types/BuildOpts.hs
+++ b/src/Stack/Types/BuildOpts.hs
@@ -16,6 +16,7 @@ module Stack.Types.BuildOpts
 import           Stack.Prelude
 import           Stack.Types.BuildOptsMonoid
                    ( CabalVerbosity (..), ProgressBarFormat (..) )
+import           Stack.Types.Component ( StackUnqualCompName )
 
 -- | Build options that is interpreted by the build command. This is built up
 -- from BuildOptsCLI and BuildOptsMonoid
@@ -79,7 +80,7 @@ data BuildOpts = BuildOpts
     -- ^ Ask Cabal to be verbose in its builds
   , splitObjs :: !Bool
     -- ^ Whether to enable split-objs.
-  , skipComponents :: ![Text]
+  , skipComponents :: ![StackUnqualCompName]
     -- ^ Which components to skip when building
   , interleavedOutput :: !Bool
     -- ^ Should we use the interleaved GHC output when building

--- a/src/Stack/Types/BuildOptsMonoid.hs
+++ b/src/Stack/Types/BuildOptsMonoid.hs
@@ -31,6 +31,7 @@ import           Distribution.Parsec ( Parsec (..), simpleParsec )
 import           Distribution.Verbosity ( Verbosity, normal, verbose )
 import           Generics.Deriving.Monoid ( mappenddefault, memptydefault )
 import           Stack.Prelude hiding ( trace )
+import           Stack.Types.ComponentUtils ( StackUnqualCompName )
 
 -- | Build options that may be specified in the stack.yaml or from the CLI
 data BuildOptsMonoid = BuildOptsMonoid
@@ -64,7 +65,7 @@ data BuildOptsMonoid = BuildOptsMonoid
   , reconfigure :: !FirstFalse
   , cabalVerbose :: !(First CabalVerbosity)
   , splitObjs :: !FirstFalse
-  , skipComponents :: ![Text]
+  , skipComponents :: ![StackUnqualCompName]
   , interleavedOutput :: !FirstTrue
   , progressBar :: !(First ProgressBarFormat)
   , ddumpDir :: !(First Text)

--- a/src/Stack/Types/Cache.hs
+++ b/src/Stack/Types/Cache.hs
@@ -12,7 +12,8 @@ import           Database.Persist.Sql
                    , SqlType (..)
                    )
 import           Stack.Prelude
-import           Stack.Types.GhcPkgId ( GhcPkgId, parseGhcPkgId, ghcPkgIdToText )
+import           Stack.Types.GhcPkgId
+                   ( GhcPkgId, ghcPkgIdToText, parseGhcPkgId )
 
 -- | Type of config cache
 data ConfigCacheType

--- a/src/Stack/Types/Cache.hs
+++ b/src/Stack/Types/Cache.hs
@@ -12,7 +12,7 @@ import           Database.Persist.Sql
                    , SqlType (..)
                    )
 import           Stack.Prelude
-import           Stack.Types.GhcPkgId ( GhcPkgId, parseGhcPkgId, unGhcPkgId )
+import           Stack.Types.GhcPkgId ( GhcPkgId, parseGhcPkgId, ghcPkgIdToText )
 
 -- | Type of config cache
 data ConfigCacheType
@@ -24,7 +24,7 @@ data ConfigCacheType
 instance PersistField ConfigCacheType where
   toPersistValue ConfigCacheTypeConfig = PersistText "config"
   toPersistValue (ConfigCacheTypeFlagLibrary v) =
-    PersistText $ "lib:" <> unGhcPkgId v
+    PersistText $ "lib:" <> ghcPkgIdToText v
   toPersistValue (ConfigCacheTypeFlagExecutable v) =
     PersistText $ "exe:" <> T.pack (packageIdentifierString v)
   fromPersistValue (PersistText t) =

--- a/src/Stack/Types/CompCollection.hs
+++ b/src/Stack/Types/CompCollection.hs
@@ -34,9 +34,8 @@ import qualified Data.Map as M
 import qualified Data.Set as Set
 import           Stack.Prelude
 import           Stack.Types.Component
-                   ( HasBuildInfo, HasName, StackBuildInfo (..)
-                   , StackUnqualCompName (..)
-                   )
+                   ( HasBuildInfo, HasName, StackBuildInfo (..) )
+import           Stack.Types.ComponentUtils ( StackUnqualCompName, unqualCompToText )
 
 -- | A type representing collections of components, distinguishing buildable
 -- components and non-buildable components.
@@ -116,12 +115,12 @@ getBuildableSet = M.keysSet . (.buildableOnes)
 -- | Get the names of the buildable components in the given collection, as a
 -- 'Set' of 'Text'.
 getBuildableSetText :: CompCollection component -> Set Text
-getBuildableSetText = Set.mapMonotonic (.unqualCompToText) . getBuildableSet
+getBuildableSetText = Set.mapMonotonic unqualCompToText . getBuildableSet
 
 -- | Get the names of the buildable components in the given collection, as a
 -- list of 'Text.
 getBuildableListText :: CompCollection component -> [Text]
-getBuildableListText = getBuildableListAs (.unqualCompToText)
+getBuildableListText = getBuildableListAs unqualCompToText
 
 -- | Apply the given function to the names of the buildable components in the
 -- given collection, yielding a list.
@@ -142,25 +141,24 @@ hasBuildableComponent = not . null . getBuildableSet
 -- components, yields 'Just' @component@ if the collection includes a buildable
 -- component of that name, and 'Nothing' otherwise.
 collectionLookup ::
-     Text
+     StackUnqualCompName
      -- ^ Name of the buildable component.
   -> CompCollection component
      -- ^ Collection of components.
   -> Maybe component
 collectionLookup needle haystack =
-  M.lookup (StackUnqualCompName needle) haystack.buildableOnes
+  M.lookup needle haystack.buildableOnes
 
 -- | For a given collection of components, yields a list of pairs for buildable
 -- components of the name of the component and the component.
-collectionKeyValueList :: CompCollection component -> [(Text, component)]
+collectionKeyValueList :: CompCollection component -> [(StackUnqualCompName, component)]
 collectionKeyValueList haystack =
-      (\(StackUnqualCompName k, !v) -> (k, v))
-  <$> M.toList haystack.buildableOnes
+      M.toList haystack.buildableOnes
 
 -- | Yields 'True' if, and only if, the given collection of components includes
 -- a buildable component with the given name.
 collectionMember ::
-     Text
+     StackUnqualCompName
      -- ^ Name of the buildable component.
   -> CompCollection component
      -- ^ Collection of components.

--- a/src/Stack/Types/CompCollection.hs
+++ b/src/Stack/Types/CompCollection.hs
@@ -35,7 +35,8 @@ import qualified Data.Set as Set
 import           Stack.Prelude
 import           Stack.Types.Component
                    ( HasBuildInfo, HasName, StackBuildInfo (..) )
-import           Stack.Types.ComponentUtils ( StackUnqualCompName, unqualCompToText )
+import           Stack.Types.ComponentUtils
+                   ( StackUnqualCompName, unqualCompToText )
 
 -- | A type representing collections of components, distinguishing buildable
 -- components and non-buildable components.
@@ -146,14 +147,14 @@ collectionLookup ::
   -> CompCollection component
      -- ^ Collection of components.
   -> Maybe component
-collectionLookup needle haystack =
-  M.lookup needle haystack.buildableOnes
+collectionLookup needle haystack = M.lookup needle haystack.buildableOnes
 
 -- | For a given collection of components, yields a list of pairs for buildable
 -- components of the name of the component and the component.
-collectionKeyValueList :: CompCollection component -> [(StackUnqualCompName, component)]
-collectionKeyValueList haystack =
-      M.toList haystack.buildableOnes
+collectionKeyValueList ::
+     CompCollection component
+  -> [(StackUnqualCompName, component)]
+collectionKeyValueList haystack = M.toList haystack.buildableOnes
 
 -- | Yields 'True' if, and only if, the given collection of components includes
 -- a buildable component with the given name.

--- a/src/Stack/Types/Component.hs
+++ b/src/Stack/Types/Component.hs
@@ -34,7 +34,8 @@ import           Distribution.Simple ( Extension, Language )
 import           Distribution.Utils.Path ( PackageDir, SourceDir, SymbolicPath )
 import           GHC.Records ( HasField (..) )
 import           Stack.Prelude
-import           Stack.Types.ComponentUtils ( StackUnqualCompName (..), emptyCompName )
+import           Stack.Types.ComponentUtils
+                   ( StackUnqualCompName (..), emptyCompName )
 import           Stack.Types.Dependency ( DepValue )
 import           Stack.Types.NamedComponent ( NamedComponent (..) )
 

--- a/src/Stack/Types/Component.hs
+++ b/src/Stack/Types/Component.hs
@@ -34,7 +34,7 @@ import           Distribution.Simple ( Extension, Language )
 import           Distribution.Utils.Path ( PackageDir, SourceDir, SymbolicPath )
 import           GHC.Records ( HasField (..) )
 import           Stack.Prelude
-import           Stack.Types.ComponentUtils ( StackUnqualCompName (..) )
+import           Stack.Types.ComponentUtils ( StackUnqualCompName (..), emptyCompName )
 import           Stack.Types.Dependency ( DepValue )
 import           Stack.Types.NamedComponent ( NamedComponent (..) )
 
@@ -166,22 +166,22 @@ type HasBuildInfo component = HasField "buildInfo" component StackBuildInfo
 
 instance HasField "qualifiedName" StackLibrary NamedComponent where
   getField v
-    | rawName == mempty = CLib
+    | rawName == emptyCompName = CLib
     | otherwise = CSubLib rawName
     where
-      rawName = v.name.unqualCompToText
+      rawName = v.name
 
 instance HasField "qualifiedName" StackForeignLibrary NamedComponent where
-  getField = CFlib . (.name.unqualCompToText)
+  getField = CFlib . (.name)
 
 instance HasField "qualifiedName" StackExecutable NamedComponent where
-  getField = CExe . (.name.unqualCompToText)
+  getField = CExe . (.name)
 
 instance HasField "qualifiedName" StackTestSuite NamedComponent where
-  getField = CTest . (.name.unqualCompToText)
+  getField = CTest . (.name)
 
 instance HasField "qualifiedName" StackBenchmark NamedComponent where
-  getField = CBench . (.name.unqualCompToText)
+  getField = CBench . (.name)
 
 -- | Type synonym for a 'HasField' constraint which represent a virtual field,
 -- computed from the type, the NamedComponent constructor and the name.

--- a/src/Stack/Types/ComponentUtils.hs
+++ b/src/Stack/Types/ComponentUtils.hs
@@ -12,15 +12,22 @@
 -- component and related helper functions.
 module Stack.Types.ComponentUtils
   ( StackUnqualCompName (..)
+  , unqualCompToText
+  , unqualCompFromText
+  , unqualCompToString
+  , unqualCompFromString
+  , emptyCompName
   , fromCabalName
   , toCabalName
   ) where
 
+import           Data.Aeson (FromJSON(..))
+import           Data.Hashable (Hashable(..))
+import           Distribution.Compat.Binary ( decode, encode )
 import           Distribution.PackageDescription
-                   ( UnqualComponentName, mkUnqualComponentName
-                   , unUnqualComponentName
-                   )
-import           RIO.Text (pack, unpack)
+                  ( UnqualComponentName, unUnqualComponentNameST, mkUnqualComponentName
+                  , unUnqualComponentName
+                  )
 import           Stack.Prelude
 
 -- | Type representing the name of an \'unqualified\' component (that is, the
@@ -33,15 +40,29 @@ import           Stack.Prelude
 -- Ideally, we would use the Cabal-syntax type and not 'Text', to avoid
 -- unnecessary work, but there is no 'Hashable' instance for
 -- 'Distribution.Types.UnqualComponentName.UnqualComponentName' yet.
-newtype StackUnqualCompName = StackUnqualCompName
-  { unqualCompToText :: Text
-  }
-  deriving (Data, Eq, Generic, Hashable, IsString, NFData, Ord, Read, Show, Typeable)
+newtype StackUnqualCompName = StackUnqualCompName UnqualComponentName
+  deriving (Data, Eq, Generic, IsString, NFData, Ord, Read, Show, Typeable)
+
+instance Hashable StackUnqualCompName where
+  hashWithSalt a v = hashWithSalt a (show v)
 
 fromCabalName :: UnqualComponentName -> StackUnqualCompName
-fromCabalName unqualName =
-  StackUnqualCompName $ pack . unUnqualComponentName $ unqualName
+fromCabalName = StackUnqualCompName
 
 toCabalName :: StackUnqualCompName -> UnqualComponentName
-toCabalName (StackUnqualCompName unqualName) =
-  mkUnqualComponentName (unpack unqualName)
+toCabalName (StackUnqualCompName unqualName) = unqualName
+
+unqualCompToString :: StackUnqualCompName -> String
+unqualCompToString = unUnqualComponentName . toCabalName
+unqualCompFromString :: String -> StackUnqualCompName
+unqualCompFromString = StackUnqualCompName . mkUnqualComponentName
+unqualCompToText :: StackUnqualCompName -> Text
+unqualCompToText = (decode . encode) . unUnqualComponentNameST . toCabalName
+unqualCompFromText :: Text -> StackUnqualCompName
+unqualCompFromText = StackUnqualCompName . decode . encode
+
+emptyCompName :: StackUnqualCompName
+emptyCompName = StackUnqualCompName $ mkUnqualComponentName ""
+
+instance FromJSON StackUnqualCompName where
+  parseJSON = fmap (StackUnqualCompName . decode . encode) <$> parseJSON @Text

--- a/src/Stack/Types/ComponentUtils.hs
+++ b/src/Stack/Types/ComponentUtils.hs
@@ -21,13 +21,13 @@ module Stack.Types.ComponentUtils
   , toCabalName
   ) where
 
-import           Data.Aeson (FromJSON(..))
-import           Data.Hashable (Hashable(..))
+import           Data.Aeson ( FromJSON (..) )
+import           Data.Hashable ( Hashable (..) )
 import           Distribution.Compat.Binary ( decode, encode )
 import           Distribution.PackageDescription
-                  ( UnqualComponentName, unUnqualComponentNameST, mkUnqualComponentName
-                  , unUnqualComponentName
-                  )
+                   ( UnqualComponentName, mkUnqualComponentName
+                   , unUnqualComponentName, unUnqualComponentNameST
+                   )
 import           Stack.Prelude
 
 -- | Type representing the name of an \'unqualified\' component (that is, the

--- a/src/Stack/Types/Dependency.hs
+++ b/src/Stack/Types/Dependency.hs
@@ -93,4 +93,4 @@ depValueToTarget dv = case dv.depType of
  where
   completeSet dlib =
     (if dlib.main then Set.insert CLib else id) $ sublibSet dlib
-  sublibSet dlib = Set.mapMonotonic (CSubLib . unqualCompToText) dlib.subLib
+  sublibSet dlib = Set.mapMonotonic CSubLib dlib.subLib

--- a/src/Stack/Types/GhcPkgId.hs
+++ b/src/Stack/Types/GhcPkgId.hs
@@ -17,11 +17,12 @@ import           Data.Attoparsec.Text
                    )
 import           Data.Char ( isAlphaNum )
 import           Data.Hashable ( Hashable(..) )
-import           Database.Persist.Sql ( PersistField (..), PersistFieldSql (..) )
+import           Database.Persist.Sql
+                   ( PersistField (..), PersistFieldSql (..) )
 import           Distribution.Compat.Binary ( decode, encode )
+import           Distribution.Types.UnitId ( UnitId, mkUnitId, unUnitId )
 import           Stack.Prelude
 import           Text.Read ( Read (..) )
-import Distribution.Types.UnitId (UnitId, mkUnitId, unUnitId)
 
 -- | A parse fail.
 newtype GhcPkgIdParseFail

--- a/src/Stack/Types/NamedComponent.hs
+++ b/src/Stack/Types/NamedComponent.hs
@@ -25,7 +25,9 @@ module Stack.Types.NamedComponent
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import           Stack.Prelude
-import           Stack.Types.ComponentUtils (StackUnqualCompName, unqualCompToText, unqualCompToString)
+import           Stack.Types.ComponentUtils
+                   ( StackUnqualCompName, unqualCompToString, unqualCompToText
+                   )
 
 -- | Type representing components of a fully-resolved Cabal package.
 data NamedComponent

--- a/src/Stack/Types/NamedComponent.hs
+++ b/src/Stack/Types/NamedComponent.hs
@@ -71,10 +71,10 @@ renderPkgComponent :: (PackageName, NamedComponent) -> Text
 renderPkgComponent (pkg, comp) =
   fromPackageName pkg <> ":" <> renderComponent comp
 
-exeComponents :: Set NamedComponent -> Set Text
+exeComponents :: Set NamedComponent -> Set StackUnqualCompName
 exeComponents = Set.fromList . mapMaybe mExeName . Set.toList
  where
-  mExeName (CExe name) = Just $ unqualCompToText name
+  mExeName (CExe name) = Just name
   mExeName _ = Nothing
 
 testComponents :: Set NamedComponent -> Set StackUnqualCompName
@@ -83,16 +83,16 @@ testComponents = Set.fromList . mapMaybe mTestName . Set.toList
   mTestName (CTest name) = Just name
   mTestName _ = Nothing
 
-benchComponents :: Set NamedComponent -> Set Text
+benchComponents :: Set NamedComponent -> Set StackUnqualCompName
 benchComponents = Set.fromList . mapMaybe mBenchName . Set.toList
  where
-  mBenchName (CBench name) = Just $ unqualCompToText name
+  mBenchName (CBench name) = Just name
   mBenchName _ = Nothing
 
-subLibComponents :: Set NamedComponent -> Set Text
+subLibComponents :: Set NamedComponent -> Set StackUnqualCompName
 subLibComponents = Set.fromList . mapMaybe mSubLibName . Set.toList
  where
-  mSubLibName (CSubLib name) = Just $ unqualCompToText name
+  mSubLibName (CSubLib name) = Just name
   mSubLibName _ = Nothing
 
 isCLib :: NamedComponent -> Bool

--- a/src/Stack/Types/SourceMap.hs
+++ b/src/Stack/Types/SourceMap.hs
@@ -194,7 +194,9 @@ ppComponentsMaybe compType pp = do
     [ maybe [] (const $ catMaybes [compType CLib]) (C.condLibrary gpd)
     , mapMaybe ((compType . CExe . fromCabalName) . fst) (C.condExecutables gpd)
     , mapMaybe ((compType . CTest . fromCabalName) . fst) (C.condTestSuites gpd)
-    , mapMaybe ((compType . CBench . fromCabalName) . fst) (C.condBenchmarks gpd)
+    , mapMaybe
+        ((compType . CBench . fromCabalName) . fst)
+        (C.condBenchmarks gpd)
     ]
 
 -- | Version for the given 'ProjectPackage

--- a/stack.cabal
+++ b/stack.cabal
@@ -381,6 +381,7 @@ library
     , fsnotify >=0.4.1
     , generic-deriving
     , ghc-boot
+    , hashable
     , hi-file-parser >=0.1.6.0
     , hpack >=0.36.0
     , hpc
@@ -503,6 +504,7 @@ executable stack
     , fsnotify >=0.4.1
     , generic-deriving
     , ghc-boot
+    , hashable
     , hi-file-parser >=0.1.6.0
     , hpack >=0.36.0
     , hpc
@@ -604,6 +606,7 @@ executable stack-integration-test
     , fsnotify >=0.4.1
     , generic-deriving
     , ghc-boot
+    , hashable
     , hi-file-parser >=0.1.6.0
     , hpack >=0.36.0
     , hpc
@@ -721,6 +724,7 @@ test-suite stack-unit-test
     , fsnotify >=0.4.1
     , generic-deriving
     , ghc-boot
+    , hashable
     , hi-file-parser >=0.1.6.0
     , hpack >=0.36.0
     , hpc


### PR DESCRIPTION
This is a first step for #6593, the changes in DumpPackage are not done here, because a first move was to bring some types closer to cabal, step by step.
This includes 2 major changes :
- GhcPkgId is now a wrapper over UnitId
- StackUnqualCompName is now a nextype over its cabal counterpart, and generalized wherever we can (instead of Text)

The second change is also a refactoring towards better type safety and documentation. It should also increase overall stack's speed by two aspects : better memory layout with ShortText, and less translation work from cabal.

Indicative integration tests speed:
1185 ubuntu
951 macos
1491 windows
So this corroborates a small speedup (compared to baseline https://github.com/commercialhaskell/stack/pull/6615)