### PR TITLE
Re #6944 Warn if `--force-dirty` redundant

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,8 @@ Behavior changes:
 * With Nix integration, Stack uses `nix-instantiate` before `nix-shell`,
   enabling Stack to catch and report when the Nix expression cannot be
   evaluated by Nix. The `nix-instantiate-options` option is added, accordingly.
+* Stack's `build` command now warns if `--force-dirty` is specified but no
+  local packages will be built.
 
 Other enhancements:
 

--- a/src/Stack/Build.hs
+++ b/src/Stack/Build.hs
@@ -199,9 +199,20 @@ build msetLocalFiles = do
             boptsCli.initialBuildSteps
 
   allowLocals <- view $ configL . to (.allowLocals)
-  unless allowLocals $ case justLocals plan of
-    [] -> pure ()
-    localsIdents -> throwM $ LocalPackagesPresent localsIdents
+  case justLocals plan of
+    [] -> when bopts.forceDirty $ prettyWarn $
+         fillSep
+           [ style Shell "--force-dirty"
+           , flow "is specified but no local packages will be built."
+           ]
+      <> blankLine
+      <> flow "If your aim is that Stack rebuilds an installed package (one \
+              \registered in the relevant package database) that Stack deems \
+              \immutable, first unregister it from the database by commanding:"
+      <> blankLine
+      <> style Shell "stack exec -- ghc-pkg unregister --force <package>"
+    localsIdents -> unless allowLocals $
+      throwM $ LocalPackagesPresent localsIdents
 
   checkCabalVersion
   haddockCompsSupported <- warnAboutHaddockComps bopts


### PR DESCRIPTION
See:
* #6944 
* #6948 

* [x] Any changes that could be relevant to users have been recorded in ChangeLog.md.
* [x] The documentation has been updated, if necessary

Please also shortly describe how you tested your change. Bonus points for added tests!
