### PR TITLE
Depend on `Cabal-3.14.*`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/stack.cabal linguist-generated=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -349,7 +349,8 @@ Stack aims to depend on well-known packages. The specific versions on which it
 depends at any time are specified by `package.yaml` and `stack.yaml`. It does
 not aim to be compatible with more than one version of the `Cabal` package at
 any time. At the time of writing (August 2025) the package versions are
-primarily ones in Stackage snapshot LTS Haskell 24.4 (for GHC 9.10.2) and
+primarily ones in Stackage snapshot LTS Haskell 24.4 (for GHC 9.10.2), the
+latest version of `Cabal` released on Hackage (`Cabal-3.14.2.0`) and
 `pantry-0.11.0`.
 
 A Stack executable makes use of Cabal (the library) through a small 'Setup'

--- a/Setup.hs
+++ b/Setup.hs
@@ -25,6 +25,7 @@ import           Distribution.Simple.Utils
 import           Distribution.Types.PackageName ( unPackageName )
 import           Distribution.Types.UnqualComponentName
                    ( unUnqualComponentName )
+import           Distribution.Utils.Path ( interpretSymbolicPathCWD )
 import           Distribution.Verbosity ( Verbosity, normal )
 import           System.FilePath ( (</>) )
 
@@ -47,7 +48,7 @@ generateBuildModule ::
   -> LocalBuildInfo
   -> IO ()
 generateBuildModule verbosity pkg lbi = do
-  let dir = autogenPackageModulesDir lbi
+  let dir = interpretSymbolicPathCWD (autogenPackageModulesDir lbi)
   createDirectoryIfMissingVerbose verbosity True dir
   withLibLBI pkg lbi $ \_ libcfg -> do
     withExeLBI pkg lbi $ \exe clbi -> do

--- a/package.yaml
+++ b/package.yaml
@@ -33,7 +33,7 @@ homepage: http://haskellstack.org
 custom-setup:
   dependencies:
   - base >= 4.14.3.0 && < 5
-  - Cabal < 3.14
+  - Cabal >= 3.14 && < 3.16
   - filepath
 extra-source-files:
 # note: leaving out 'package.yaml' because it causes confusion with hackage metadata revisions
@@ -65,7 +65,7 @@ ghc-options:
 - -optP-Wno-nonportable-include-path
 dependencies:
 - base >= 4.16.0.0 && < 5
-- Cabal >= 3.8.1.0 && < 3.14
+- Cabal >= 3.14 && < 3.16
 - aeson >= 2.0.3.0
 - aeson-warning-parser >= 0.1.1
 - ansi-terminal >= 1.0.2

--- a/src/Stack/Component.hs
+++ b/src/Stack/Component.hs
@@ -35,6 +35,7 @@ import           Distribution.PackageDescription
 import           Distribution.Types.BuildInfo ( BuildInfo )
 import           Distribution.Package ( mkPackageName )
 import qualified Distribution.PackageDescription as Cabal
+import           Distribution.Utils.Path (interpretSymbolicPathCWD)
 import           GHC.Records ( HasField )
 import           Stack.Prelude
 import           Stack.Types.Component
@@ -73,7 +74,7 @@ stackExecutableFromCabal :: Executable -> StackExecutable
 stackExecutableFromCabal cabalExecutable = StackExecutable
   { name = fromCabalName cabalExecutable.exeName
   , buildInfo = stackBuildInfoFromCabal cabalExecutable.buildInfo
-  , modulePath = cabalExecutable.modulePath
+  , modulePath = interpretSymbolicPathCWD cabalExecutable.modulePath
   }
 
 stackForeignLibraryFromCabal :: ForeignLib -> StackForeignLibrary
@@ -107,9 +108,9 @@ stackBuildInfoFromCabal buildInfoV = gatherComponentToolsAndDepsFromCabal
   StackBuildInfo
     { buildable = buildInfoV.buildable
     , otherModules = buildInfoV.otherModules
-    , jsSources = buildInfoV.jsSources
+    , jsSources = map interpretSymbolicPathCWD buildInfoV.jsSources
     , hsSourceDirs = buildInfoV.hsSourceDirs
-    , cSources = buildInfoV.cSources
+    , cSources = map interpretSymbolicPathCWD buildInfoV.cSources
     , dependency = mempty
     , unknownTools = mempty
     , cppOptions = buildInfoV.cppOptions
@@ -117,10 +118,10 @@ stackBuildInfoFromCabal buildInfoV = gatherComponentToolsAndDepsFromCabal
     , options = buildInfoV.options
     , allLanguages = Cabal.allLanguages buildInfoV
     , usedExtensions = Cabal.usedExtensions buildInfoV
-    , includeDirs = buildInfoV.includeDirs
+    , includeDirs = map interpretSymbolicPathCWD buildInfoV.includeDirs
     , extraLibs = buildInfoV.extraLibs
-    , extraLibDirs = buildInfoV.extraLibDirs
-    , frameworks = buildInfoV.frameworks
+    , extraLibDirs = map interpretSymbolicPathCWD buildInfoV.extraLibDirs
+    , frameworks = map interpretSymbolicPathCWD buildInfoV.frameworks
     }
 
 -- | Iterate on all three dependency list given, and transform and sort them

--- a/src/Stack/ComponentFile.hs
+++ b/src/Stack/ComponentFile.hs
@@ -36,7 +36,8 @@ import           Distribution.PackageDescription
                    ( BenchmarkInterface (..), TestSuiteInterface (..) )
 import           Distribution.Text ( display )
 import           Distribution.Utils.Path
-                   ( PackageDir, SourceDir, SymbolicPath, getSymbolicPath )
+                   ( Pkg, Source, SymbolicPath, getSymbolicPath )
+import qualified Distribution.Utils.Path as Cabal
 import           GHC.Records ( HasField )
 import qualified HiFileParser as Iface
 import           Path
@@ -91,7 +92,7 @@ stackBenchmarkFiles bench =
   exposed :: [DotCabalDescriptor]
   exposed =
     case bench.interface of
-      BenchmarkExeV10 _ fp -> [DotCabalMain fp]
+      BenchmarkExeV10 _ fp -> [DotCabalMain $ getSymbolicPath fp]
       BenchmarkUnsupported _ -> []
 
   bnames :: [DotCabalDescriptor]
@@ -113,7 +114,7 @@ stackTestSuiteFiles test =
   exposed :: [DotCabalDescriptor]
   exposed =
     case test.interface of
-      TestSuiteExeV10 _ fp -> [DotCabalMain fp]
+      TestSuiteExeV10 _ fp -> [DotCabalMain $ getSymbolicPath fp]
       TestSuiteLibV09 _ mn -> [DotCabalModule mn]
       TestSuiteUnsupported _ -> []
 
@@ -168,7 +169,7 @@ stackLibraryFiles lib =
 -- | Get all files referenced by the component.
 resolveComponentFiles ::
      ( CAndJsSources rec
-     , HasField "hsSourceDirs" rec [SymbolicPath PackageDir SourceDir]
+     , HasField "hsSourceDirs" rec [SymbolicPath Pkg (Cabal.Dir Source)]
      )
   => NamedComponent
   -> rec

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -61,7 +61,7 @@ import           Distribution.Simple.PackageDescription ( readHookedBuildInfo )
 import           Distribution.System ( OS (..), Arch, Platform (..) )
 import           Distribution.Text ( display )
 import qualified Distribution.Types.CondTree as Cabal
-import           Distribution.Utils.Path ( getSymbolicPath )
+import           Distribution.Utils.Path ( makeSymbolicPath, getSymbolicPath )
 import           Distribution.Verbosity ( silent )
 import           Distribution.Version
                    ( anyVersion, mkVersion, orLaterVersion )
@@ -131,8 +131,8 @@ import           RIO.Seq ((|>))
 --
 -- NOTE: not to be confused with BuildInfo, an Stack-internal datatype.
 readDotBuildinfo :: MonadIO m => Path Abs File -> m HookedBuildInfo
-readDotBuildinfo buildinfofp =
-  liftIO $ readHookedBuildInfo silent (toFilePath buildinfofp)
+readDotBuildinfo =
+  liftIO . readHookedBuildInfo silent Nothing . makeSymbolicPath . toFilePath
 
 -- | Resolve a parsed Cabal file into a t'Package', which contains all of the
 -- info needed for Stack to build the t'Package' given the current

--- a/src/Stack/SDist.hs
+++ b/src/Stack/SDist.hs
@@ -572,18 +572,7 @@ checkPackageInExtractedTarball pkgDir = do
     , flow "for common mistakes using Cabal version"
     , fromString $ versionString cabalVersion <> "."
     ]
-  let pkgChecks =
-        -- MSS 2017-12-12: Try out a few different variants of pkgDesc to try
-        -- and provoke an error or warning. I don't know why, but when using
-        -- `Just pkgDesc`, it appears that Cabal does not detect that `^>=` is
-        -- used with `cabal-version: 1.24` or earlier. It seems like pkgDesc
-        -- (the one we create) does not populate the `buildDepends` field,
-        -- whereas flattenPackageDescription from Cabal does. In any event,
-        -- using `Nothing` seems more logical for this check anyway, and the
-        -- fallback to `Just pkgDesc` is just a crazy sanity check.
-        case Check.checkPackage gpd of
-          [] -> Check.checkConfiguredPackage pkgDesc
-          x -> x
+  let pkgChecks = Check.checkPackage gpd
   fileChecks <-
     liftIO $ Check.checkPackageFiles minBound pkgDesc (toFilePath pkgDir)
   let checks = pkgChecks ++ fileChecks

--- a/src/Stack/Types/Component.hs
+++ b/src/Stack/Types/Component.hs
@@ -31,7 +31,8 @@ import           Distribution.ModuleName ( ModuleName )
 import           Distribution.PackageDescription
                    ( BenchmarkInterface, Dependency, TestSuiteInterface )
 import           Distribution.Simple ( Extension, Language )
-import           Distribution.Utils.Path ( PackageDir, SourceDir, SymbolicPath )
+import           Distribution.Utils.Path ( Pkg, Source, SymbolicPath )
+import qualified Distribution.Utils.Path as Cabal
 import           GHC.Records ( HasField (..) )
 import           Stack.Prelude
 import           Stack.Types.ComponentUtils
@@ -133,7 +134,7 @@ data StackBuildInfo = StackBuildInfo
     -- ^ Only used in file gathering. See usage in "Stack.ComponentFile" module.
   , jsSources :: [FilePath]
     -- ^ Only used in file gathering. See usage in "Stack.ComponentFile" module.
-  , hsSourceDirs :: [SymbolicPath PackageDir SourceDir]
+  , hsSourceDirs :: [SymbolicPath Pkg (Cabal.Dir Source)]
     -- ^ Only used in file & opts gathering. See usage in "Stack.ComponentFile"
     -- module for fle gathering.
   , cSources :: [FilePath]

--- a/stack.cabal
+++ b/stack.cabal
@@ -159,7 +159,7 @@ source-repository head
 
 custom-setup
   setup-depends:
-      Cabal <3.14
+      Cabal >=3.14 && <3.16
     , base >=4.14.3.0 && <5
     , filepath
 
@@ -419,7 +419,7 @@ library
       src
   ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -Wmissing-export-lists -optP-Wno-nonportable-include-path -Widentities
   build-depends:
-      Cabal >=3.8.1.0 && <3.14
+      Cabal >=3.14 && <3.16
     , aeson >=2.0.3.0
     , aeson-warning-parser >=0.1.1
     , ansi-terminal >=1.0.2
@@ -542,7 +542,7 @@ executable stack
       app
   ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -Wmissing-export-lists -optP-Wno-nonportable-include-path -threaded -rtsopts
   build-depends:
-      Cabal >=3.8.1.0 && <3.14
+      Cabal >=3.14 && <3.16
     , aeson >=2.0.3.0
     , aeson-warning-parser >=0.1.1
     , ansi-terminal >=1.0.2
@@ -645,7 +645,7 @@ executable stack-integration-test
       tests/integration/lib
   ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -Wmissing-export-lists -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      Cabal >=3.8.1.0 && <3.14
+      Cabal >=3.14 && <3.16
     , aeson >=2.0.3.0
     , aeson-warning-parser >=0.1.1
     , ansi-terminal >=1.0.2
@@ -762,7 +762,7 @@ test-suite stack-unit-test
       tests/unit
   ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -Wmissing-export-lists -optP-Wno-nonportable-include-path -threaded
   build-depends:
-      Cabal >=3.8.1.0 && <3.14
+      Cabal >=3.14 && <3.16
     , QuickCheck
     , aeson >=2.0.3.0
     , aeson-warning-parser >=0.1.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,9 @@
 snapshot: lts-24.4 # GHC 9.10.2
 
 extra-deps:
+# lts-24.4 specifies Cabal-3.12.1.0
+- Cabal-syntax-3.14.2.0
+- Cabal-3.14.2.0
 # lts-24.4 specifies pantry-0.10.1
 - pantry-0.11.0@sha256:d23aad04f560280264bde7a8d20ed158a668c037c303dc00793d8af61176c491,7542
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,6 +5,20 @@
 
 packages:
 - completed:
+    hackage: Cabal-syntax-3.14.2.0@sha256:16766e2cd18f98bf259d2caf2b507764ebdfff0b16c2fb5b293fc57c1137af6f,7380
+    pantry-tree:
+      sha256: 737f9522e754f8c1610a115a01bb264924a7cde1c931e285f3758ba46f145443
+      size: 10977
+  original:
+    hackage: Cabal-syntax-3.14.2.0
+- completed:
+    hackage: Cabal-3.14.2.0@sha256:f98aa86a37b9920dc6dfc8d79119a10df69542734f158a1c66ff144592f1d004,14148
+    pantry-tree:
+      sha256: 6094a5f661024a46193c4b27ec92123bf4677bec2f275ab14405eeee98fe8d9e
+      size: 12219
+  original:
+    hackage: Cabal-3.14.2.0
+- completed:
     hackage: pantry-0.11.0@sha256:d23aad04f560280264bde7a8d20ed158a668c037c303dc00793d8af61176c491,7542
     pantry-tree:
       sha256: 0b8e1d77c3ea3d95a544fadfeaa4c92ec63c581f778fd65036395eaa021686c2


### PR DESCRIPTION
Using `Cabal-3.14.*` is one of the required changes for GHC 9.12.  I need this for a personal project right now.  The purpose of this PR is not to necessarily have it merged right away, but rather to avoid duplicated work when Stack upgrades to GHC 9.12.

@mpilgrem from what I understand, we don't want CPP to support multiple versions of Cabal, right?

Do we ever use a more recent version of Cabal than what ships with GHC?  If "no", then this PR has to wait until we upgrade to GHC 9.12.