### PR TITLE
Fix #6616 Use GHC's -package-id rather than -package

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,11 @@ Other enhancements:
 
 Bug fixes:
 
+* `stack script --package <pkg-name>` now uses GHC's `-package-id` option to
+  expose the installed package, rather than GHC's `-package` option. For
+  packages with public sub-libraries, `-package <pkg>` can expose an
+  installed package other than one listed by `ghc-pkg list <pkg>`.
+
 ## v3.5.1 - 2025-03-29
 
 **Changes since v3.3.1:**


### PR DESCRIPTION
See:
* #6616

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Relying on the CI for now.