### PR TITLE
Re #6749 Allow `wiredInPackages` to depend on `ActualCompiler`

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -245,16 +245,16 @@
 
 # Anti-pattern: unsafe functions
 [[ignore]]
-  id = "OBS-STAN-0212-5rtOmw-480:33"
+  id = "OBS-STAN-0212-5rtOmw-505:33"
 # ✦ Description:   Usage of unsafe functions breaks referential transparency
 # ✦ Category:      #Unsafe #AntiPattern
 # ✦ File:          src\Stack\Constants.hs
 #
-#  479 ┃
-#  480 ┃ setupGhciShimCode = byteString $(do
-#  481 ┃     path <- makeRelativeToProject "src/setup-shim/StackSetupShim.hs"
-#  482 ┃     embedFile path)
-#  483 ┃
+#  504 ┃
+#  505 ┃ setupGhciShimCode = byteString $(do
+#  506 ┃     path <- makeRelativeToProject "src/setup-shim/StackSetupShim.hs"
+#  507 ┃     embedFile path)
+#  508 ┃
 
 # Anti-pattern: unsafe functions
 [[ignore]]

--- a/src/Stack/Build/ConstructPlan.hs
+++ b/src/Stack/Build/ConstructPlan.hs
@@ -521,6 +521,7 @@ checkCallStackAndAddDep ::
   -> M (Either ConstructPlanException AddDepRes)
 checkCallStackAndAddDep name = do
   ctx <- ask
+  let compiler = ctx.ctxEnvConfig.sourceMap.compiler
   res <- if name `elem` ctx.callStack
     then do
       logDebugPlanS "checkCallStackAndAddDep" $
@@ -537,7 +538,7 @@ checkCallStackAndAddDep name = do
              "No package info for "
           <> fromPackageName name
           <> "."
-        pure $ Left $ UnknownPackage name
+        pure $ Left $ UnknownPackage compiler name
       Just packageInfo ->
         -- Add the current package name to the head of the call stack.
         local (\ctx' -> ctx' { callStack = name : ctx'.callStack }) $
@@ -863,7 +864,7 @@ processDep pkgId name value = do
     Left e -> do
       addParent
       let bd = case e of
-            UnknownPackage name' -> assert (name' == name) NotInBuildPlan
+            UnknownPackage _ name' -> assert (name' == name) NotInBuildPlan
             DependencyCycleDetected names -> BDDependencyCycleDetected names
             -- Ultimately we won't show any information on this to the user;
             -- we'll allow the dependency failures alone to display to avoid

--- a/src/Stack/BuildPlan.hs
+++ b/src/Stack/BuildPlan.hs
@@ -407,11 +407,11 @@ checkSnapBuildPlan pkgDirs flags snapCandidate = do
       else pure $ BuildPlanCheckFail f cerrs compiler
  where
   compilerErrors compiler errs
-    | whichCompiler compiler == Ghc = ghcErrors errs
+    | whichCompiler compiler == Ghc = ghcErrors compiler errs
     | otherwise = Map.empty
 
-  isGhcWiredIn p _ = p `Set.member` wiredInPackages
-  ghcErrors = Map.filterWithKey isGhcWiredIn
+  isGhcWiredIn compiler p _ = p `Set.member` wiredInPackages compiler
+  ghcErrors compiler = Map.filterWithKey (isGhcWiredIn compiler)
 
 -- | Find a snapshot and set of flags that is compatible with and matches as
 -- best as possible with the given 'GenericPackageDescription's.

--- a/src/Stack/Ls.hs
+++ b/src/Stack/Ls.hs
@@ -299,7 +299,7 @@ listGlobalsCmd opts = do
 listDependencies :: ListDepsOpts -> RIO Runner ()
 listDependencies opts = do
   let dotOpts = opts.dotOpts
-  (pkgs, resultGraph) <- createPrunedDependencyGraph dotOpts
+  (_, pkgs, resultGraph) <- createPrunedDependencyGraph dotOpts
   liftIO $ case opts.format of
     ListDepsTree treeOpts ->
       T.putStrLn "Packages"

--- a/src/Stack/New.hs
+++ b/src/Stack/New.hs
@@ -48,8 +48,8 @@ import           Path.IO
                    ( doesDirExist, doesFileExist, ensureDir, getCurrentDir )
 import           RIO.Process ( proc, runProcess_, withWorkingDir )
 import           Stack.Constants
-                   ( altGitHubTokenEnvVar, backupUrlRelPath, gitHubBasicAuthType
-                   , gitHubTokenEnvVar, stackDotYaml, wiredInPackages
+                   ( allWiredInPackages, altGitHubTokenEnvVar, backupUrlRelPath
+                   , gitHubBasicAuthType, gitHubTokenEnvVar, stackDotYaml
                    )
 import           Stack.Constants.Config ( templatesDir )
 import           Stack.Init ( InitOpts (..), initProject )
@@ -195,7 +195,7 @@ instance Pretty NewPrettyException where
              (map fromPackageName sortedWiredInPackages :: [StyleDoc])
          )
    where
-    sortedWiredInPackages = L.sort $ S.toList wiredInPackages
+    sortedWiredInPackages = L.sort $ S.toList allWiredInPackages
   pretty (AttemptedOverwrites name fps) =
     "[S-3113]"
     <> line
@@ -249,7 +249,7 @@ newCmd (newOpts, initOpts) =
 -- | Create a new project with the given options.
 new :: HasConfig env => NewOpts -> Bool -> RIO env (Path Abs Dir)
 new opts forceOverwrite = do
-  when (project `elem` wiredInPackages) $
+  when (project `elem` allWiredInPackages) $
       prettyThrowM $ MagicPackageNameInvalid projectName
   pwd <- getCurrentDir
   absDir <- if bare

--- a/src/Stack/Types/Build/Exception.hs
+++ b/src/Stack/Types/Build/Exception.hs
@@ -699,12 +699,13 @@ pprintExceptions exceptions configFile stackRoot isImplicitGlobal parentMap want
         pkgName' = style Current (fromPackageName pkg.name)
         pkgIdent = style Current (fromPackageId $ packageIdentifier pkg)
   -- Skip these when they are redundant with 'NotInBuildPlan' info.
-  pprintException (UnknownPackage name)
+  pprintException (UnknownPackage compiler name)
     | name `Set.member` allNotInBuildPlan = Nothing
-    | name `Set.member` wiredInPackages = Just $ fillSep
-        [ flow "Can't build a package with same name as a wired-in-package:"
-        , style Current . fromPackageName $ name
-        ]
+    | name `Set.member` wiredInPackages compiler =
+        Just $ fillSep
+          [ flow "Can't build a package with same name as a wired-in-package:"
+          , style Current . fromPackageName $ name
+          ]
     | Just pruned <- Map.lookup name prunedGlobalDeps =
         let prunedDeps =
               map (style Current . fromPackageName) pruned
@@ -813,8 +814,9 @@ data ConstructPlanException
   | DependencyPlanFailures
       Package
       (Map PackageName (VersionRange, LatestApplicableVersion, BadDependency))
-  | UnknownPackage PackageName -- TODO perhaps this constructor will be removed,
-                               -- and BadDependency will handle it all
+  | UnknownPackage ActualCompiler PackageName
+    -- TODO perhaps this constructor will be removed, and BadDependency will
+    -- handle it all
   -- ^ Recommend adding to extra-deps, give a helpful version number?
   deriving (Eq, Show, Typeable)
 


### PR DESCRIPTION
See:
* #6749

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
