### PR TITLE
Refactor

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -1,11 +1,11 @@
 # Partial: base/head
 # Usage of partial function 'head' for lists
 [[ignore]]
-  id = "OBS-STAN-0001-1XF2BN-54:1"
+  id = "OBS-STAN-0001-1XF2BN-73:1"
 # ✦ Category:      #Partial #List
 # ✦ File:          src\Stack\Storage\Project.hs
 #
-#   54 ┃ share [ mkPersist sqlSettings
+#   73 ┃ share [ mkPersist sqlSettings
 
 # Partial: base/head
 # Usage of partial function 'head' for lists
@@ -151,14 +151,14 @@
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]
-  id = "OBS-STAN-0203-tuE+RG-248:24"
+  id = "OBS-STAN-0203-tuE+RG-249:24"
 # ✦ Description:   Usage of 'pack' function that doesn't handle Unicode characters
 # ✦ Category:      #AntiPattern
 # ✦ File:          src\Stack\Build\ExecutePackage.hs
 #
-#   247 ┃
-#   248 ┃   newConfigFileRoot <- S8.pack . toFilePath <$> view configFileRootL
-#   249 ┃                        ^^^^^^^
+#   248 ┃
+#   249 ┃   newConfigFileRoot <- S8.pack . toFilePath <$> view configFileRootL
+#   250 ┃                        ^^^^^^^
 
 # Anti-pattern: Data.ByteString.Char8.pack
 [[ignore]]

--- a/package.yaml
+++ b/package.yaml
@@ -201,6 +201,7 @@ library:
   - Stack.Config.ConfigureScript
   - Stack.Config.Docker
   - Stack.Config.Nix
+  - Stack.ConfigureOpts
   - Stack.ConfigCmd
   - Stack.Constants
   - Stack.Constants.Config

--- a/src/Stack/Build/ExecutePackage.hs
+++ b/src/Stack/Build/ExecutePackage.hs
@@ -70,6 +70,8 @@ import           Stack.Build.ExecuteEnv
                    )
 import           Stack.Build.Source ( addUnlistedToBuildCache )
 import           Stack.Config.ConfigureScript ( ensureConfigureScript )
+import           Stack.ConfigureOpts
+                   ( configureOptsFromBase, renderConfigureOpts )
 import           Stack.Constants
                    ( bindirSuffix, compilerOptionsCabalFlag, testGhcEnvRelFile )
 import           Stack.Constants.Config
@@ -114,7 +116,6 @@ import           Stack.Types.ComponentUtils
 import           Stack.Types.Config ( Config (..), HasConfig (..) )
 import           Stack.Types.ConfigureOpts
                    ( BaseConfigOpts (..), ConfigureOpts (..) )
-import qualified Stack.Types.ConfigureOpts as ConfigureOpts
 import           Stack.Types.Curator ( Curator (..) )
 import           Stack.Types.DumpPackage ( DumpPackage (..) )
 import           Stack.Types.EnvConfig
@@ -195,7 +196,7 @@ getConfigCache ee task installedMap enableTest enableBench = do
       -- where it was the opposite resulted in this. It doesn't seem to make any
       -- difference anyway.
       allDepsMap = Map.union missing' task.present
-      configureOpts' = ConfigureOpts.configureOpts
+      configureOpts' = configureOptsFromBase
         cOpts.envConfig
         cOpts.baseConfigOpts
         allDepsMap
@@ -304,7 +305,7 @@ ensureConfig newConfigCache pkgDir buildOpts announce cabal cabalFP task = do
         Right x -> pure $ concat ["--with-", name, "=", x]
     let allOpts =
              concat exes
-          <> ConfigureOpts.renderConfigureOpts newConfigCache.configureOpts
+          <> renderConfigureOpts newConfigCache.configureOpts
     -- Configure cabal with arguments determined by
     -- Stack.Types.Build.configureOpts
     cabal KeepTHLoading $ "configure" : allOpts

--- a/src/Stack/ConfigureOpts.hs
+++ b/src/Stack/ConfigureOpts.hs
@@ -1,0 +1,215 @@
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE NoFieldSelectors    #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings   #-}
+
+{-|
+Module      : Stack.ConfigureOpts
+License     : BSD-3-Clause
+-}
+
+module Stack.ConfigureOpts
+  ( configureOptsFromBase
+  , configureOptsFromDb
+  , renderConfigureOpts
+  , packageConfigureOptsFromPackage
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import           Database.Persist ( Entity, entityVal )
+import           Distribution.Types.MungedPackageName
+                   ( decodeCompatPackageName )
+import           Distribution.Types.PackageName ( unPackageName )
+import           Distribution.Types.UnqualComponentName
+                   ( unUnqualComponentName )
+import           GHC.Records ( HasField )
+import           Path ( (</>), parseRelDir )
+import           Path.Extra ( toFilePathNoTrailingSep )
+import           Stack.Constants
+                   ( bindirSuffix, compilerOptionsCabalFlag, docDirSuffix
+                   , relDirEtc, relDirLib, relDirLibexec, relDirShare
+                   )
+import           Stack.Prelude
+import           Stack.Types.BuildOpts ( BuildOpts (..) )
+import           Stack.Types.Compiler ( whichCompiler )
+import           Stack.Types.Config ( Config (..), HasConfig (..) )
+import           Stack.Types.ConfigureOpts
+                   ( BaseConfigOpts (..), ConfigureOpts (..)
+                   , PackageConfigureOpts (..) )
+import           Stack.Types.EnvConfig ( EnvConfig, actualCompilerVersionL )
+import           Stack.Types.GhcPkgId ( GhcPkgId, ghcPkgIdString )
+import           Stack.Types.IsMutable ( IsMutable (..) )
+import           Stack.Types.Package ( Package(..), packageIdentifier )
+import           System.FilePath ( pathSeparator )
+
+packageConfigureOptsFromPackage ::
+     Package
+  -> PackageConfigureOpts
+packageConfigureOptsFromPackage pkg = PackageConfigureOpts
+  { pkgCabalConfigOpts = pkg.cabalConfigOpts
+  , pkgGhcOptions = pkg.ghcOptions
+  , pkgFlags = pkg.flags
+  , pkgDefaultFlags = pkg.defaultFlags
+  , pkgIdentifier = packageIdentifier pkg
+  }
+
+configureOptsFromDb ::
+     ( HasField "configCacheDirOptionValue" b1 String
+     , HasField "configCacheNoDirOptionValue" b2 String
+     )
+  => [Entity b1]
+  -> [Entity b2]
+  -> ConfigureOpts
+configureOptsFromDb x y = ConfigureOpts
+  { pathRelated = map ((.configCacheDirOptionValue) . entityVal) x
+  , nonPathRelated = map ((.configCacheNoDirOptionValue) . entityVal) y
+  }
+
+-- | Render a @BaseConfigOpts@ to an actual list of options
+configureOptsFromBase ::
+     EnvConfig
+  -> BaseConfigOpts
+  -> Map PackageIdentifier GhcPkgId -- ^ dependencies
+  -> Bool -- ^ local non-extra-dep?
+  -> IsMutable
+  -> PackageConfigureOpts
+  -> ConfigureOpts
+configureOptsFromBase econfig bco deps isLocal isMutable pkgConfigureOpts =
+  ConfigureOpts
+    { pathRelated = configureOptsPathRelated bco isMutable pkgConfigureOpts
+    , nonPathRelated =
+        configureOptsNonPathRelated econfig bco deps isLocal pkgConfigureOpts
+    }
+
+configureOptsPathRelated ::
+     BaseConfigOpts
+  -> IsMutable
+  -> PackageConfigureOpts
+  -> [String]
+configureOptsPathRelated bco isMutable pkgOpts = concat
+  [ ["--user", "--package-db=clear", "--package-db=global"]
+  , map (("--package-db=" ++) . toFilePathNoTrailingSep) $ case isMutable of
+      Immutable -> bco.extraDBs ++ [bco.snapDB]
+      Mutable -> bco.extraDBs ++ [bco.snapDB] ++ [bco.localDB]
+  , [ "--libdir=" ++ toFilePathNoTrailingSep (installRoot </> relDirLib)
+    , "--bindir=" ++ toFilePathNoTrailingSep (installRoot </> bindirSuffix)
+    , "--datadir=" ++ toFilePathNoTrailingSep (installRoot </> relDirShare)
+    , "--libexecdir=" ++ toFilePathNoTrailingSep (installRoot </> relDirLibexec)
+    , "--sysconfdir=" ++ toFilePathNoTrailingSep (installRoot </> relDirEtc)
+    , "--docdir=" ++ toFilePathNoTrailingSep docDir
+    , "--htmldir=" ++ toFilePathNoTrailingSep docDir
+    , "--haddockdir=" ++ toFilePathNoTrailingSep docDir]
+  ]
+ where
+  installRoot =
+    case isMutable of
+      Immutable -> bco.snapInstallRoot
+      Mutable -> bco.localInstallRoot
+  docDir =
+    case pkgVerDir of
+      Nothing -> installRoot </> docDirSuffix
+      Just dir -> installRoot </> docDirSuffix </> dir
+  pkgVerDir = parseRelDir
+    (  packageIdentifierString pkgOpts.pkgIdentifier
+    ++ [pathSeparator]
+    )
+
+-- | Same as 'configureOpts', but does not include directory path options
+configureOptsNonPathRelated ::
+     EnvConfig
+  -> BaseConfigOpts
+  -> Map PackageIdentifier GhcPkgId -- ^ Dependencies.
+  -> Bool -- ^ Is this a local, non-extra-dep?
+  -> PackageConfigureOpts
+  -> [String]
+configureOptsNonPathRelated econfig bco deps isLocal package = concat
+  [ depOptions
+  , [ "--enable-library-profiling"
+    | bopts.libProfile || bopts.exeProfile
+    ]
+  , ["--enable-profiling" | bopts.exeProfile && isLocal]
+  , ["--enable-split-objs" | bopts.splitObjs]
+  , [ "--disable-library-stripping"
+    | not $ bopts.libStrip || bopts.exeStrip
+    ]
+  , ["--disable-executable-stripping" | not bopts.exeStrip && isLocal]
+  , flags
+  , map T.unpack package.pkgCabalConfigOpts
+  , processGhcOptions package.pkgGhcOptions
+  , map ("--extra-include-dirs=" ++) config.extraIncludeDirs
+  , map ("--extra-lib-dirs=" ++) config.extraLibDirs
+  , maybe
+      []
+      (\customGcc -> ["--with-gcc=" ++ toFilePath customGcc])
+      config.overrideGccPath
+  , ["--exact-configuration"]
+  , ["--ghc-option=-fhide-source-paths" | hideSourcePaths]
+  ]
+ where
+  -- This function parses the GHC options that are providing in the
+  -- stack.yaml file. In order to handle RTS arguments correctly, we need
+  -- to provide the RTS arguments as a single argument.
+  processGhcOptions :: [Text] -> [String]
+  processGhcOptions args =
+    let (preRtsArgs, mid) = break ("+RTS" ==) args
+        (rtsArgs, end) = break ("-RTS" ==) mid
+        fullRtsArgs =
+          case rtsArgs of
+            [] ->
+              -- This means that we didn't have any RTS args - no `+RTS` - and
+              -- therefore no need for a `-RTS`.
+              []
+            _ ->
+              -- In this case, we have some RTS args. `break` puts the `"-RTS"`
+              -- string in the `snd` list, so we want to append it on the end of
+              -- `rtsArgs` here.
+              --
+              -- We're not checking that `-RTS` is the first element of `end`.
+              -- This is because the GHC RTS allows you to omit a trailing -RTS
+              -- if that's the last of the arguments. This permits a GHC options
+              -- in stack.yaml that matches what you might pass directly to GHC.
+              [T.unwords $ rtsArgs ++ ["-RTS"]]
+        -- We drop the first element from `end`, because it is always either
+        -- `"-RTS"` (and we don't want that as a separate argument) or the list
+        -- is empty (and `drop _ [] = []`).
+        postRtsArgs = drop 1 end
+        newArgs = concat [preRtsArgs, fullRtsArgs, postRtsArgs]
+    in  concatMap (\x -> [compilerOptionsCabalFlag wc, T.unpack x]) newArgs
+
+  wc = view (actualCompilerVersionL . to whichCompiler) econfig
+
+  hideSourcePaths = config.hideSourcePaths
+
+  config = view configL econfig
+  bopts = bco.buildOpts
+  mapAndAppend fn = Map.foldrWithKey' (fmap (:) . fn)
+  -- Unioning atop defaults is needed so that all flags are specified with
+  -- --exact-configuration.
+  flags = mapAndAppend
+    renderFlags
+    []
+    (package.pkgFlags `Map.union` package.pkgDefaultFlags)
+  renderFlags name enabled =
+       "-f"
+    <> (if enabled then "" else "-")
+    <> flagNameString name
+
+  depOptions = mapAndAppend toDepOption [] deps
+
+  toDepOption (PackageIdentifier name _) gid = concat
+    [ "--dependency="
+    , depOptionKey
+    , "="
+    , ghcPkgIdString gid
+    ]
+   where
+    MungedPackageName subPkgName lib = decodeCompatPackageName name
+    depOptionKey = case lib of
+      LMainLibName -> unPackageName name
+      LSubLibName cn ->
+        unPackageName subPkgName <> ":" <> unUnqualComponentName cn
+
+-- | Render configure options as a single list of options.
+renderConfigureOpts :: ConfigureOpts -> [String]
+renderConfigureOpts copts = copts.pathRelated ++ copts.nonPathRelated

--- a/src/Stack/Storage/Project.hs
+++ b/src/Stack/Storage/Project.hs
@@ -37,6 +37,7 @@ import           Database.Persist.TH
                    , sqlSettings
                    )
 import           Pantry.SQLite ( initStorage, withStorage_ )
+import           Stack.ConfigureOpts ( configureOptsFromDb )
 import           Stack.Prelude
 import           Stack.Storage.Util
                    ( handleMigrationException, listUpdateDiff, setUpdateDiff
@@ -46,8 +47,7 @@ import           Stack.Types.BuildConfig
                    ( BuildConfig (..), HasBuildConfig (..) )
 import           Stack.Types.Cache
                    ( CachePkgSrc, ConfigCache (..), ConfigCacheType )
-import           Stack.Types.ConfigureOpts
-                   ( ConfigureOpts (..), configureOptsFromDb )
+import           Stack.Types.ConfigureOpts ( ConfigureOpts (..) )
 import           Stack.Types.GhcPkgId ( GhcPkgId )
 import           Stack.Types.Storage ( ProjectStorage (..) )
 

--- a/src/Stack/Types/ConfigureOpts.hs
+++ b/src/Stack/Types/ConfigureOpts.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE NoFieldSelectors    #-}
-{-# LANGUAGE OverloadedRecordDot #-}
-{-# LANGUAGE OverloadedStrings   #-}
 
 {-|
 Module      : Stack.Types.ConfigureOpts
@@ -12,37 +10,11 @@ module Stack.Types.ConfigureOpts
   ( ConfigureOpts (..)
   , BaseConfigOpts (..)
   , PackageConfigureOpts (..)
-  , configureOpts
-  , configureOptsFromDb
-  , renderConfigureOpts
-  , packageConfigureOptsFromPackage
   ) where
 
-import qualified Data.Map as Map
-import qualified Data.Text as T
-import           Database.Persist ( Entity, entityVal )
-import           Distribution.Types.MungedPackageName
-                   ( decodeCompatPackageName )
-import           Distribution.Types.PackageName ( unPackageName )
-import           Distribution.Types.UnqualComponentName
-                   ( unUnqualComponentName )
-import           GHC.Records ( HasField )
-import           Path ( (</>), parseRelDir )
-import           Path.Extra ( toFilePathNoTrailingSep )
-import           Stack.Constants
-                   ( bindirSuffix, compilerOptionsCabalFlag, docDirSuffix
-                   , relDirEtc, relDirLib, relDirLibexec, relDirShare
-                   )
 import           Stack.Prelude
 import           Stack.Types.BuildOpts ( BuildOpts (..) )
 import           Stack.Types.BuildOptsCLI ( BuildOptsCLI )
-import           Stack.Types.Compiler ( whichCompiler )
-import           Stack.Types.Config ( Config (..), HasConfig (..) )
-import           Stack.Types.EnvConfig ( EnvConfig, actualCompilerVersionL )
-import           Stack.Types.GhcPkgId ( GhcPkgId, ghcPkgIdString )
-import           Stack.Types.IsMutable ( IsMutable (..) )
-import           Stack.Types.Package ( Package(..), packageIdentifier )
-import           System.FilePath ( pathSeparator )
 
 -- | Basic information used to calculate what the configure options are
 data BaseConfigOpts = BaseConfigOpts
@@ -67,172 +39,6 @@ data PackageConfigureOpts = PackageConfigureOpts
   }
   deriving Show
 
-packageConfigureOptsFromPackage ::
-     Package
-  -> PackageConfigureOpts
-packageConfigureOptsFromPackage pkg = PackageConfigureOpts
-  { pkgCabalConfigOpts = pkg.cabalConfigOpts
-  , pkgGhcOptions = pkg.ghcOptions
-  , pkgFlags = pkg.flags
-  , pkgDefaultFlags = pkg.defaultFlags
-  , pkgIdentifier = packageIdentifier pkg
-  }
-
-configureOptsFromDb ::
-     ( HasField "configCacheDirOptionValue" b1 String
-     , HasField "configCacheNoDirOptionValue" b2 String
-     )
-  => [Entity b1]
-  -> [Entity b2]
-  -> ConfigureOpts
-configureOptsFromDb x y = ConfigureOpts
-  { pathRelated = map ((.configCacheDirOptionValue) . entityVal) x
-  , nonPathRelated = map ((.configCacheNoDirOptionValue) . entityVal) y
-  }
-
--- | Render a @BaseConfigOpts@ to an actual list of options
-configureOpts ::
-     EnvConfig
-  -> BaseConfigOpts
-  -> Map PackageIdentifier GhcPkgId -- ^ dependencies
-  -> Bool -- ^ local non-extra-dep?
-  -> IsMutable
-  -> PackageConfigureOpts
-  -> ConfigureOpts
-configureOpts econfig bco deps isLocal isMutable pkgConfigureOpts = ConfigureOpts
-  { pathRelated = configureOptsPathRelated bco isMutable pkgConfigureOpts
-  , nonPathRelated =
-      configureOptsNonPathRelated econfig bco deps isLocal pkgConfigureOpts
-  }
-
-configureOptsPathRelated ::
-     BaseConfigOpts
-  -> IsMutable
-  -> PackageConfigureOpts
-  -> [String]
-configureOptsPathRelated bco isMutable pkgOpts = concat
-  [ ["--user", "--package-db=clear", "--package-db=global"]
-  , map (("--package-db=" ++) . toFilePathNoTrailingSep) $ case isMutable of
-      Immutable -> bco.extraDBs ++ [bco.snapDB]
-      Mutable -> bco.extraDBs ++ [bco.snapDB] ++ [bco.localDB]
-  , [ "--libdir=" ++ toFilePathNoTrailingSep (installRoot </> relDirLib)
-    , "--bindir=" ++ toFilePathNoTrailingSep (installRoot </> bindirSuffix)
-    , "--datadir=" ++ toFilePathNoTrailingSep (installRoot </> relDirShare)
-    , "--libexecdir=" ++ toFilePathNoTrailingSep (installRoot </> relDirLibexec)
-    , "--sysconfdir=" ++ toFilePathNoTrailingSep (installRoot </> relDirEtc)
-    , "--docdir=" ++ toFilePathNoTrailingSep docDir
-    , "--htmldir=" ++ toFilePathNoTrailingSep docDir
-    , "--haddockdir=" ++ toFilePathNoTrailingSep docDir]
-  ]
- where
-  installRoot =
-    case isMutable of
-      Immutable -> bco.snapInstallRoot
-      Mutable -> bco.localInstallRoot
-  docDir =
-    case pkgVerDir of
-      Nothing -> installRoot </> docDirSuffix
-      Just dir -> installRoot </> docDirSuffix </> dir
-  pkgVerDir = parseRelDir
-    (  packageIdentifierString pkgOpts.pkgIdentifier
-    ++ [pathSeparator]
-    )
-
--- | Same as 'configureOpts', but does not include directory path options
-configureOptsNonPathRelated ::
-     EnvConfig
-  -> BaseConfigOpts
-  -> Map PackageIdentifier GhcPkgId -- ^ Dependencies.
-  -> Bool -- ^ Is this a local, non-extra-dep?
-  -> PackageConfigureOpts
-  -> [String]
-configureOptsNonPathRelated econfig bco deps isLocal package = concat
-  [ depOptions
-  , [ "--enable-library-profiling"
-    | bopts.libProfile || bopts.exeProfile
-    ]
-  , ["--enable-profiling" | bopts.exeProfile && isLocal]
-  , ["--enable-split-objs" | bopts.splitObjs]
-  , [ "--disable-library-stripping"
-    | not $ bopts.libStrip || bopts.exeStrip
-    ]
-  , ["--disable-executable-stripping" | not bopts.exeStrip && isLocal]
-  , flags
-  , map T.unpack package.pkgCabalConfigOpts
-  , processGhcOptions package.pkgGhcOptions
-  , map ("--extra-include-dirs=" ++) config.extraIncludeDirs
-  , map ("--extra-lib-dirs=" ++) config.extraLibDirs
-  , maybe
-      []
-      (\customGcc -> ["--with-gcc=" ++ toFilePath customGcc])
-      config.overrideGccPath
-  , ["--exact-configuration"]
-  , ["--ghc-option=-fhide-source-paths" | hideSourcePaths]
-  ]
- where
-  -- This function parses the GHC options that are providing in the
-  -- stack.yaml file. In order to handle RTS arguments correctly, we need
-  -- to provide the RTS arguments as a single argument.
-  processGhcOptions :: [Text] -> [String]
-  processGhcOptions args =
-    let (preRtsArgs, mid) = break ("+RTS" ==) args
-        (rtsArgs, end) = break ("-RTS" ==) mid
-        fullRtsArgs =
-          case rtsArgs of
-            [] ->
-              -- This means that we didn't have any RTS args - no `+RTS` - and
-              -- therefore no need for a `-RTS`.
-              []
-            _ ->
-              -- In this case, we have some RTS args. `break` puts the `"-RTS"`
-              -- string in the `snd` list, so we want to append it on the end of
-              -- `rtsArgs` here.
-              --
-              -- We're not checking that `-RTS` is the first element of `end`.
-              -- This is because the GHC RTS allows you to omit a trailing -RTS
-              -- if that's the last of the arguments. This permits a GHC options
-              -- in stack.yaml that matches what you might pass directly to GHC.
-              [T.unwords $ rtsArgs ++ ["-RTS"]]
-        -- We drop the first element from `end`, because it is always either
-        -- `"-RTS"` (and we don't want that as a separate argument) or the list
-        -- is empty (and `drop _ [] = []`).
-        postRtsArgs = drop 1 end
-        newArgs = concat [preRtsArgs, fullRtsArgs, postRtsArgs]
-    in  concatMap (\x -> [compilerOptionsCabalFlag wc, T.unpack x]) newArgs
-
-  wc = view (actualCompilerVersionL . to whichCompiler) econfig
-
-  hideSourcePaths = config.hideSourcePaths
-
-  config = view configL econfig
-  bopts = bco.buildOpts
-  mapAndAppend fn = Map.foldrWithKey' (fmap (:) . fn)
-  -- Unioning atop defaults is needed so that all flags are specified with
-  -- --exact-configuration.
-  flags = mapAndAppend
-    renderFlags
-    []
-    (package.pkgFlags `Map.union` package.pkgDefaultFlags)
-  renderFlags name enabled =
-       "-f"
-    <> (if enabled then "" else "-")
-    <> flagNameString name
-
-  depOptions = mapAndAppend toDepOption [] deps
-
-  toDepOption (PackageIdentifier name _) gid = concat
-    [ "--dependency="
-    , depOptionKey
-    , "="
-    , ghcPkgIdString gid
-    ]
-   where
-    MungedPackageName subPkgName lib = decodeCompatPackageName name
-    depOptionKey = case lib of
-      LMainLibName -> unPackageName name
-      LSubLibName cn ->
-        unPackageName subPkgName <> ":" <> unUnqualComponentName cn
-
 -- | Configure options to be sent to Setup.hs configure.
 data ConfigureOpts = ConfigureOpts
   { pathRelated :: ![String]
@@ -245,7 +51,3 @@ data ConfigureOpts = ConfigureOpts
   deriving (Data, Eq, Generic, Show, Typeable)
 
 instance NFData ConfigureOpts
-
--- | Render configure options as a single list of options.
-renderConfigureOpts :: ConfigureOpts -> [String]
-renderConfigureOpts copts = copts.pathRelated ++ copts.nonPathRelated

--- a/src/Stack/Types/FileDigestCache.hs
+++ b/src/Stack/Types/FileDigestCache.hs
@@ -12,8 +12,8 @@ module Stack.Types.FileDigestCache
   ) where
 
 import qualified Data.Map.Strict as Map
-import           Stack.Prelude
 import qualified Pantry.SHA256 as SHA256
+import           Stack.Prelude
 
 -- | Type synonym representing caches of digests of files.
 type FileDigestCache = IORef (Map FilePath SHA256)

--- a/stack.cabal
+++ b/stack.cabal
@@ -236,6 +236,7 @@ library
       Stack.Config.ConfigureScript
       Stack.Config.Docker
       Stack.Config.Nix
+      Stack.ConfigureOpts
       Stack.ConfigCmd
       Stack.Constants
       Stack.Constants.Config


### PR DESCRIPTION
Rename `BuildCache` as `BuildFileCache`.

Rename field of `BuildFileCache` as `fileCache` (`times` was a misnomer).

Move `FileCacheInfo` from `Stack.Types.Package` to be co-located with `BuildFileCache`.

Use type synonym `FileCache`.

Move `toCachePkgSrc` to `Stack.Build.ConstructPlan` (the only place it is used).

Move functions from `Stack.Types.ConfigureOpts` to `Stack.ConfigureOpts`, to avoid cyclic module dependencies.

Rename `configureOpts` to `configureOptsFromBase` to avoid clash with `ConfigCache` field name.

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI.
