### PR TITLE
doc/tutorial/index.md: Fixed "Stackage" link.

### DIFF
--- a/doc/tutorial/index.md
+++ b/doc/tutorial/index.md
@@ -84,7 +84,7 @@ code to build packages and components of packages using GHC.
 
 Two important public databases are **Hackage**
 [(the  Haskell Package Repository)](https://hackage.haskell.org/) and
-[**Stackage**](https://hackage.haskell.org/).
+[**Stackage**](https://www.stackage.org/).
 
 ~~~mermaid
 flowchart LR


### PR DESCRIPTION
The first "Stackage" link in the documentation pointed to hackage...

* [ ] Any changes that could be relevant to users have been recorded in ChangeLog.md.
        (This documentation fix may not be big enough to warrant a ChangeLog entry.)

* [x ] The documentation has been updated, if necessary
         (This request is only about a documentation update.)

I tested the change by following the updated link in the Preview.
