### PR TITLE
fix(doc.haddock_command): mismatching header for command

### DIFF
--- a/doc/commands/haddock_command.md
+++ b/doc/commands/haddock_command.md
@@ -1,6 +1,6 @@
 <div class="hidden-warning"><a href="https://docs.haskellstack.org/"><img src="https://cdn.jsdelivr.net/gh/commercialhaskell/stack/doc/img/hidden-warning.svg"></a></div>
 
-# The `stack bench` command
+# The `stack haddock` command
 
 ~~~text
 stack haddock [TARGET] [--dry-run] [--pedantic] [--fast] [--ghc-options OPTIONS]


### PR DESCRIPTION
Found that the documentation has a mismatching header for the command name stack bench instead of stack haddock.

* [X] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [X] The documentation has been updated, if necessary

No tests are necessary.

(Not sure if creating a new fork was the right way to change the base branch)