### PR TITLE
Re #6633 Refactor `Stack.Docker` vis-a-vis `keepStdinOpen`

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -116,14 +116,14 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-axv1UG-355:32"
+  id = "OBS-STAN-0203-axv1UG-354:32"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Docker.hs
 #
-#  354 ┃
-#  355 ┃     hashRepoName = Hash.hash . BS.pack . takeWhile (\c -> c /= ':' && c /= '@')
-#  356 ┃                                ^^^^^^^
+#  353 ┃
+#  354 ┃     hashRepoName = Hash.hash . BS.pack . takeWhile (\c -> c /= ':' && c /= '@')
+#  355 ┃                                ^^^^^^^
 
 # Data types with non-strict fields
 # Defining lazy fields in data types can lead to unexpected space leaks


### PR DESCRIPTION
The only logical change is that the repeated `not docker.detach` is avoided.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary