### PR TITLE
Fix #6919 Switch search order of MSYS2 dirs in the Stack environment

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,9 @@ Behavior changes:
   `recent-snapshots: https://stackage.org/api/v1/snapshots`.
 * The `--[no-]keep-ghc-rts` flag of Stack's `config env` command is now enabled
   by default, consistent with Stack's `exec` command.
+* On Windows, in the Stack environment, the MSYS2 `usr/local/bin` directory (if
+  it exists) is now searched before the MSYS2 `usr/bin` directory, rather than
+  after.
 
 Other enhancements:
 

--- a/doc/topics/stack_environment.md
+++ b/doc/topics/stack_environment.md
@@ -74,14 +74,14 @@ The GHC-supplied MinGW `bin` directory.
 The `bin` directory for the specified MSYS2 environment of the
 [Stack-supplied MSYS2](developing_on_windows.md).
 
-## Stack-supplied MSYS2 `usr\bin` directory (Windows only)
-
-The `usr\bin` directory for the
-[Stack-supplied MSYS2](developing_on_windows.md).
-
 ## Stack-supplied MSYS2 `usr\local\bin` directory (Windows only)
 
 The `usr\local\bin` directory for the
+[Stack-supplied MSYS2](developing_on_windows.md).
+
+## Stack-supplied MSYS2 `usr\bin` directory (Windows only)
+
+The `usr\bin` directory for the
 [Stack-supplied MSYS2](developing_on_windows.md).
 
 ## Specified extra paths

--- a/src/Stack/Setup/Installed.hs
+++ b/src/Stack/Setup/Installed.hs
@@ -160,8 +160,10 @@ toolExtraDirs tool = do
       pure mempty
         { bins =
             [ dir </> relDirMsysEnvPrefix </> relDirBin
-            , dir </> relDirUsr </> relDirBin
+              -- Stack follows the Unix-like convention that usr/local/bin
+              -- should have search priority over usr/bin.
             , dir </> relDirUsr </> relDirLocal </> relDirBin
+            , dir </> relDirUsr </> relDirBin
             ]
         , includes =
             [ dir </> relDirMsysEnvPrefix </> relDirInclude


### PR DESCRIPTION
See: 
* #6919

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
