### PR TITLE
Reduce code duplication

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -244,6 +244,7 @@ library:
   - Stack.Options.NewParser
   - Stack.Options.NixParser
   - Stack.Options.PackageParser
+  - Stack.Options.PackagesParser
   - Stack.Options.PathParser
   - Stack.Options.PvpBoundsParser
   - Stack.Options.SDistParser

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -25,7 +25,6 @@ spitting out a warning that "you should run `stk init` to make things better".
 module Stack.Config
   ( loadConfig
   , loadConfigYaml
-  , packagesParser
   , getImplicitGlobalProjectDir
   , getSnapshots
   , makeConcreteSnapshot
@@ -67,7 +66,6 @@ import qualified Hpack
 import           GHC.Conc ( getNumProcessors )
 import           Network.HTTP.StackClient
                    ( httpJSON, parseUrlThrow, getResponseBody )
-import           Options.Applicative ( Parser, help, long, metavar, strOption )
 import           Pantry ( loadSnapshot )
 import           Path
                    ( PathException (..), (</>), parent, parseAbsDir
@@ -1291,32 +1289,27 @@ getDefaultUserConfigPath configRoot = do
     liftIO $ writeBinaryFileAtomic userConfigPath defaultConfigYaml
   pure userConfigPath
 
-packagesParser :: Parser [String]
-packagesParser = many (strOption
-                   (long "package" <>
-                     metavar "PACKAGE" <>
-                     help "Add a package (can be specified multiple times)"))
-
+-- | The contents of the default Stack global configuration file.
 defaultConfigYaml :: (IsString s, Semigroup s) => s
 defaultConfigYaml =
-  "# This file contains default non-project-specific settings for Stack, used\n" <>
-  "# in all projects. For more information about Stack's configuration, see\n" <>
-  "# http://docs.haskellstack.org/en/stable/configure/yaml/\n" <>
-  "\n" <>
-  "# The following parameters are used by 'stack new' to automatically fill fields\n" <>
-  "# in the Cabal file. We recommend uncommenting them and filling them out if\n" <>
-  "# you intend to use 'stack new'.\n" <>
-  "# See https://docs.haskellstack.org/en/stable/configure/yaml/non-project/#templates\n" <>
-  "templates:\n" <>
-  "  params:\n" <>
-  "#    author-name:\n" <>
-  "#    author-email:\n" <>
-  "#    copyright:\n" <>
-  "#    github-username:\n" <>
-  "\n" <>
-  "# The following parameter specifies Stack's output styles; STYLES is a\n" <>
-  "# colon-delimited sequence of key=value, where 'key' is a style name and\n" <>
-  "# 'value' is a semicolon-delimited list of 'ANSI' SGR (Select Graphic\n" <>
-  "# Rendition) control codes (in decimal). Use 'stack ls stack-colors --basic'\n" <>
-  "# to see the current sequence.\n" <>
-  "# stack-colors: STYLES\n"
+  "# This file contains default non-project-specific settings for Stack, used\n\
+  \# in all projects. For more information about Stack's configuration, see\n\
+  \# http://docs.haskellstack.org/en/stable/configure/yaml/\n\
+  \\n\
+  \# The following parameters are used by 'stack new' to automatically fill fields\n\
+  \# in the Cabal file. We recommend uncommenting them and filling them out if\n\
+  \# you intend to use 'stack new'.\n\
+  \# See https://docs.haskellstack.org/en/stable/configure/yaml/non-project/#templates\n\
+  \templates:\n\
+  \  params:\n\
+  \#    author-name:\n\
+  \#    author-email:\n\
+  \#    copyright:\n\
+  \#    github-username:\n\
+  \\n\
+  \# The following parameter specifies Stack's output styles; STYLES is a\n\
+  \# colon-delimited sequence of key=value, where 'key' is a style name and\n\
+  \# 'value' is a semicolon-delimited list of 'ANSI' SGR (Select Graphic\n\
+  \# Rendition) control codes (in decimal). Use 'stack ls stack-colors --basic'\n\
+  \# to see the current sequence.\n\
+  \# stack-colors: STYLES\n"

--- a/src/Stack/Options/GhciParser.hs
+++ b/src/Stack/Options/GhciParser.hs
@@ -19,10 +19,10 @@ import           Options.Applicative.Builder.Extra
                    ( boolFlags, boolFlagsNoDefault, fileExtCompleter
                    , textArgument, textOption
                    )
-import           Stack.Config ( packagesParser )
 import           Stack.Ghci ( GhciOpts (..) )
 import           Stack.Options.Completion ( ghcOptsCompleter, targetCompleter )
 import           Stack.Options.FlagsParser ( flagsParser )
+import           Stack.Options.PackagesParser ( packagesParser )
 import           Stack.Prelude
 
 -- | Parser for GHCI options

--- a/src/Stack/Options/PackagesParser.hs
+++ b/src/Stack/Options/PackagesParser.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-|
+Module      : Stack.Options.PackagesParser
+Description : Parser for one or more package names.
+License     : BSD-3-Clause
+
+Parser for one or more package names.
+-}
+
+module Stack.Options.PackagesParser
+  ( packagesParser
+  ) where
+
+import           Options.Applicative ( Parser, help, long, metavar, strOption )
+import           Stack.Prelude
+
+-- | Parser for one or more package names.
+packagesParser :: Parser [String]
+packagesParser = many
+  ( strOption
+      (  long "package"
+      <> metavar "PACKAGE"
+      <> help "Add a package (can be specified multiple times)"
+      )
+  )

--- a/src/Stack/Options/ScriptParser.hs
+++ b/src/Stack/Options/ScriptParser.hs
@@ -19,6 +19,7 @@ import           Options.Applicative
 import           Options.Applicative.Builder.Extra
                    ( boolFlags, fileExtCompleter )
 import           Stack.Options.Completion ( ghcOptsCompleter )
+import           Stack.Options.PackagesParser ( packagesParser )
 import           Stack.Prelude
 import           Stack.Script
                    ( ScriptExecute (..), ScriptOpts (..), ShouldRun (..) )
@@ -26,11 +27,7 @@ import           Stack.Script
 -- | Parse command line arguments for Stack's @script@ command.
 scriptOptsParser :: Parser ScriptOpts
 scriptOptsParser = ScriptOpts
-  <$> many (strOption
-        (  long "package"
-        <> metavar "PACKAGE"
-        <> help "Add a package (can be specified multiple times)."
-        ))
+  <$> packagesParser
   <*> strArgument
         (  metavar "FILE"
         <> completer (fileExtCompleter [".hs", ".lhs"])

--- a/stack.cabal
+++ b/stack.cabal
@@ -280,6 +280,7 @@ library
       Stack.Options.NewParser
       Stack.Options.NixParser
       Stack.Options.PackageParser
+      Stack.Options.PackagesParser
       Stack.Options.PathParser
       Stack.Options.PvpBoundsParser
       Stack.Options.SDistParser


### PR DESCRIPTION
Moves `packagesParser` into its own module, and uses it in modules `Stack.Options.GhciParser` and `Stack.Options.ScriptParser`.

Creates `loadCommonPackage'` and uses it in `loadCommonPackage` and `loadLocalPackage`.

Also adds missing Haddock documentation.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
