### PR TITLE
Fix #6820 Update building GHC from source

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,9 @@ Behavior changes:
   `ls dependencies` command, so that the nodes of
   `stack dot --external --depth 0` are the same as the packages listed by
   `stack ls dependencies --depth 0`.
+* When building GHC from source, on Windows, the default Hadrian build target is
+  `reloc-binary-dist` and the default path to the GHC built by Hadrian is
+  `_build/reloc-bindist`.
 
 Other enhancements:
 
@@ -33,6 +36,10 @@ Other enhancements:
   specified).
 * Add option `-w` as synonym for `--stack-yaml`.
 * `stack new` now allows `codeberg:` as a service for template downloads
+* In YAML configuration files, the `compiler-target` and
+  `compiler-bindist-path` keys are introduced to allow, when building GHC from
+  source, the Hadrian build target and Hadrian path to the built GHC to be
+  specified.
 
 Bug fixes:
 

--- a/doc/topics/GHC_from_source.md
+++ b/doc/topics/GHC_from_source.md
@@ -23,6 +23,10 @@ In the following example the commit ID is "5be7ad..." and the flavour is
 compiler: ghc-git-5be7ad7861c8d39f60b7101fd8d8e816ff50353a-quick
 ~~~
 
+The [`-j`, `--jobs` option](../configure/global_flags.md#-jobs-or-j-option) at
+the command line or the [`jobs`](../configure/yaml/non-project.md#jobs) option
+in a YAML configuraton file can be used to specify Hadrian's `-j[<n>]` flag.
+
 By default, the code is retrieved from the main GHC repository. If you want to
 select another repository, use the `compiler-repository` option in a YAML
 configuration file:
@@ -32,6 +36,40 @@ compiler-repository: git://my/ghc/repository
 # default
 # compiler-repository: https://gitlab.haskell.org/ghc/ghc.git
 ~~~
+
+By default, the Hadrian build target is `reloc-binary-dist` on Windows and
+`binary-dist` on other operating systems. If you want to specify another
+Hadrian build target, use the `compiler-target` option in a YAML configuration
+file:
+
+~~~yaml
+compiler-target: binary-dist
+# default (Windows)
+# compiler-target: reloc-binary-dist
+# default (non-Windows)
+# compiler-target: binary-dist
+~~~
+
+By default, Stack assumes that the path to the binary distribution built by
+Hadrian is `_build/reloc-bindist` on Windows and `_build/bindist` on other
+operating systems. If you want to specify another path, use the
+`compiler-bindist-path` option in a YAML configuration file:
+
+~~~yaml
+compiler-bindist-path: _build/bindist
+# default (Windows)
+# compiler-bindist-path: _build/reloc-bindist
+# default (non-Windows)
+# compiler-bindist-path: _build/bindist
+~~~
+
+!!! note
+
+    The Hadrian build target `reloc-binary-dist` was introduced with Git commit
+    id
+    [`fe23629b147d419053052e6e881f6e8ddfbf3bae`](https://gitlab.haskell.org/ghc/ghc/-/commit/fe23629b147d419053052e6e881f6e8ddfbf3bae).
+
+    Once introduced, the target must be used on Windows.
 
 Stack does not check the compiler version when it uses a compiler built from
 source. It is assumed that the built compiler is recent enough as Stack does not
@@ -65,13 +103,17 @@ fully managed by Stack.
     configure: error: GHC version 9.2 or later is required to compile GHC.
     ~~~
 
-    The resolution is: (1) to specify an alternative snapshot (one that
-    specifies a sufficiently recent version of GHC) on the command line, using
-    Stack's option `--snapshot <snapshot>`. Stack will use that snapshot when
-    running GHC's `configure` script; and (2) to set the contents of the `STACK`
-    environment variable to be `stack --snapshot <snapshot>`. Hadrian's
-    `build-stack` script wil refer to that environment variable for the Stack
-    command it uses.
+    The resolution is:
+
+    1.  to specify an alternative snapshot (one that specifies a sufficiently
+        recent version of GHC) on the command line, using Stack's option
+        `--snapshot <snapshot>`. Stack will use that snapshot when running GHC's
+        `configure` script; and
+
+    2.  to set the contents of the `STACK` environment variable to be
+        `stack --snapshot <snapshot>`. If `<snapshot>` is a path to a local YAML
+        file, it needs to be an absolute one. Hadrian's `build-stack` script
+        will refer to that environment variable for the Stack command it uses.
 
 ### Hadrian prerequisites
 
@@ -127,8 +169,10 @@ Stack will build and install `happy` and `alex`, if not already on the PATH.
     # documentation from a single source file, including `makeinfo`.
     stack exec -- pacman --sync mingw-w64-x86_64-ca-certificates
     # Common CA (certificate authority) certificates.
-    stack exec -- pip install -U sphinx
+    stack exec -- pacman -sync mingw-w64-x86_64-python-sphinx
     # Sphinx is the Python documentation generator.
+    stack exec -- pacman -sync mingw-w64-x86_64-texlive-full
+    # The TeX Live distribution.
     ~~~
 
     Hadrian may require certain LaTeX packages and may prompt for these to be

--- a/src/Stack/Config.hs
+++ b/src/Stack/Config.hs
@@ -113,7 +113,10 @@ import           Stack.Types.Build.Exception
 import           Stack.Types.BuildConfig ( BuildConfig (..) )
 import           Stack.Types.BuildOpts ( BuildOpts (..) )
 import           Stack.Types.ColorWhen ( ColorWhen (..) )
-import           Stack.Types.Compiler ( defaultCompilerRepository )
+import           Stack.Types.Compiler
+                   ( defaultCompilerBindistPath, defaultCompilerRepository
+                   , defaultCompilerTarget
+                   )
 import           Stack.Types.Config
                    ( Config (..), HasConfig (..), askLatestSnapshotUrl
                    , configProjectRoot, stackRootL, workDirL
@@ -286,6 +289,12 @@ configFromConfigMonoid
         compilerRepository = fromFirst
           defaultCompilerRepository
           configMonoid.compilerRepository
+        compilerTarget = fromFirst
+          defaultCompilerTarget
+          configMonoid.compilerTarget
+        compilerBindistPath = fromFirst
+          defaultCompilerBindistPath
+          configMonoid.compilerBindistPath
         ghcBuild = getFirst configMonoid.ghcBuild
         installGHC = fromFirstTrue configMonoid.installGHC
         installMsys = fromFirst installGHC configMonoid.installMsys
@@ -595,6 +604,8 @@ configFromConfigMonoid
                 , msysEnvironment
                 , compilerCheck
                 , compilerRepository
+                , compilerTarget
+                , compilerBindistPath
                 , localBin
                 , fileWatchHook
                 , requireStackVersion

--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -40,7 +40,8 @@ import           Stack.Types.ApplyGhcOptions ( ApplyGhcOptions (..) )
 import           Stack.Types.ApplyProgOptions ( ApplyProgOptions (..) )
 import           Stack.Types.BuildOpts ( BuildOpts )
 import           Stack.Types.CabalConfigKey ( CabalConfigKey )
-import           Stack.Types.Compiler ( CompilerRepository )
+import           Stack.Types.Compiler
+                   ( CompilerBindistPath, CompilerRepository, CompilerTarget )
 import           Stack.Types.CompilerBuild ( CompilerBuild )
 import           Stack.Types.Docker ( DockerOpts )
 import           Stack.Types.DumpLogs ( DumpLogs )
@@ -114,6 +115,10 @@ data Config = Config
     -- ^ Specifies which versions of the compiler are acceptable.
   , compilerRepository      :: !CompilerRepository
     -- ^ Specifies the repository containing the compiler sources
+  , compilerTarget          :: !CompilerTarget
+    -- ^ Specifies the Hadrian build target
+  , compilerBindistPath     :: !CompilerBindistPath
+    -- ^ Specifies the Hadrian path to built binary distribution
   , localBin                :: !(Path Abs Dir)
     -- ^ Directory we should install executables into
   , fileWatchHook           :: !(Maybe (Path Abs File))

--- a/src/Stack/Types/ConfigMonoid.hs
+++ b/src/Stack/Types/ConfigMonoid.hs
@@ -44,7 +44,8 @@ import           Stack.Types.BuildOptsMonoid ( BuildOptsMonoid )
 import           Stack.Types.Casa ( CasaOptsMonoid )
 import           Stack.Types.CabalConfigKey ( CabalConfigKey )
 import           Stack.Types.ColorWhen ( ColorWhen )
-import           Stack.Types.Compiler ( CompilerRepository )
+import           Stack.Types.Compiler
+                   ( CompilerBindistPath, CompilerRepository, CompilerTarget )
 import           Stack.Types.CompilerBuild ( CompilerBuild )
 import           Stack.Types.Docker ( DockerOptsMonoid, VersionRangeJSON (..) )
 import           Stack.Types.DumpLogs ( DumpLogs )
@@ -101,6 +102,10 @@ data ConfigMonoid = ConfigMonoid
     -- ^ See: 'Stack.Types.Config.compilerCheck'
   , compilerRepository      :: !(First CompilerRepository)
     -- ^ See: 'Stack.Types.Config.compilerRepository'
+  , compilerTarget          :: !(First CompilerTarget)
+    -- ^ See: 'Stack.Types.Config.compilerTarget'
+  , compilerBindistPath     :: !(First CompilerBindistPath)
+    -- ^ See: 'Stack.Types.Config.compilerBindistPath'
   , requireStackVersion     :: !IntersectingVersionRange
     -- ^ See: 'Stack.Types.Config.requireStackVersion'
   , arch                    :: !(First String)
@@ -289,6 +294,9 @@ parseConfigMonoidObject rootDir obj = do
       pure (First scmInit,fromMaybe M.empty params)
   compilerCheck <- First <$> obj ..:? configMonoidCompilerCheckName
   compilerRepository <- First <$> (obj ..:? configMonoidCompilerRepositoryName)
+  compilerTarget <- First <$> (obj ..:? configMonoidCompilerTargetName)
+  compilerBindistPath <-
+    First <$> (obj ..:? configMonoidCompilerBindistPathName)
 
   options <- Map.map (.ghcOptions) <$>
     obj ..:? configMonoidGhcOptionsName ..!= (mempty :: Map GhcOptionKey GhcOptions)
@@ -381,6 +389,8 @@ parseConfigMonoidObject rootDir obj = do
     , msysEnvironment
     , compilerCheck
     , compilerRepository
+    , compilerTarget
+    , compilerBindistPath
     , requireStackVersion
     , arch
     , ghcVariant
@@ -537,6 +547,12 @@ configMonoidCompilerCheckName = "compiler-check"
 
 configMonoidCompilerRepositoryName :: Text
 configMonoidCompilerRepositoryName = "compiler-repository"
+
+configMonoidCompilerTargetName :: Text
+configMonoidCompilerTargetName = "compiler-target"
+
+configMonoidCompilerBindistPathName :: Text
+configMonoidCompilerBindistPathName = "compiler-bindist-path"
 
 configMonoidGhcOptionsName :: Text
 configMonoidGhcOptionsName = "ghc-options"


### PR DESCRIPTION
See:
* #6820

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally on Windows 11 and Ubuntu (via WSL), with `ghc-git-02150b65487cb675480ed8697c956f5b69190882-quick` (that is tag `ghc-9.14.1-rc1`).

That version of Hadrian needed the override snapshot:
~~~yaml
snapshot: lts-24.11 # GHC 9.10.2

packages:
- Cabal-3.14.0.0
- Cabal-syntax-3.14.0.0
- directory-1.3.9.0
- file-io-0.1.4
- filepath-1.4.300.2
- process-1.6.25.0
- unix-2.8.5.1
- Win32-2.14.1.0 # Hadrian fails to include this
- time-1.12.2 # Hadrian fails to include this
~~~