### PR TITLE
Fix #5305 Extend `stack script --extra-dep` to any immutable extra-dep

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,10 @@ Behavior changes:
 Other enhancements:
 
 * Bump to Hpack 0.38.1.
+* The `--extra-dep` option of Stack's `script` command now accepts a YAML value
+  specifying any immutable extra-dep. Previously only an extra-dep in the
+  package index that could be specified by a YAML string (for example,
+  `acme-missiles-0.3@rev:0`) was accepted.
 
 Bug fixes:
 

--- a/doc/commands/script_command.md
+++ b/doc/commands/script_command.md
@@ -6,7 +6,7 @@
 stack script [--package PACKAGE] FILE
              [-- ARGUMENT(S) (e.g. stack script X.hs -- argument(s) to program).]
              [--compile | --optimize] [--[no-]use-root] [--ghc-options OPTIONS]
-             [--extra-dep PACKAGE-VERSION] [--no-run]
+             [--extra-dep EXTRA-DEP] [--no-run]
 ~~~
 
 The `stack script` command either runs a specified Haskell source file (using
@@ -52,18 +52,21 @@ For example:
 stack script --snapshot lts-23.17 MyScript.hs
 ~~~
 
-An extra-dep from the package index can be added to the snapshot on the command
-line with the `--extra-dep` option (which can be specified multiple times).
+An immutable extra-dep can be added to the snapshot on the command line with the
+`--extra-dep` option (which can be specified multiple times).
 
-Such an extra-dep can be specified using a valid YAML string value. For further
-information, see the [package location](../topics/package_location.md)
-documentation. Examples are:
+An extra-dep is specified using a valid YAML value. For further information, see
+the [package location](../topics/package_location.md) documentation. Examples
+are:
 
 ~~~text
---extra-dep acme-missiles-0.3
 --extra-dep acme-missiles-0.3@rev:0
---extra-dep acme-missiles-0.3@sha256:2ba66a092a32593880a87fb00f3213762d7bca65a687d45965778deb8694c5d1,613
+--extra-dep '{git: git@github.com:yesodweb/wai, commit: '2f8a8e1b771829f4a8a77c0111352ce45a14c30f', subdirs: [auto-update, wai]}
+--extra-dep acme-missiles-0.3.tar.gz
 ~~~
+
+Relative paths to local archive files are assumed to be relative to the
+directory in which the script file is located.
 
 GHC boot packages that have been 'replaced' (see further below) can be specified
 as an `--extra-dep`.

--- a/doc/topics/scripts.md
+++ b/doc/topics/scripts.md
@@ -174,16 +174,20 @@ options, or by providing a comma or space separated list. For example:
 ## Using extra-deps
 
 As with using [`stack script`](../commands/script_command.md) at the command
-line, you can also specify one or more extra-deps from the package index using a
-valid YAML string for each. For example:
+line, you can also specify one or more extra-deps using a valid YAML value for
+each. For example:
 
 ~~~haskell
 #!/usr/bin/env stack
 {- stack script
    --snapshot lts-23.17
-   --extra-dep acme-missile-0.3@rev:0
+   --extra-dep acme-missiles-0.3@rev:0
+   --extra-dep "{git: git@github.com:yesodweb/wai, commit: '2f8a8e1b771829f4a8a77c0111352ce45a14c30f', subdirs: [auto-update, wai]}"
 -}
 ~~~
+
+Relative paths to local archive files are assumed to be relative to the
+directory in which the script file is located.
 
 ## Stack configuration for scripts
 

--- a/package.yaml
+++ b/package.yaml
@@ -99,7 +99,7 @@ dependencies:
 - neat-interpolation
 - open-browser
 - optparse-applicative >= 0.18.1.0
-- pantry >= 0.10.0
+- pantry >= 0.10.1
 - path >= 0.9.5
 - path-io
 # In order for Cabal (the tool) to build Stack, it needs to be told of the

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -874,7 +874,7 @@ withBuildConfig inner = do
  where
   getEmptyProject ::
        Maybe RawSnapshotLocation
-    -> [PackageIdentifierRevision]
+    -> [RawPackageLocationImmutable]
     -> RIO Config Project
   getEmptyProject mSnapshot extraDeps = do
     snapshot <- case mSnapshot of
@@ -895,7 +895,7 @@ withBuildConfig inner = do
     pure Project
       { userMsg = Nothing
       , packages = []
-      , extraDeps = map (RPLImmutable . flip RPLIHackage Nothing) extraDeps
+      , extraDeps = map RPLImmutable extraDeps
       , flagsByPkg = mempty
       , snapshot
       , compiler = Nothing

--- a/src/Stack/Options/ScriptParser.hs
+++ b/src/Stack/Options/ScriptParser.hs
@@ -58,8 +58,9 @@ scriptOptsParser = ScriptOpts
         ))
   <*> many (option extraDepRead
         (  long "extra-dep"
-        <> metavar "PACKAGE-VERSION"
-        <> help "Extra dependencies to be added to the snapshot."
+        <> metavar "EXTRA-DEP"
+        <> help "An immutable extra dependency to be added to the snapshot \
+                \(can be specified multiple times)."
         ))
   <*> (   flag' NoRun
             (  long "no-run"
@@ -69,4 +70,4 @@ scriptOptsParser = ScriptOpts
       )
  where
   extraDepRead = eitherReader $
-                   mapLeft show . parsePackageIdentifierRevision . fromString
+                   mapLeft show . parseRawPackageLocationImmutables . fromString

--- a/src/Stack/Types/ProjectConfig.hs
+++ b/src/Stack/Types/ProjectConfig.hs
@@ -16,7 +16,7 @@ data ProjectConfig a
   | PCGlobalProject
     -- ^ No project was found when using 'SYLDefault'. Instead, use
     -- the implicit global.
-  | PCNoProject ![PackageIdentifierRevision]
+  | PCNoProject ![RawPackageLocationImmutable]
     -- ^ Use a no project run. This comes from 'SYLNoProject'.
 
 -- | Yields 'True' only if the project configuration information is for the

--- a/src/Stack/Types/StackYamlLoc.hs
+++ b/src/Stack/Types/StackYamlLoc.hs
@@ -13,7 +13,7 @@ data StackYamlLoc
     -- ^ Use the standard parent-directory-checking logic
   | SYLOverride !(Path Abs File)
     -- ^ Use a specific stack.yaml file provided
-  | SYLNoProject ![PackageIdentifierRevision]
+  | SYLNoProject ![RawPackageLocationImmutable]
     -- ^ Do not load up a project, just user configuration. Include
     -- the given extra dependencies with the snapshot.
   | SYLGlobalProject

--- a/stack.cabal
+++ b/stack.cabal
@@ -440,7 +440,7 @@ library
     , neat-interpolation
     , open-browser
     , optparse-applicative >=0.18.1.0
-    , pantry >=0.10.0
+    , pantry >=0.10.1
     , path >=0.9.5
     , path-io
     , persistent >=2.14.0.0 && <2.15
@@ -563,7 +563,7 @@ executable stack
     , neat-interpolation
     , open-browser
     , optparse-applicative >=0.18.1.0
-    , pantry >=0.10.0
+    , pantry >=0.10.1
     , path >=0.9.5
     , path-io
     , persistent >=2.14.0.0 && <2.15
@@ -667,7 +667,7 @@ executable stack-integration-test
     , open-browser
     , optparse-applicative >=0.18.1.0
     , optparse-generic
-    , pantry >=0.10.0
+    , pantry >=0.10.1
     , path >=0.9.5
     , path-io
     , persistent >=2.14.0.0 && <2.15
@@ -784,7 +784,7 @@ test-suite stack-unit-test
     , neat-interpolation
     , open-browser
     , optparse-applicative >=0.18.1.0
-    , pantry >=0.10.0
+    , pantry >=0.10.1
     , path >=0.9.5
     , path-io
     , persistent >=2.14.0.0 && <2.15

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,8 @@ snapshot: lts-23.17 # GHC 9.8.4
 extra-deps:
 # lts-23.17 provides hpack-0.37.0
 - hpack-0.38.1
+# lts-23.17 provides pantry-0.10.0.
+- pantry-0.10.1
 
 docker:
   enable: false

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,6 +11,13 @@ packages:
       size: 3798
   original:
     hackage: hpack-0.38.1
+- completed:
+    hackage: pantry-0.10.1@sha256:f776cd39c211128561a80a865545fd3b7caec9935ceedd7f2d14c341d0b0ca41,7896
+    pantry-tree:
+      sha256: 101b1db0815386bebc32dec0db3611969efc6a432cf866c173dc2971b369211d
+      size: 2722
+  original:
+    hackage: pantry-0.10.1
 snapshots:
 - completed:
     sha256: 2763632e4c4094ce12f5ae12b22f524cdc6453b6b19007ff164a37fd9d2ea829


### PR DESCRIPTION
See:
* #5305

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Tested locally on Windows.

Currently depends on an unreleased version of `pantry-0.10.1`.