### PR TITLE
Fix #6720 Involve lld linker on Ubuntu

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -87,6 +87,10 @@ jobs:
 
         if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]
         then
+          # Install a faster linker (lld) than Ubuntu's default.
+          # stack-integration-test will seek to use it as the linker on Linux.
+          sudo apt-get update
+          sudo apt-get install -y lld
           # Set up Nix for Stack's tests that require it.
           #
           # Install Nix via the single-user installation...

--- a/etc/scripts/release.hs
+++ b/etc/scripts/release.hs
@@ -235,9 +235,13 @@ rules global args = do
       ["--pedantic", "--no-haddock-deps", "--test"]
       ["--haddock" | global.gTestHaddocks]
       ["stack"]
+    -- We use the target Stack to execute the target stack-integration-test
+    -- outside of any Alpine Linux Docker container as the default linker on
+    -- Alpine Linux is ld.bfd and it is remarkably slow. stack-integration-test
+    -- will seek to use lld as the linker on Linux.
     () <- cmd
-      stackProgName -- Use the platform's Stack
-      global.gStackArgs -- Possibiy to set up a Docker container
+      (global.gProjectRoot </> releaseBinDir </> binaryName </>
+          stackExeFileName) -- Use the target Stack
       ["exec"] -- To execute the target stack-integration-test
       [ global.gProjectRoot </> releaseBinDir </> binaryName </>
           "stack-integration-test"


### PR DESCRIPTION
See:
* #6720

`integration-tests.yml` now installs `lld` on the GitHub hosted runner `ubuntu-latest`.

`release.hs check` executes `stack-integration-test` outside of any Alpine Linux Docker container.

`stack-integration-test` uses `lld` on Linux, and expects it to be on the PATH.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI
