### PR TITLE
Fix #6826 Ignore the `mainLibraryHasExposedModules package` test

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,8 @@ Behavior changes:
 * When building GHC from source, on Windows, the default Hadrian build target is
   `reloc-binary-dist` and the default path to the GHC built by Hadrian is
   `_build/reloc-bindist`.
+* Stack's `haddock` command no longer requires a package to have a main library
+  that exposes modules.
 
 Other enhancements:
 

--- a/doc/commands/build_command.md
+++ b/doc/commands/build_command.md
@@ -348,11 +348,6 @@ sets this flag.
 Stack applies Haddock's `--gen-contents` and `--gen-index` flags to generate a
 single HTML contents and index for multiple sets of Haddock documentation.
 
-!!! note
-
-    If a package does not have a main library that exposes modules, Haddock
-    documentation will not be built for that package, irrespective of the flag.
-
 !!! warning
 
     On Windows, the values for the `haddock-interfaces` and `haddock-html` keys

--- a/src/Stack/Package.hs
+++ b/src/Stack/Package.hs
@@ -23,7 +23,6 @@ module Stack.Package
   , packageDependencies
   , applyForceCustomBuild
   , hasBuildableMainLibrary
-  , mainLibraryHasExposedModules
   , packageUnknownTools
   , buildableForeignLibs
   , buildableSubLibs
@@ -650,15 +649,6 @@ applyForceCustomBuild cabalVersion package
 hasBuildableMainLibrary :: Package -> Bool
 hasBuildableMainLibrary package =
   maybe False isComponentBuildable package.library
-
--- | Check if the main library has any exposed modules.
---
--- This should become irrelevant at some point since there's nothing inherently
--- wrong or different with packages exposing only modules in internal libraries
--- (for instance).
-mainLibraryHasExposedModules :: Package -> Bool
-mainLibraryHasExposedModules package =
-  maybe False (not . null . (.exposedModules)) package.library
 
 -- | Aggregate all unknown tools from all components. Mostly meant for
 -- build tools specified in the legacy manner (build-tools:) that failed the


### PR DESCRIPTION
See:
* #6826

`mainLibraryHasExposedModules` is, consequently, no longer relevant and is removed.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
