### PR TITLE
Fix #6678 Add Cabal boot package to `setup-depends` deps, when needed

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -72,14 +72,14 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-erw24B-1031:3"
+  id = "OBS-STAN-0203-erw24B-1039:3"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\ExecuteEnv.hs
 #
-#  1030 ┃
-#  1031 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
-#  1032 ┃   ^^^^^^^
+#  1038 ┃
+#  1039 ┃   S8.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6Q"
+#  1040 ┃   ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,10 @@ Behavior changes:
   (Latin-1) character in Stack's 'programs' path, as `hsc2hs` does not work if
   there is such a character in the path to its default template
   `template-hsc.h`.
+* Stack customizes setup using `Cabal`, so if a `setup-depends` field does not
+  mention it as a dependency, Stack warns and adds the GHC boot package as a
+  dependency. Previously, Stack would not do so but only warn that build errors
+  were likely.
 
 Other enhancements:
 

--- a/doc/commands/build_command.md
+++ b/doc/commands/build_command.md
@@ -213,8 +213,7 @@ information about how these dependencies get specified.
 If a package description specifies a custom build type, it must also specify a
 custom setup. That should list the dependencies needed to compile `Setup.hs`.
 Stack further customises the setup, using the `Cabal` package. If that package
-is not listed, Stack will not add the package as a dependency but warn that
-build errors are likely.
+is not listed, Stack will warn and add the GHC boot package as a dependency. 
 
 In addition to specifying targets, you can also control what gets built, or
 retained, with the flags and options listed below. You can also affect what gets


### PR DESCRIPTION
See:
* #6678

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested locally on Windows with:
* `gi-gtk-4.0.12@rev:0` (no Cabal dependency)
* `gi-gtk-4.0.12@rev:1` (Cabal dependency added)
