### PR TITLE
Fix #6749 `wiredInPackages` depends on `ActualCompiler`

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -245,16 +245,16 @@
 
 # Anti-pattern: unsafe functions
 [[ignore]]
-  id = "OBS-STAN-0212-5rtOmw-505:33"
+  id = "OBS-STAN-0212-5rtOmw-499:33"
 # ✦ Description:   Usage of unsafe functions breaks referential transparency
 # ✦ Category:      #Unsafe #AntiPattern
 # ✦ File:          src\Stack\Constants.hs
 #
-#  504 ┃
-#  505 ┃ setupGhciShimCode = byteString $(do
-#  506 ┃     path <- makeRelativeToProject "src/setup-shim/StackSetupShim.hs"
-#  507 ┃     embedFile path)
-#  508 ┃
+#  498 ┃
+#  499 ┃ setupGhciShimCode = byteString $(do
+#  500 ┃     path <- makeRelativeToProject "src/setup-shim/StackSetupShim.hs"
+#  501 ┃     embedFile path)
+#  502 ┃
 
 # Anti-pattern: unsafe functions
 [[ignore]]

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,9 @@ Major changes:
 
 Behavior changes:
 
-* Stack now treats `ghc-internal` as a GHC wired-in package.
+* Where applicable and Stack supports the GHC version, only the wired-in
+  packages of the actual version of GHC used are treated as wired-in packages.
+* Stack now recognises `ghc-internal` as a GHC wired-in package.
 * The configuration option `package-index` has a new default value: the `keyids`
   key lists the keys of the Hackage root key holders applicable from 2025-07-24.
 

--- a/doc/commands/new_command.md
+++ b/doc/commands/new_command.md
@@ -31,6 +31,15 @@ or Number categories (Nd (decimal), Nl (letter), or No (other)).
 
 !!! note
 
+    `stack new` will decline to accept a package name that is a GHC wired-in
+    package for a version of GHC that is supported by Stack.
+
+    Stack treats the following as the names of 'wired-in' packages: `base`,
+    `ghc-bignum`, `ghc-prim`, `ghc`, `ghc-internal`, `integer-gmp`,
+    `integer-simple`, `interactive`, `rts` and `template-haskell`.
+
+!!! note
+
     In the case of Hackage and acceptable package names, an alphanumeric
     character is limited to one of `A` to `Z`, `a` to `z`, and `0` to `9`.
 

--- a/doc/configure/yaml/project.md
+++ b/doc/configure/yaml/project.md
@@ -214,10 +214,6 @@ the same name.
     that the build plan refers to two versions of `process` and warn that the
     build is likely to fail.
 
-    Stack treats the following as the names of 'wired-in' packages: `base`,
-    `ghc-bignum`, `ghc-prim`, `ghc`, `ghc-internal`, `integer-gmp`,
-    `integer-simple`, `interactive`, `rts` and `template-haskell`.
-
 ## flags
 
 Default: `{}`


### PR DESCRIPTION
See:
* #6749 

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
