### PR TITLE
Add missing space in coverage report error message

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -44,7 +44,7 @@ Bug fixes:
 * Stack's `dot` command now gives all nodes with no dependencies in the graph
   the maximum rank, not just those nodes with no relevant dependencies at all
   (being only `rts`, when `--external` is specified).
-* Fixed a missing space in error message for S-8215.
+* Improved error messages for S-4634 and S-8215.
 
 ## v3.7.1 - 2025-06-28
 

--- a/src/Stack/Coverage.hs
+++ b/src/Stack/Coverage.hs
@@ -262,12 +262,14 @@ generateHpcReportInternal
           prettyError $
             "[S-4634]"
             <> line
-            <> flow "Didn't find"
-            <> style File ".tix"
-            <> "for"
-            <> report
-            <> flow "- expected to find it at"
-            <> pretty tixSrc <> "."
+            <> fillSep
+                 [ flow "Didn't find"
+                 , style File ".tix"
+                 , "for"
+                 , report
+                 , flow "- expected to find it at"
+                 , pretty tixSrc <> "."
+                 ]
           pure Nothing
         else (`catch` \(err :: ProcessException) -> do
                logError $ displayShow err
@@ -278,8 +280,10 @@ generateHpcReportInternal
                prettyError
                  ( "[S-8215]"
                    <> line
-                   <> flow "Error occurred while producing "
-                   <> report <> "."
+                   <> fillSep
+                        [ flow "Error occurred while producing"
+                        , report <> "."
+                        ]
                  )) $ do
           -- Directories for .mix files.
           hpcRelDir <- hpcRelativeDir


### PR DESCRIPTION
This error message glues two words together:

```
Error: [S-8215]
       Error occurred while producingcombined coverage report.
```

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

I couldn't find any tests for the messages to update.
