### PR TITLE
Fix typo in warning for space in local programs path

### DIFF
--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -394,7 +394,7 @@ configFromConfigMonoid
                )
           <> blankLine
           <> fillSep
-               [ flow "To avoid sucn problems, use the"
+               [ flow "To avoid such problems, use the"
                , style Shell "local-programs-path"
                , flow "non-project specific configuration option to specify an \
                       \alternative path without those characteristics."


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Fix a typo: 'To avoid sucn problems' -> 'To avoid such problems'