### PR TITLE
Fix #6897 Allow config set snapshot with non-synonym values

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -41,6 +41,8 @@ Other enhancements:
   different snapshots can use `!include` to avoid duplicating shared settings.
 * Stack's `config set` command raises an error if the target configuration file
   excludes the key being set and includes an `!include` directive.
+* Stack's `config set snapshot` command now works with other snapshot values
+  in addition to snapshot synonymns.
 
 Bug fixes:
 

--- a/doc/commands/config_command.md
+++ b/doc/commands/config_command.md
@@ -179,6 +179,9 @@ A snapshot of `lts` or `nightly` will be translated into the most recent
 available. A snapshot of `lts-22` will be translated into the most recent
 available in the `lts-22` sequence.
 
+Snapshot values that are compiler versions, a URL or a local file path are also
+accepted.
+
 If a (deprecated) `resolver` key is present, it will be replaced by a `snapshot`
 key.
 

--- a/src/Stack/ConfigCmd.hs
+++ b/src/Stack/ConfigCmd.hs
@@ -288,7 +288,20 @@ snapshotValue root snapshot = do
   concreteSnapshot <- makeConcreteSnapshot snapshot'
   -- Check that the snapshot actually exists
   void $ loadSnapshot =<< completeSnapshotLocation concreteSnapshot
-  pure (Yaml.toJSON concreteSnapshot)
+  rslValue concreteSnapshot
+
+rslValue :: HasConfig env => RawSnapshotLocation -> RIO env Yaml.Value
+rslValue (RSLCompiler compiler) = pure $ Yaml.toJSON compiler
+rslValue (RSLUrl url Nothing) = pure $ Yaml.toJSON url
+rslValue (RSLUrl url _) = do
+  -- I can't see how this would ever arise, but it is added for completeness:
+  prettyWarnL
+    [ flow "The specified snapshot value is a URL. The associated SHA256 hash \
+           \and file size will be ignored."
+    ]
+  pure $ Yaml.toJSON url
+rslValue (RSLFilePath rp) = pure $ Yaml.toJSON $ resolvedRelative rp
+rslValue rsl = pure $ Yaml.toJSON rsl
 
 cfgCmdSetKeys :: ConfigCmdSet -> NonEmpty (NonEmpty Text)
 cfgCmdSetKeys (ConfigCmdSetSnapshot _) = [["snapshot"], ["resolver"]]

--- a/tests/integration/tests/6879-stack-yaml-includes/Main.hs
+++ b/tests/integration/tests/6879-stack-yaml-includes/Main.hs
@@ -36,17 +36,16 @@ main = do
     ["--stack-yaml", "stack-not-including-flags.yaml", "run"]
     (checkFor "TEST_FLAG was set\n")
 
--- Disabling test, pending investigation ...
--- -- Check that 'config set' succeeds when the key already exists in a
--- -- stack.yaml file that uses !include directives
--- stackCheckStderr
---   ["--stack-yaml", "stack-including-flags.yaml", "config", "set", "snapshot", "ghc-9.10.3"]
---   (expectMessage "already")
--- -- Check that 'config set' succeeds when the key already exists in a
--- -- stack.yaml file that uses !include directives (with newline variant)
--- stackCheckStderr
---   ["--stack-yaml", "stack-including-flags-with-newline.yaml", "config", "set", "snapshot", "ghc-9.10.3"]
---   (expectMessage "already")
+  -- Check that 'config set' succeeds when the key already exists in a
+  -- stack.yaml file that uses !include directives
+  stackCheckStderr
+    ["--stack-yaml", "stack-including-flags.yaml", "config", "set", "snapshot", "ghc-9.10.3"]
+    (expectMessage "already")
+  -- Check that 'config set' succeeds when the key already exists in a
+  -- stack.yaml file that uses !include directives (with newline variant)
+  stackCheckStderr
+    ["--stack-yaml", "stack-including-flags-with-newline.yaml", "config", "set", "snapshot", "ghc-9.10.3"]
+    (expectMessage "already")
 
   -- Check that 'config set' raises an error when the key does not exist in a
   -- stack.yaml file that uses !include directives


### PR DESCRIPTION
See:
* #6897 

Also re-enables part of integration test `6879-stack-yaml-includes`.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Tested locally on Windows 11.
