### PR TITLE
Fix #6775 `--PROG-option=<argument>` passes without added quotes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,9 @@ Other enhancements:
 
 Bug fixes:
 
+* `--PROG-option=<argument>` passes `--PROG-option=<argument>` (and not
+  `--PROG-option="<argument>"`) to Cabal (the library).
+
 ## v3.7.1 - 2025-06-28
 
 **Changes since v3.5.1:**

--- a/src/Stack/Types/BuildOptsCLI.hs
+++ b/src/Stack/Types/BuildOptsCLI.hs
@@ -97,23 +97,27 @@ data BuildCommand
   | Install
   deriving (Eq, Show)
 
--- | Generate a list of --PROG-option="<argument>" arguments for all PROGs.
+-- | Generate a list of @--PROG-option=<argument>@ arguments for all PROGs.
+
+-- At the command line, --PROG-option="<argument>" is received as
+-- --PROG-option=<argument> (without quotes). However, with the process library,
+-- what is received is --PROG-option="<argument>" (with quotes), which is NOT
+-- what is required.
 boptsCLIAllProgOptions :: BuildOptsCLI -> [Text]
 boptsCLIAllProgOptions boptsCLI =
   concatMap progOptionArgs boptsCLI.progsOptions
  where
-  -- Generate a list of --PROG-option="<argument>" arguments for a PROG.
+  -- Generate a list of --PROG-option=<argument> arguments for a PROG.
   progOptionArgs :: (Text, [Text]) -> [Text]
   progOptionArgs (prog, opts) = map progOptionArg opts
    where
-    -- Generate a --PROG-option="<argument>" argument for a PROG and option.
+    -- Generate a --PROG-option=<argument> argument for a PROG and option.
     progOptionArg :: Text -> Text
     progOptionArg opt = T.concat
       [ "--"
       , prog
-      , "-option=\""
+      , "-option="
       , opt
-      , "\""
       ]
 
 -- | Only flags set via 'ACFByName'


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
