### PR TITLE
Fix #6858 Don't prune when all dependencies pruned

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,9 @@ Other enhancements:
 
 Bug fixes:
 
+* Stack's `dot` and `ls dependencies` commands no longer prune a package with
+  dependencies only because all its direct dependencies are to be pruned.
+
 ## v3.9.3 - 2026-02-19
 
 Release notes:

--- a/doc/commands/dot_command.md
+++ b/doc/commands/dot_command.md
@@ -31,8 +31,7 @@ By default:
     project packages). Pass the `--reach <packages>` option to exclude packages
     (including project packages) that cannot reach any of the specified packages
     in the dependency graph. In both cases, `<packages>` is a list of package
-    names separated by commas. A package with dependencies is pruned if all of
-    its direct dependencies are pruned;
+    names separated by commas;
 *   for all relevant project packages, relevant dependencies are included in the
     output. However, each project package for which dependencies are included
     can be specified as a target argument. The argument uses the same format as

--- a/doc/commands/ls_command.md
+++ b/doc/commands/ls_command.md
@@ -72,8 +72,7 @@ By default:
     project packages). Pass the `--reach <packages>` option to exclude packages
     (including project packages) that cannot reach any of the specified packages
     in the dependency graph. In both cases, `<packages>` is a list of package
-    names separated by commas. A package with dependencies is pruned if all of
-    its direct dependencies are pruned;
+    names separated by commas;
 *   for all relevant project packages, relevant dependencies are included in the
     output. However, each project package for which dependencies are included
     can be specified as a target argument. The argument uses the same format as

--- a/src/Stack/DependencyGraph.hs
+++ b/src/Stack/DependencyGraph.hs
@@ -397,9 +397,7 @@ pruneGraph dontPrune names =
     if pkg `F.elem` names
       then Nothing
       else let filtered = Set.filter (`F.notElem` names) pkgDeps
-           in  if Set.null filtered && not (Set.null pkgDeps)
-                 then Nothing
-                 else Just (filtered, x))
+           in  Just (filtered, x))
 
 -- | Make sure that all unreachable nodes (orphans) are pruned
 pruneUnreachable ::


### PR DESCRIPTION
See:
* #6858

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
