### PR TITLE
Use dedicated JSON endpoint for snapshots

### DIFF
--- a/src/Stack/Ls.hs
+++ b/src/Stack/Ls.hs
@@ -223,7 +223,7 @@ handleRemote lsOpts = do
     LsStyles _ -> pure ()
     LsTools _ -> pure ()
  where
-  urlInfo = "https://www.stackage.org/snapshots"
+  urlInfo = "https://www.stackage.org/api/v1/snapshots"
 
 -- | Function underlying the @stack ls@ command.
 lsCmd :: LsCmdOpts -> RIO Runner ()


### PR DESCRIPTION
Closes https://github.com/commercialhaskell/stack/issues/6871

For context on the changing API, see:

* https://github.com/commercialhaskell/stackage-server/issues/355 (initial change)
* https://github.com/commercialhaskell/stackage-server/issues/365 (bugfix for breaking Stack)

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md. **(none)**
* [x] The documentation has been updated, if necessary **(none)**

## Testing
BEFORE:

```
$ stack -- ls snapshots remote |& head -n2
JSONParseException Request {
  host                 = "www.stackage.org"
```

AFTER:

```
$ stack run stack -- ls snapshots remote |& head -n5
a month ago

Snapshot name: nightly-2026-03-14
Stackage Nightly 2026-03-14 (ghc-9.12.3)
```

