### PR TITLE
Fix #6630 Also take exectutable file name into account, for '`stack`'

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,10 @@ Bug fixes:
 * Stack's in-app messages refer to https://haskellstack.org as currently
   structured. (Most URLs in older Stack versions are redirected.)
 
+* Stack's `upgrade` command only treats the current running Stack executable
+  as '`stack`' if the executable file is named `stack` or, on Windows,
+  `stack.exe`. Previously only how it was invoked was considered.
+
 ## v3.1.1 - 2024-07-28
 
 Release notes:

--- a/doc/commands/upgrade_command.md
+++ b/doc/commands/upgrade_command.md
@@ -37,10 +37,11 @@ By default:
   (replacing any existing executable named `stack` there);
 
 * if the current running Stack executable is '`stack`' (that is, it was invoked
-  as `stack` or, on Windows, `stack.exe` - this is case insensitive), an
-  existing binary distribution will replace it. If the executable is located
-  outside of Stack's local binary directory, pass the `--only-local-bin` flag to
-  skip that step;
+  as `stack` or, on Windows, `stack.exe` - this is case insensitive - and the
+  Stack executable file is named `stack` or, on Windows, `stack.exe` - this is
+  case sensitive), an existing binary distribution will replace it. If the
+  executable is located outside of Stack's local binary directory, pass the
+  `--only-local-bin` flag to skip that step;
 
 * if the current running Stack executable is not '`stack`' (as described above),
   an existing binary distribution will only be put in Stack's local binary


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested `stack upgrade` locally on Windows, including with a symbolic link.
