### PR TITLE
Rationalise Nix packages required to build Stack

### DIFF
--- a/stack-ghc-9.12.4.yaml
+++ b/stack-ghc-9.12.4.yaml
@@ -1,6 +1,7 @@
 # This is an experimental project-level configuration, to see if Stack can be
 # built with GHC 9.12.4.
 snapshot: nightly-2026-07-02 # GHC 9.12.4
+compiler-check: match-exact # Protect against RCs of GHC 9.12.5
 
 extra-deps:
 # nightly-2026-07-02 specifies Cabal-3.14.2.0
@@ -18,8 +19,8 @@ docker:
 nix:
   # --nix on the command-line to enable.
   packages:
+  - pkg-config
   - zlib
-  - unzip
 
 flags:
   stack:

--- a/stack-ghc-9.12.5.yaml
+++ b/stack-ghc-9.12.5.yaml
@@ -22,8 +22,8 @@ docker:
 nix:
   # --nix on the command-line to enable.
   packages:
+  - pkg-config
   - zlib
-  - unzip
 
 flags:
   stack:

--- a/stack-ghc-9.14.1.yaml
+++ b/stack-ghc-9.14.1.yaml
@@ -19,8 +19,8 @@ docker:
 nix:
   # --nix on the command-line to enable.
   packages:
+  - pkg-config
   - zlib
-  - unzip
 
 flags:
   stack:

--- a/stack.yaml
+++ b/stack.yaml
@@ -62,8 +62,8 @@ docker:
 nix:
   # --nix on the command-line to enable.
   packages:
+  - pkg-config
   - zlib
-  - unzip
 
 flags:
   stack:


### PR DESCRIPTION
Stack itself (as opposed to its dependencies) cannot be built on NixOS/with Nix due to a Cabal bug but tests on NixOS suggest that package digest needs pkg-config and zlib but that unzip is not required to build Stack on Nix.

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests! Relying on CI
