### PR TITLE
`stack sdist`\`upload` identify Cabal version used to check packages

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,8 @@ Other enhancements:
   `install-msys` option in YAML configuration files.
 * Option `allow-newer-deps` is no longer classified as experimental in
   documentation.
+* `stack sdist` and `stack upload` report the version of Cabal (the library)
+  being used to check packages.
 
 Bug fixes:
 

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -42,6 +42,7 @@ import qualified Distribution.PackageDescription.Check as Check
 import qualified Distribution.PackageDescription.Parsec as Cabal
 import           Distribution.PackageDescription.PrettyPrint
                    ( showGenericPackageDescription )
+import           Distribution.Simple.Utils ( cabalVersion )
 import           Distribution.Version
                    ( earlierVersion, hasLowerBound, hasUpperBound, isAnyVersion
                    , orLaterVersion, simplifyVersionRange
@@ -574,7 +575,8 @@ checkPackageInExtractedTarball pkgDir = do
   prettyInfoL
     [ flow "Checking package"
     , style Current (fromPackageName name)
-    , flow "for common mistakes."
+    , flow "for common mistakes using Cabal version"
+    , fromString $ versionString cabalVersion <> "."
     ]
   let pkgChecks =
         -- MSS 2017-12-12: Try out a few different variants of pkgDesc to try


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally with `stack sdist`.
