### PR TITLE
Re #6630 Add `progName`, `mExecutablePath` to `GlobalOpts`

### DIFF
--- a/doc/commands/exec_command.md
+++ b/doc/commands/exec_command.md
@@ -19,8 +19,10 @@ By default:
 * the `GHC_PACKAGE_PATH` environment variable is set for the command's process.
   Pass the flag `--no-ghc-package-path` to not set the environment variable;
 
-* the `STACK_EXE` environment variable is set for the command's process. Pass
-  the flag `--no-stack-exe` to not set the environment variable; and
+* if the operating system provides a reliable way to determine it and where a
+  result was available, the `STACK_EXE` environment variable is set to the path
+  to the current Stack executable for the command's process. Pass the flag
+  `--no-stack-exe` to not set the environment variable; and
 
 * the specified executable is executed in the current directory. Pass the option
   `--cwd <directory>` to execute the executable in the specified directory.

--- a/doc/maintainers/stack_errors.md
+++ b/doc/maintainers/stack_errors.md
@@ -5,7 +5,7 @@
 In connection with considering Stack's support of the
 [Haskell Error Index](https://errors.haskell.org/) initiative, this page seeks
 to take stock of the errors that Stack itself can raise, by reference to the
-`master` branch of the Stack repository. Last updated: 2024-06-03.
+`master` branch of the Stack repository. Last updated: 2024-08-02.
 
 *   `Stack.main`: catches exceptions from action `commandLineHandler`.
 
@@ -424,6 +424,7 @@ to take stock of the errors that Stack itself can raise, by reference to the
         [S-6854] | BadMsysEnvironment MsysEnvironment Arch
         [S-5006] | NoDefaultMsysEnvironmentBug
         [S-8398] | ConfigFileNotProjectLevelBug
+        [S-6890] | NoExecutablePath String
         ~~~
 
     -   `Stack.Types.Config.ParseAbsolutePathException`

--- a/src/Stack.hs
+++ b/src/Stack.hs
@@ -82,7 +82,8 @@ main = do
     Left (exitCode :: ExitCode) ->
       throwIO exitCode
     Right (globalMonoid, run) -> do
-      global <- globalOptsFromMonoid isTerminal globalMonoid
+      global <-
+        globalOptsFromMonoid progName mExecutablePath isTerminal globalMonoid
       when (global.logLevel == LevelDebug) $
         hPutStrLn stderr versionString'
       whenJust global.reExecVersion $ \expectVersion -> do

--- a/src/Stack/Build/Execute.hs
+++ b/src/Stack/Build/Execute.hs
@@ -66,8 +66,7 @@ import           Stack.Types.Compiler ( ActualCompiler (..) )
 import           Stack.Types.CompilerPaths ( HasCompiler (..), getGhcPkgExe )
 import           Stack.Types.ComponentUtils
                    ( StackUnqualCompName, unqualCompToString )
-import           Stack.Types.Config
-                   ( Config (..), HasConfig (..), buildOptsL )
+import           Stack.Types.Config ( Config (..), HasConfig (..), buildOptsL )
 import           Stack.Types.ConfigureOpts
                    ( BaseConfigOpts (..) )
 import           Stack.Types.DumpPackage ( DumpPackage (..) )
@@ -87,10 +86,9 @@ import           Stack.Types.NamedComponent
 import           Stack.Types.Package
                    ( LocalPackage (..), Package (..), packageIdentifier )
 import           Stack.Types.Platform ( HasPlatform (..) )
-import           Stack.Types.Runner ( HasRunner, terminalL )
+import           Stack.Types.Runner ( HasRunner, terminalL, viewExecutablePath )
 import           Stack.Types.SourceMap ( Target )
 import qualified System.Directory as D
-import           System.Environment ( getExecutablePath )
 import qualified System.FilePath as FP
 
 -- | Fetch the packages necessary for a build, for example in combination with
@@ -282,7 +280,8 @@ copyExecutables exes = do
           Platform _ Windows -> ".exe"
           _ -> ""
 
-  currExe <- liftIO getExecutablePath -- needed for windows, see below
+  -- needed for windows, see below
+  currExe <- toFilePath <$> viewExecutablePath
 
   installed <- forMaybeM (Map.toList exes) $ \(name, loc) -> do
     let strName = unqualCompToString name

--- a/src/Stack/Nix.hs
+++ b/src/Stack/Nix.hs
@@ -24,9 +24,10 @@ import           Stack.Types.BuildConfig ( wantedCompilerVersionL )
 import           Stack.Types.Config
                    ( Config (..), HasConfig (..), configProjectRoot )
 import           Stack.Types.Docker ( reExecArgName )
+import           Stack.Types.Runner ( viewExecutablePath )
 import           Stack.Types.Nix ( NixOpts (..) )
 import           Stack.Types.Version ( showStackVersion )
-import           System.Environment ( getArgs, getExecutablePath, lookupEnv )
+import           System.Environment ( getArgs, lookupEnv )
 import qualified System.FilePath as F
 
 -- | Type representing exceptions thrown by functions exported by the
@@ -49,7 +50,7 @@ runShellAndExit = do
              -- first stack when restarting in the container
            | otherwise =
                ("--" ++ reExecArgName ++ "=" ++ showStackVersion) : origArgs
-  exePath <- liftIO getExecutablePath
+  exePath <- toFilePath <$> viewExecutablePath
   config <- view configL
   envOverride <- view processContextL
   local (set processContextL envOverride) $ do

--- a/src/Stack/Options/Completion.hs
+++ b/src/Stack/Options/Completion.hs
@@ -48,16 +48,17 @@ ghcOptsCompleter = mkCompleter $ \inputRaw -> pure $
 -- TODO: Ideally this would pay attention to --stack-yaml, may require
 -- changes to optparse-applicative.
 
-buildConfigCompleter ::
-     (String -> RIO EnvConfig [String])
-  -> Completer
+buildConfigCompleter :: (String -> RIO EnvConfig [String]) -> Completer
 buildConfigCompleter inner = mkCompleter $ \inputRaw -> do
   let input = unescapeBashArg inputRaw
   case input of
     -- If it looks like a flag, skip this more costly completion.
     ('-': _) -> pure []
     _ -> do
-      go' <- globalOptsFromMonoid False mempty
+      -- We do not need to specify the name of the current Stack executable, as
+      -- it was invoked, or the path to the current Stack executable, as
+      -- withDefaultEnvConfig does not need either.
+      go' <- globalOptsFromMonoid "" Nothing False mempty
       let go = go' { logLevel = LevelOther "silent" }
       withRunnerGlobal go $ withConfig NoReexec $ withDefaultEnvConfig $ inner input
 

--- a/src/Stack/Options/GlobalParser.hs
+++ b/src/Stack/Options/GlobalParser.hs
@@ -114,10 +114,16 @@ globalOptsParser currentDir kind = GlobalOptsMonoid
 -- | Create GlobalOpts from GlobalOptsMonoid.
 globalOptsFromMonoid ::
      MonadIO m
-  => Bool
+  => String
+     -- ^ The name of the current Stack executable, as it was invoked.
+  -> Maybe (Path Abs File)
+     -- ^ The path to the current Stack executable, if the operating system
+     -- provides a reliable way to determine it and where a result was
+     -- available.
+  -> Bool
   -> GlobalOptsMonoid
   -> m GlobalOpts
-globalOptsFromMonoid defaultTerminal globalMonoid = do
+globalOptsFromMonoid progName mExecutablePath defaultTerminal globalMonoid = do
   snapshot <- for (getFirst globalMonoid.snapshot) $ \us -> do
     root <-
       case globalMonoid.snapshotRoot of
@@ -149,6 +155,8 @@ globalOptsFromMonoid defaultTerminal globalMonoid = do
     , termWidthOpt = getFirst globalMonoid.termWidthOpt
     , stackYaml
     , lockFileBehavior
+    , progName
+    , mExecutablePath
     }
 
 -- | Default logging level should be something useful but not crazy.

--- a/src/Stack/Options/LsParser.hs
+++ b/src/Stack/Options/LsParser.hs
@@ -160,8 +160,7 @@ formatSubCommand ::
   -> OA.Mod OA.CommandFields ListDepsOpts
 formatSubCommand cmd desc formatParser =
   OA.command
-    cmd
-    (OA.info (toListDepsOptsParser formatParser) (OA.progDesc desc))
+    cmd (OA.info (toListDepsOptsParser formatParser) (OA.progDesc desc))
 
 listDepsTextParser :: OA.Parser ListDepsFormat
 listDepsTextParser =

--- a/src/Stack/Types/Config/Exception.hs
+++ b/src/Stack/Types/Config/Exception.hs
@@ -168,6 +168,7 @@ data ConfigPrettyException
   | BadMsysEnvironment !MsysEnvironment !Arch
   | NoMsysEnvironmentBug
   | ConfigFileNotProjectLevelBug
+  | NoExecutablePath !String
   deriving (Show, Typeable)
 
 instance Pretty ConfigPrettyException where
@@ -238,6 +239,14 @@ instance Pretty ConfigPrettyException where
     flow "No default MSYS2 environment."
   pretty ConfigFileNotProjectLevelBug = bugPrettyReport "[S-8398]" $
     flow "The configuration file is not a project-level one."
+  pretty (NoExecutablePath progName) =
+    "[S-6890]"
+    <> line
+    <> fillSep
+         [ flow "The path for the executable file invoked as"
+         , style Shell (fromString progName)
+         , flow "can not be identified."
+         ]
 
 instance Exception ConfigPrettyException
 

--- a/src/Stack/Types/GlobalOpts.hs
+++ b/src/Stack/Types/GlobalOpts.hs
@@ -17,27 +17,33 @@ import          Stack.Types.Snapshot ( AbstractSnapshot )
 
 -- | Parsed global command-line options.
 data GlobalOpts = GlobalOpts
-  { reExecVersion :: !(Maybe String)
+  { reExecVersion    :: !(Maybe String)
     -- ^ Expected re-exec in container version
   , dockerEntrypoint :: !(Maybe DockerEntrypoint)
     -- ^ Data used when Stack is acting as a Docker entrypoint (internal use
     -- only)
-  , logLevel     :: !LogLevel -- ^ Log level
-  , timeInLog    :: !Bool -- ^ Whether to include timings in logs.
-  , rslInLog     :: !Bool
+  , logLevel         :: !LogLevel -- ^ Log level
+  , timeInLog        :: !Bool -- ^ Whether to include timings in logs.
+  , rslInLog         :: !Bool
     -- ^ Whether to include raw snapshot layer (RSL) in logs.
-  , planInLog :: !Bool
+  , planInLog        :: !Bool
     -- ^ Whether to include debug information about the construction of the
     -- build plan in logs.
-  , configMonoid :: !ConfigMonoid
+  , configMonoid     :: !ConfigMonoid
     -- ^ Config monoid, for passing into 'loadConfig'
-  , snapshot     :: !(Maybe AbstractSnapshot) -- ^ Snapshot override
-  , compiler     :: !(Maybe WantedCompiler) -- ^ Compiler override
-  , terminal     :: !Bool -- ^ We're in a terminal?
-  , stylesUpdate :: !StylesUpdate -- ^ SGR (Ansi) codes for styles
-  , termWidthOpt  :: !(Maybe Int) -- ^ Terminal width override
-  , stackYaml    :: !StackYamlLoc -- ^ Override project stack.yaml
+  , snapshot         :: !(Maybe AbstractSnapshot) -- ^ Snapshot override
+  , compiler         :: !(Maybe WantedCompiler) -- ^ Compiler override
+  , terminal         :: !Bool -- ^ We're in a terminal?
+  , stylesUpdate     :: !StylesUpdate -- ^ SGR (Ansi) codes for styles
+  , termWidthOpt     :: !(Maybe Int) -- ^ Terminal width override
+  , stackYaml        :: !StackYamlLoc -- ^ Override project stack.yaml
   , lockFileBehavior :: !LockFileBehavior
+  , progName         :: !String
+    -- ^ The name of the current Stack executable, as it was invoked.
+  , mExecutablePath  :: !(Maybe (Path Abs File))
+    -- ^ The path to the current Stack executable, if the operating system
+    -- provides a reliable way to determine it and where a result was
+    -- available.
   }
 
 globalOptsBuildOptsMonoidL :: Lens' GlobalOpts BuildOptsMonoid

--- a/tests/unit/Stack/ConfigSpec.hs
+++ b/tests/unit/Stack/ConfigSpec.hs
@@ -168,7 +168,7 @@ spec = beforeAll setup $ do
 
   describe "parseProjectAndConfigMonoid" $ do
     let loadProject' fp inner = do
-          globalOpts <- globalOptsFromMonoid False mempty
+          globalOpts <- globalOptsFromMonoid "" Nothing False mempty
           withRunnerGlobal globalOpts { logLevel = logLevel } $ do
               iopc <- loadConfigYaml (
                 parseProjectAndConfigMonoid (parent fp)
@@ -199,7 +199,7 @@ spec = beforeAll setup $ do
 
   describe "loadConfig" $ do
     let loadConfig' inner = do
-          globalOpts <- globalOptsFromMonoid False mempty
+          globalOpts <- globalOptsFromMonoid "" Nothing False mempty
           withRunnerGlobal globalOpts { logLevel = logLevel } $
             loadConfig inner
     -- TODO(danburton): make sure parent dirs also don't have config file

--- a/tests/unit/Stack/NixSpec.hs
+++ b/tests/unit/Stack/NixSpec.hs
@@ -53,7 +53,8 @@ spec :: Spec
 spec = beforeAll setup $ do
   let loadConfig' :: ConfigMonoid -> (Config -> IO ()) -> IO ()
       loadConfig' cmdLineArgs inner = do
-        globalOpts <- globalOptsFromMonoid False mempty { configMonoid = cmdLineArgs }
+        globalOpts <-
+          globalOptsFromMonoid "" Nothing False mempty { configMonoid = cmdLineArgs }
         withRunnerGlobal globalOpts { GlobalOpts.logLevel = LevelOther "silent" } $
           loadConfig (liftIO . inner)
       inTempDir test = do


### PR DESCRIPTION
This assumes that `progName` and `mExecutablePath` (the code in module `Stack`) are immutable and can sensibly be added as fields to `GlobalOpts`.

So, the code in modules `Stack.Build.Execute`, `Stack.Docker`, `Stack.Nix` and `Stack.Setup` does not need to use `getExecutablePath` and the code in `Stack.Docker` does not to use `getProgName`.

`getExecutablePath :: IO FilePath` and `mExecutablePath :: Maybe (Path Abs File)`, so the former can yield `argv[0]` if the file path is unavailable when the latter yields `Nothing`. `Nothing` should not feature on Linux, macOS, Windows, FreeBSD, NetBSD and Solaris.

In respect of that:

* in `Stack.Build.Execute`, the usage is Windows;
* in `Stack.Docker`, the usage is Linux and macOS;
* in `Stack.Nix`, the usage must be Linux and macOS;
* in `Stack.Setup`, the `parseAbsFile` would have caused an error with `argv[0]`.

A pretty exception `NoExecutablePath` is added.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary.