### PR TITLE
Fix #6643 Respect `--no-run-tests`, `--no-run-benchmarks` when listing actions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,10 @@ Behavior changes:
   character in Stack's 'programs' path, as GHC 9.4.1 and later do not work if
   there is a space in the path to the `ghc` executable. S-8432 now presents as a
   warning and not an error.
+* Stack respects the `--no-run-tests` and `--no-run-benchmarks` flags when
+  determining build actions. Previously Stack respected the flags when executing
+  the run test suites or run benchmarks actions for each targeted project
+  package.
 
 Other enhancements:
 

--- a/doc/maintainers/stack_errors.md
+++ b/doc/maintainers/stack_errors.md
@@ -5,7 +5,7 @@
 In connection with considering Stack's support of the
 [Haskell Error Index](https://errors.haskell.org/) initiative, this page seeks
 to take stock of the errors that Stack itself can raise, by reference to the
-`master` branch of the Stack repository. Last updated: 2024-08-02.
+`master` branch of the Stack repository. Last updated: 2024-09-07.
 
 *   `Stack.main`: catches exceptions from action `commandLineHandler`.
 
@@ -385,6 +385,7 @@ to take stock of the errors that Stack itself can raise, by reference to the
         [S-8100] | GHCProfOptionInvalid
         [S-1727] | NotOnlyLocal [PackageName] [Text]
         [S-6362] | CompilerVersionMismatch (Maybe (ActualCompiler, Arch)) (WantedCompiler, Arch) GHCVariant CompilerBuild VersionCheck WantedCompilerSetter Text
+        [S-4660] | ActionNotFilteredBug StyleDoc
         ~~~
 
     -   `Stack.Types.Compiler.CompilerException`

--- a/src/Stack/Build/ExecutePackage.hs
+++ b/src/Stack/Build/ExecutePackage.hs
@@ -996,15 +996,7 @@ singleTest topts testsToRun ac ee task installedMap = do
                       announce "rerunning previously failed test"
                       pure True
                 TSUnknown -> pure True
-          else do
-            -- This should never be reached, because the action should have been
-            -- filtered out in Stack.Build.Execute.toActions. However, we leave
-            -- it as is, for now. The alternative would be to throw a Stack bug.
-            notifyIfNoRunTests <- view $ configL . to (.notifyIfNoRunTests)
-            when notifyIfNoRunTests $
-              announce "Test running disabled by --no-run-tests flag."
-            pure False
-
+          else prettyThrowM $ ActionNotFilteredBug "singleTest"
       when toRun $ do
         buildDir <- distDirFromDir pkgDir
         hpcDir <- hpcDirFromDir pkgDir
@@ -1265,20 +1257,10 @@ singleBench beopts benchesToRun ac ee task installedMap = do
       let args = map unqualCompToString benchesToRun <> maybe []
                        ((:[]) . ("--benchmark-options=" <>))
                        beopts.additionalArgs
-
       toRun <-
         if beopts.runBenchmarks
           then pure True
-          else do
-            -- This should never be reached, because the action should have been
-            -- filtered out in Stack.Build.Execute.toActions. However, we leave
-            -- it as is, for now. The alternative would be to throw a Stack bug.
-            notifyIfNoRunBenchmarks <-
-              view $ configL . to (.notifyIfNoRunBenchmarks)
-            when notifyIfNoRunBenchmarks $
-              announce "Benchmark running disabled by --no-run-benchmarks flag."
-            pure False
-
+          else prettyThrowM $ ActionNotFilteredBug "singleBench"
       when toRun $ do
         announce "benchmarks"
         cabal CloseOnException KeepTHLoading ("bench" : args)

--- a/src/Stack/Build/ExecutePackage.hs
+++ b/src/Stack/Build/ExecutePackage.hs
@@ -997,6 +997,9 @@ singleTest topts testsToRun ac ee task installedMap = do
                       pure True
                 TSUnknown -> pure True
           else do
+            -- This should never be reached, because the action should have been
+            -- filtered out in Stack.Build.Execute.toActions. However, we leave
+            -- it as is, for now. The alternative would be to throw a Stack bug.
             notifyIfNoRunTests <- view $ configL . to (.notifyIfNoRunTests)
             when notifyIfNoRunTests $
               announce "Test running disabled by --no-run-tests flag."
@@ -1267,6 +1270,9 @@ singleBench beopts benchesToRun ac ee task installedMap = do
         if beopts.runBenchmarks
           then pure True
           else do
+            -- This should never be reached, because the action should have been
+            -- filtered out in Stack.Build.Execute.toActions. However, we leave
+            -- it as is, for now. The alternative would be to throw a Stack bug.
             notifyIfNoRunBenchmarks <-
               view $ configL . to (.notifyIfNoRunBenchmarks)
             when notifyIfNoRunBenchmarks $

--- a/src/Stack/Types/Build/Exception.hs
+++ b/src/Stack/Types/Build/Exception.hs
@@ -261,6 +261,7 @@ data BuildPrettyException
       VersionCheck
       WantedCompilerSetter -- Way that the wanted compiler is set
       StyleDoc -- recommended resolution
+  | ActionNotFilteredBug StyleDoc
   deriving (Show, Typeable)
 
 instance Pretty BuildPrettyException where
@@ -450,6 +451,12 @@ instance Pretty BuildPrettyException where
          ]
     <> blankLine
     <> resolution
+  pretty (ActionNotFilteredBug source) = bugPrettyReport "S-4660" $
+    fillSep
+      [ source
+      , flow "is seeking to run an action that should have been filtered from \
+             \the list of actions."
+      ]
 
 instance Exception BuildPrettyException
 

--- a/tests/integration/tests/3959-order-of-flags/Main.hs
+++ b/tests/integration/tests/3959-order-of-flags/Main.hs
@@ -17,5 +17,5 @@ checkFlagsAfterCommand = stackCheckStderr ["build", "--test", "--no-run-tests"] 
 
 checker :: String -> IO ()
 checker output = do
-  let testsAreDisabled = any (\ln -> "Test running disabled by" `isInfixOf` ln) (lines output)
+  let testsAreDisabled = any (\ln -> "All test running disabled by" `isInfixOf` ln) (lines output)
   unless testsAreDisabled $ fail "Tests should not be run"


### PR DESCRIPTION
See:
* #6643 

Puts notification (if enabled) in `Stack.Build.Execute.executePlan'`.

In `Stack.Build.Execute.toActions`:

* does not add action `singleTest` if `not runTests`; and
* does not add action `singleBench` if `not runBenchmarks`.

Please include the following checklist in your pull request:

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!