### PR TITLE
Re #6784 Consistent depth, recognise wired-in packaged, bottom line nodes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,10 @@ Behavior changes:
 * Stack now recognises `ghc-internal` as a GHC wired-in package.
 * The configuration option `package-index` has a new default value: the `keyids`
   key lists the keys of the Hackage root key holders applicable from 2025-07-24.
+* Stack's `dot` command now treats `--depth` the same way as the
+  `ls dependencies` command, so that the nodes of
+  `stack dot --external --depth 0` are the same as the packages listed by
+  `stack ls dependencies --depth 0`.
 
 Other enhancements:
 
@@ -27,6 +31,11 @@ Bug fixes:
 * `--PROG-option=<argument>` passes `--PROG-option=<argument>` (and not
   `--PROG-option="<argument>"`) to Cabal (the library).
 * The message S-7151 now presents as an error, with advice, and not as a bug.
+* Stack's `dot` command now uses a box to identify all GHC wired-in packages,
+  not just those with no dependencies (being only `rts`).
+* Stack's `dot` command now gives all nodes with no dependencies in the graph
+  the maximum rank, not just those nodes with no relevant dependencies at all
+  (being only `rts`, when `--external` is specified).
 
 ## v3.7.1 - 2025-06-28
 

--- a/doc/commands/dot_command.md
+++ b/doc/commands/dot_command.md
@@ -49,6 +49,12 @@ By default:
     to use a hint file for global packages. If a hint file is used, GHC does not
     need to be installed.
 
+All GHC wired-in packages are identified by a rectangular box.
+
+Nodes with no dependencies in the graph are given the maximum rank in the DOT
+language (that is, the `dot` executable will place those nodes on the bottom row
+of the diagram).
+
 ## Examples
 
 The following examples are based on a version of the


### PR DESCRIPTION
See:
* #6784

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally with toy packages.
