### PR TITLE
Fix #6931 Use absolute builddir with withCabal

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,9 @@ Other enhancements:
 
 Bug fixes:
 
+* On Windows, Stack's `build` command now accepts a build directory that is a
+  long path.
+
 ##  v3.11.1 - 2026-05-30
 
 **Changes since v3.9.3:**

--- a/src/Stack/Build/ExecuteEnv.hs
+++ b/src/Stack/Build/ExecuteEnv.hs
@@ -732,7 +732,7 @@ withSingleContext
           , keepGhcRts = False
           }
     menv <- liftIO $ config.processContextSettings envSettings
-    distRelativeDir' <- distRelativeDir
+    distDir' <- distDirFromDir pkgDir
     setupexehs <-
       -- Avoid broken Setup.hs files causing problems for simple build
       -- types, see:
@@ -913,7 +913,7 @@ withSingleContext
                   <> cabalPackageArg
 
           setupArgs =
-            ("--builddir=" ++ toFilePathNoTrailingSep distRelativeDir') : args
+            ("--builddir=" ++ toFilePathNoTrailingSep distDir') : args
 
           depToMungedPkgNames ::
                PackageName


### PR DESCRIPTION
* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
