### PR TITLE
Re #6861 Specify `LANG=C.UTF-8` rather than `en_US.UTF-8`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,10 @@ Major changes:
 
 Behavior changes:
 
+* When Stack's Nix integration is enabled and a `shell-file` is not specified,
+  Stack sets `LANG=C.UTF-8` (rather than `en_US.UTF-8`, which may not be
+  available if Stack has been built from source).
+
 Other enhancements:
 
 Bug fixes:

--- a/src/Stack/Nix.hs
+++ b/src/Stack/Nix.hs
@@ -122,9 +122,10 @@ runShellAndExit = do
                   -- LD_LIBRARY_PATH is set because for now it's needed by
                   -- builds using Template Haskell
                 , "STACK_IN_NIX_EXTRA_ARGS = stackExtraArgs; "
-                  -- overriding default locale so Unicode output using base
-                  -- won't be broken
-                , "LANG=\"en_US.UTF-8\";"
+                  -- Overriding default locale so Unicode output using base
+                  -- won't be broken (including on systems that do not provide
+                  -- locale en_US.UTF-8):
+                , "LANG=\"C.UTF-8\";"
                 , "} \"\""
                 ]
             ]

--- a/tests/integration/tests/4095-utf8-pure-nix/Main.hs
+++ b/tests/integration/tests/4095-utf8-pure-nix/Main.hs
@@ -1,6 +1,7 @@
 -- Stack supports Unicode code points in a Nix environment.
 --
 -- See: https://github.com/commercialhaskell/stack/issues/4095
+-- See: https://github.com/commercialhaskell/stack/pull/6945
 
 import           Control.Monad ( unless )
 import           Data.Maybe ( isJust )
@@ -20,7 +21,9 @@ main
   | otherwise = do
       isInContainer <- getInContainer
       unless isInContainer $ do
+         -- Building causes GHC to emit Unicode:
          stack ["build", "--nix-pure"]
+         -- Running causes the executable to output Unicode:
          stack ["exec", "--nix-pure", "myExe"]
 
 -- | 'True' if we are currently running inside a Docker container.

--- a/tests/integration/tests/4095-utf8-pure-nix/files/app/Main.hs
+++ b/tests/integration/tests/4095-utf8-pure-nix/files/app/Main.hs
@@ -1,5 +1,4 @@
-import           System.IO ( stdout )
-import           Text.Printf ( hPrintf )
+import           Lib ( unicode )
 
 main :: IO ()
-main = hPrintf stdout "平和"
+main = unicode

--- a/tests/integration/tests/4095-utf8-pure-nix/files/package.yaml
+++ b/tests/integration/tests/4095-utf8-pure-nix/files/package.yaml
@@ -5,7 +5,12 @@ name: myPackage
 dependencies:
 - base
 
+library:
+  source-dirs: src
+
 executables:
   myExe:
     source-dirs: app
     main: Main.hs
+    dependencies:
+    - myPackage

--- a/tests/integration/tests/4095-utf8-pure-nix/files/src/Lib.hs
+++ b/tests/integration/tests/4095-utf8-pure-nix/files/src/Lib.hs
@@ -1,0 +1,7 @@
+module Lib
+  ( unicode
+  ) where
+
+{-# WARNING unicode "Warning itself emits unicode: 😊" #-}
+unicode :: IO ()
+unicode = putStrLn "Function outputs unicode: 😊"


### PR DESCRIPTION
See:
* https://github.com/commercialhaskell/stack/pull/6945#issuecomment-4912733394

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!

An existing integration test is extended.
