### PR TITLE
Build Stack against tls-2.1.8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,9 +348,9 @@ compatibility with a range of versions of GHC that a library package (such as
 Stack aims to depend on well-known packages. The specific versions on which it
 depends at any time are specified by `package.yaml` and `stack.yaml`. It does
 not aim to be compatible with more than one version of the `Cabal` package at
-any time. At the time of writing (March 2025) the package versions are
+any time. At the time of writing (May 2025) the package versions are
 primarily ones in Stackage snapshot LTS Haskell 23.17 (for GHC 9.8.4) and
-`hpack-0.38.1`.
+`hpack-0.38.1`, `pantry-0.10.1` and `tls-2.1.8`.
 
 A Stack executable makes use of Cabal (the library) through a small 'Setup'
 executable that it compiles from Haskell source code. The executable compiles

--- a/cabal.config
+++ b/cabal.config
@@ -139,7 +139,7 @@ constraints:
   , optparse-applicative ==0.18.1.0
   , optparse-simple ==0.1.1.4
   , os-string ==2.0.7
-  , pantry ==0.10.0
+  , pantry ==0.10.1
   , parsec ==3.1.17.0
   , parser-combinators ==1.3.0
   , path ==0.9.5
@@ -202,7 +202,7 @@ constraints:
   , these ==1.2.1
   , time ==1.12.2
   , time-compat ==1.9.7
-  , tls ==2.1.1
+  , tls ==2.1.8
   , transformers ==0.6.1.0
   , transformers-base ==0.4.6
   , transformers-compat ==0.7.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,9 +2,11 @@ snapshot: lts-23.17 # GHC 9.8.4
 
 extra-deps:
 # lts-23.17 provides hpack-0.37.0
-- hpack-0.38.1
+- hpack-0.38.1@rev:0
 # lts-23.17 provides pantry-0.10.0.
-- pantry-0.10.1
+- pantry-0.10.1@rev:0
+# lts-23.17 provides tls-2.1.1
+- tls-2.1.8@rev:0
 
 docker:
   enable: false

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -10,14 +10,21 @@ packages:
       sha256: 9e2282f08da4349844e64cdf21d2aac6cc2bf21b4b8ca9e09707877ad0f5dd0f
       size: 3798
   original:
-    hackage: hpack-0.38.1
+    hackage: hpack-0.38.1@rev:0
 - completed:
     hackage: pantry-0.10.1@sha256:f776cd39c211128561a80a865545fd3b7caec9935ceedd7f2d14c341d0b0ca41,7896
     pantry-tree:
       sha256: 101b1db0815386bebc32dec0db3611969efc6a432cf866c173dc2971b369211d
       size: 2722
   original:
-    hackage: pantry-0.10.1
+    hackage: pantry-0.10.1@rev:0
+- completed:
+    hackage: tls-2.1.8@sha256:69b583c77cc25d8efd62fd48462f469a7c66db551013db753e4062e3b56576f9,6223
+    pantry-tree:
+      sha256: 59190b5a3cf91ba383c94e893a409526dadd66b44e1c7dd0598603d2b580fe2a
+      size: 6925
+  original:
+    hackage: tls-2.1.8@rev:0
 snapshots:
 - completed:
     sha256: 2763632e4c4094ce12f5ae12b22f524cdc6453b6b19007ff164a37fd9d2ea829


### PR DESCRIPTION
`tls-2.1.10` is released, but it requires `random >= 1.3`.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
